### PR TITLE
feat: auto-create .mcp.json during mapify init

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,11 @@ MAP uses MCP (Model Context Protocol) servers for enhanced capabilities:
 - **sequential-thinking** - Chain-of-thought reasoning for complex problems
 - **deepwiki** - GitHub repository intelligence
 
-Configuration files: `.claude/mcp_config.json` and `mcp_config.json`
+During `mapify init`, two configuration files are created:
+- **`.mcp.json`** - Project-level Claude Code MCP server registration (standard format)
+- **`.claude/mcp_config.json`** - Internal MAP Framework agent-to-MCP mappings
+
+If `.mcp.json` already exists, `mapify init` will merge new servers without overwriting your existing configuration.
 
 **See [ARCHITECTURE.md](docs/ARCHITECTURE.md#mcp-integration) for complete setup and usage patterns**
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -25,12 +25,14 @@ Or install globally:
 
 __version__ = "1.7.0"
 
+import copy
 import os
 import subprocess
 import sys
 import shutil
 import json
 import sqlite3
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, List, Dict, Any
@@ -1649,6 +1651,221 @@ def create_mcp_config(project_path: Path, mcp_servers: List[str]) -> None:
     config_file.write_text(json.dumps(config, indent=2))
 
 
+# =============================================================================
+# Project-level .mcp.json functions (for Claude Code MCP server configuration)
+# =============================================================================
+
+
+def build_standard_mcp_servers() -> Dict[str, Dict[str, Any]]:
+    """Build standard MCP server configurations for Claude Code .mcp.json format.
+
+    Returns dict mapping server names to their Claude Code MCP configurations.
+    Uses verified configurations from production installations.
+
+    Note: These configs are for the project-level .mcp.json file that Claude Code
+    reads, separate from the internal .claude/mcp_config.json.
+    """
+    return {
+        "sequential-thinking": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+        },
+        "context7": {
+            "type": "http",
+            "url": "https://mcp.context7.com/mcp",
+        },
+        "deepwiki": {
+            "type": "http",
+            "url": "https://mcp.deepwiki.com/mcp",
+        },
+    }
+
+
+def read_project_mcp_json(path: Path) -> Optional[Dict[str, Any]]:
+    """Read .mcp.json from project root.
+
+    Args:
+        path: Path to .mcp.json file
+
+    Returns:
+        Parsed JSON dict if file exists and is valid, None otherwise
+
+    Handles:
+        - File not found (returns None)
+        - Invalid JSON (logs warning, creates backup, returns None)
+        - Permission errors (logs warning, returns None)
+    """
+    if not path.exists():
+        return None
+
+    try:
+        content = path.read_text(encoding="utf-8")
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        console.print(f"[yellow]Warning:[/yellow] Invalid JSON in {path.name}: {e}")
+        # Create backup with timestamp + UUID to prevent race conditions
+        # UUID ensures unique names even with concurrent processes
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        unique_id = uuid.uuid4().hex[:8]
+        backup_path = path.with_suffix(f".backup.{timestamp}_{unique_id}.json")
+        try:
+            if path.exists():  # Check before rename to handle concurrent processes
+                path.rename(backup_path)
+                console.print(
+                    f"[dim]Backed up corrupted file to {backup_path.name}[/dim]"
+                )
+            else:
+                console.print(
+                    "[dim]Corrupted file already removed by another process[/dim]"
+                )
+        except OSError as backup_error:
+            console.print(
+                f"[yellow]Warning:[/yellow] Could not create backup: {backup_error}"
+            )
+        return None
+    except (OSError, PermissionError) as e:
+        console.print(f"[yellow]Warning:[/yellow] Cannot read {path.name}: {e}")
+        return None
+
+
+def write_project_mcp_json(path: Path, config: Dict[str, Any]) -> None:
+    """Write .mcp.json to project root with proper formatting.
+
+    Args:
+        path: Path to .mcp.json file
+        config: Configuration dict to write
+
+    Raises:
+        OSError: If write fails (permission, disk space, etc.)
+
+    Format:
+        - indent=2 for readability
+        - UTF-8 encoding
+        - Newline at end of file
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(config, indent=2, ensure_ascii=False)
+    path.write_text(content + "\n", encoding="utf-8")
+
+
+def merge_mcp_json(
+    existing: Dict[str, Any], new_servers: Dict[str, Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Merge new MCP servers into existing .mcp.json configuration.
+
+    Args:
+        existing: Existing .mcp.json content (may be empty dict)
+        new_servers: Dict mapping server names to their configs
+
+    Returns:
+        Merged configuration with existing servers preserved
+
+    Behavior:
+        - Preserves existing mcpServers entries (user customizations)
+        - Only adds new servers that don't exist
+        - Preserves other top-level keys (e.g., custom settings)
+    """
+    result = copy.deepcopy(existing)
+
+    # Ensure mcpServers key exists
+    if "mcpServers" not in result:
+        result["mcpServers"] = {}
+
+    # Merge servers - existing entries take precedence (never overwrite user configs)
+    for server_name, server_config in new_servers.items():
+        if server_name not in result["mcpServers"]:
+            result["mcpServers"][server_name] = server_config
+
+    return result
+
+
+def create_or_merge_project_mcp_json(
+    project_path: Path, mcp_servers: List[str]
+) -> None:
+    """Create or merge .mcp.json in project root for Claude Code.
+
+    Args:
+        project_path: Project root directory
+        mcp_servers: List of MCP server names to configure (e.g., ["cipher", "context7"])
+
+    Behavior:
+        - If mcp_servers is empty: No file created/modified (early return)
+        - If .mcp.json exists: merge new servers (preserve existing)
+        - If .mcp.json missing: create new with selected servers
+        - Console output shows whether created or merged
+        - Existing user servers NEVER overwritten
+        - System directories (/etc, /sys, etc.) are rejected for safety
+
+    This creates the project-level .mcp.json that Claude Code uses,
+    separate from the internal .claude/mcp_config.json.
+
+    Raises:
+        typer.Exit(1): On file write errors or invalid paths
+    """
+    # Path validation - resolve to prevent traversal
+    resolved_path = project_path.resolve()
+
+    # Validate against system directories (defense-in-depth)
+    forbidden_prefixes = ["/etc", "/sys", "/proc", "/boot", "/dev", "/var/run"]
+    resolved_str = str(resolved_path)
+    for forbidden in forbidden_prefixes:
+        if resolved_str == forbidden or resolved_str.startswith(forbidden + "/"):
+            console.print(
+                f"[red]Error:[/red] Cannot initialize in system directory {forbidden}"
+            )
+            raise typer.Exit(1)
+
+    mcp_json_path = resolved_path / ".mcp.json"
+
+    # Build standard server configs for requested servers
+    all_standard_servers = build_standard_mcp_servers()
+    selected_servers = {
+        name: config
+        for name, config in all_standard_servers.items()
+        if name in mcp_servers
+    }
+
+    if not selected_servers:
+        # No servers to configure
+        return
+
+    # Read existing config if present
+    existing_config = read_project_mcp_json(mcp_json_path)
+
+    try:
+        if existing_config is not None:
+            # Merge mode - preserve existing entries
+            merged_config = merge_mcp_json(existing_config, selected_servers)
+            write_project_mcp_json(mcp_json_path, merged_config)
+
+            # Count how many new servers were added
+            existing_servers = existing_config.get("mcpServers", {})
+            new_count = len([s for s in selected_servers if s not in existing_servers])
+            if new_count > 0:
+                console.print(
+                    f"[green]✓[/green] Merged {new_count} new server(s) into .mcp.json"
+                )
+            else:
+                console.print(
+                    "[green]✓[/green] .mcp.json already contains all requested servers"
+                )
+        else:
+            # Create mode - new file
+            new_config: Dict[str, Any] = {"mcpServers": selected_servers}
+            write_project_mcp_json(mcp_json_path, new_config)
+            console.print(
+                f"[green]✓[/green] Created .mcp.json with {len(selected_servers)} server(s)"
+            )
+
+        # Show which servers are configured
+        console.print(
+            f"[dim]  Configured: {', '.join(sorted(selected_servers.keys()))}[/dim]"
+        )
+    except OSError as e:
+        console.print(f"[red]Error:[/red] Failed to write .mcp.json: {e}")
+        raise typer.Exit(1) from e
+
+
 def init_git_repo(project_path: Path, quiet: bool = False) -> bool:
     """Initialize a git repository"""
     try:
@@ -2030,10 +2247,17 @@ def init(
         tracker.complete("install-hooks", f"{hooks_count} {hooks_word} installed")
 
     if selected_mcp_servers:
-        tracker.add("mcp-config", "Create MCP config file")
+        # Create internal MCP config (for MAP Framework agent mappings)
+        tracker.add("mcp-config", "Create internal MCP config")
         tracker.start("mcp-config")
         create_mcp_config(project_path, selected_mcp_servers)
         tracker.complete("mcp-config", f"{len(selected_mcp_servers)} servers")
+
+        # Create/merge project .mcp.json (for Claude Code MCP server registration)
+        tracker.add("mcp-project", "Create/merge .mcp.json")
+        tracker.start("mcp-project")
+        create_or_merge_project_mcp_json(project_path, selected_mcp_servers)
+        tracker.complete("mcp-project", "Claude Code MCP config")
 
     # Initialize playbook database
     tracker.add("init-playbook", "Initialize playbook database")

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -16,15 +16,20 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from mapify_cli import (
     app,
+    build_standard_mcp_servers,
     create_agent_files,
     create_command_files,
     create_commands_dir,
+    create_or_merge_project_mcp_json,
     create_ssl_context,
     get_latest_release,
     get_templates_dir,
     init_git_repo,
     is_command,
     is_git_repo,
+    merge_mcp_json,
+    read_project_mcp_json,
+    write_project_mcp_json,
 )
 
 runner = CliRunner()
@@ -962,3 +967,210 @@ class TestPlaybookSubcommands:
         output = json.loads(result.stdout)
         assert output["status"] == "error"
         assert "not found" in output["message"].lower()
+
+
+class TestMcpJsonConfig:
+    """Test .mcp.json creation and merging functionality."""
+
+    def test_build_standard_mcp_servers_returns_all_servers(self):
+        """Test that build_standard_mcp_servers returns all expected servers."""
+        servers = build_standard_mcp_servers()
+
+        expected_servers = [
+            "sequential-thinking",
+            "context7",
+            "deepwiki",
+        ]
+        for server in expected_servers:
+            assert server in servers, f"Missing server: {server}"
+
+    def test_build_standard_mcp_servers_correct_types(self):
+        """Test that servers have correct transport types."""
+        servers = build_standard_mcp_servers()
+
+        # stdio servers should have 'command' key
+        for server_name in ["sequential-thinking"]:
+            assert "command" in servers[server_name], f"{server_name} missing command"
+            assert "args" in servers[server_name], f"{server_name} missing args"
+
+        # http servers should have 'type' and 'url' keys
+        for server_name in ["context7", "deepwiki"]:
+            assert (
+                servers[server_name].get("type") == "http"
+            ), f"{server_name} should be http"
+            assert "url" in servers[server_name], f"{server_name} missing url"
+
+    def test_read_project_mcp_json_missing_file(self, tmp_path):
+        """Test reading non-existent .mcp.json returns None."""
+        mcp_file = tmp_path / ".mcp.json"
+        result = read_project_mcp_json(mcp_file)
+        assert result is None
+
+    def test_read_project_mcp_json_valid_file(self, tmp_path):
+        """Test reading valid .mcp.json returns parsed content."""
+        mcp_file = tmp_path / ".mcp.json"
+        config = {"mcpServers": {"test": {"command": "test"}}}
+        mcp_file.write_text(json.dumps(config))
+
+        result = read_project_mcp_json(mcp_file)
+        assert result == config
+
+    def test_read_project_mcp_json_invalid_json(self, tmp_path):
+        """Test reading invalid JSON returns None and creates backup."""
+        import re
+
+        mcp_file = tmp_path / ".mcp.json"
+        mcp_file.write_text("{ invalid json }")
+
+        result = read_project_mcp_json(mcp_file)
+
+        assert result is None
+        # Check that backup was created with correct naming pattern
+        backup_files = list(tmp_path.glob(".mcp.backup.*.json"))
+        assert len(backup_files) == 1
+
+        # Verify backup filename matches expected format: YYYYMMDD_HHMMSS_XXXXXXXX (8 hex chars)
+        backup_name = backup_files[0].name
+        assert re.match(
+            r"\.mcp\.backup\.\d{8}_\d{6}_[a-f0-9]{8}\.json$", backup_name
+        ), f"Backup name doesn't match expected format: {backup_name}"
+
+    def test_write_project_mcp_json_creates_file(self, tmp_path):
+        """Test writing .mcp.json creates file with correct format."""
+        mcp_file = tmp_path / ".mcp.json"
+        config = {"mcpServers": {"test": {"command": "test"}}}
+
+        write_project_mcp_json(mcp_file, config)
+
+        assert mcp_file.exists()
+        content = mcp_file.read_text()
+        assert content.endswith("\n")  # Should have trailing newline
+        parsed = json.loads(content)
+        assert parsed == config
+
+    def test_write_project_mcp_json_permission_error(self, tmp_path):
+        """Test write_project_mcp_json raises OSError on permission denied."""
+        mcp_file = tmp_path / ".mcp.json"
+        mcp_file.touch()
+        mcp_file.chmod(0o444)  # Read-only
+
+        config = {"mcpServers": {"test": {"command": "test"}}}
+
+        with pytest.raises(OSError):
+            write_project_mcp_json(mcp_file, config)
+
+        # Cleanup: restore permissions so tmp_path cleanup works
+        mcp_file.chmod(0o644)
+
+    def test_merge_mcp_json_preserves_existing(self):
+        """Test that merge preserves existing servers."""
+        existing = {
+            "mcpServers": {
+                "user-server": {"command": "user-cmd"},
+            }
+        }
+        new_servers = {
+            "context7": {"type": "http", "url": "https://mcp.context7.com/mcp"},
+        }
+
+        result = merge_mcp_json(existing, new_servers)
+
+        assert "user-server" in result["mcpServers"]
+        assert "context7" in result["mcpServers"]
+        assert result["mcpServers"]["user-server"]["command"] == "user-cmd"
+
+    def test_merge_mcp_json_does_not_overwrite(self):
+        """Test that merge does not overwrite existing servers with same name."""
+        existing = {
+            "mcpServers": {
+                "context7": {"type": "http", "url": "https://custom.url"},  # User's custom
+            }
+        }
+        new_servers = {
+            "context7": {"type": "http", "url": "https://mcp.context7.com/mcp"},  # Standard
+        }
+
+        result = merge_mcp_json(existing, new_servers)
+
+        # User's custom config should be preserved
+        assert result["mcpServers"]["context7"]["url"] == "https://custom.url"
+
+    def test_merge_mcp_json_adds_mcpservers_key(self):
+        """Test that merge adds mcpServers key if missing."""
+        existing = {"other_key": "value"}
+        new_servers = {"context7": {"type": "http", "url": "https://mcp.context7.com/mcp"}}
+
+        result = merge_mcp_json(existing, new_servers)
+
+        assert "mcpServers" in result
+        assert "context7" in result["mcpServers"]
+        assert "other_key" in result  # Other keys preserved
+
+    def test_create_or_merge_new_file(self, tmp_path):
+        """Test creating new .mcp.json when file doesn't exist."""
+        create_or_merge_project_mcp_json(tmp_path, ["deepwiki", "context7"])
+
+        mcp_file = tmp_path / ".mcp.json"
+        assert mcp_file.exists()
+
+        config = json.loads(mcp_file.read_text())
+        assert "mcpServers" in config
+        assert "deepwiki" in config["mcpServers"]
+        assert "context7" in config["mcpServers"]
+        assert len(config["mcpServers"]) == 2
+
+    def test_create_or_merge_existing_file(self, tmp_path):
+        """Test merging into existing .mcp.json."""
+        # Create existing file with user's server
+        mcp_file = tmp_path / ".mcp.json"
+        existing_config = {
+            "mcpServers": {
+                "ChunkHound": {"command": "chunkhound", "args": ["mcp"]},
+            }
+        }
+        mcp_file.write_text(json.dumps(existing_config))
+
+        # Run merge
+        create_or_merge_project_mcp_json(tmp_path, ["deepwiki"])
+
+        # Verify merge
+        config = json.loads(mcp_file.read_text())
+        assert "ChunkHound" in config["mcpServers"]  # User's server preserved
+        assert "deepwiki" in config["mcpServers"]  # New server added
+
+    def test_create_or_merge_empty_servers_list(self, tmp_path):
+        """Test that empty servers list doesn't create file."""
+        create_or_merge_project_mcp_json(tmp_path, [])
+
+        mcp_file = tmp_path / ".mcp.json"
+        assert not mcp_file.exists()
+
+    def test_create_or_merge_filters_unknown_servers(self, tmp_path):
+        """Test that unknown server names are ignored."""
+        create_or_merge_project_mcp_json(
+            tmp_path, ["deepwiki", "unknown-server", "context7"]
+        )
+
+        mcp_file = tmp_path / ".mcp.json"
+        config = json.loads(mcp_file.read_text())
+
+        assert "deepwiki" in config["mcpServers"]
+        assert "context7" in config["mcpServers"]
+        assert "unknown-server" not in config["mcpServers"]
+
+    def test_init_creates_mcp_json(self, tmp_path):
+        """Test that mapify init creates .mcp.json file."""
+        os.chdir(tmp_path)
+
+        result = runner.invoke(app, ["init", ".", "--force", "--mcp", "docs"])
+
+        # Allow exit code 0 or initialization messages
+        mcp_file = tmp_path / ".mcp.json"
+        assert (
+            mcp_file.exists()
+        ), f"Expected .mcp.json to be created. Output: {result.output}"
+
+        config = json.loads(mcp_file.read_text())
+        assert "mcpServers" in config
+        # docs = context7 + deepwiki
+        assert "context7" in config["mcpServers"] or "deepwiki" in config["mcpServers"]


### PR DESCRIPTION
## Summary

- Add automatic creation/merging of project-level `.mcp.json` file for Claude Code MCP server registration during `mapify init`
- Merge with existing `.mcp.json` if present, preserving user configurations (e.g., ChunkHound)
- Add path boundary validation and race-condition safe backup handling

## Changes

**New functions in `src/mapify_cli/__init__.py`:**
- `build_standard_mcp_servers()` - Returns standard MCP server configurations
- `read_project_mcp_json()` - Reads with error handling and timestamped+UUID backup
- `write_project_mcp_json()` - Writes with proper formatting
- `merge_mcp_json()` - Non-destructive merge preserving user configs
- `create_or_merge_project_mcp_json()` - Orchestrates the workflow with system directory validation

**Documentation:**
- Updated README.md MCP Integration section explaining two config files

## Test plan

- [x] 15 new tests in `TestMcpJsonConfig` class
- [x] All 58 tests passing
- [x] Manual testing of creation and merge scenarios
- [x] Black formatting verified