### PR TITLE
fix: ensure playbook.json migration during init --force

### DIFF
--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -2046,6 +2046,48 @@ def init(
         from mapify_cli.playbook_manager import PlaybookManager
 
         playbook_db_path = project_path / ".claude" / "playbook.db"
+        playbook_json_path = project_path / ".claude" / "playbook.json"
+
+        # When --force is used and playbook.json exists, handle migration scenarios
+        if force and playbook_json_path.exists() and playbook_db_path.exists():
+            # Check if the existing DB has valid schema (requires both bullets and metadata tables)
+            db_is_valid = False
+            try:
+                test_conn = sqlite3.connect(str(playbook_db_path))
+                cursor = test_conn.cursor()
+                # Check for required tables
+                cursor.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('bullets', 'metadata')"
+                )
+                table_count = cursor.fetchone()[0]
+                test_conn.close()
+                db_is_valid = table_count == 2  # Both tables must exist
+            except sqlite3.Error:
+                db_is_valid = False
+
+            if not db_is_valid:
+                # DB is missing required schema or corrupted - remove it to allow migration
+                try:
+                    playbook_db_path.unlink()
+                    console.print(
+                        "[yellow]Removing incomplete playbook.db to migrate from playbook.json[/yellow]"
+                    )
+                except OSError:
+                    pass  # If we can't remove it, let PlaybookManager handle the error
+            else:
+                # DB is valid but playbook.json also exists - remove stale JSON to avoid confusion
+                # Create backup first in case user needs it
+                backup_path = str(playbook_json_path) + ".stale"
+                try:
+                    import shutil
+
+                    shutil.move(str(playbook_json_path), backup_path)
+                    console.print(
+                        f"[yellow]Moved stale playbook.json to {backup_path} (valid playbook.db already exists)[/yellow]"
+                    )
+                except OSError:
+                    pass  # If we can't move it, it's not critical
+
         manager = PlaybookManager(
             db_path=str(playbook_db_path), use_semantic_search=False
         )

--- a/src/mapify_cli/playbook_manager.py
+++ b/src/mapify_cli/playbook_manager.py
@@ -574,7 +574,7 @@ class PlaybookManager:
 
         conn.close()
 
-        # Create backup of JSON
+        # Create backup of JSON and remove original
         backup_path = (
             str(self.playbook_path)
             + f".backup.{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
@@ -586,6 +586,20 @@ class PlaybookManager:
             file=sys.stderr,
         )
         print(f"✅ JSON backup saved to {backup_path}", file=sys.stderr)
+
+        # Remove original playbook.json to avoid confusion
+        # The backup is always available if needed
+        try:
+            self.playbook_path.unlink()
+            print(
+                f"✅ Removed {self.playbook_path} (backup preserved)",
+                file=sys.stderr,
+            )
+        except OSError as e:
+            print(
+                f"⚠️ Could not remove {self.playbook_path}: {e}",
+                file=sys.stderr,
+            )
 
     def _load_playbook_from_db(self) -> Dict:
         """Load playbook structure from SQLite database for backward compatibility."""


### PR DESCRIPTION
## Summary

- Fix migration from `playbook.json` to `playbook.db` when using `mapify init --force`
- Detect and remove invalid/incomplete `playbook.db` before attempting migration
- Properly clean up stale `playbook.json` files after migration or when valid DB exists

## Problem

When a user had `playbook.json` and ran `mapify init --force`, migration would fail if there was also a corrupt/incomplete `playbook.db` because:
1. The `PlaybookManager` only migrates if `playbook.db` doesn't exist
2. If `playbook.db` exists (even if corrupt), no migration happens

## Changes

**In `src/mapify_cli/__init__.py` (init command):**
- Added logic before creating `PlaybookManager` to detect and remove invalid `playbook.db` when `--force` is used
- Checks if DB has required `bullets` and `metadata` tables
- If DB is invalid but JSON exists → remove DB to allow migration
- If DB is valid but JSON also exists → move JSON to `.stale` to avoid confusion

**In `src/mapify_cli/playbook_manager.py` (migration):**
- After successful migration, now deletes the original `playbook.json` (backup is preserved)
- Previously, JSON was kept alongside the new DB, causing potential confusion

## Scenarios Now Handled

| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| Only `playbook.json` | ✅ Migrates | ✅ Migrates + deletes JSON |
| Empty `playbook.db` + `playbook.json` | ❌ Fails | ✅ Removes empty DB, migrates |
| Incomplete schema DB + `playbook.json` | ❌ Fails | ✅ Removes invalid DB, migrates |
| Valid DB + `playbook.json` | ✅ Uses DB | ✅ Uses DB + moves JSON to `.stale` |
| Fresh directory (no files) | ✅ Creates new | ✅ Creates new |

## Test plan

- [x] Tested scenario: only playbook.json exists
- [x] Tested scenario: empty playbook.db + playbook.json
- [x] Tested scenario: incomplete DB schema + playbook.json
- [x] Tested scenario: valid DB + stale playbook.json
- [x] Tested scenario: fresh directory (no files)
- [x] All existing tests pass