### PR TITLE
Fix playbook agent confusion: SQLite migration and cipher integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -126,7 +126,7 @@ fi
 
 ❌ **ПЛОХО**:
 - "Я сам проанализирую успех и напишу lessons learned"
-- "Я сам обновлю playbook.json"
+- "Я сам обновлю playbook напрямую" (через sqlite3 или Edit)
 - "Пропущу Reflector для простой задачи"
 
 ✅ **ХОРОШО**:
@@ -138,7 +138,7 @@ fi
 ### Почему это важно?
 
 **Двойная система памяти**:
-- **Playbook** (`.claude/playbook.json`) - проектные паттерны
+- **Playbook** (`.claude/playbook.db` SQLite) - проектные паттерны
 - **Cipher** (MCP tool) - кросс-проектные знания
 
 Когда пропускаешь агентов:
@@ -146,6 +146,27 @@ fi
 - ❌ Cipher НЕ обновляется (MCP tools не вызываются)
 - ❌ Знания не дедуплицируются (cipher_memory_search не вызывается)
 - ❌ Будущие workflows не получают преимуществ
+
+## Playbook Update Rules
+
+**CRITICAL: How to Update Playbook**
+
+✅ **CORRECT WAY (via Curator agent)**:
+1. Call `Task(subagent_type="curator", ...)`
+2. Curator outputs JSON delta operations
+3. Apply via: `mapify playbook apply-delta curator_operations.json`
+
+❌ **NEVER DO THIS**:
+- ❌ `sqlite3 .claude/playbook.db "UPDATE bullets SET..."`  (direct SQL)
+- ❌ `Edit(.claude/playbook.db, ...)` (Edit tool on binary file)
+- ❌ Reading/writing playbook.json (doesn't exist anymore - migrated to SQLite)
+- ❌ Manually creating JSON and applying without Curator review
+
+**Why**:
+- Curator validates quality, checks duplicates, scores patterns
+- `apply-delta` maintains playbook integrity, handles transactions
+- Direct sqlite breaks schema, bypasses validation
+- playbook.json is legacy (removed in favor of playbook.db)
 
 ## Template Variable Protection
 

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -117,19 +117,30 @@ mapify recitation create "$TASK_ID" "$ARGUMENTS" "$SUBTASKS_JSON"
 
 ## Step 3: For Each Subtask - Efficient Loop
 
-### 3.1 Get Relevant Playbook Bullets
+### 3.1 Get Relevant Playbook Context
 
-Query playbook using FTS5 (faster for large playbooks):
+**Step A: Query Local Playbook**:
 
 ```bash
-# Query playbook using FTS5 full-text search
-PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5 --mode local)
+# Query playbook using FTS5 (project-specific patterns)
+PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5)
+```
+
+**Step B: Search Cipher** (optional but recommended):
+
+```
+# Get cross-project patterns via MCP tool
+mcp__cipher__cipher_memory_search(
+  query="[subtask concept]",
+  top_k=5
+)
 ```
 
 **Benefits over grep/read:**
 - Works with large playbooks (>256KB)
 - FTS5 full-text search with relevance ranking
 - Quality-scored results
+- Cipher adds cross-project validated patterns
 
 ### 3.1.5 Update Recitation Plan
 

--- a/docs/PLAYBOOK-CIPHER-INTEGRATION.md
+++ b/docs/PLAYBOOK-CIPHER-INTEGRATION.md
@@ -1,0 +1,161 @@
+# Playbook + Cipher Integration Guide
+
+## Problem Statement
+
+Claude Code agents struggle with dual-memory system (playbook + cipher) because they don't understand that these are **separate tools** that must be called independently.
+
+### The Confusion
+
+❌ **Wrong mental model**: "I can use `mapify playbook query --mode hybrid` to search both"
+
+✅ **Correct model**: "I must call TWO separate tools and combine results myself"
+
+## Why `--mode hybrid` Doesn't Work in Workflows
+
+When agents execute:
+```bash
+mapify playbook query "pattern" --mode hybrid
+```
+
+**What happens**:
+1. Bash spawns separate Python process
+2. That process has NO access to MCP tools
+3. `_query_cipher()` returns empty list (graceful degradation)
+4. Result: only local playbook searched
+
+**From playbook_manager.py:1267-1271**:
+```python
+else:
+    # In production, this would be called via MCP tool invocation
+    # by Claude's orchestration layer. For library usage without
+    # MCP, return empty results gracefully.
+    return []
+```
+
+## Correct Approach: Two-Step Pattern
+
+### Step 1: Query Local Playbook (via Bash)
+
+```bash
+PLAYBOOK_RESULTS=$(mapify playbook query "[task description]" --limit 5)
+```
+
+**Why this works**:
+- CLI tool, fast (<50ms)
+- FTS5 full-text search
+- Quality-scored results
+- Project-specific patterns
+
+### Step 2: Query Cipher (via MCP Tool)
+
+```
+mcp__cipher__cipher_memory_search(
+  query="[task description similar pattern]",
+  top_k=5
+)
+```
+
+**Why this works**:
+- Direct MCP tool call (Claude can invoke it)
+- Cross-project validated patterns
+- Semantic search
+- Broader knowledge base
+
+### Step 3: Agent Combines Results
+
+Agent receives:
+- Local playbook patterns (project-specific)
+- Cipher patterns (cross-project, validated)
+- Combines both to inform implementation
+
+## Updated Workflow Pattern
+
+### Before (Incorrect)
+
+```bash
+# This doesn't actually search cipher!
+PLAYBOOK_BULLETS=$(mapify playbook query "auth" --mode hybrid)
+```
+
+### After (Correct)
+
+```bash
+# Step 1: Get local project patterns
+PLAYBOOK_BULLETS=$(mapify playbook query "JWT authentication" --limit 5)
+```
+
+```
+# Step 2: Get cross-project patterns (separate MCP call)
+Task(
+  subagent_type="general-purpose",
+  prompt="Before implementing, search cipher for similar patterns:
+
+Call mcp__cipher__cipher_memory_search with query='JWT authentication pattern' and top_k=5
+
+Then review both:
+- Local playbook results: $PLAYBOOK_BULLETS
+- Cipher results: [from MCP call]
+
+Identify best practices from both sources."
+)
+```
+
+## When to Use Each Source
+
+| Source | Use When | Tool |
+|--------|----------|------|
+| **Local Playbook** | Project-specific patterns, conventions, past lessons from THIS project | `mapify playbook query` (Bash) |
+| **Cipher** | Cross-project validated patterns, general best practices, similar solutions from OTHER projects | `mcp__cipher__cipher_memory_search` (MCP) |
+
+## Example: Actor Implementation
+
+**Correct pattern**:
+
+```markdown
+### 3.1 Get Relevant Context
+
+**Step 1 - Local Playbook**:
+\`\`\`bash
+PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5)
+\`\`\`
+
+**Step 2 - Cipher Cross-Project Patterns**:
+Before implementing, call:
+- `mcp__cipher__cipher_memory_search(query="[subtask concept]", top_k=5)`
+
+**Step 3 - Combine Insights**:
+Review both sources:
+- Playbook shows project-specific conventions
+- Cipher shows validated cross-project patterns
+- Use playbook for "how we do it HERE"
+- Use cipher for "how it's done WELL elsewhere"
+```
+
+## CLI Modes Documentation (Clarified)
+
+The `--mode` parameter in `mapify playbook query` is for:
+
+1. **Testing/development**: When playbook_manager has `_cipher_callback` registered
+2. **Future standalone mode**: When cipher backend runs as separate service
+3. **Currently**: Has NO effect in MAP workflows (always returns empty for cipher)
+
+**For MAP workflows, ignore `--mode` parameter** and use two-step pattern above.
+
+## Implementation Checklist
+
+To fix agent confusion:
+
+- [ ] Remove mentions of `--mode hybrid` from workflow commands
+- [ ] Keep `--mode local` or no mode (they're equivalent)
+- [ ] Add explicit "Search cipher" step AFTER playbook query
+- [ ] Show examples of combining both sources
+- [ ] Update USAGE.md to clarify mode limitations
+- [ ] Update workflow commands (map-feature, map-efficient, etc.)
+
+## Summary
+
+✅ **Do**: Use `mapify playbook query` (local) + `mcp__cipher__cipher_memory_search` (MCP)
+
+❌ **Don't**: Use `mapify playbook query --mode hybrid` and expect cipher results
+
+**Why**: Bash commands can't invoke MCP tools. Claude agents must call MCP tools directly.

--- a/docs/PLAYBOOK-CIPHER-INTEGRATION.md
+++ b/docs/PLAYBOOK-CIPHER-INTEGRATION.md
@@ -115,9 +115,8 @@ Identify best practices from both sources."
 ### 3.1 Get Relevant Context
 
 **Step 1 - Local Playbook**:
-\`\`\`bash
+```bash
 PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5)
-\`\`\`
 
 **Step 2 - Cipher Cross-Project Patterns**:
 Before implementing, call:

--- a/docs/PLAYBOOK-USAGE-GUIDE.md
+++ b/docs/PLAYBOOK-USAGE-GUIDE.md
@@ -1,0 +1,140 @@
+# Playbook Usage Guide for Agents
+
+## Common Mistakes to Avoid
+
+### ❌ Mistake #1: Looking for playbook.json
+
+**Wrong mental model**: "I need to read .claude/playbook.json"
+
+**Reality**: Playbook migrated to SQLite in 2024. The file `.claude/playbook.json` no longer exists.
+
+**Correct approach**:
+```bash
+# Query playbook via CLI (reads from playbook.db)
+mapify playbook query "pattern description" --limit 5
+```
+
+### ❌ Mistake #2: Direct SQLite Modifications
+
+**Wrong mental model**: "I'll update playbook directly with sqlite3"
+
+**Example of what NOT to do**:
+```bash
+# ❌ NEVER DO THIS
+sqlite3 .claude/playbook.db "UPDATE bullets SET helpful_count = 10 WHERE id = 'impl-0001'"
+```
+
+**Why this is dangerous**:
+- Bypasses quality validation
+- No deduplication check
+- Breaks helpful_count integrity (supposed to be incremented via Curator)
+- No audit trail
+- Can corrupt database schema
+
+**Correct approach**:
+```bash
+# ✅ Always use Curator agent + CLI
+# 1. Curator creates delta operations (JSON)
+# 2. Apply via CLI:
+mapify playbook apply-delta curator_operations.json
+```
+
+### ❌ Mistake #3: Using Edit Tool on Binary Files
+
+**Wrong mental model**: "I'll use Edit tool to update playbook.db"
+
+**Reality**: `.claude/playbook.db` is a binary SQLite database, not a text file. Edit tool will corrupt it.
+
+**Correct approach**: Never edit playbook.db directly. Always use `mapify playbook` CLI commands.
+
+## Correct Playbook Workflow
+
+### Reading from Playbook
+
+**Step 1: Query local playbook** (via Bash):
+```bash
+PLAYBOOK_RESULTS=$(mapify playbook query "[task description]" --limit 5)
+```
+
+**Step 2: Search cipher for cross-project patterns** (via MCP tool):
+```
+mcp__cipher__cipher_memory_search(
+  query="[pattern type]",
+  top_k=5
+)
+```
+
+**Step 3: Combine both sources** in your analysis/implementation.
+
+### Writing to Playbook
+
+**ONLY via Curator Agent**:
+
+```
+1. Reflector extracts lessons → JSON output
+2. Curator processes lessons → delta operations JSON:
+   {
+     "operations": [
+       {"operation": "ADD", "section": "...", "content": "...", ...},
+       {"operation": "UPDATE", "bullet_id": "impl-0001", "field": "helpful_count", ...}
+     ]
+   }
+3. Orchestrator applies: mapify playbook apply-delta curator_output.json
+```
+
+**Curator's role**:
+- Validates quality (content length, code examples, specificity)
+- Checks for duplicates (via cipher search)
+- Assigns proper sections and IDs
+- Maintains helpful_count integrity
+- Creates audit trail
+
+## Quick Reference
+
+| Task | Correct Tool | Wrong Approach |
+|------|-------------|----------------|
+| **Read playbook** | `mapify playbook query` | Reading .claude/playbook.json |
+| **Search patterns** | `mapify playbook query` + `cipher_memory_search` (MCP) | Using `--mode hybrid` flag |
+| **Update playbook** | Curator agent → `mapify playbook apply-delta` | Direct sqlite3 commands |
+| **Add new bullet** | Curator agent → ADD operation | Manually editing JSON/DB |
+| **Increment helpful_count** | Curator agent → UPDATE operation | sqlite3 UPDATE command |
+
+## File Locations
+
+- **Playbook Database**: `.claude/playbook.db` (SQLite, binary, DO NOT EDIT)
+- **Playbook Bullets Summary**: Generated on-the-fly by `mapify playbook query`
+- **Delta Operations**: Temporary JSON files (e.g., `curator_operations.json`)
+- **Legacy playbook.json**: Removed in 2024 migration (DO NOT create)
+
+## CLI Commands Reference
+
+```bash
+# Query playbook (most common)
+mapify playbook query "error handling" --limit 5
+
+# Query with filters
+mapify playbook query "JWT auth" --section SECURITY_PATTERNS --min-quality 3
+
+# Apply Curator operations
+mapify playbook apply-delta curator_output.json
+
+# Validate playbook integrity (for debugging)
+mapify playbook validate
+
+# Export for backup (JSON format)
+mapify playbook export --output backup.json
+```
+
+## When to Update This Guide
+
+Update this guide when:
+- New common mistakes are observed in agent behavior
+- Playbook schema changes
+- New CLI commands added
+- Migration patterns change
+
+## See Also
+
+- [PLAYBOOK-CIPHER-INTEGRATION.md](PLAYBOOK-CIPHER-INTEGRATION.md) - How to use playbook + cipher together
+- [docs/USAGE.md](USAGE.md) - Full mapify CLI documentation
+- [.claude/agents/curator.md](../.claude/agents/curator.md) - Curator agent details

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -97,15 +97,28 @@ mapify playbook query "testing strategies" --format json
 
 **Query modes:**
 - `--mode local` (default) - Search local playbook only (fast, <50ms)
-- `--mode hybrid` - Search both playbook and cipher (comprehensive)
-- `--mode cipher` - Search cipher only (cross-project patterns)
+- `--mode hybrid` - Intended for future standalone mode (currently NO-OP in workflows)
+- `--mode cipher` - Reserved for future cipher backend
+
+**IMPORTANT for MAP Workflows:**
+
+⚠️ The `--mode hybrid` flag **does not work** in MAP workflows because:
+- `mapify playbook query` runs as separate bash process
+- Separate processes cannot invoke Claude MCP tools
+- Cipher search returns empty list (graceful degradation)
+
+**Correct approach for MAP workflows:**
+1. Use `mapify playbook query` (local playbook via Bash)
+2. Separately call `mcp__cipher__cipher_memory_search` (cross-project via MCP tool)
+3. Agent combines both sources
+
+See [PLAYBOOK-CIPHER-INTEGRATION.md](PLAYBOOK-CIPHER-INTEGRATION.md) for details.
 
 **Why use `query` instead of `search`:**
 - ✅ **Works with large playbooks** - Handles >256KB (current playbook: 270KB)
 - ✅ **FTS5 full-text search** - 10x faster than grep
 - ✅ **Relevance ranking** - Best patterns first
 - ✅ **Quality scoring** - Prioritizes proven patterns (helpful_count - harmful_count)
-- ✅ **Cipher integration** - Optional cross-project knowledge
 
 ### Apply Delta Operations (MAP Workflow Integration)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -97,7 +97,7 @@ mapify playbook query "testing strategies" --format json
 
 **Query modes:**
 - `--mode local` (default) - Search local playbook only (fast, <50ms)
-- `--mode hybrid` - Intended for future standalone mode (currently NO-OP in workflows)
+- `--mode hybrid` - Intended for future standalone mode (in workflows, gracefully degrades to local-only search)
 - `--mode cipher` - Reserved for future cipher backend
 
 **IMPORTANT for MAP Workflows:**

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -117,19 +117,30 @@ mapify recitation create "$TASK_ID" "$ARGUMENTS" "$SUBTASKS_JSON"
 
 ## Step 3: For Each Subtask - Efficient Loop
 
-### 3.1 Get Relevant Playbook Bullets
+### 3.1 Get Relevant Playbook Context
 
-Query playbook using FTS5 (faster for large playbooks):
+**Step A: Query Local Playbook**:
 
 ```bash
-# Query playbook using FTS5 full-text search
-PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5 --mode local)
+# Query playbook using FTS5 (project-specific patterns)
+PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5)
+```
+
+**Step B: Search Cipher** (optional but recommended):
+
+```
+# Get cross-project patterns via MCP tool
+mcp__cipher__cipher_memory_search(
+  query="[subtask concept]",
+  top_k=5
+)
 ```
 
 **Benefits over grep/read:**
 - Works with large playbooks (>256KB)
 - FTS5 full-text search with relevance ranking
 - Quality-scored results
+- Cipher adds cross-project validated patterns
 
 ### 3.1.5 Update Recitation Plan
 

--- a/src/mapify_cli/templates/commands/map-feature.md
+++ b/src/mapify_cli/templates/commands/map-feature.md
@@ -124,26 +124,38 @@ mapify recitation create feat_1760783000 "Add user authentication" '[{"id":1,"de
 
 For each subtask from task-decomposer output:
 
-### 3.1 Get Relevant Playbook Bullets
+### 3.1 Get Relevant Playbook Context
 
-Query playbook using task context (faster and works with large playbooks):
+**Step A: Query Local Playbook** (project-specific patterns):
 
 ```bash
-# Query playbook using FTS5 full-text search
-PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5 --mode local)
+# Query playbook using FTS5 full-text search (local project patterns)
+PLAYBOOK_BULLETS=$(mapify playbook query "[subtask description]" --limit 5)
 ```
 
 **Why use `mapify playbook query` instead of grep/read:**
 - ✅ Works with large playbooks (>256KB) - grep/read fails
 - ✅ FTS5 full-text search - faster and more accurate than grep
 - ✅ Ranked by relevance - best patterns first
-- ✅ Optional cipher integration (--mode hybrid) for broader knowledge
 - ✅ Quality scoring - prioritizes proven patterns
 
-**Search modes:**
-- `--mode local` (default) - Search local playbook only (fast)
-- `--mode hybrid` - Search both playbook and cipher (broader knowledge)
-- `--mode cipher` - Search cipher only (cross-project patterns)
+**Step B: Search Cipher** (cross-project validated patterns):
+
+IMPORTANT: Also search cipher directly via MCP tool for broader knowledge:
+
+```
+# Call this BEFORE Actor to get cross-project patterns
+mcp__cipher__cipher_memory_search(
+  query="[subtask concept or pattern type]",
+  top_k=5
+)
+```
+
+**Why separate tools:**
+- Playbook (via Bash): Project-specific conventions and lessons
+- Cipher (via MCP): Cross-project validated patterns
+- Bash commands can't invoke MCP tools - must call separately
+- Agent combines both sources for richer context
 
 ### 3.1.5 Update Recitation Plan (BEFORE Actor)
 


### PR DESCRIPTION
## Summary

Fixes three recurring issues where Claude Code agents struggled with playbook usage:

1. ❌ Looking for legacy `.claude/playbook.json` (migrated to SQLite in 2024)
2. ❌ Attempting direct SQLite modifications via `sqlite3` commands
3. ❌ Using `--mode hybrid` flag expecting cipher integration (doesn't work in bash workflows)

## Changes

### 1. Playbook + Cipher Integration (Commit 4e48e6e)

**Problem**: `mapify playbook query --mode hybrid` doesn't actually search cipher because:
- Bash commands spawn separate processes
- Separate processes can't invoke Claude MCP tools
- `_query_cipher()` returns empty list (graceful degradation)

**Solution**: Two-step pattern
```bash
# Step 1: Local playbook (via Bash)
PLAYBOOK_BULLETS=$(mapify playbook query "task" --limit 5)

# Step 2: Cipher (via MCP tool directly)
mcp__cipher__cipher_memory_search(query="task pattern", top_k=5)
```

**Files changed**:
- `.claude/commands/map-efficient.md` - Added two-step pattern
- `src/mapify_cli/templates/commands/map-feature.md` - Added two-step pattern
- `src/mapify_cli/templates/commands/map-efficient.md` - Synced changes
- `docs/USAGE.md` - Added warning about --mode hybrid limitations
- **New**: `docs/PLAYBOOK-CIPHER-INTEGRATION.md` - Technical deep-dive (161 lines)

### 2. Playbook.db Usage Clarification (Commit a5d0340)

**Problem**: Agents looking for `playbook.json` and trying direct sqlite access

**Solution**: 
- Updated `.claude/CLAUDE.md` to reference `playbook.db` (SQLite)
- Added "Playbook Update Rules" section with explicit warnings:
  - ❌ `sqlite3 .claude/playbook.db "UPDATE..."`
  - ❌ `Edit(.claude/playbook.db, ...)`
  - ❌ Reading/writing playbook.json
  - ✅ Curator agent → `mapify playbook apply-delta`

**Files changed**:
- `.claude/CLAUDE.md` - Updated references, added rules section
- **New**: `docs/PLAYBOOK-USAGE-GUIDE.md` - Comprehensive guide (140 lines)

## Impact

✅ Agents will understand playbook.json doesn't exist  
✅ Agents will use correct workflow: Curator → apply-delta  
✅ Agents will search both playbook AND cipher correctly  
✅ No more direct sqlite modifications  

## Testing

- Verified `mapify playbook query` works correctly (local only)
- Confirmed `--mode hybrid` returns local-only results (as expected)
- Validated documentation clarity with examples

## Documentation

- **PLAYBOOK-CIPHER-INTEGRATION.md**: Why --mode hybrid doesn't work, correct two-step pattern
- **PLAYBOOK-USAGE-GUIDE.md**: Common mistakes, correct workflows, CLI reference
- **.claude/CLAUDE.md**: Updated playbook rules for MAP workflow enforcement

## Stats

- **7 files changed**: +391/-22 lines
- **2 new guides**: 301 lines of documentation
- **5 files updated**: Workflow commands and core documentation

## Checklist

- [x] All workflow commands updated with two-step pattern
- [x] Documentation clarifies playbook.db (not .json)
- [x] Warnings against direct sqlite access added
- [x] Two comprehensive guides created
- [x] Template files synced
- [x] No breaking changes (CLI behavior unchanged)