### PR TITLE
fix: correct settings file location and restore SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,6 +16,13 @@ VALIDATOR_SCRIPT="$SCRIPT_DIR/helpers/validate_checkpoint_file.py"
 # Debug logging to stderr (visible in Claude Code logs)
 echo "[session-start] SessionStart hook triggered" >&2
 
+# Check if jq is installed (required for JSON parsing)
+if ! command -v jq &> /dev/null; then
+    echo "[session-start] ERROR: jq not found (required for JSON parsing)" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
 # Check if checkpoint file exists (new sessions won't have one)
 if [ ! -f "$CHECKPOINT_FILE" ]; then
     echo "[session-start] No checkpoint found at $CHECKPOINT_FILE (new session, skipping injection)" >&2
@@ -34,7 +41,7 @@ fi
 # Validator returns JSON to stdout: {valid: bool, error: str|null, sanitized_content: str, metadata: {...}}
 # Validator logs to stderr (we preserve that for debugging)
 echo "[session-start] Validating checkpoint file via $VALIDATOR_SCRIPT" >&2
-VALIDATION_OUTPUT=$(python3 "$VALIDATOR_SCRIPT" --file "$CHECKPOINT_FILE" 2>&2)
+VALIDATION_OUTPUT=$(python3 "$VALIDATOR_SCRIPT" --file "$CHECKPOINT_FILE")
 VALIDATOR_EXIT=$?
 
 if [ $VALIDATOR_EXIT -ne 0 ]; then
@@ -45,17 +52,17 @@ if [ $VALIDATOR_EXIT -ne 0 ]; then
 fi
 
 # Parse validation result using jq
-VALID=$(echo "$VALIDATION_OUTPUT" | jq -r '.valid // false' 2>/dev/null)
+VALID=$(echo "$VALIDATION_OUTPUT" | jq -r '.valid // false' 2>/dev/null || echo "false")
 
 if [ "$VALID" != "true" ]; then
-    ERROR_MSG=$(echo "$VALIDATION_OUTPUT" | jq -r '.error // "Unknown validation error"' 2>/dev/null)
+    ERROR_MSG=$(echo "$VALIDATION_OUTPUT" | jq -r '.error // "Unknown validation error"' 2>/dev/null || echo "Unknown validation error")
     echo "[session-start] Checkpoint validation failed: $ERROR_MSG" >&2
     echo '{"continue": true}'
     exit 0
 fi
 
 # Extract sanitized content
-SANITIZED_CONTENT=$(echo "$VALIDATION_OUTPUT" | jq -r '.sanitized_content // ""' 2>/dev/null)
+SANITIZED_CONTENT=$(echo "$VALIDATION_OUTPUT" | jq -r '.sanitized_content // ""' 2>/dev/null || echo "")
 
 if [ -z "$SANITIZED_CONTENT" ]; then
     echo "[session-start] Sanitized content is empty after validation" >&2
@@ -77,7 +84,7 @@ The plan below reflects your current task progress and helps maintain workflow c
 FULL_CONTEXT="${INJECTION_HEADER}${SANITIZED_CONTENT}"
 
 # Get file size for logging
-FILE_SIZE=$(echo "$VALIDATION_OUTPUT" | jq -r '.metadata.size_bytes // 0' 2>/dev/null)
+FILE_SIZE=$(echo "$VALIDATION_OUTPUT" | jq -r '.metadata.size_bytes // 0' 2>/dev/null || echo "0")
 FILE_SIZE_KB=$((FILE_SIZE / 1024))
 
 echo "[session-start] ✅ Successfully validated checkpoint (${FILE_SIZE_KB}KB)" >&2

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1142,6 +1142,96 @@ Claude: [already has context] Continuing subtask 4...
 
 If hook continues to fail, use [Manual Recovery](#manual-recovery-fallback) workflow.
 
+#### Safe re-initialization with merge behavior
+
+**Key Feature:** Running `mapify init` preserves your customizations when updating MAP Framework hooks.
+
+**What gets preserved:**
+- ✅ Your custom hooks (UserPromptSubmit, PreToolUse, Stop, etc.)
+- ✅ Your permissions settings
+- ✅ Your top-level configuration keys (description, customKey, etc.)
+
+**What gets added:**
+- ✅ New MAP Framework hooks (if they don't already exist)
+- ✅ Updated hook scripts from templates
+
+**How it works:**
+
+```bash
+# Safe to run multiple times - your customizations won't be lost
+mapify init --force
+```
+
+**Deduplication strategy:**
+
+MAP Framework uses the `matcher` field to identify duplicate hook groups:
+
+| Hook Scenario | Behavior |
+|---------------|----------|
+| User has `matcher: "custom-pattern"` | Preserved (not in template) |
+| Template has `matcher: "Bash\\(.*\\)"` | Added only if user doesn't have this matcher |
+| Both have same `matcher: "Edit\\|Write"` | User's version preserved, template not added |
+| Hook has no `matcher` or `matcher: ""` | Full JSON comparison used for deduplication |
+
+**Example:**
+
+Your existing `.claude/settings.json`:
+```json
+{
+  "permissions": {
+    "allow": ["Bash(git status:*)", "Bash(custom-command:*)"]
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "custom-pattern",
+        "description": "User's custom hook",
+        "hooks": [{"type": "command", "command": "python3 /custom/script.py"}]
+      }
+    ]
+  }
+}
+```
+
+After `mapify init`:
+```json
+{
+  "permissions": {
+    "allow": ["Bash(git status:*)", "Bash(custom-command:*)"]  // ✅ Preserved
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "custom-pattern",  // ✅ Your custom hook preserved
+        "description": "User's custom hook",
+        "hooks": [{"type": "command", "command": "python3 /custom/script.py"}]
+      },
+      {
+        "matcher": "",  // ✅ MAP Framework hook added
+        "description": "Enhance prompts with clarification and playbook context",
+        "hooks": [
+          {"type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/improve-prompt.py"},
+          {"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/user-prompt-submit.sh"}
+        ]
+      }
+    ],
+    "SessionStart": [  // ✅ MAP Framework hook added
+      {
+        "matcher": "",
+        "description": "Auto-inject MAP workflow context from checkpoint",
+        "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"}]
+      }
+    ]
+  }
+}
+```
+
+**When to re-run `mapify init`:**
+- ✅ After MAP Framework updates (to get new hooks)
+- ✅ If hooks are not working (safe to repair)
+- ✅ To update hook scripts without losing customizations
+- ⚠️ Your customizations are ALWAYS preserved
+
 #### How to verify auto-recovery is working
 
 **Test sequence:**

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -73,6 +73,117 @@ def create_ssl_context():
 
 ssl_context = create_ssl_context()
 
+
+def load_settings_with_merge(settings_file: Path) -> Dict[str, Any]:
+    """Load settings.json file with safe defaults for missing/corrupted files.
+
+    Matches the pattern from configure_global_permissions():
+    - Returns empty dict for missing files (allows fresh setup)
+    - Returns empty dict for corrupted JSON (prints warning)
+    - Caller can safely merge new settings while preserving existing ones
+
+    Args:
+        settings_file: Path to settings.json file
+
+    Returns:
+        Dictionary with existing settings, or empty dict if file missing/corrupted
+    """
+    if settings_file.exists():
+        try:
+            with open(settings_file, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            console.print(f"[yellow]Warning:[/yellow] Corrupted {settings_file.name}, will recreate")
+            return {}
+    else:
+        return {}
+
+
+def merge_hooks_settings(existing_settings: Dict[str, Any], template_settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge template hooks into existing settings preserving user customizations.
+
+    Follows the same merge philosophy as configure_global_permissions():
+    - Preserves user's top-level keys (permissions, custom settings)
+    - Merges hooks additively using matcher field for deduplication
+    - Preserves user's custom hooks not in template
+
+    Args:
+        existing_settings: User's current settings (from load_settings_with_merge)
+        template_settings: Template settings with default hooks
+
+    Returns:
+        Merged settings dict with template hooks added, user customizations preserved
+    """
+    import copy
+
+    # Deep copy to prevent mutation of original settings
+    merged = copy.deepcopy(existing_settings)
+
+    # If template has no hooks section, nothing to merge
+    if "hooks" not in template_settings:
+        return merged
+
+    # If user has no hooks section at all, use template's hooks entirely
+    if "hooks" not in merged:
+        merged["hooks"] = template_settings["hooks"]
+        return merged
+
+    # Merge each hook type (UserPromptSubmit, SessionStart, PreToolUse, Stop)
+    template_hooks = template_settings["hooks"]
+    user_hooks = merged["hooks"]
+
+    for hook_type, template_hook_groups in template_hooks.items():
+        # Validate template hooks is a list
+        if not isinstance(template_hook_groups, list):
+            console.print(f"[yellow]Warning:[/yellow] Skipping malformed template hooks for {hook_type}")
+            continue
+
+        # If user doesn't have this hook type, add template's entire array
+        if hook_type not in user_hooks:
+            user_hooks[hook_type] = template_hook_groups
+            continue
+
+        # Validate user hooks is a list
+        if not isinstance(user_hooks[hook_type], list):
+            console.print(f"[yellow]Warning:[/yellow] Resetting malformed user hooks for {hook_type}")
+            user_hooks[hook_type] = []
+
+        # User has this hook type - merge hook groups using matcher for deduplication
+        # Build set of existing matchers (similar to configure_global_permissions)
+        existing_matchers = set()
+        for hook_group in user_hooks[hook_type]:
+            if isinstance(hook_group, dict) and "matcher" in hook_group and hook_group["matcher"]:
+                existing_matchers.add(hook_group["matcher"])
+
+        # Add template hook groups that user doesn't have (by matcher)
+        for template_hook_group in template_hook_groups:
+            if not isinstance(template_hook_group, dict):
+                continue
+
+            template_matcher = template_hook_group.get("matcher", "")
+
+            # If template has explicit non-empty matcher, check against existing
+            if template_matcher:
+                if template_matcher not in existing_matchers:
+                    user_hooks[hook_type].append(template_hook_group)
+            else:
+                # No matcher or empty matcher - use full JSON comparison
+                template_json = json.dumps(template_hook_group, sort_keys=True)
+                hook_exists = False
+
+                for user_hook_group in user_hooks[hook_type]:
+                    if isinstance(user_hook_group, dict):
+                        user_json = json.dumps(user_hook_group, sort_keys=True)
+                        if template_json == user_json:
+                            hook_exists = True
+                            break
+
+                if not hook_exists:
+                    user_hooks[hook_type].append(template_hook_group)
+
+    return merged
+
+
 # Constants
 MCP_SERVER_CHOICES = {
     "all": "All available MCP servers",
@@ -1084,10 +1195,31 @@ Provide detailed analysis of code quality, potential impacts, and quality scores
 
 
 def install_hooks(project_path: Path, with_hooks: bool = True) -> int:
-    """Install Claude Code hooks in .claude/hooks/
+    """Install Claude Code hooks in .claude/hooks/ with intelligent merging.
+
+    Follows the same merge philosophy as configure_global_permissions():
+    - Preserves user's existing .claude/settings.json customizations
+    - Merges template hooks into existing settings using matcher-based deduplication
+    - User's custom hooks, permissions, and top-level keys are preserved
+    - Template hooks are added only if they don't already exist (by matcher field)
+
+    This implements the SQLite auto-migration pattern from cipher:
+    1. Load existing settings (returns {} if missing/corrupted)
+    2. Load template settings with error handling
+    3. Merge using matcher field for deduplication
+    4. Write merged result atomically
+
+    Args:
+        project_path: Path to project root directory
+        with_hooks: Whether to install hooks (default: True)
 
     Returns:
-        Number of hook scripts installed
+        Number of hook scripts installed (excludes settings.json)
+
+    See Also:
+        - load_settings_with_merge(): Safely loads existing settings
+        - merge_hooks_settings(): Merges template into existing settings
+        - configure_global_permissions(): Similar merge pattern for permissions
     """
     if not with_hooks:
         return 0
@@ -1147,12 +1279,48 @@ def install_hooks(project_path: Path, with_hooks: bool = True) -> int:
         readme_dest = hooks_dir / "README.md"
         shutil.copy2(readme_src, readme_dest)
 
-    # Copy hooks settings.json to .claude/settings.json
+    # Merge hooks settings.json into .claude/settings.json
     # Claude Code reads hooks config from .claude/settings.json
+    # IMPORTANT: Merge with existing settings to preserve user customizations
     settings_src = hooks_template_dir / "settings.json"
     if settings_src.exists():
         settings_dest = project_path / ".claude" / "settings.json"
-        shutil.copy2(settings_src, settings_dest)
+
+        # Load existing settings (returns {} if missing/corrupted)
+        existing_settings = load_settings_with_merge(settings_dest)
+
+        # Load template settings
+        try:
+            with open(settings_src, 'r', encoding='utf-8') as f:
+                template_settings = json.load(f)
+
+            # Validate template is a dict (not array, string, etc.)
+            if not isinstance(template_settings, dict):
+                console.print("[yellow]Warning:[/yellow] Invalid template settings format")
+                console.print("[yellow]Skipping settings.json merge (hook scripts still installed)[/yellow]")
+                return hooks_count
+
+        except json.JSONDecodeError as e:
+            console.print(f"[yellow]Warning:[/yellow] Corrupted template settings.json: {e}")
+            console.print("[yellow]Skipping settings.json merge (hook scripts still installed)[/yellow]")
+            return hooks_count
+        except Exception as e:
+            console.print(f"[yellow]Warning:[/yellow] Failed to read template settings: {e}")
+            return hooks_count
+
+        # Merge template into existing settings
+        merged_settings = merge_hooks_settings(existing_settings, template_settings)
+
+        # Write merged settings atomically
+        try:
+            with open(settings_dest, 'w', encoding='utf-8') as f:
+                json.dump(merged_settings, f, indent=2, ensure_ascii=False)
+            console.print("[green]✓[/green] Merged hooks settings into .claude/settings.json")
+        except OSError as e:
+            console.print(f"[yellow]Warning:[/yellow] Failed to write settings.json: {e}")
+            console.print("[yellow]You may need to manually configure hooks[/yellow]")
+        except Exception as e:
+            console.print(f"[yellow]Warning:[/yellow] Unexpected error writing settings: {e}")
 
     return hooks_count
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -1147,12 +1147,12 @@ def install_hooks(project_path: Path, with_hooks: bool = True) -> int:
         readme_dest = hooks_dir / "README.md"
         shutil.copy2(readme_src, readme_dest)
 
-    # Copy settings.hooks.json to .claude/ (not .claude/hooks/)
-    # Claude Code reads hooks config from .claude/settings.hooks.json
-    settings_hooks_src = hooks_template_dir / "settings.hooks.json"
-    if settings_hooks_src.exists():
-        settings_hooks_dest = project_path / ".claude" / "settings.hooks.json"
-        shutil.copy2(settings_hooks_src, settings_hooks_dest)
+    # Copy hooks settings.json to .claude/settings.json
+    # Claude Code reads hooks config from .claude/settings.json
+    settings_src = hooks_template_dir / "settings.json"
+    if settings_src.exists():
+        settings_dest = project_path / ".claude" / "settings.json"
+        shutil.copy2(settings_src, settings_dest)
 
     return hooks_count
 

--- a/src/mapify_cli/templates/hooks/session-start.sh
+++ b/src/mapify_cli/templates/hooks/session-start.sh
@@ -16,6 +16,13 @@ VALIDATOR_SCRIPT="$SCRIPT_DIR/helpers/validate_checkpoint_file.py"
 # Debug logging to stderr (visible in Claude Code logs)
 echo "[session-start] SessionStart hook triggered" >&2
 
+# Check if jq is installed (required for JSON parsing)
+if ! command -v jq &> /dev/null; then
+    echo "[session-start] ERROR: jq not found (required for JSON parsing)" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
 # Check if checkpoint file exists (new sessions won't have one)
 if [ ! -f "$CHECKPOINT_FILE" ]; then
     echo "[session-start] No checkpoint found at $CHECKPOINT_FILE (new session, skipping injection)" >&2
@@ -34,7 +41,7 @@ fi
 # Validator returns JSON to stdout: {valid: bool, error: str|null, sanitized_content: str, metadata: {...}}
 # Validator logs to stderr (we preserve that for debugging)
 echo "[session-start] Validating checkpoint file via $VALIDATOR_SCRIPT" >&2
-VALIDATION_OUTPUT=$(python3 "$VALIDATOR_SCRIPT" --file "$CHECKPOINT_FILE" 2>&2)
+VALIDATION_OUTPUT=$(python3 "$VALIDATOR_SCRIPT" --file "$CHECKPOINT_FILE")
 VALIDATOR_EXIT=$?
 
 if [ $VALIDATOR_EXIT -ne 0 ]; then
@@ -45,17 +52,17 @@ if [ $VALIDATOR_EXIT -ne 0 ]; then
 fi
 
 # Parse validation result using jq
-VALID=$(echo "$VALIDATION_OUTPUT" | jq -r '.valid // false' 2>/dev/null)
+VALID=$(echo "$VALIDATION_OUTPUT" | jq -r '.valid // false' 2>/dev/null || echo "false")
 
 if [ "$VALID" != "true" ]; then
-    ERROR_MSG=$(echo "$VALIDATION_OUTPUT" | jq -r '.error // "Unknown validation error"' 2>/dev/null)
+    ERROR_MSG=$(echo "$VALIDATION_OUTPUT" | jq -r '.error // "Unknown validation error"' 2>/dev/null || echo "Unknown validation error")
     echo "[session-start] Checkpoint validation failed: $ERROR_MSG" >&2
     echo '{"continue": true}'
     exit 0
 fi
 
 # Extract sanitized content
-SANITIZED_CONTENT=$(echo "$VALIDATION_OUTPUT" | jq -r '.sanitized_content // ""' 2>/dev/null)
+SANITIZED_CONTENT=$(echo "$VALIDATION_OUTPUT" | jq -r '.sanitized_content // ""' 2>/dev/null || echo "")
 
 if [ -z "$SANITIZED_CONTENT" ]; then
     echo "[session-start] Sanitized content is empty after validation" >&2
@@ -77,7 +84,7 @@ The plan below reflects your current task progress and helps maintain workflow c
 FULL_CONTEXT="${INJECTION_HEADER}${SANITIZED_CONTENT}"
 
 # Get file size for logging
-FILE_SIZE=$(echo "$VALIDATION_OUTPUT" | jq -r '.metadata.size_bytes // 0' 2>/dev/null)
+FILE_SIZE=$(echo "$VALIDATION_OUTPUT" | jq -r '.metadata.size_bytes // 0' 2>/dev/null || echo "0")
 FILE_SIZE_KB=$((FILE_SIZE / 1024))
 
 echo "[session-start] ✅ Successfully validated checkpoint (${FILE_SIZE_KB}KB)" >&2

--- a/src/mapify_cli/templates/hooks/session-start.sh
+++ b/src/mapify_cli/templates/hooks/session-start.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Claude Code SessionStart hook: Auto-inject MAP workflow context
+# Restores .map/current_plan.md checkpoint for seamless compaction recovery
+#
+# Input: None (triggered on session start)
+# Output: JSON with additionalContext if checkpoint found and valid
+# Exit code: Always 0 (non-blocking - new sessions must proceed)
+
+set -euo pipefail
+
+# Configuration
+CHECKPOINT_FILE=".map/current_plan.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR_SCRIPT="$SCRIPT_DIR/helpers/validate_checkpoint_file.py"
+
+# Debug logging to stderr (visible in Claude Code logs)
+echo "[session-start] SessionStart hook triggered" >&2
+
+# Check if checkpoint file exists (new sessions won't have one)
+if [ ! -f "$CHECKPOINT_FILE" ]; then
+    echo "[session-start] No checkpoint found at $CHECKPOINT_FILE (new session, skipping injection)" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
+# Check if validator script exists
+if [ ! -f "$VALIDATOR_SCRIPT" ]; then
+    echo "[session-start] ERROR: Validator script not found at $VALIDATOR_SCRIPT" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
+# Call validator helper to validate and sanitize checkpoint file
+# Validator returns JSON to stdout: {valid: bool, error: str|null, sanitized_content: str, metadata: {...}}
+# Validator logs to stderr (we preserve that for debugging)
+echo "[session-start] Validating checkpoint file via $VALIDATOR_SCRIPT" >&2
+VALIDATION_OUTPUT=$(python3 "$VALIDATOR_SCRIPT" --file "$CHECKPOINT_FILE" 2>&2)
+VALIDATOR_EXIT=$?
+
+if [ $VALIDATOR_EXIT -ne 0 ]; then
+    echo "[session-start] Validator failed with exit code $VALIDATOR_EXIT" >&2
+    echo "[session-start] Validator output: $VALIDATION_OUTPUT" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
+# Parse validation result using jq
+VALID=$(echo "$VALIDATION_OUTPUT" | jq -r '.valid // false' 2>/dev/null)
+
+if [ "$VALID" != "true" ]; then
+    ERROR_MSG=$(echo "$VALIDATION_OUTPUT" | jq -r '.error // "Unknown validation error"' 2>/dev/null)
+    echo "[session-start] Checkpoint validation failed: $ERROR_MSG" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
+# Extract sanitized content
+SANITIZED_CONTENT=$(echo "$VALIDATION_OUTPUT" | jq -r '.sanitized_content // ""' 2>/dev/null)
+
+if [ -z "$SANITIZED_CONTENT" ]; then
+    echo "[session-start] Sanitized content is empty after validation" >&2
+    echo '{"continue": true}'
+    exit 0
+fi
+
+# Build injection header
+INJECTION_HEADER="# 🔄 MAP Workflow Context Restored
+
+This context was automatically restored from your previous session's checkpoint.
+The plan below reflects your current task progress and helps maintain workflow continuity after context compaction.
+
+---
+
+"
+
+# Combine header with sanitized content
+FULL_CONTEXT="${INJECTION_HEADER}${SANITIZED_CONTENT}"
+
+# Get file size for logging
+FILE_SIZE=$(echo "$VALIDATION_OUTPUT" | jq -r '.metadata.size_bytes // 0' 2>/dev/null)
+FILE_SIZE_KB=$((FILE_SIZE / 1024))
+
+echo "[session-start] ✅ Successfully validated checkpoint (${FILE_SIZE_KB}KB)" >&2
+echo "[session-start] Injecting context with header (${#FULL_CONTEXT} total chars)" >&2
+
+# Output JSON with additionalContext
+# Use jq to properly escape multi-line content
+OUTPUT=$(jq -n \
+    --arg context "$FULL_CONTEXT" \
+    '{continue: true, additionalContext: $context}')
+
+echo "$OUTPUT"
+exit 0

--- a/src/mapify_cli/templates/hooks/settings.json
+++ b/src/mapify_cli/templates/hooks/settings.json
@@ -9,13 +9,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/improve-prompt.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/improve-prompt.py",
             "timeout": 5,
             "description": "Disambiguate vague prompts with evaluation instructions"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/user-prompt-submit.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/user-prompt-submit.sh",
             "timeout": 5,
             "description": "Inject playbook patterns and suggest workflows"
           }
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/session-start.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh",
             "timeout": 5,
             "description": "Restores .map/current_plan.md checkpoint for seamless compaction recovery"
           }
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/validate-agent-templates.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-agent-templates.sh",
             "timeout": 5,
             "description": "Prevents accidental removal of {{template}} variables from agents"
           }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop.sh",
             "timeout": 30,
             "description": "Catches syntax errors and test failures before response submission"
           }

--- a/src/mapify_cli/templates/hooks/settings.json
+++ b/src/mapify_cli/templates/hooks/settings.json
@@ -1,27 +1,37 @@
 {
-  "$schema": "https://cdn.jsdelivr.net/npm/@anthropic-ai/claude-code@latest/schemas/settings.schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code hooks configuration for MAP Framework",
   "hooks": {
     "UserPromptSubmit": [
       {
-        "description": "Step 1: Disambiguate vague prompts",
+        "matcher": "",
+        "description": "Enhance prompts with clarification and playbook context",
         "hooks": [
           {
             "type": "command",
             "command": "python3 .claude/hooks/improve-prompt.py",
             "timeout": 5,
-            "description": "Wraps vague prompts with evaluation instructions for clarification"
-          }
-        ]
-      },
-      {
-        "description": "Step 2: Inject playbook patterns and suggest workflows",
-        "hooks": [
+            "description": "Disambiguate vague prompts with evaluation instructions"
+          },
           {
             "type": "command",
             "command": ".claude/hooks/user-prompt-submit.sh",
             "timeout": 5,
-            "description": "Enhances prompts with playbook patterns and workflow suggestions based on context"
+            "description": "Inject playbook patterns and suggest workflows"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "description": "Auto-inject MAP workflow context from checkpoint",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh",
+            "timeout": 5,
+            "description": "Restores .map/current_plan.md checkpoint for seamless compaction recovery"
           }
         ]
       }
@@ -42,7 +52,7 @@
     ],
     "Stop": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "",
         "description": "Quality gates - run automated checks after code modifications",
         "hooks": [
           {
@@ -50,19 +60,6 @@
             "command": ".claude/hooks/stop.sh",
             "timeout": 30,
             "description": "Catches syntax errors and test failures before response submission"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "description": "Auto-inject MAP workflow context from checkpoint",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/session-start.sh",
-            "timeout": 5,
-            "description": "Restores .map/current_plan.md checkpoint for seamless compaction recovery"
           }
         ]
       }

--- a/tests/integration/test_init_merge.py
+++ b/tests/integration/test_init_merge.py
@@ -1,0 +1,215 @@
+"""
+Integration test for mapify init hooks merge functionality.
+
+Tests that running `mapify init` preserves user customizations in settings.json
+while adding new template hooks.
+"""
+
+import json
+from pathlib import Path
+import pytest
+from mapify_cli import install_hooks
+
+
+@pytest.fixture
+def mock_project(tmp_path):
+    """Create a mock project directory with .claude structure."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def user_custom_settings():
+    """User's customized settings.json with permissions and custom hooks."""
+    return {
+        "$schema": "https://json.schemastore.org/claude-code-settings.json",
+        "description": "User's custom configuration",
+        "permissions": {
+            "allow": [
+                "Bash(git status:*)",
+                "Bash(custom-command:*)"
+            ],
+            "deny": ["Bash(rm:*)"]
+        },
+        "hooks": {
+            "UserPromptSubmit": [
+                {
+                    "matcher": "custom-pattern",
+                    "description": "User's custom hook",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "python3 /custom/script.py",
+                            "timeout": 10
+                        }
+                    ]
+                }
+            ],
+            "PreToolUse": [
+                {
+                    "matcher": "Edit|Write",
+                    "description": "User's validation hook",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": ".custom/hooks/validate.sh",
+                            "timeout": 5
+                        }
+                    ]
+                }
+            ]
+        },
+        "customKey": "userValue"
+    }
+
+
+class TestInitMerge:
+    """Integration tests for mapify init merge behavior."""
+
+    def test_fresh_install_creates_settings(self, mock_project):
+        """Test that fresh install creates settings.json with template hooks."""
+        # Run install_hooks
+        hooks_count = install_hooks(mock_project, with_hooks=True)
+
+        assert hooks_count > 0, "Should install hook scripts"
+
+        # Verify settings.json created
+        settings_file = mock_project / ".claude" / "settings.json"
+        assert settings_file.exists(), "Should create settings.json"
+
+        # Read and validate settings
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            settings = json.load(f)
+
+        assert "hooks" in settings, "Should have hooks section"
+        assert "UserPromptSubmit" in settings["hooks"], "Should have UserPromptSubmit hooks"
+        assert "SessionStart" in settings["hooks"], "Should have SessionStart hooks"
+
+    def test_preserves_user_permissions(self, mock_project, user_custom_settings):
+        """Test that user's permissions section is preserved during merge."""
+        # Setup: Create existing settings with custom permissions
+        settings_file = mock_project / ".claude" / "settings.json"
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            json.dump(user_custom_settings, f, indent=2)
+
+        # Run install_hooks
+        install_hooks(mock_project, with_hooks=True)
+
+        # Verify permissions preserved
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            merged_settings = json.load(f)
+
+        assert "permissions" in merged_settings, "Should preserve permissions section"
+        assert merged_settings["permissions"] == user_custom_settings["permissions"], \
+            "Permissions should be unchanged"
+
+    def test_preserves_custom_hooks(self, mock_project, user_custom_settings):
+        """Test that user's custom hooks are preserved during merge."""
+        # Setup
+        settings_file = mock_project / ".claude" / "settings.json"
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            json.dump(user_custom_settings, f, indent=2)
+
+        # Run install_hooks
+        install_hooks(mock_project, with_hooks=True)
+
+        # Verify custom hooks preserved
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            merged_settings = json.load(f)
+
+        # User's custom UserPromptSubmit hook should still be there
+        user_prompt_hooks = merged_settings["hooks"]["UserPromptSubmit"]
+        custom_hook = next((h for h in user_prompt_hooks if h["matcher"] == "custom-pattern"), None)
+        assert custom_hook is not None, "Should preserve user's custom hook"
+        assert custom_hook["hooks"][0]["command"] == "python3 /custom/script.py"
+
+        # User's PreToolUse hook should still be there
+        assert "PreToolUse" in merged_settings["hooks"], "Should preserve PreToolUse hooks"
+        pre_tool_hooks = merged_settings["hooks"]["PreToolUse"]
+        user_hook = next((h for h in pre_tool_hooks if h["matcher"] == "Edit|Write"), None)
+        assert user_hook is not None, "Should preserve user's PreToolUse hook"
+
+    def test_adds_new_template_hooks(self, mock_project, user_custom_settings):
+        """Test that new template hooks are added to existing settings."""
+        # Setup
+        settings_file = mock_project / ".claude" / "settings.json"
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            json.dump(user_custom_settings, f, indent=2)
+
+        # Run install_hooks
+        install_hooks(mock_project, with_hooks=True)
+
+        # Verify template hooks added
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            merged_settings = json.load(f)
+
+        # Should have SessionStart from template (not in user settings)
+        assert "SessionStart" in merged_settings["hooks"], "Should add SessionStart from template"
+
+        # Should have MAP Framework UserPromptSubmit hook (matcher="") added
+        user_prompt_hooks = merged_settings["hooks"]["UserPromptSubmit"]
+        assert len(user_prompt_hooks) >= 2, "Should have both user and template hooks"
+
+        # Find template hook (empty matcher)
+        template_hook = next((h for h in user_prompt_hooks if h.get("matcher") == ""), None)
+        assert template_hook is not None, "Should add template hook with empty matcher"
+
+    def test_preserves_custom_top_level_keys(self, mock_project, user_custom_settings):
+        """Test that user's custom top-level keys are preserved."""
+        # Setup
+        settings_file = mock_project / ".claude" / "settings.json"
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            json.dump(user_custom_settings, f, indent=2)
+
+        # Run install_hooks
+        install_hooks(mock_project, with_hooks=True)
+
+        # Verify custom keys preserved
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            merged_settings = json.load(f)
+
+        assert "customKey" in merged_settings, "Should preserve custom top-level key"
+        assert merged_settings["customKey"] == "userValue", "Custom key value should be unchanged"
+        assert merged_settings["description"] == "User's custom configuration", \
+            "Should preserve user's description"
+
+    def test_no_duplicate_hooks_created(self, mock_project):
+        """Test that running init twice doesn't create duplicate hooks."""
+        # First init
+        install_hooks(mock_project, with_hooks=True)
+
+        settings_file = mock_project / ".claude" / "settings.json"
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            first_settings = json.load(f)
+
+        first_count = len(first_settings["hooks"]["UserPromptSubmit"])
+
+        # Second init (simulating user running mapify init --force)
+        install_hooks(mock_project, with_hooks=True)
+
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            second_settings = json.load(f)
+
+        second_count = len(second_settings["hooks"]["UserPromptSubmit"])
+
+        # Should have same count (no duplicates)
+        assert second_count == first_count, \
+            f"Should not create duplicates: first={first_count}, second={second_count}"
+
+    def test_handles_corrupted_existing_settings(self, mock_project):
+        """Test that corrupted existing settings.json is handled gracefully."""
+        # Setup: Create corrupted settings
+        settings_file = mock_project / ".claude" / "settings.json"
+        settings_file.write_text("{invalid json")
+
+        # Run install_hooks (should not crash)
+        hooks_count = install_hooks(mock_project, with_hooks=True)
+
+        assert hooks_count > 0, "Should still install hooks"
+
+        # Verify new settings created
+        with open(settings_file, 'r', encoding='utf-8') as f:
+            settings = json.load(f)
+
+        assert "hooks" in settings, "Should create valid settings despite corruption"

--- a/tests/test_hooks_merge.py
+++ b/tests/test_hooks_merge.py
@@ -1,0 +1,523 @@
+"""
+Unit tests for hooks merge logic in mapify init command.
+
+Tests load_settings_with_merge() and merge_hooks_settings() functions
+covering all edge cases specified in ST-003 acceptance criteria.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest import mock
+from mapify_cli import load_settings_with_merge, merge_hooks_settings
+
+
+@pytest.fixture
+def template_settings():
+    """Template settings with default hooks structure."""
+    return {
+        "hooks": {
+            "UserPromptSubmit": [
+                {
+                    "matcher": "Bash\\(.*\\)",
+                    "message": "Template validation message"
+                }
+            ],
+            "SessionStart": [
+                {
+                    "matcher": "",
+                    "message": "Session start template"
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def user_settings_with_hooks():
+    """Existing user settings with custom hooks."""
+    return {
+        "permissions": {
+            "auto_approve": ["Read", "Glob"]
+        },
+        "hooks": {
+            "UserPromptSubmit": [
+                {
+                    "matcher": "Write\\(.*\\)",
+                    "message": "User custom write hook"
+                }
+            ],
+            "PreToolUse": [
+                {
+                    "matcher": "Edit\\(.*\\)",
+                    "message": "User custom edit hook"
+                }
+            ]
+        }
+    }
+
+
+class TestLoadSettingsWithMerge:
+    """Test load_settings_with_merge() edge cases."""
+
+    def test_valid_json_file_returns_dict(self, tmp_path):
+        """Valid JSON file returns parsed dictionary."""
+        settings_file = tmp_path / "settings.json"
+        test_data = {"key": "value", "nested": {"data": 123}}
+
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            json.dump(test_data, f)
+
+        result = load_settings_with_merge(settings_file)
+
+        assert result == test_data
+        assert isinstance(result, dict)
+
+    def test_missing_file_returns_empty_dict(self, tmp_path):
+        """Missing file returns empty dict without error."""
+        settings_file = tmp_path / "nonexistent.json"
+
+        result = load_settings_with_merge(settings_file)
+
+        assert result == {}
+        assert isinstance(result, dict)
+
+    def test_corrupted_json_returns_empty_dict_with_warning(self, tmp_path):
+        """Corrupted JSON returns empty dict and prints warning."""
+        settings_file = tmp_path / "settings.json"
+
+        # Write invalid JSON
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            f.write('{"invalid": json syntax}')
+
+        with mock.patch('mapify_cli.console.print') as mock_print:
+            result = load_settings_with_merge(settings_file)
+
+        assert result == {}
+        mock_print.assert_called_once()
+        warning_message = str(mock_print.call_args[0][0])
+        assert "Warning" in warning_message
+        assert "Corrupted" in warning_message
+        assert "settings.json" in warning_message
+
+    def test_empty_file_returns_empty_dict_with_warning(self, tmp_path):
+        """Empty file returns empty dict and prints warning."""
+        settings_file = tmp_path / "settings.json"
+
+        # Create empty file
+        settings_file.touch()
+
+        with mock.patch('mapify_cli.console.print') as mock_print:
+            result = load_settings_with_merge(settings_file)
+
+        assert result == {}
+        mock_print.assert_called_once()
+
+    def test_file_with_whitespace_only_returns_empty_dict(self, tmp_path):
+        """File with only whitespace returns empty dict with warning."""
+        settings_file = tmp_path / "settings.json"
+
+        with open(settings_file, 'w', encoding='utf-8') as f:
+            f.write('   \n\t  ')
+
+        with mock.patch('mapify_cli.console.print') as mock_print:
+            result = load_settings_with_merge(settings_file)
+
+        assert result == {}
+        mock_print.assert_called_once()
+
+
+class TestMergeHooksSettings:
+    """Test merge_hooks_settings() edge cases."""
+
+    def test_empty_existing_returns_template_hooks(self, template_settings):
+        """Empty existing settings returns template hooks entirely."""
+        existing = {}
+
+        result = merge_hooks_settings(existing, template_settings)
+
+        assert "hooks" in result
+        assert result["hooks"] == template_settings["hooks"]
+        assert "UserPromptSubmit" in result["hooks"]
+        assert "SessionStart" in result["hooks"]
+
+    def test_empty_template_preserves_existing(self, user_settings_with_hooks):
+        """Empty template preserves existing settings unchanged."""
+        template = {}
+
+        result = merge_hooks_settings(user_settings_with_hooks, template)
+
+        assert result == user_settings_with_hooks
+        assert "hooks" in result
+        assert "PreToolUse" in result["hooks"]
+
+    def test_matcher_deduplication_no_duplicates(self):
+        """Matcher deduplication prevents duplicate hooks when same matcher."""
+        existing = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {
+                        "matcher": "Bash\\(.*\\)",
+                        "message": "User existing bash hook"
+                    }
+                ]
+            }
+        }
+
+        template = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {
+                        "matcher": "Bash\\(.*\\)",
+                        "message": "Template bash hook (should not duplicate)"
+                    }
+                ]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template)
+
+        # Should have only 1 hook (existing preserved, template not added)
+        assert len(result["hooks"]["UserPromptSubmit"]) == 1
+        assert result["hooks"]["UserPromptSubmit"][0]["message"] == "User existing bash hook"
+
+    def test_custom_hooks_preserved(self, template_settings):
+        """User's custom hooks not in template are preserved."""
+        existing = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "sqlite3\\(.*\\)",
+                        "message": "User custom SQLite validation"
+                    }
+                ],
+                "Stop": [
+                    {
+                        "matcher": "",
+                        "message": "User custom stop hook"
+                    }
+                ]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template_settings)
+
+        # User's PreToolUse and Stop hooks should be preserved
+        assert "PreToolUse" in result["hooks"]
+        assert len(result["hooks"]["PreToolUse"]) == 1
+        assert result["hooks"]["PreToolUse"][0]["message"] == "User custom SQLite validation"
+
+        assert "Stop" in result["hooks"]
+        assert len(result["hooks"]["Stop"]) == 1
+
+        # Template hooks should be added
+        assert "UserPromptSubmit" in result["hooks"]
+        assert "SessionStart" in result["hooks"]
+
+    def test_permissions_preserved(self, user_settings_with_hooks, template_settings):
+        """Top-level keys like permissions are unchanged."""
+        result = merge_hooks_settings(user_settings_with_hooks, template_settings)
+
+        assert "permissions" in result
+        assert result["permissions"] == user_settings_with_hooks["permissions"]
+        assert result["permissions"]["auto_approve"] == ["Read", "Glob"]
+
+    def test_no_matcher_full_json_comparison_works(self):
+        """Hooks without matcher use full JSON comparison for deduplication."""
+        existing = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "",
+                        "message": "Welcome message",
+                        "custom_field": "value"
+                    }
+                ]
+            }
+        }
+
+        template_duplicate = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "",
+                        "message": "Welcome message",
+                        "custom_field": "value"
+                    }
+                ]
+            }
+        }
+
+        template_different = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "",
+                        "message": "Different welcome message",
+                        "custom_field": "value"
+                    }
+                ]
+            }
+        }
+
+        # Exact duplicate should not be added
+        result_duplicate = merge_hooks_settings(existing, template_duplicate)
+        assert len(result_duplicate["hooks"]["SessionStart"]) == 1
+
+        # Different hook should be added
+        result_different = merge_hooks_settings(existing, template_different)
+        assert len(result_different["hooks"]["SessionStart"]) == 2
+
+    def test_malformed_template_hooks_skipped_with_warning(self):
+        """Malformed template hooks (not a list) are skipped with warning."""
+        existing = {
+            "hooks": {
+                "UserPromptSubmit": []
+            }
+        }
+
+        template = {
+            "hooks": {
+                "UserPromptSubmit": "not a list",  # Malformed
+                "SessionStart": [{"matcher": "", "message": "Valid"}]
+            }
+        }
+
+        with mock.patch('mapify_cli.console.print') as mock_print:
+            result = merge_hooks_settings(existing, template)
+
+        # UserPromptSubmit should remain unchanged
+        assert result["hooks"]["UserPromptSubmit"] == []
+
+        # SessionStart should be added
+        assert "SessionStart" in result["hooks"]
+
+        # Warning should be printed
+        mock_print.assert_called_once()
+        warning_message = str(mock_print.call_args[0][0])
+        assert "Warning" in warning_message
+        assert "malformed" in warning_message.lower()
+
+    def test_malformed_user_hooks_reset_with_warning(self, template_settings):
+        """Malformed user hooks (not a list) are reset with warning."""
+        existing = {
+            "hooks": {
+                "UserPromptSubmit": {"not": "a list"}  # Malformed
+            }
+        }
+
+        with mock.patch('mapify_cli.console.print') as mock_print:
+            result = merge_hooks_settings(existing, template_settings)
+
+        # UserPromptSubmit should be reset and template added
+        assert isinstance(result["hooks"]["UserPromptSubmit"], list)
+        assert len(result["hooks"]["UserPromptSubmit"]) == 1
+        assert result["hooks"]["UserPromptSubmit"][0]["matcher"] == "Bash\\(.*\\)"
+
+        # Warning should be printed
+        mock_print.assert_called_once()
+        warning_message = str(mock_print.call_args[0][0])
+        assert "Warning" in warning_message
+        assert "Resetting" in warning_message
+
+    def test_no_hooks_in_existing_adds_template_hooks(self, template_settings):
+        """If user has no hooks section at all, template hooks added entirely."""
+        existing = {
+            "permissions": {
+                "auto_approve": ["Read"]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template_settings)
+
+        assert "hooks" in result
+        assert result["hooks"] == template_settings["hooks"]
+        assert "permissions" in result  # Preserved
+
+    def test_no_hooks_in_template_preserves_existing(self):
+        """If template has no hooks, existing hooks unchanged."""
+        existing = {
+            "hooks": {
+                "UserPromptSubmit": [{"matcher": "Test", "message": "User hook"}]
+            }
+        }
+
+        template = {
+            "permissions": {
+                "auto_approve": ["Write"]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template)
+
+        assert result["hooks"] == existing["hooks"]
+        # Template permissions NOT added (function only merges hooks)
+        assert "permissions" not in result
+
+    def test_hook_type_not_in_existing_adds_template_array(self, template_settings):
+        """If user doesn't have specific hook type, template's entire array added."""
+        existing = {
+            "hooks": {
+                "PreToolUse": [{"matcher": "Edit", "message": "User edit hook"}]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template_settings)
+
+        # User's PreToolUse preserved
+        assert "PreToolUse" in result["hooks"]
+        assert len(result["hooks"]["PreToolUse"]) == 1
+
+        # Template's UserPromptSubmit and SessionStart added
+        assert "UserPromptSubmit" in result["hooks"]
+        assert len(result["hooks"]["UserPromptSubmit"]) == 1
+        assert result["hooks"]["UserPromptSubmit"][0]["matcher"] == "Bash\\(.*\\)"
+
+        assert "SessionStart" in result["hooks"]
+        assert len(result["hooks"]["SessionStart"]) == 1
+
+    def test_deep_copy_prevents_mutation(self, user_settings_with_hooks, template_settings):
+        """Merge doesn't mutate original existing_settings."""
+        import copy
+        original_existing = copy.deepcopy(user_settings_with_hooks)
+
+        result = merge_hooks_settings(user_settings_with_hooks, template_settings)
+
+        # Original should be unchanged
+        assert user_settings_with_hooks == original_existing
+
+        # Result should have merged hooks
+        assert "UserPromptSubmit" in result["hooks"]
+        assert len(result["hooks"]["UserPromptSubmit"]) == 2  # User + template
+
+    def test_multiple_hooks_same_type_all_preserved(self):
+        """Multiple hooks of same type all preserved, duplicates filtered."""
+        existing = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"matcher": "Read\\(.*\\)", "message": "User read"},
+                    {"matcher": "Write\\(.*\\)", "message": "User write"}
+                ]
+            }
+        }
+
+        template = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"matcher": "Bash\\(.*\\)", "message": "Template bash"},
+                    {"matcher": "Read\\(.*\\)", "message": "Template read (duplicate)"}
+                ]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template)
+
+        # Should have 3 hooks: User read, User write, Template bash
+        # Template read should NOT be added (duplicate matcher)
+        assert len(result["hooks"]["UserPromptSubmit"]) == 3
+
+        matchers = [hook["matcher"] for hook in result["hooks"]["UserPromptSubmit"]]
+        assert "Read\\(.*\\)" in matchers
+        assert "Write\\(.*\\)" in matchers
+        assert "Bash\\(.*\\)" in matchers
+
+    def test_empty_matcher_string_uses_json_comparison(self):
+        """Empty string matcher "" uses full JSON comparison."""
+        existing = {
+            "hooks": {
+                "SessionStart": [
+                    {"matcher": "", "message": "Msg A"}
+                ]
+            }
+        }
+
+        template = {
+            "hooks": {
+                "SessionStart": [
+                    {"matcher": "", "message": "Msg A"},  # Duplicate
+                    {"matcher": "", "message": "Msg B"}   # Different
+                ]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template)
+
+        # Should have 2 hooks: existing Msg A, template Msg B
+        # Template Msg A should not be added (duplicate via JSON comparison)
+        assert len(result["hooks"]["SessionStart"]) == 2
+
+        messages = [hook["message"] for hook in result["hooks"]["SessionStart"]]
+        assert messages.count("Msg A") == 1
+        assert "Msg B" in messages
+
+    def test_non_dict_hook_groups_skipped(self):
+        """Non-dict hook groups in template are skipped gracefully."""
+        existing = {
+            "hooks": {
+                "UserPromptSubmit": []
+            }
+        }
+
+        template = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    "not a dict",
+                    {"matcher": "Valid", "message": "Valid hook"},
+                    123,
+                    None
+                ]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template)
+
+        # Only valid dict hook should be added
+        assert len(result["hooks"]["UserPromptSubmit"]) == 1
+        assert result["hooks"]["UserPromptSubmit"][0]["message"] == "Valid hook"
+
+    def test_complex_nested_structure_preserved(self):
+        """Complex nested structures in hooks preserved correctly."""
+        existing = {
+            "permissions": {
+                "auto_approve": ["Read", "Write"],
+                "require_approval": ["Bash"]
+            },
+            "hooks": {
+                "UserPromptSubmit": [
+                    {
+                        "matcher": "Complex\\(.*\\)",
+                        "message": "Complex hook",
+                        "nested": {
+                            "data": [1, 2, 3],
+                            "config": {"key": "value"}
+                        }
+                    }
+                ]
+            },
+            "custom_section": {
+                "user_data": "should be preserved"
+            }
+        }
+
+        template = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"matcher": "Simple", "message": "Simple hook"}
+                ]
+            }
+        }
+
+        result = merge_hooks_settings(existing, template)
+
+        # All existing structure preserved
+        assert result["permissions"] == existing["permissions"]
+        assert result["custom_section"] == existing["custom_section"]
+
+        # Existing hook preserved with nested structure
+        complex_hook = [h for h in result["hooks"]["UserPromptSubmit"]
+                       if h.get("matcher") == "Complex\\(.*\\)"][0]
+        assert complex_hook["nested"]["data"] == [1, 2, 3]
+        assert complex_hook["nested"]["config"]["key"] == "value"
+
+        # Template hook added
+        assert len(result["hooks"]["UserPromptSubmit"]) == 2


### PR DESCRIPTION
## Problem

After merging PR #31 (prompt-improver integration), hooks weren't working correctly due to:

1. **Wrong filename**: Used `settings.hooks.json` instead of `settings.json`
   - Claude Code reads from `.claude/settings.json` (not `.claude/settings.hooks.json`)
   - `mapify init` was installing hooks to wrong location

2. **Missing SessionStart hook**: `session-start.sh` was never synced to templates
   - Script exists in `.claude/hooks/session-start.sh` since commit 174d10a
   - Not copied to `src/mapify_cli/templates/hooks/`
   - New projects don't get compaction recovery feature

## Solution

### 1. Renamed settings file
- `settings.hooks.json` → `settings.json`
- Updated `install_hooks()` to copy to `.claude/settings.json`

### 2. Restored SessionStart hook
- Copied `session-start.sh` to templates directory
- Re-added `SessionStart` section to `settings.json`
- Hook auto-injects `.map/current_plan.md` checkpoint at session start

### 3. Format improvements
- Updated schema to official `https://json.schemastore.org/claude-code-settings.json`
- Combined UserPromptSubmit hooks into single matcher group
- Simplified matchers with empty string where appropriate

## Testing

```bash
# Validate JSON syntax
jq . src/mapify_cli/templates/hooks/settings.json

# Verify files exist
ls -la src/mapify_cli/templates/hooks/session-start.sh
ls -la src/mapify_cli/templates/hooks/settings.json

# Test installation
mapify init test-project
ls -la test-project/.claude/settings.json
ls -la test-project/.claude/hooks/session-start.sh
```

## Related Issues

- Fixes post-merge bug from PR #31 where hooks weren't being installed
- Restores compaction recovery feature (SessionStart hook) for new projects