### PR TITLE
Handle missing recitation subtask IDs

### DIFF
--- a/src/mapify_cli/recitation_manager.py
+++ b/src/mapify_cli/recitation_manager.py
@@ -151,15 +151,23 @@ class RecitationManager:
                 "'python -m mapify_cli.recitation_manager create <task_id> <goal> <subtasks_json>'"
             )
 
-        for subtask in plan.subtasks:
-            if subtask.id == subtask_id:
-                subtask.status = status
-                if status == 'in_progress':
-                    plan.current_subtask_id = subtask_id
-                    subtask.iterations += 1
-                if error:
-                    subtask.errors.append(error)
-                break
+        # Find the target subtask up front so we can validate and log reliably
+        target_subtask = next(
+            (subtask for subtask in plan.subtasks if subtask.id == subtask_id),
+            None
+        )
+
+        if target_subtask is None:
+            raise ValueError(
+                f"Subtask with id {subtask_id} was not found in the current plan"
+            )
+
+        target_subtask.status = status
+        if status == 'in_progress':
+            plan.current_subtask_id = subtask_id
+            target_subtask.iterations += 1
+        if error:
+            target_subtask.errors.append(error)
 
         plan.updated_at = datetime.now().isoformat()
 
@@ -175,7 +183,7 @@ class RecitationManager:
                     "subtask_id": subtask_id,
                     "status": status,
                     "error": error,
-                    "iterations": subtask.iterations if subtask else None
+                    "iterations": target_subtask.iterations
                 }
             )
 

--- a/tests/test_recitation_manager.py
+++ b/tests/test_recitation_manager.py
@@ -442,11 +442,9 @@ class TestEdgeCases:
         """Test updating a subtask that doesn't exist"""
         manager.create_plan('test', 'Test', sample_subtasks)
 
-        # Should not raise error, but also shouldn't update anything
-        plan = manager.update_subtask_status(999, 'completed')
-
-        # No subtask should be completed
-        assert all(st.status == 'pending' for st in plan.subtasks)
+        # Should raise an error when subtask ID is not found
+        with pytest.raises(ValueError, match="Subtask with id 999"):
+            manager.update_subtask_status(999, 'completed')
 
     def test_long_error_message(self, manager, sample_subtasks):
         """Test that long error messages are truncated in markdown"""


### PR DESCRIPTION
## Summary
- validate that RecitationManager.update_subtask_status locates the requested subtask before updating it
- reuse the located subtask when logging status updates to avoid stale references
- update the edge-case test to expect a ValueError when a subtask id is missing

## Testing
- pytest tests/test_recitation_manager.py::TestEdgeCases::test_update_nonexistent_subtask -q (fails: ModuleNotFoundError: mapify_cli)


------
https://chatgpt.com/codex/tasks/task_e_68f713d262e08324b764075e2b91c6f6