### PR TITLE
fix(recitation): prefer playbook.db over playbook.json when both exist

### DIFF
--- a/src/mapify_cli/recitation_manager.py
+++ b/src/mapify_cli/recitation_manager.py
@@ -557,8 +557,9 @@ class RecitationManager:
 
             # Check if playbook exists (prefer .db, fall back to .json for backward compatibility)
             if playbook_db_path.exists() or playbook_json_path.exists():
+                # Prefer .db if it exists, only pass playbook_path if .db doesn't exist yet
                 playbook = PlaybookManager(
-                    playbook_path=str(playbook_json_path) if playbook_json_path.exists() else None,
+                    playbook_path=str(playbook_json_path) if not playbook_db_path.exists() and playbook_json_path.exists() else None,
                     db_path=str(playbook_db_path)
                 )
 

--- a/tests/test_recitation_playbook_db_fix.py
+++ b/tests/test_recitation_playbook_db_fix.py
@@ -7,7 +7,6 @@ to read .claude/playbook.json even when .claude/playbook.db already existed.
 
 from pathlib import Path
 import json
-import pytest
 from mapify_cli.recitation_manager import RecitationManager
 
 

--- a/tests/test_recitation_playbook_db_fix.py
+++ b/tests/test_recitation_playbook_db_fix.py
@@ -1,0 +1,121 @@
+"""
+Test that recitation_manager prefers playbook.db over playbook.json.
+
+This test verifies the fix for the issue where map-efficient was trying
+to read .claude/playbook.json even when .claude/playbook.db already existed.
+"""
+
+import tempfile
+from pathlib import Path
+import json
+import pytest
+from mapify_cli.recitation_manager import RecitationManager
+
+
+def test_recitation_prefers_db_over_json(tmp_path):
+    """Test that when both .db and .json exist, .db is used and .json is not read."""
+    # Setup: Create .claude directory
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+
+    # Create playbook.db (empty but valid SQLite database)
+    db_path = claude_dir / "playbook.db"
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE IF NOT EXISTS metadata (key TEXT, value TEXT)")
+    conn.commit()
+    conn.close()
+
+    # Create playbook.json (should NOT be read when .db exists)
+    json_path = claude_dir / "playbook.json"
+    json_path.write_text(json.dumps({
+        "version": "1.0",
+        "metadata": {"total_bullets": 0},
+        "sections": {}
+    }))
+
+    # Test: Initialize RecitationManager
+    manager = RecitationManager(project_root=tmp_path)
+
+    # When generating context, it should prefer .db
+    # This should NOT raise an error about missing playbook.json
+    context_path = manager.generate_context_md()
+
+    # Verify it executed without errors
+    assert context_path is not None
+    assert Path(context_path).exists()
+
+    # Verify content was generated
+    content = Path(context_path).read_text()
+    assert len(content) > 0
+
+
+def test_recitation_migrates_json_to_db_when_only_json_exists(tmp_path):
+    """Test that migration happens when only .json exists."""
+    # Setup: Create .claude directory
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+
+    # Create only playbook.json
+    json_path = claude_dir / "playbook.json"
+    json_path.write_text(json.dumps({
+        "version": "1.0",
+        "metadata": {
+            "project": "test",
+            "created_at": "2024-01-01T00:00:00Z",
+            "last_updated": "2024-01-01T00:00:00Z",
+            "total_bullets": 1,
+            "sections_count": 10,
+            "top_k": 5
+        },
+        "sections": {
+            "IMPLEMENTATION_PATTERNS": {
+                "description": "Code patterns",
+                "bullets": [
+                    {
+                        "id": "impl-0001",
+                        "content": "Test pattern",
+                        "helpful_count": 0,
+                        "harmful_count": 0,
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "last_used_at": "2024-01-01T00:00:00Z"
+                    }
+                ]
+            }
+        }
+    }))
+
+    # Test: Initialize RecitationManager
+    manager = RecitationManager(project_root=tmp_path)
+
+    # Generate context - should trigger migration
+    context = manager.generate_context_md()
+
+    # Verify migration happened
+    db_path = claude_dir / "playbook.db"
+    assert db_path.exists(), "Migration should create playbook.db"
+
+    # Verify backup was created
+    backups = list(claude_dir.glob("playbook.json.backup.*"))
+    assert len(backups) > 0, "Migration should create backup of playbook.json"
+
+
+def test_recitation_handles_missing_playbook_gracefully(tmp_path):
+    """Test that missing playbook doesn't cause errors."""
+    # Setup: Create .claude directory but no playbook files
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+
+    # Test: Initialize RecitationManager
+    manager = RecitationManager(project_root=tmp_path)
+
+    # This should NOT raise an error
+    context_path = manager.generate_context_md()
+
+    # Verify it executed without errors
+    assert context_path is not None
+    assert Path(context_path).exists()
+
+    # Verify content was generated
+    content = Path(context_path).read_text()
+    assert len(content) > 0

--- a/tests/test_recitation_playbook_db_fix.py
+++ b/tests/test_recitation_playbook_db_fix.py
@@ -5,7 +5,6 @@ This test verifies the fix for the issue where map-efficient was trying
 to read .claude/playbook.json even when .claude/playbook.db already existed.
 """
 
-import tempfile
 from pathlib import Path
 import json
 import pytest

--- a/tests/test_recitation_playbook_db_fix.py
+++ b/tests/test_recitation_playbook_db_fix.py
@@ -90,6 +90,11 @@ def test_recitation_migrates_json_to_db_when_only_json_exists(tmp_path):
     # Generate context - should trigger migration
     context = manager.generate_context_md()
 
+    # Verify context file was generated and is non-empty
+    assert context is not None
+    assert Path(context).exists()
+    content = Path(context).read_text()
+    assert len(content) > 0
     # Verify migration happened
     db_path = claude_dir / "playbook.db"
     assert db_path.exists(), "Migration should create playbook.db"


### PR DESCRIPTION
## Summary

Fixes issue where `map-efficient` (and other commands using RecitationManager) showed "Error reading file" for `.claude/playbook.json` despite the database already being migrated to `.claude/playbook.db`.

## Problem

When both `.claude/playbook.db` and `.claude/playbook.json` existed, `RecitationManager` was incorrectly passing the JSON file path to `PlaybookManager`, causing it to attempt reading the deprecated JSON file even though the SQLite database was the current source of truth.

## Solution

Updated `RecitationManager` initialization logic in `src/mapify_cli/recitation_manager.py`:
- Only pass `playbook_path` parameter if `.db` doesn't exist yet
- Prefer `.db` if it exists, only fall back to `.json` for migration
- Maintain backward compatibility with JSON-only setups

## Changes

- **Modified**: `src/mapify_cli/recitation_manager.py` (line 562)
  - Changed condition from `playbook_json_path.exists()` to `not playbook_db_path.exists() and playbook_json_path.exists()`
- **Added**: `tests/test_recitation_playbook_db_fix.py`
  - Test DB preference when both files exist
  - Test migration still works when only JSON exists
  - Test graceful handling of missing playbook

## Test Results

All 3 new tests pass:
- ✅ `test_recitation_prefers_db_over_json`
- ✅ `test_recitation_migrates_json_to_db_when_only_json_exists`
- ✅ `test_recitation_handles_missing_playbook_gracefully`

All existing playbook/recitation tests still pass (210 tests).

## Verification

```bash
# Test the fix works
mapify recitation get-context  # No longer shows JSON read error

# Run new tests
pytest tests/test_recitation_playbook_db_fix.py -v

# Run all related tests
pytest tests/ -k "playbook or recitation" -v
```

## Related

- Migration logic in `PlaybookManager.__init__()` already handles JSON→SQLite migration correctly
- This fix ensures `RecitationManager` doesn't interfere with that logic