### PR TITLE
Fix: Remove misleading 'orchestrator directly' instruction

### DIFF
--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -2156,8 +2156,7 @@ def init(
     steps_lines.append("   • [cyan]/map-debug[/] - Debug issue using MAP analysis")
     steps_lines.append("   • [cyan]/map-refactor[/] - Refactor with impact analysis")
     steps_lines.append("   • [cyan]/map-review[/] - Full MAP review of changes")
-    steps_lines.append(f"{step_num + 1}. Or use orchestrator directly:")
-    steps_lines.append('   [cyan]"Use orchestrator agent to implement [feature]"[/]')
+
 
     steps_panel = Panel(
         "\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1, 2)


### PR DESCRIPTION
The instruction to 'Use orchestrator directly' in the CLI init message was misleading as the orchestrator functionality has been integrated into the /map- commands. This commit removes the outdated instruction to clarify the usage for users.