### PR TITLE
fix: remove playbook.json references from codebase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -113,14 +113,12 @@ pytest tests/test_template_sync.py -v
 ❌ **NEVER DO THIS**:
 - ❌ `sqlite3 .claude/playbook.db "UPDATE bullets SET..."`  (direct SQL)
 - ❌ `Edit(.claude/playbook.db, ...)` (Edit tool on binary file)
-- ❌ Reading/writing playbook.json (doesn't exist anymore - migrated to SQLite)
 - ❌ Manually creating JSON and applying without Curator review
 
 **Why**:
 - Curator validates quality, checks duplicates, scores patterns
 - `apply-delta` maintains playbook integrity, handles transactions
 - Direct sqlite breaks schema, bypasses validation
-- playbook.json is legacy (removed in favor of playbook.db)
 
 ## Template Variable Protection
 

--- a/.claude/agents/curator.md
+++ b/.claude/agents/curator.md
@@ -339,7 +339,7 @@ mapify playbook apply-delta operations.json --dry-run
 - ❌ `sqlite3 .claude/playbook.db "UPDATE bullets SET..."` → Direct SQL bypasses validation
 - ❌ `Edit(.claude/playbook.db, ...)` → Cannot edit binary database
 - ❌ Using "op" field → ✅ Correct field name is "type"
-- ❌ Reading/writing playbook.json → ✅ Migrated to playbook.db (SQLite)
+- ❌ Using legacy JSON format → ✅ Use playbook.db (SQLite)
 
 **Why apply-delta is mandatory**:
 - Validates operations before applying

--- a/.claude/skills/map-cli-reference/SKILL.md
+++ b/.claude/skills/map-cli-reference/SKILL.md
@@ -124,9 +124,9 @@ mapify upgrade
 ✅ **CORRECT**: `mapify playbook apply-delta operations.json`
 📝 **Explanation**: Cannot edit binary SQLite database. Generate delta operations JSON and apply via CLI.
 
-❌ **WRONG**: Reading/writing `playbook.json`
+❌ **WRONG**: Using legacy JSON format for playbook
 ✅ **CORRECT**: `mapify playbook query "..."`
-📝 **Explanation**: `playbook.json` is deprecated (migrated to `playbook.db`). Use CLI commands to interact with playbook.
+📝 **Explanation**: Playbook uses SQLite database (`playbook.db`). Use CLI commands to interact with playbook.
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,10 @@ htmlcov/
 
 # ACE Playbook - user-specific data
 .claude/embeddings_cache/
+# LEGACY: playbook.json entries for migration support (ignore old format files)
 .claude/playbook.json
 .claude/playbook.json.backup.*
+# Current format: SQLite database
 .claude/playbook.db
 .claude/playbook.db-shm
 .claude/playbook.db-wal

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -913,7 +913,7 @@ Provenance:
 3. **Detects contradictions** with ContradictionDetector
 4. Decides: ADD/UPDATE/SKIP bullet based on conflicts
 5. **Inserts entities/relationships** into SQLite via PlaybookManager
-6. Updates playbook.json (backward compatibility)
+6. Updates playbook.db
 
 **Contradiction Detection Flow:**
 ```python
@@ -1063,7 +1063,7 @@ for entity in recent:
 - **USES**: X uses Y as dependency (pytest USES Python)
 - **DEPENDS_ON**: X requires Y to function (MAP-workflow DEPENDS_ON playbook.db)
 - **CONTRADICTS**: X conflicts with Y (generic-exception CONTRADICTS specific-exceptions)
-- **SUPERSEDES**: X replaces Y (playbook.db SUPERSEDES playbook.json)
+- **SUPERSEDES**: X replaces Y (SQLite SUPERSEDES JSON format)
 - **IMPLEMENTS**: X implements pattern Y (retry-logic IMPLEMENTS resilience-pattern)
 - **CAUSES**: X causes problem Y (race-condition CAUSES data-corruption)
 - **PREVENTS**: X prevents problem Y (mutex-lock PREVENTS race-condition)

--- a/docs/CLI_COMMAND_REFERENCE.md
+++ b/docs/CLI_COMMAND_REFERENCE.md
@@ -204,7 +204,6 @@ mapify playbook apply-delta operations.json --dry-run
 ❌ **NEVER DO THIS**:
 - `sqlite3 .claude/playbook.db "UPDATE bullets SET..."`
 - `Edit(.claude/playbook.db, ...)`
-- Manually editing playbook.json (deprecated)
 
 ✅ **ALWAYS USE**: `mapify playbook apply-delta`
 
@@ -604,7 +603,6 @@ Updates agent templates in `.claude/agents/` to latest versions.
 |---------|-----------|-------------|
 | `sqlite3 .claude/playbook.db "UPDATE..."` | `mapify playbook apply-delta ops.json` | Direct DB access breaks integrity |
 | `Edit(.claude/playbook.db, ...)` | `mapify playbook apply-delta ops.json` | Cannot edit binary DB |
-| Reading `playbook.json` | `mapify playbook query "..."` | `playbook.json` is deprecated |
 
 ---
 

--- a/docs/CLI_REFERENCE.json
+++ b/docs/CLI_REFERENCE.json
@@ -741,9 +741,9 @@
         "explanation": "Use apply-delta with JSON delta operations"
       },
       {
-        "category": "legacy_reference",
-        "mistake": "Reading playbook.json",
-        "reason": "playbook.json is deprecated (migrated to playbook.db)",
+        "category": "legacy_format",
+        "mistake": "Using legacy JSON format for playbook",
+        "reason": "Playbook uses SQLite database (playbook.db)",
         "correction": "mapify playbook query \"...\"",
         "explanation": "Use CLI commands to interact with playbook.db"
       }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -232,7 +232,7 @@ If you prefer manual setup:
    │   │   ├── map-refactor.md       # Refactor workflow entry point
    │   │   └── map-review.md         # Review workflow entry point
    │   ├── mcp_config.json
-   │   └── playbook.json              # ACE: Knowledge base
+   │   └── playbook.db                # ACE: Knowledge base (SQLite)
    ```
 
 ## Verify Installation

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -249,7 +249,6 @@ This section documents frequently encountered CLI command errors and their corre
 |------------------|-------------------|-----|
 | `sqlite3 .claude/playbook.db "UPDATE bullets SET..."` | `mapify playbook apply-delta ops.json` | Direct database access breaks integrity, bypasses validation, and corrupts FTS5 indexes. |
 | `Edit(.claude/playbook.db, ...)` | `mapify playbook apply-delta ops.json` | Cannot edit binary SQLite database. Generate delta operations JSON and apply via CLI. |
-| Reading/writing `playbook.json` | `mapify playbook query "..."` | `playbook.json` is deprecated (migrated to `playbook.db` in v2.2). Use CLI commands to interact with playbook. |
 
 ### Wrong Operation Field Name
 
@@ -334,7 +333,7 @@ Instead of treating playbook bullets as plain text, the KG:
 | USES | X uses Y as dependency | pytest USES Python |
 | DEPENDS_ON | X requires Y to function | retry-pattern DEPENDS_ON exponential-backoff |
 | CONTRADICTS | X conflicts with Y | generic-exception CONTRADICTS specific-exceptions |
-| SUPERSEDES | X replaces Y | playbook.db SUPERSEDES playbook.json |
+| SUPERSEDES | X replaces Y | SQLite SUPERSEDES JSON format |
 | IMPLEMENTS | X implements pattern Y | retry-logic IMPLEMENTS resilience-pattern |
 | CAUSES | X causes problem Y | race-condition CAUSES data-corruption |
 | PREVENTS | X prevents problem Y | mutex-lock PREVENTS race-condition |

--- a/presentation/en/04-getting-started.md
+++ b/presentation/en/04-getting-started.md
@@ -106,7 +106,7 @@ Copy selected components into an existing project:
 │   ├── map-debug.md
 │   ├── map-refactor.md
 │   └── map-review.md
-└── playbook.json     # ACE knowledge base
+└── playbook.db       # ACE knowledge base (SQLite)
 ```
 
 **Benefits:**

--- a/presentation/ru/04-начало-работы.md
+++ b/presentation/ru/04-начало-работы.md
@@ -106,7 +106,7 @@ cd map-framework
 │   ├── map-debug.md
 │   ├── map-refactor.md
 │   └── map-review.md
-└── playbook.json     # ACE knowledge base
+└── playbook.db       # ACE knowledge base (SQLite)
 ```
 
 **Преимущества:**

--- a/src/mapify_cli/playbook_manager.py
+++ b/src/mapify_cli/playbook_manager.py
@@ -81,9 +81,11 @@ class PlaybookManager:
                 self.db_path = Path(".claude/playbook.db")
             else:
                 self.db_path = Path(db_path)
-            self.playbook_path = (
-                self.db_path.parent / "playbook.json"
-            )  # For migration check only
+            # LEGACY: playbook.json path for migration support only.
+            # This allows users upgrading from older versions to have their
+            # playbook.json automatically migrated to playbook.db.
+            # DO NOT use playbook_path for new functionality.
+            self.playbook_path = self.db_path.parent / "playbook.json"
 
         # Check if DB exists, if not but JSON exists → migrate
         if not self.db_path.exists() and self.playbook_path.exists():
@@ -449,10 +451,17 @@ class PlaybookManager:
 
     def _migrate_json_to_sqlite(self) -> None:
         """
-        Migrate existing playbook.json to SQLite database.
+        LEGACY MIGRATION: Migrate existing playbook.json to SQLite database.
+
+        This method is intentionally preserved for backward compatibility.
+        It allows users upgrading from MAP Framework versions < 2.2 to have
+        their playbook.json automatically migrated to the new playbook.db format.
+
+        The references to playbook.json in this method are intentional and
+        should NOT be removed - they are part of the migration logic.
 
         Steps:
-        1. Load playbook.json
+        1. Load legacy playbook.json
         2. Create SQLite schema
         3. Insert all bullets into bullets table
         4. Insert metadata

--- a/src/mapify_cli/recitation_manager.py
+++ b/src/mapify_cli/recitation_manager.py
@@ -586,6 +586,8 @@ class RecitationManager:
             from mapify_cli.playbook_manager import PlaybookManager
 
             playbook_db_path = self.project_root / ".claude" / "playbook.db"
+            # LEGACY: playbook_json_path is only used for backward compatibility
+            # to support migration from older versions. DO NOT use for new functionality.
             playbook_json_path = self.project_root / ".claude" / "playbook.json"
 
             # Check if playbook exists (prefer .db, fall back to .json for backward compatibility)

--- a/src/mapify_cli/relationship_detector.py
+++ b/src/mapify_cli/relationship_detector.py
@@ -29,7 +29,7 @@ class RelationshipType(Enum):
     USES = "USES"  # A uses B (pytest USES Python)
     DEPENDS_ON = "DEPENDS_ON"  # A depends on B (MAP-workflow DEPENDS_ON playbook.db)
     CONTRADICTS = "CONTRADICTS"  # A contradicts B (generic-exception CONTRADICTS specific-exceptions)
-    SUPERSEDES = "SUPERSEDES"  # A replaces B (playbook.db SUPERSEDES playbook.json)
+    SUPERSEDES = "SUPERSEDES"  # A replaces B (SQLite SUPERSEDES JSON-storage)
     RELATED_TO = "RELATED_TO"  # Generic relationship (fallback)
 
     # Bonus 4 types (for comprehensive graph)

--- a/src/mapify_cli/schemas.py
+++ b/src/mapify_cli/schemas.py
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS relationships (
         'USES',          -- Entity A uses Entity B (e.g., 'pytest' USES 'Python')
         'DEPENDS_ON',    -- A depends on B (e.g., 'MAP-workflow' DEPENDS_ON 'playbook.db')
         'CONTRADICTS',   -- A contradicts B (e.g., 'generic-exception' CONTRADICTS 'specific-exceptions')
-        'SUPERSEDES',    -- A replaces B (e.g., 'playbook.db' SUPERSEDES 'playbook.json')
+        'SUPERSEDES',    -- A replaces B (e.g., 'SQLite' SUPERSEDES 'JSON-storage')
         'RELATED_TO',    -- Generic relationship (fallback)
         'IMPLEMENTS',    -- A implements pattern B (e.g., 'retry-logic' IMPLEMENTS 'resilience-pattern')
         'CAUSES',        -- A causes B (e.g., 'race-condition' CAUSES 'data-corruption')

--- a/src/mapify_cli/templates/agents/curator.md
+++ b/src/mapify_cli/templates/agents/curator.md
@@ -339,7 +339,7 @@ mapify playbook apply-delta operations.json --dry-run
 - ❌ `sqlite3 .claude/playbook.db "UPDATE bullets SET..."` → Direct SQL bypasses validation
 - ❌ `Edit(.claude/playbook.db, ...)` → Cannot edit binary database
 - ❌ Using "op" field → ✅ Correct field name is "type"
-- ❌ Reading/writing playbook.json → ✅ Migrated to playbook.db (SQLite)
+- ❌ Using legacy JSON format → ✅ Use playbook.db (SQLite)
 
 **Why apply-delta is mandatory**:
 - Validates operations before applying

--- a/src/mapify_cli/templates/skills/map-cli-reference/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-cli-reference/SKILL.md
@@ -124,9 +124,9 @@ mapify upgrade
 ✅ **CORRECT**: `mapify playbook apply-delta operations.json`
 📝 **Explanation**: Cannot edit binary SQLite database. Generate delta operations JSON and apply via CLI.
 
-❌ **WRONG**: Reading/writing `playbook.json`
+❌ **WRONG**: Using legacy JSON format for playbook
 ✅ **CORRECT**: `mapify playbook query "..."`
-📝 **Explanation**: `playbook.json` is deprecated (migrated to `playbook.db`). Use CLI commands to interact with playbook.
+📝 **Explanation**: Playbook uses SQLite database (`playbook.db`). Use CLI commands to interact with playbook.
 
 ---
 

--- a/tests/test_playbook_init_fix.py
+++ b/tests/test_playbook_init_fix.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Test suite for playbook.db initialization fix."""
+"""
+Test suite for playbook.db initialization fix.
+
+IMPORTANT: This file contains references to playbook.json for testing
+LEGACY MIGRATION functionality. These tests ensure backward compatibility
+for users upgrading from older MAP Framework versions (< 2.2).
+
+DO NOT remove playbook.json references - they are part of migration tests.
+"""
 
 import json
 import os

--- a/tests/test_playbook_migration.py
+++ b/tests/test_playbook_migration.py
@@ -3,6 +3,14 @@ Unit tests for PlaybookManager SQLite migration functionality.
 
 Tests the automatic migration from JSON to SQLite storage and
 schema idempotency.
+
+IMPORTANT: This file intentionally contains references to playbook.json
+because it tests the LEGACY MIGRATION functionality. These tests ensure
+that users upgrading from older MAP Framework versions (< 2.2) can have
+their playbook.json files automatically migrated to playbook.db.
+
+DO NOT remove playbook.json references from this file - they are part
+of the migration test suite, not production code.
 """
 
 import json

--- a/tests/test_recitation_playbook_db_fix.py
+++ b/tests/test_recitation_playbook_db_fix.py
@@ -3,6 +3,14 @@ Test that recitation_manager prefers playbook.db over playbook.json.
 
 This test verifies the fix for the issue where map-efficient was trying
 to read .claude/playbook.json even when .claude/playbook.db already existed.
+
+IMPORTANT: This file intentionally contains references to playbook.json
+because it tests the LEGACY MIGRATION and backward compatibility behavior.
+These tests ensure that:
+1. When both .db and .json exist, the .db takes precedence
+2. When only .json exists, automatic migration to .db occurs
+
+DO NOT remove playbook.json references - they are part of migration tests.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

- Remove playbook.json references from user-facing code and documentation
- Update auto-approval rules to use playbook.db and mapify CLI commands
- Add clarifying comments to migration code for backward compatibility
- Sync template changes between .claude/ and src/mapify_cli/templates/

## Problem

Agents were trying to use `jq`/`cat` on non-existent `playbook.json` because auto-approval rules in `~/.claude/CLAUDE.md` referenced the deprecated file format.

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| Global config | `~/.claude/CLAUDE.md` | Updated auto-approval rules to use `playbook.db` |
| Project config | `.claude/CLAUDE.md` | Removed playbook.json warnings |
| Agent templates | `curator.md` | Updated deprecation messages |
| Skills | `map-cli-reference/SKILL.md` | Updated CLI examples |
| Documentation | 7 files in docs/ and presentation/ | Updated installation guides |
| Source code | 4 files | Added clarifying comments |
| Tests | 3 files | Added header comments |

## Test plan

- [x] Template sync tests pass (47/47)
- [x] Migration tests still work
- [x] Pre-commit hooks pass