### PR TITLE
fix: CRITICAL - prevent mapify init --force from deleting user files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**CRITICAL: Template Synchronization Bugfix:**
+- **Fixed `mapify init --force` deleting user's custom files** (Critical Bug)
+  - **Problem**: `install_hooks()` used `shutil.rmtree()` to delete entire `.claude/hooks/helpers/` directory before copying templates, destroying all user's custom helper scripts
+  - **Solution**: Changed to individual file copying with `shutil.copy2()` - only updates template files, preserves user files
+  - **Impact**: Users can now safely run `mapify init --force` to update templates without losing their custom scripts
+  - **Files affected**: `src/mapify_cli/__init__.py` (lines 1118-1140)
+  - **Test coverage**: Added comprehensive regression test `test_init_force_preserves_user_files` in `tests/test_mapify_cli.py`
+  - **Verified**: Test creates user files in `.claude/hooks/helpers/`, runs `--force`, confirms files still exist with original content
+  - **Related fix**: Added `validate_checkpoint_file.py` to templates (was missing, causing deletion during `--force`)
+
 ## [1.2.1] - 2025-11-02
 
 ### Fixed

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -1116,16 +1116,28 @@ def install_hooks(project_path: Path, with_hooks: bool = True) -> int:
         hooks_count += 1
 
     # Copy helpers directory (Python helper scripts)
+    # IMPORTANT: Only copy/update files from templates, preserve user's custom files
     helpers_src = hooks_template_dir / "helpers"
     if helpers_src.exists() and helpers_src.is_dir():
         helpers_dest = hooks_dir / "helpers"
-        if helpers_dest.exists():
-            shutil.rmtree(helpers_dest)
-        shutil.copytree(helpers_src, helpers_dest)
-        # Make Python scripts executable
-        for py_file in helpers_dest.glob("*.py"):
-            if py_file.name != "__init__.py":
-                py_file.chmod(py_file.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        helpers_dest.mkdir(exist_ok=True)  # Create dir if doesn't exist
+
+        # Copy each file individually (preserves user files not in templates)
+        for helper_file in helpers_src.rglob("*"):
+            if helper_file.is_file():
+                # Compute relative path from helpers_src
+                rel_path = helper_file.relative_to(helpers_src)
+                dest_file = helpers_dest / rel_path
+
+                # Create parent directory if needed
+                dest_file.parent.mkdir(parents=True, exist_ok=True)
+
+                # Copy template file (overwrites if exists)
+                shutil.copy2(helper_file, dest_file)
+
+                # Make Python scripts executable (except __init__.py)
+                if dest_file.suffix == ".py" and dest_file.name != "__init__.py":
+                    dest_file.chmod(dest_file.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
     # Copy README.md
     readme_src = hooks_template_dir / "README.md"

--- a/src/mapify_cli/templates/hooks/helpers/validate_checkpoint_file.py
+++ b/src/mapify_cli/templates/hooks/helpers/validate_checkpoint_file.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Helper script for checkpoint file validation with security checks.
+
+This script validates checkpoint files from .map/ directory with multiple
+security layers to prevent:
+- Path traversal attacks (../, absolute paths)
+- Size bomb attacks (files >256KB)
+- Control character injection (terminal escape codes)
+- UTF-8 encoding errors
+
+Security Design (Defense-in-Depth):
+1. Path validation: Ensure file is within .map/ directory only
+2. Size validation: Reject files >256KB before reading
+3. Content sanitization: Strip control characters except newlines/tabs
+4. UTF-8 validation: Handle encoding errors gracefully
+
+All checks use AND logic - file must pass ALL layers to be valid.
+"""
+
+import sys
+import json
+import re
+import argparse
+from pathlib import Path
+from typing import Dict, Optional, Any
+
+# Security constants
+MAX_FILE_SIZE_BYTES = 256 * 1024  # 256KB
+ALLOWED_BASE_DIR = ".map"  # Only allow files from .map/ directory
+
+# Regex to strip control characters except newline (\n) and tab (\t)
+# Removes: \x00-\x08, \x0b-\x0d (includes \r), \x0e-\x1f, \x7f (DELETE)
+# Also removes Unicode control characters: \u0080-\u009f, \u2028, \u2029
+CONTROL_CHAR_PATTERN = re.compile(r'[\x00-\x08\x0b-\x0d\x0e-\x1f\x7f\u0080-\u009f\u2028\u2029]')
+
+
+def validate_path_security(file_path: str, base_dir: str = ALLOWED_BASE_DIR) -> Dict[str, Any]:
+    """Validate file path is within allowed directory (prevents path traversal).
+
+    Security checks:
+    1. Resolve to absolute path (handles .., symlinks)
+    2. Verify resolved path starts with base_dir absolute path
+    3. Reject absolute paths that escape base_dir
+
+    Args:
+        file_path: User-provided file path (can be relative or absolute)
+        base_dir: Allowed base directory (default: .map/)
+
+    Returns:
+        Dict with:
+        - valid: bool (True if path is safe)
+        - error: str (error message if invalid, None if valid)
+        - resolved_path: Path (resolved absolute path if valid, None if invalid)
+    """
+    try:
+        # Convert to Path objects
+        user_path = Path(file_path)
+        base_path = Path(base_dir).resolve()
+
+        # Resolve user path to absolute (follows symlinks, resolves ..)
+        # If file doesn't exist, resolve() still works for path validation
+        resolved = user_path.resolve()
+
+        # Security check: Ensure resolved path is within base_dir
+        # Use is_relative_to() if Python 3.9+, else check with string prefix
+        try:
+            # Python 3.9+
+            if not resolved.is_relative_to(base_path):
+                return {
+                    "valid": False,
+                    "error": f"Path traversal detected: {file_path} escapes {base_dir}/ directory",
+                    "resolved_path": None
+                }
+        except AttributeError:
+            # Python 3.8 fallback: Check if resolved path starts with base_path
+            try:
+                resolved.relative_to(base_path)
+            except ValueError:
+                return {
+                    "valid": False,
+                    "error": f"Path traversal detected: {file_path} escapes {base_dir}/ directory",
+                    "resolved_path": None
+                }
+
+        return {
+            "valid": True,
+            "error": None,
+            "resolved_path": resolved
+        }
+
+    except Exception as e:
+        return {
+            "valid": False,
+            "error": f"Path validation error: {str(e)}",
+            "resolved_path": None
+        }
+
+
+def validate_file_size(file_path: Path, max_size: int = MAX_FILE_SIZE_BYTES) -> Dict[str, Any]:
+    """Validate file size is within allowed limit (prevents size bomb attacks).
+
+    Security: Check size BEFORE reading file into memory.
+
+    Args:
+        file_path: Resolved path to file
+        max_size: Maximum allowed size in bytes (default: 256KB)
+
+    Returns:
+        Dict with:
+        - valid: bool (True if size acceptable)
+        - error: str (error message if too large, None if valid)
+        - size_bytes: int (actual file size)
+    """
+    try:
+        # Check file exists
+        if not file_path.exists():
+            return {
+                "valid": False,
+                "error": f"File not found: {file_path}",
+                "size_bytes": 0
+            }
+
+        if not file_path.is_file():
+            return {
+                "valid": False,
+                "error": f"Not a regular file: {file_path}",
+                "size_bytes": 0
+            }
+
+        # Get file size without reading content
+        size_bytes = file_path.stat().st_size
+
+        if size_bytes > max_size:
+            size_kb = size_bytes / 1024
+            max_kb = max_size / 1024
+            return {
+                "valid": False,
+                "error": f"File too large: {size_kb:.1f}KB exceeds {max_kb:.0f}KB limit",
+                "size_bytes": size_bytes
+            }
+
+        return {
+            "valid": True,
+            "error": None,
+            "size_bytes": size_bytes
+        }
+
+    except Exception as e:
+        return {
+            "valid": False,
+            "error": f"Size validation error: {str(e)}",
+            "size_bytes": 0
+        }
+
+
+def sanitize_content(content: str) -> str:
+    """Sanitize file content by removing control characters.
+
+    Security: Strip control characters that could cause terminal injection
+    or break JSON parsing, while preserving newlines and tabs.
+
+    Removes:
+    - \x00-\x08: NULL, control codes
+    - \x0b-\x0c: Vertical tab, form feed
+    - \x0e-\x1f: More control codes (including ESC)
+    - \x7f: DELETE character
+
+    Preserves:
+    - \x09: Tab (\t)
+    - \x0a: Newline (\n)
+
+    (Carriage return \r is REMOVED for terminal safety)
+
+    Args:
+        content: Raw file content
+
+    Returns:
+        Sanitized content with control characters removed
+    """
+    return CONTROL_CHAR_PATTERN.sub('', content)
+
+
+def read_and_validate_content(file_path: Path) -> Dict[str, Any]:
+    """Read file and validate UTF-8 encoding.
+
+    Args:
+        file_path: Resolved path to file
+
+    Returns:
+        Dict with:
+        - valid: bool (True if content readable)
+        - error: str (error message if unreadable, None if valid)
+        - content: str (raw file content if valid, None if invalid)
+    """
+    try:
+        # Read with explicit UTF-8 encoding and error handling
+        content = file_path.read_text(encoding='utf-8', errors='strict')
+
+        return {
+            "valid": True,
+            "error": None,
+            "content": content
+        }
+
+    except UnicodeDecodeError as e:
+        return {
+            "valid": False,
+            "error": f"Invalid UTF-8 encoding: {str(e)}",
+            "content": None
+        }
+    except Exception as e:
+        return {
+            "valid": False,
+            "error": f"Failed to read file: {str(e)}",
+            "content": None
+        }
+
+
+def validate_checkpoint_file(file_path: str, base_dir: str = ALLOWED_BASE_DIR, max_size: int = MAX_FILE_SIZE_BYTES) -> Dict[str, Any]:
+    """Validate checkpoint file with multiple security layers (defense-in-depth).
+
+    Security layers (all must pass - AND logic):
+    1. Path validation: Ensure file is within specified base directory
+    2. Size validation: Reject files exceeding size limit
+    3. Content reading: Validate UTF-8 encoding
+    4. Sanitization: Strip control characters
+
+    Args:
+        file_path: User-provided file path
+        base_dir: Allowed base directory (default: .map/)
+        max_size: Maximum file size in bytes (default: 256KB)
+
+    Returns:
+        Dict with:
+        - valid: bool (True only if ALL checks pass)
+        - error: str (first error encountered, None if all pass)
+        - sanitized_content: str (sanitized content if valid, empty if invalid)
+        - metadata: dict (validation details: size, path)
+    """
+    metadata = {
+        "original_path": file_path,
+        "resolved_path": None,
+        "size_bytes": 0
+    }
+
+    # Layer 1: Path security validation
+    path_result = validate_path_security(file_path, base_dir)
+    if not path_result["valid"]:
+        return {
+            "valid": False,
+            "error": path_result["error"],
+            "sanitized_content": "",
+            "metadata": metadata
+        }
+
+    resolved_path = path_result["resolved_path"]
+    metadata["resolved_path"] = str(resolved_path)
+
+    # Layer 2: Size validation (before reading)
+    size_result = validate_file_size(resolved_path, max_size)
+    if not size_result["valid"]:
+        return {
+            "valid": False,
+            "error": size_result["error"],
+            "sanitized_content": "",
+            "metadata": metadata
+        }
+
+    metadata["size_bytes"] = size_result["size_bytes"]
+
+    # Layer 3: Read content with UTF-8 validation
+    content_result = read_and_validate_content(resolved_path)
+    if not content_result["valid"]:
+        return {
+            "valid": False,
+            "error": content_result["error"],
+            "sanitized_content": "",
+            "metadata": metadata
+        }
+
+    # Layer 4: Sanitize content (remove control characters)
+    sanitized = sanitize_content(content_result["content"])
+
+    # All layers passed - return sanitized content
+    return {
+        "valid": True,
+        "error": None,
+        "sanitized_content": sanitized,
+        "metadata": metadata
+    }
+
+
+def main():
+    """Main entry point for validation helper script."""
+    parser = argparse.ArgumentParser(
+        description='Validate checkpoint file with security checks'
+    )
+    parser.add_argument(
+        '--file',
+        required=True,
+        help='Path to checkpoint file (must be in .map/ directory)'
+    )
+    parser.add_argument(
+        '--base-dir',
+        default=ALLOWED_BASE_DIR,
+        help=f'Base directory for validation (default: {ALLOWED_BASE_DIR})'
+    )
+    parser.add_argument(
+        '--max-size-kb',
+        type=int,
+        default=256,
+        help='Maximum file size in KB (default: 256)'
+    )
+
+    args = parser.parse_args()
+
+    # Convert max_size_kb to bytes
+    max_size_bytes = args.max_size_kb * 1024
+
+    # Validate file with custom parameters
+    result = validate_checkpoint_file(args.file, args.base_dir, max_size_bytes)
+
+    # Log to stderr for debugging
+    if result["valid"]:
+        size_kb = result["metadata"]["size_bytes"] / 1024
+        print(f"[validate_checkpoint_file] ✓ Valid file: {args.file} ({size_kb:.1f}KB)", file=sys.stderr)
+    else:
+        print(f"[validate_checkpoint_file] ✗ Invalid file: {result['error']}", file=sys.stderr)
+
+    # Output JSON to stdout
+    print(json.dumps(result, indent=2))
+
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except Exception as e:
+        # Fatal error - output error JSON and exit cleanly
+        print(f"[validate_checkpoint_file] Fatal error: {e}", file=sys.stderr)
+        error_result = {
+            "valid": False,
+            "error": f"Unexpected error: {str(e)}",
+            "sanitized_content": "",
+            "metadata": {}
+        }
+        print(json.dumps(error_result, indent=2))
+        sys.exit(0)  # Exit 0 to avoid blocking hooks

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -316,6 +316,75 @@ class TestInitCommand:
         assert "claude-reviewer" in mcp_config["mcp_servers"]
         assert "sequential-thinking" in mcp_config["mcp_servers"]
 
+    @mock.patch("mapify_cli.select_with_arrows")
+    @mock.patch("mapify_cli.select_multiple_with_arrows")
+    def test_init_force_preserves_user_files(self, mock_select_multiple, mock_select, tmp_path):
+        """Test that 'mapify init --force' preserves user's custom files.
+
+        Critical bug regression test: Verify that reinitializing a project with --force
+        does NOT delete user's custom files in .claude/hooks/helpers/.
+
+        This test ensures:
+        1. Template files are updated when running init --force
+        2. User's custom files are preserved (not deleted)
+        3. Both template and custom files coexist after --force
+        """
+        os.chdir(tmp_path)
+        mock_select.return_value = "none"
+
+        # Step 1: Initialize project first time
+        result1 = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
+        assert result1.exit_code == 0, f"First init failed: {result1.stdout}"
+
+        # Step 2: Create user's custom file in .claude/hooks/helpers/
+        helpers_dir = tmp_path / ".claude" / "hooks" / "helpers"
+        assert helpers_dir.exists(), "Helpers directory should exist after init"
+
+        user_file = helpers_dir / "user_custom_helper.py"
+        user_file_content = "# User's custom helper script - DO NOT DELETE!\ndef custom_function():\n    pass\n"
+        user_file.write_text(user_file_content)
+
+        # Also create a subdirectory with a user file to test recursive preservation
+        user_subdir = helpers_dir / "custom"
+        user_subdir.mkdir()
+        user_subfile = user_subdir / "custom_module.py"
+        user_subfile_content = "# User's custom module\nCUSTOM_VALUE = 42\n"
+        user_subfile.write_text(user_subfile_content)
+
+        # Verify user files exist before --force
+        assert user_file.exists(), "User file should exist before --force"
+        assert user_subfile.exists(), "User subdirectory file should exist before --force"
+
+        # Step 3: Get list of template files before --force
+        template_files_before = set(helpers_dir.rglob("*.py")) - {user_file, user_subfile}
+        assert len(template_files_before) > 0, "Should have template files from first init"
+
+        # Step 4: Run init --force to reinitialize
+        result2 = runner.invoke(app, ["init", ".", "--force", "--no-git", "--mcp", "none"])
+        assert result2.exit_code == 0, f"Second init --force failed: {result2.stdout}"
+
+        # Step 5: Verify user files still exist with original content
+        assert user_file.exists(), "CRITICAL: User file was deleted by init --force!"
+        assert user_file.read_text() == user_file_content, "User file content was modified!"
+
+        assert user_subfile.exists(), "CRITICAL: User subdirectory file was deleted by init --force!"
+        assert user_subfile.read_text() == user_subfile_content, "User subdirectory file content was modified!"
+
+        # Step 6: Verify template files were updated (still exist)
+        template_files_after = set(helpers_dir.rglob("*.py")) - {user_file, user_subfile}
+        assert len(template_files_after) > 0, "Template files should still exist after --force"
+
+        # Verify at least some common template files exist
+        expected_template_files = ["quality_gates.py", "inject_playbook_bullets.py", "__init__.py"]
+        for template_file in expected_template_files:
+            assert (helpers_dir / template_file).exists(), f"Template file {template_file} should exist after --force"
+
+        # Step 7: Verify both user and template files coexist
+        all_files = set(helpers_dir.rglob("*.py"))
+        assert user_file in all_files, "User file should be in final file list"
+        assert user_subfile in all_files, "User subdirectory file should be in final file list"
+        assert len(all_files) >= len(template_files_after) + 2, "Should have both template and user files"
+
 
 class TestCheckCommand:
     """Test the check command."""


### PR DESCRIPTION
## 🚨 Critical Bug Fix

**Severity:** CRITICAL - Data Loss  
**Affected:** All users running `mapify init --force`

## Problem

`mapify init --force` was **deleting all user's custom files** in `.claude/hooks/helpers/` directory:

```python
# ❌ BEFORE (destructive):
if helpers_dest.exists():
    shutil.rmtree(helpers_dest)  # Deletes EVERYTHING including user files!
shutil.copytree(helpers_src, helpers_dest)
```

**Impact:**
- Users lost their custom helper scripts when re-initializing
- No warning given before deletion
- Affected all custom files in `.claude/hooks/helpers/`

## Solution

Changed to **individual file copying** - only updates template files, preserves user files:

```python
# ✅ AFTER (safe):
helpers_dest.mkdir(exist_ok=True)
for helper_file in helpers_src.rglob("*"):
    if helper_file.is_file():
        shutil.copy2(helper_file, dest_file)  # Only copies template files
```

## Changes

### Core Fix
- **src/mapify_cli/__init__.py** (lines 1118-1140): Replaced `rmtree()` with individual file copying
- **Result:** Template files update, user files preserved, both coexist safely

### Test Coverage
- **tests/test_mapify_cli.py**: Added `test_init_force_preserves_user_files`
  - Creates user files before `--force`
  - Verifies preservation after `--force`
  - Tests subdirectory preservation (recursive)
  - **Status:** ✅ PASSED

### Related Fix
- **src/mapify_cli/templates/hooks/helpers/validate_checkpoint_file.py**: Added missing template file
  - Previously missing from templates, causing deletion during `--force`
  - Now included, prevents future deletions

### Documentation
- **CHANGELOG.md**: Documented critical bugfix with problem/solution/impact

## Testing

```bash
pytest tests/test_mapify_cli.py::TestInitCommand::test_init_force_preserves_user_files -v
# ✅ PASSED in 4.89s
```

Test verifies:
1. ✅ User files preserved after `--force`
2. ✅ Template files updated correctly
3. ✅ Both file types coexist
4. ✅ File contents unchanged

## Impact

### Before (Broken)
```
mapify init --force
# ❌ All user files in .claude/hooks/helpers/ DELETED
```

### After (Fixed)
```
mapify init --force
# ✅ Template files updated
# ✅ User files preserved
# ✅ No data loss
```

## Safety Analysis

Checked other functions for similar issues:
- ✅ `create_agent_files()`: Safe (uses individual `shutil.copy2()`)
- ✅ `create_command_files()`: Safe (uses individual `shutil.copy2()`)
- ❌ `install_hooks()`: **FIXED** (was using `rmtree()`)

## Regression Prevention

- Added comprehensive test with 7 verification steps
- Test runs in CI on every commit
- Covers both top-level and subdirectory user files

## Commits

- `4263666` fix: sync validate_checkpoint_file.py to templates
- `63ba513` fix: CRITICAL - prevent mapify init --force from deleting user files

## Checklist

- [x] Problem identified and documented
- [x] Solution implemented and tested
- [x] Regression test added (PASSED)
- [x] CHANGELOG updated
- [x] No similar issues in other functions
- [x] Ready for review

---

**Recommendation:** Merge immediately to prevent further data loss for users.