### PR TITLE
fix: use correct subagent_type in /map-efficient workflow

### DIFF
--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -4,6 +4,34 @@ description: Optimized workflow with batched learning (RECOMMENDED for token-con
 
 # MAP Efficient Workflow
 
+**CRITICAL INSTRUCTION:** This is an **automated sequential workflow**. You MUST execute ALL steps from start to finish without stopping. After calling each subagent, IMMEDIATELY proceed to the next step in the workflow. DO NOT wait for user input between steps.
+
+**🚨 ABSOLUTELY FORBIDDEN 🚨**
+
+You are **STRICTLY PROHIBITED** from:
+
+❌ **"Optimizing" the workflow by skipping agents** - Each agent MUST be called
+❌ **"Using general-purpose instead of specialized agents"** - USE the correct subagent_type
+❌ **"Doing Reflector/Curator work manually"** - This breaks cipher integration
+❌ **"Combining steps to save time"** - Each agent MUST be called individually
+❌ **"Skipping batched reflection at end"** - MANDATORY for learning
+❌ **Any variation of "I'll optimize by..."** - NO ADDITIONAL OPTIMIZATION ALLOWED
+
+**IF YOU VIOLATE THESE RULES:**
+- cipher_memory_search won't be called → duplicate knowledge
+- cipher_extract_and_operate_memory won't be called → knowledge won't be shared
+- The ENTIRE PURPOSE of MAP Framework will be defeated
+
+**YOU MUST:**
+✅ Call task-decomposer FIRST (not general-purpose)
+✅ Call actor for EACH subtask (not general-purpose)
+✅ Call monitor after EACH actor (not general-purpose)
+✅ Call reflector at END for batched learning
+✅ Call curator at END for playbook update
+✅ Verify each agent used required MCP tools (check output)
+
+---
+
 **✅ RECOMMENDED: Best Balance of Speed and Quality**
 
 This workflow provides **intelligent token optimization (30-40% savings)** while **preserving MAP's core value**:
@@ -66,9 +94,11 @@ Use `mapify playbook query` or `mapify playbook search` to get relevant patterns
 
 ## Step 2: Task Decomposition
 
+Call the task-decomposer subagent (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="task-decomposer",
   description="Decompose task into subtasks",
   prompt="Break down this task into atomic subtasks (≤8):
 
@@ -152,9 +182,11 @@ PLAN_CONTEXT=$(mapify recitation get-context)
 
 ### 3.2 Call Actor to Implement
 
+**⚠️ MUST use subagent_type="actor"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="actor",
   description="Implement subtask [ID]",
   prompt="Implement this subtask:
 
@@ -183,9 +215,11 @@ Provide FULL file content for each change, not diffs."
 
 ### 3.3 Call Monitor to Validate
 
+**⚠️ MUST use subagent_type="monitor"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="monitor",
   description="Validate implementation",
   prompt="Review this implementation:
 
@@ -236,9 +270,11 @@ mapify recitation update "ST-001" in_progress "Monitor feedback: [error details]
 - `subtask.risk_level === 'low'` AND
 - `monitor.high_risk_detected === false`
 
+**⚠️ MUST use subagent_type="predictor"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="predictor",
   description="Analyze implementation impact",
   prompt="Analyze the impact of this implementation:
 
@@ -286,9 +322,11 @@ After ALL subtasks completed, perform batched reflection and curation:
 
 ### 4.1 Batch Reflector Analysis
 
+**⚠️ MUST use subagent_type="reflector"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="reflector",
   description="Extract lessons from all subtasks",
   prompt="Extract structured lessons from this ENTIRE workflow:
 
@@ -332,9 +370,11 @@ Output JSON with:
 
 ### 4.2 Batch Curator Update
 
+**⚠️ MUST use subagent_type="curator"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="curator",
   description="Update playbook with workflow learnings",
   prompt="Integrate batched learnings into playbook:
 

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -4,6 +4,34 @@ description: Optimized workflow with batched learning (RECOMMENDED for token-con
 
 # MAP Efficient Workflow
 
+**CRITICAL INSTRUCTION:** This is an **automated sequential workflow**. You MUST execute ALL steps from start to finish without stopping. After calling each subagent, IMMEDIATELY proceed to the next step in the workflow. DO NOT wait for user input between steps.
+
+**🚨 ABSOLUTELY FORBIDDEN 🚨**
+
+You are **STRICTLY PROHIBITED** from:
+
+❌ **"Optimizing" the workflow by skipping agents** - Each agent MUST be called
+❌ **"Using general-purpose instead of specialized agents"** - USE the correct subagent_type
+❌ **"Doing Reflector/Curator work manually"** - This breaks cipher integration
+❌ **"Combining steps to save time"** - Each agent MUST be called individually
+❌ **"Skipping batched reflection at end"** - MANDATORY for learning
+❌ **Any variation of "I'll optimize by..."** - NO ADDITIONAL OPTIMIZATION ALLOWED
+
+**IF YOU VIOLATE THESE RULES:**
+- cipher_memory_search won't be called → duplicate knowledge
+- cipher_extract_and_operate_memory won't be called → knowledge won't be shared
+- The ENTIRE PURPOSE of MAP Framework will be defeated
+
+**YOU MUST:**
+✅ Call task-decomposer FIRST (not general-purpose)
+✅ Call actor for EACH subtask (not general-purpose)
+✅ Call monitor after EACH actor (not general-purpose)
+✅ Call reflector at END for batched learning
+✅ Call curator at END for playbook update
+✅ Verify each agent used required MCP tools (check output)
+
+---
+
 **✅ RECOMMENDED: Best Balance of Speed and Quality**
 
 This workflow provides **intelligent token optimization (30-40% savings)** while **preserving MAP's core value**:
@@ -66,9 +94,11 @@ Use `mapify playbook query` or `mapify playbook search` to get relevant patterns
 
 ## Step 2: Task Decomposition
 
+Call the task-decomposer subagent (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="task-decomposer",
   description="Decompose task into subtasks",
   prompt="Break down this task into atomic subtasks (≤8):
 
@@ -152,9 +182,11 @@ PLAN_CONTEXT=$(mapify recitation get-context)
 
 ### 3.2 Call Actor to Implement
 
+**⚠️ MUST use subagent_type="actor"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="actor",
   description="Implement subtask [ID]",
   prompt="Implement this subtask:
 
@@ -183,9 +215,11 @@ Provide FULL file content for each change, not diffs."
 
 ### 3.3 Call Monitor to Validate
 
+**⚠️ MUST use subagent_type="monitor"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="monitor",
   description="Validate implementation",
   prompt="Review this implementation:
 
@@ -236,9 +270,11 @@ mapify recitation update "ST-001" in_progress "Monitor feedback: [error details]
 - `subtask.risk_level === 'low'` AND
 - `monitor.high_risk_detected === false`
 
+**⚠️ MUST use subagent_type="predictor"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="predictor",
   description="Analyze implementation impact",
   prompt="Analyze the impact of this implementation:
 
@@ -286,9 +322,11 @@ After ALL subtasks completed, perform batched reflection and curation:
 
 ### 4.1 Batch Reflector Analysis
 
+**⚠️ MUST use subagent_type="reflector"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="reflector",
   description="Extract lessons from all subtasks",
   prompt="Extract structured lessons from this ENTIRE workflow:
 
@@ -332,9 +370,11 @@ Output JSON with:
 
 ### 4.2 Batch Curator Update
 
+**⚠️ MUST use subagent_type="curator"** (NOT general-purpose):
+
 ```
 Task(
-  subagent_type="general-purpose",
+  subagent_type="curator",
   description="Update playbook with workflow learnings",
   prompt="Integrate batched learnings into playbook:
 


### PR DESCRIPTION
## Summary

- Fix `/map-efficient` command using `general-purpose` instead of specialized agents
- All agent calls now use correct `subagent_type` values
- Add explicit "ABSOLUTELY FORBIDDEN" block to prevent optimization shortcuts

## Problem

`/map-efficient` was completely broken because it used `subagent_type="general-purpose"` for ALL agent calls:

| Agent | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| task-decomposer | `general-purpose` | `task-decomposer` |
| actor | `general-purpose` | `actor` |
| monitor | `general-purpose` | `monitor` |
| predictor | `general-purpose` | `predictor` |
| reflector | `general-purpose` | `reflector` |
| curator | `general-purpose` | `curator` |

This caused:
1. Agents not following specialized templates from `.claude/agents/`
2. MCP tools never called (`cipher_memory_search`, etc.)
3. Very slow operations (agent "reinvents the wheel")
4. No learning captured (cipher integration broken)

## Root Cause

When `/map-efficient` was created, all Task() calls were templated with `general-purpose` instead of the actual agent types. This was likely a copy-paste error that was never caught.

Compare with `/map-release` which correctly uses specialized agents and has the "ABSOLUTELY FORBIDDEN" block.

## Changes

- Replace all `subagent_type="general-purpose"` with correct agent types
- Add warning notes on each Task() call: `⚠️ MUST use subagent_type="X"`
- Add "ABSOLUTELY FORBIDDEN" enforcement block at top
- Sync to `src/mapify_cli/templates/commands/`

## Test plan

- [x] Verify all Task() calls use correct subagent_type
- [x] Verify templates synced to src/mapify_cli/templates/
- [ ] Manual test: run `/map-efficient` on a simple task