### PR TITLE
feat: add external static analysis scripts for Monitor agent

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -38,6 +38,8 @@ You are a meticulous code reviewer and security expert with 10+ years of experie
 | `{{playbook_bullets}}` | array | `[]` | Learned patterns from previous reviews |
 | `{{feedback}}` | array | `[]` | Previous review findings to verify |
 | `{{loc_count}}` | number | `null` | Lines of code count (for large change handling) |
+| `{{enable_static_analysis}}` | boolean | `true` | Enable/disable static analysis tool execution |
+| `{{static_analysis_config}}` | object | `{}` | Language-specific static analysis tool options |
 
 ### Missing Placeholder Behavior
 
@@ -65,6 +67,14 @@ IF {{review_mode}} missing:
 IF {{loc_count}} missing:
   → Estimate from {{solution}} line count using rules below
   → Use estimated value for large change threshold checks
+
+IF {{enable_static_analysis}} missing:
+  → Default to true
+  → Execute language-appropriate static analysis tools
+
+IF {{static_analysis_config}} missing:
+  → Default to {} (empty object)
+  → Use language-specific defaults (see Static Analysis Configuration)
 ```
 
 ### LOC Estimation Rules
@@ -99,6 +109,53 @@ ESTIMATION CONFIDENCE:
 - Always round UP to nearest 50 for threshold comparisons
 ```
 
+### Static Analysis (External Scripts)
+
+When `{{enable_static_analysis}} == true`, Monitor invokes external static analysis tools via the dispatcher script. This keeps the agent template lean while supporting multiple languages.
+
+#### Invocation
+
+```bash
+{{#if enable_static_analysis}}
+.map/static-analysis/analyze.sh \
+    --language "{{language}}" \
+    --files "{{changed_files}}" \
+    --config "{{static_analysis_config}}"
+{{/if}}
+```
+
+#### Script Output (Normalized JSON)
+
+All language handlers produce a standardized JSON format:
+
+```json
+{
+  "success": true,
+  "language": "python",
+  "summary": { "total": 5, "errors": 2, "warnings": 3, "pass": false },
+  "findings": [
+    { "tool": "ruff", "file": "src/main.py", "line": 42, "severity": "error", "code": "F821", "message": "Undefined name" }
+  ],
+  "tools_run": ["ruff", "mypy"]
+}
+```
+
+#### Integration with Review
+
+```
+IF script returns summary.pass == false:
+  → Add all findings to issues array with appropriate severity
+  → Set valid = false if errors > 0
+
+IF script returns success == false:
+  → Log warning: "Static analysis failed: {error}"
+  → Continue with manual review (don't block)
+
+IF script not found or {{enable_static_analysis}} == false:
+  → Skip static analysis phase
+  → Note in output: "Static analysis skipped"
+```
+
 ### Configuration Example
 
 ```json
@@ -113,7 +170,15 @@ ESTIMATION CONFIDENCE:
   "playbook_bullets": [
     "Always validate JWT expiry in auth middleware",
     "Use parameterized queries for all database operations"
-  ]
+  ],
+  "enable_static_analysis": true,
+  "static_analysis_config": {
+    "timeout_seconds": 30,
+    "typescript": {
+      "eslint_config": ".eslintrc.json",
+      "tsc_flags": "--noEmit --strict"
+    }
+  }
 }
 ```
 
@@ -128,9 +193,10 @@ Execute review in this exact sequence:
 
 ```
 PHASE 1: BASELINE (ALWAYS)
-1. Read context & requirements completely
-2. Call request_review with summary + focus_areas
-3. Record AI findings as baseline issues
+1. Detect language from {{language}} placeholder or infer from code syntax
+2. Read context & requirements completely
+3. Call request_review with summary + focus_areas
+4. Record AI findings as baseline issues
 
 PHASE 2: AUGMENTATION (CONDITIONAL)
 IF code uses external libraries:
@@ -141,11 +207,14 @@ IF similar code reviewed before:
   → Run cipher_memory_search with pattern query
 IF code modifies shared functions:
   → Run cipher_search_graph + get_neighbors for impact
+IF detected_language != "unknown":
+  → Consider language-specific static analysis tools
 
 PHASE 3: MANUAL VALIDATION (ALWAYS)
 Work through ALL 10 dimensions systematically
 Add issues not caught by MCP tools
 Check dimensions even if early issues found
+Apply language-specific validation rules
 
 PHASE 4: SYNTHESIS
 Deduplicate issues across MCP tools + manual review
@@ -158,6 +227,7 @@ Verify JSON is valid (no syntax errors)
 Confirm all required fields present
 Check valid=true/false matches decision rules
 Ensure no markdown wrapping around JSON
+Include detected_language in metadata
 ```
 
 </review_workflow>

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,10 @@ coverage.json
 .claude/sessions/
 .claude/metrics/
 .claude/cache/
-.map/
+
+# MAP runtime files (but keep static-analysis scripts)
+.map/*
+!.map/static-analysis/
 
 # Temporary verification files
 mapify_cli_verification_*.json

--- a/.map/static-analysis/analyze.sh
+++ b/.map/static-analysis/analyze.sh
@@ -37,12 +37,12 @@ if [[ -z "$LANGUAGE" || "$LANGUAGE" == "auto" ]]; then
     elif [[ -f "Cargo.toml" ]]; then
         LANGUAGE="rust"
     else
-        # Try to detect from file extensions
-        if ls *.py 2>/dev/null | head -1 >/dev/null; then
+        # Try to detect from file extensions using safer pattern checks
+        if compgen -G "*.py" > /dev/null; then
             LANGUAGE="python"
-        elif ls *.go 2>/dev/null | head -1 >/dev/null; then
+        elif compgen -G "*.go" > /dev/null; then
             LANGUAGE="go"
-        elif ls *.ts 2>/dev/null | head -1 >/dev/null; then
+        elif compgen -G "*.ts" > /dev/null; then
             LANGUAGE="typescript"
         else
             LANGUAGE="unknown"

--- a/.map/static-analysis/analyze.sh
+++ b/.map/static-analysis/analyze.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Static Analysis Dispatcher
+# Invokes language-specific handlers and returns normalized JSON output
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HANDLERS_DIR="${SCRIPT_DIR}/handlers"
+
+# Default values
+LANGUAGE=""
+FILES=""
+CONFIG="{}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --language) LANGUAGE="$2"; shift 2 ;;
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# Auto-detect language if not provided
+if [[ -z "$LANGUAGE" || "$LANGUAGE" == "auto" ]]; then
+    if [[ -f "pyproject.toml" || -f "requirements.txt" || -f "setup.py" ]]; then
+        LANGUAGE="python"
+    elif [[ -f "go.mod" ]]; then
+        LANGUAGE="go"
+    elif [[ -f "package.json" ]]; then
+        # Check for TypeScript
+        if [[ -f "tsconfig.json" ]]; then
+            LANGUAGE="typescript"
+        else
+            LANGUAGE="javascript"
+        fi
+    elif [[ -f "Cargo.toml" ]]; then
+        LANGUAGE="rust"
+    else
+        # Try to detect from file extensions
+        if ls *.py 2>/dev/null | head -1 >/dev/null; then
+            LANGUAGE="python"
+        elif ls *.go 2>/dev/null | head -1 >/dev/null; then
+            LANGUAGE="go"
+        elif ls *.ts 2>/dev/null | head -1 >/dev/null; then
+            LANGUAGE="typescript"
+        else
+            LANGUAGE="unknown"
+        fi
+    fi
+fi
+
+# Check if handler exists
+HANDLER="${HANDLERS_DIR}/${LANGUAGE}.sh"
+if [[ ! -x "$HANDLER" ]]; then
+    # Return JSON indicating no handler
+    cat <<EOF
+{
+    "success": false,
+    "language": "${LANGUAGE}",
+    "error": "No handler for language: ${LANGUAGE}",
+    "summary": { "total": 0, "errors": 0, "warnings": 0, "pass": true },
+    "findings": [],
+    "tools_run": []
+}
+EOF
+    exit 0
+fi
+
+# Execute handler
+"$HANDLER" --files "$FILES" --config "$CONFIG"

--- a/.map/static-analysis/analyze.sh
+++ b/.map/static-analysis/analyze.sh
@@ -50,6 +50,16 @@ if [[ -z "$LANGUAGE" || "$LANGUAGE" == "auto" ]]; then
     fi
 fi
 
+# Validate language against whitelist to prevent path traversal
+case "$LANGUAGE" in
+    python|go|javascript|typescript|rust|unknown)
+        # allowed values
+        ;;
+    *)
+        LANGUAGE="unknown"
+        ;;
+esac
+
 # Check if handler exists
 HANDLER="${HANDLERS_DIR}/${LANGUAGE}.sh"
 if [[ ! -x "$HANDLER" ]]; then

--- a/.map/static-analysis/handlers/common.sh
+++ b/.map/static-analysis/handlers/common.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Common utilities for static analysis handlers
+# Source this file at the beginning of each handler
+
+# Accumulator for findings - use array instead of repeated jq concatenation
+declare -a FINDINGS_ARRAY=()
+
+# Add findings to accumulator (avoids O(n²) concatenation)
+add_findings() {
+    local findings_json="$1"
+    if [[ -n "$findings_json" && "$findings_json" != "[]" && "$findings_json" != "null" ]]; then
+        FINDINGS_ARRAY+=("$findings_json")
+    fi
+}
+
+# Merge all findings into single JSON array
+merge_findings() {
+    if [[ ${#FINDINGS_ARRAY[@]} -eq 0 ]]; then
+        echo "[]"
+        return
+    fi
+
+    # Concatenate all arrays efficiently with jq
+    printf '%s\n' "${FINDINGS_ARRAY[@]}" | jq -s 'add // []' 2>/dev/null || echo "[]"
+}
+
+# Generate summary and output final JSON
+# Usage: generate_output "language"
+generate_output() {
+    local language="$1"
+    local all_findings
+    all_findings=$(merge_findings)
+
+    # Calculate summary
+    local error_count warning_count total_count tools_json
+    error_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
+    warning_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
+    total_count=$(echo "$all_findings" | jq 'length')
+
+    # Convert tools array to JSON (handle empty array safely)
+    if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+        tools_json=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+    else
+        tools_json="[]"
+    fi
+
+    # Output normalized JSON
+    jq -n \
+        --argjson findings "$all_findings" \
+        --argjson errors "$error_count" \
+        --argjson warnings "$warning_count" \
+        --argjson total "$total_count" \
+        --argjson tools "$tools_json" \
+        --arg language "$language" \
+        '{
+            success: true,
+            language: $language,
+            summary: {
+                total: $total,
+                errors: $errors,
+                warnings: $warnings,
+                pass: ($errors == 0)
+            },
+            findings: $findings,
+            tools_run: $tools
+        }'
+}
+
+# Safe JSON string escaping
+json_escape() {
+    local str="$1"
+    # Escape backslashes first, then quotes
+    str="${str//\\/\\\\}"
+    str="${str//\"/\\\"}"
+    str="${str//$'\t'/\\t}"
+    str="${str//$'\r'/\\r}"
+    str="${str//$'\n'/\\n}"
+    echo "$str"
+}
+
+# Parse tool output line with robust handling of colons in filenames
+# Usage: parse_line "file:line:col:message" -> sets FILE, LINE, COL, MESSAGE
+parse_colon_delimited() {
+    local input="$1"
+    local -n out_file="$2"
+    local -n out_line="$3"
+    local -n out_col="$4"
+    local -n out_msg="$5"
+
+    # Try file:line:col:message pattern first
+    if [[ "$input" =~ ^(.+):([0-9]+):([0-9]+):(.*)$ ]]; then
+        out_file="${BASH_REMATCH[1]}"
+        out_line="${BASH_REMATCH[2]}"
+        out_col="${BASH_REMATCH[3]}"
+        out_msg="${BASH_REMATCH[4]}"
+        return 0
+    fi
+
+    # Fallback to file:line:message (no column)
+    if [[ "$input" =~ ^(.+):([0-9]+):(.*)$ ]]; then
+        out_file="${BASH_REMATCH[1]}"
+        out_line="${BASH_REMATCH[2]}"
+        out_col=0
+        out_msg="${BASH_REMATCH[3]}"
+        return 0
+    fi
+
+    return 1
+}

--- a/.map/static-analysis/handlers/common.sh
+++ b/.map/static-analysis/handlers/common.sh
@@ -79,7 +79,7 @@ json_escape() {
 }
 
 # Parse tool output line with robust handling of colons in filenames
-# Usage: parse_line "file:line:col:message" -> sets FILE, LINE, COL, MESSAGE
+# Usage: parse_colon_delimited "file:line:col:message" -> sets FILE, LINE, COL, MESSAGE
 parse_colon_delimited() {
     local input="$1"
     local -n out_file="$2"

--- a/.map/static-analysis/handlers/go.sh
+++ b/.map/static-analysis/handlers/go.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Go Static Analysis Handler
+# Tools: go vet, gofmt, staticcheck (if available)
+set -euo pipefail
+
+FILES=""
+CONFIG="{}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# If no files specified, use current directory
+if [[ -z "$FILES" ]]; then
+    FILES="./..."
+fi
+
+TOOLS_RUN=()
+ALL_FINDINGS="[]"
+
+# Run go vet
+if command -v go &> /dev/null; then
+    TOOLS_RUN+=("go vet")
+    VET_OUT=$(timeout 30 go vet $FILES 2>&1 || true)
+
+    if [[ -n "$VET_OUT" ]]; then
+        VET_NORM=$(echo "$VET_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line rest; do
+            message=$(echo "$rest" | sed 's/"/\\"/g' | xargs)
+            echo "{\"tool\":\"go vet\",\"file\":\"$file\",\"line\":$line,\"column\":0,\"severity\":\"error\",\"code\":\"vet\",\"message\":\"$message\",\"fixable\":false}"
+        done | jq -s '.' 2>/dev/null || echo "[]")
+
+        if [[ -n "$VET_NORM" && "$VET_NORM" != "null" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $VET_NORM" | jq -s 'add // []')
+        fi
+    fi
+fi
+
+# Run gofmt check
+if command -v gofmt &> /dev/null; then
+    TOOLS_RUN+=("gofmt")
+    # gofmt -l lists files that need formatting
+    if [[ "$FILES" == "./..." ]]; then
+        FMT_FILES=$(find . -name "*.go" -not -path "./vendor/*" 2>/dev/null || true)
+    else
+        FMT_FILES="$FILES"
+    fi
+
+    if [[ -n "$FMT_FILES" ]]; then
+        FMT_OUT=$(echo "$FMT_FILES" | xargs gofmt -l 2>/dev/null || true)
+
+        if [[ -n "$FMT_OUT" ]]; then
+            FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+                echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
+            done | jq -s '.' 2>/dev/null || echo "[]")
+
+            if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
+                ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
+            fi
+        fi
+    fi
+fi
+
+# Run staticcheck (if available)
+if command -v staticcheck &> /dev/null; then
+    TOOLS_RUN+=("staticcheck")
+    SC_OUT=$(timeout 60 staticcheck -f json $FILES 2>/dev/null || echo "")
+
+    if [[ -n "$SC_OUT" ]]; then
+        SC_NORM=$(echo "$SC_OUT" | jq -c '{
+            tool: "staticcheck",
+            file: .location.file,
+            line: .location.line,
+            column: .location.column,
+            severity: (if .severity == "error" then "error" else "warning" end),
+            code: .code,
+            message: .message,
+            fixable: false
+        }' 2>/dev/null | jq -s '.' || echo "[]")
+
+        if [[ -n "$SC_NORM" && "$SC_NORM" != "null" && "$SC_NORM" != "[]" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $SC_NORM" | jq -s 'add // []')
+        fi
+    fi
+fi
+
+# Calculate summary
+ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
+WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
+TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
+
+# Convert tools array to JSON
+TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+
+# Output normalized JSON
+jq -n \
+    --argjson findings "$ALL_FINDINGS" \
+    --argjson errors "$ERROR_COUNT" \
+    --argjson warnings "$WARNING_COUNT" \
+    --argjson total "$TOTAL_COUNT" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+        success: true,
+        language: "go",
+        summary: {
+            total: $total,
+            errors: $errors,
+            warnings: $warnings,
+            pass: ($errors == 0)
+        },
+        findings: $findings,
+        tools_run: $tools
+    }'

--- a/.map/static-analysis/handlers/go.sh
+++ b/.map/static-analysis/handlers/go.sh
@@ -25,7 +25,7 @@ ALL_FINDINGS="[]"
 # Run go vet
 if command -v go &> /dev/null; then
     TOOLS_RUN+=("go vet")
-    VET_OUT=$(timeout 30 go vet $FILES 2>&1 || true)
+    VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
         VET_NORM=$(echo "$VET_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line rest; do
@@ -44,22 +44,19 @@ if command -v gofmt &> /dev/null; then
     TOOLS_RUN+=("gofmt")
     # gofmt -l lists files that need formatting
     if [[ "$FILES" == "./..." ]]; then
-        FMT_FILES=$(find . -name "*.go" -not -path "./vendor/*" 2>/dev/null || true)
+        # Use null-delimited output from find to safely handle filenames with spaces
+        FMT_OUT=$(find . -name "*.go" -not -path "./vendor/*" -print0 2>/dev/null | xargs -0 gofmt -l 2>/dev/null || true)
     else
-        FMT_FILES="$FILES"
+        FMT_OUT=$(gofmt -l "$FILES" 2>/dev/null || true)
     fi
 
-    if [[ -n "$FMT_FILES" ]]; then
-        FMT_OUT=$(echo "$FMT_FILES" | xargs gofmt -l 2>/dev/null || true)
+    if [[ -n "$FMT_OUT" ]]; then
+        FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+            echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
+        done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$FMT_OUT" ]]; then
-            FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
-                echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
-            done | jq -s '.' 2>/dev/null || echo "[]")
-
-            if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
-                ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
-            fi
+        if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
         fi
     fi
 fi
@@ -67,10 +64,12 @@ fi
 # Run staticcheck (if available)
 if command -v staticcheck &> /dev/null; then
     TOOLS_RUN+=("staticcheck")
-    SC_OUT=$(timeout 60 staticcheck -f json $FILES 2>/dev/null || echo "")
+    SC_OUT=$(timeout 60 staticcheck -f json "$FILES" 2>/dev/null || echo "")
 
     if [[ -n "$SC_OUT" ]]; then
-        SC_NORM=$(echo "$SC_OUT" | jq -c '{
+        # staticcheck outputs NDJSON (one JSON object per line)
+        # Use jq -s to slurp all objects into an array, then transform each
+        SC_NORM=$(echo "$SC_OUT" | jq -s '[.[] | {
             tool: "staticcheck",
             file: .location.file,
             line: .location.line,
@@ -79,7 +78,7 @@ if command -v staticcheck &> /dev/null; then
             code: .code,
             message: .message,
             fixable: false
-        }' 2>/dev/null | jq -s '.' || echo "[]")
+        }]' 2>/dev/null || echo "[]")
 
         if [[ -n "$SC_NORM" && "$SC_NORM" != "null" && "$SC_NORM" != "[]" ]]; then
             ALL_FINDINGS=$(echo "$ALL_FINDINGS $SC_NORM" | jq -s 'add // []')
@@ -92,8 +91,12 @@ ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | le
 WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
 TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
 
-# Convert tools array to JSON
-TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+# Convert tools array to JSON (handle empty array safely)
+if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+else
+    TOOLS_JSON="[]"
+fi
 
 # Output normalized JSON
 jq -n \

--- a/.map/static-analysis/handlers/go.sh
+++ b/.map/static-analysis/handlers/go.sh
@@ -56,7 +56,7 @@ if command -v gofmt &> /dev/null; then
     fi
 
     if [[ -n "$FMT_OUT" ]]; then
-        FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+        FMT_NORM=$(echo "$FMT_OUT" | while IFS= read -r file; do
             file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")

--- a/.map/static-analysis/handlers/go.sh
+++ b/.map/static-analysis/handlers/go.sh
@@ -3,6 +3,9 @@
 # Tools: go vet, gofmt, staticcheck (if available)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 FILES=""
 CONFIG="{}"
 
@@ -20,7 +23,6 @@ if [[ -z "$FILES" ]]; then
 fi
 
 TOOLS_RUN=()
-ALL_FINDINGS="[]"
 
 # Run go vet
 if command -v go &> /dev/null; then
@@ -28,14 +30,17 @@ if command -v go &> /dev/null; then
     VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
-        VET_NORM=$(echo "$VET_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line rest; do
-            message=$(echo "$rest" | sed 's/"/\\"/g' | xargs)
-            echo "{\"tool\":\"go vet\",\"file\":\"$file\",\"line\":$line,\"column\":0,\"severity\":\"error\",\"code\":\"vet\",\"message\":\"$message\",\"fixable\":false}"
+        VET_NORM=$(echo "$VET_OUT" | while IFS= read -r line; do
+            local file lineno col msg
+            if parse_colon_delimited "$line" file lineno col msg; then
+                msg="${msg# }"
+                msg=$(json_escape "$msg")
+                file=$(json_escape "$file")
+                echo "{\"tool\":\"go vet\",\"file\":\"$file\",\"line\":$lineno,\"column\":$col,\"severity\":\"error\",\"code\":\"vet\",\"message\":\"$msg\",\"fixable\":false}"
+            fi
         done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$VET_NORM" && "$VET_NORM" != "null" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $VET_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$VET_NORM"
     fi
 fi
 
@@ -52,12 +57,11 @@ if command -v gofmt &> /dev/null; then
 
     if [[ -n "$FMT_OUT" ]]; then
         FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+            file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$FMT_NORM"
     fi
 fi
 
@@ -80,40 +84,9 @@ if command -v staticcheck &> /dev/null; then
             fixable: false
         }]' 2>/dev/null || echo "[]")
 
-        if [[ -n "$SC_NORM" && "$SC_NORM" != "null" && "$SC_NORM" != "[]" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $SC_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$SC_NORM"
     fi
 fi
 
-# Calculate summary
-ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
-WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
-TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-
-# Convert tools array to JSON (handle empty array safely)
-if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
-    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
-else
-    TOOLS_JSON="[]"
-fi
-
-# Output normalized JSON
-jq -n \
-    --argjson findings "$ALL_FINDINGS" \
-    --argjson errors "$ERROR_COUNT" \
-    --argjson warnings "$WARNING_COUNT" \
-    --argjson total "$TOTAL_COUNT" \
-    --argjson tools "$TOOLS_JSON" \
-    '{
-        success: true,
-        language: "go",
-        summary: {
-            total: $total,
-            errors: $errors,
-            warnings: $warnings,
-            pass: ($errors == 0)
-        },
-        findings: $findings,
-        tools_run: $tools
-    }'
+# Generate output using common function
+generate_output "go"

--- a/.map/static-analysis/handlers/python.sh
+++ b/.map/static-analysis/handlers/python.sh
@@ -3,6 +3,9 @@
 # Tools: ruff (linting), mypy (type checking)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 FILES=""
 CONFIG="{}"
 
@@ -20,7 +23,6 @@ if [[ -z "$FILES" ]]; then
 fi
 
 TOOLS_RUN=()
-ALL_FINDINGS="[]"
 
 # Run ruff (if available)
 if command -v ruff &> /dev/null; then
@@ -40,7 +42,7 @@ if command -v ruff &> /dev/null; then
             fixable: (.fix != null)
         }]' 2>/dev/null || echo "[]")
 
-        ALL_FINDINGS=$(echo "$ALL_FINDINGS $RUFF_NORM" | jq -s 'add // []')
+        add_findings "$RUFF_NORM"
     fi
 fi
 
@@ -49,53 +51,30 @@ if command -v mypy &> /dev/null; then
     TOOLS_RUN+=("mypy")
     MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary "$FILES" 2>&1 || true)
 
-    # Parse mypy text output to JSON
+    # Parse mypy text output to JSON using robust parsing
     if [[ -n "$MYPY_OUT" ]]; then
-        MYPY_NORM=$(echo "$MYPY_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line col rest; do
-            # Determine severity from message
-            if echo "$rest" | grep -q "error:"; then
-                severity="error"
-            else
-                severity="warning"
+        MYPY_NORM=$(echo "$MYPY_OUT" | while IFS= read -r line; do
+            local file lineno col msg
+            if parse_colon_delimited "$line" file lineno col msg; then
+                # Determine severity from message
+                local severity="warning"
+                if [[ "$msg" == *"error:"* ]]; then
+                    severity="error"
+                fi
+                # Clean up message
+                msg="${msg# }"
+                msg="${msg#error: }"
+                msg="${msg#note: }"
+                msg=$(json_escape "$msg")
+                file=$(json_escape "$file")
+
+                echo "{\"tool\":\"mypy\",\"file\":\"$file\",\"line\":$lineno,\"column\":$col,\"severity\":\"$severity\",\"code\":\"mypy\",\"message\":\"$msg\",\"fixable\":false}"
             fi
-            message=$(echo "$rest" | sed 's/^ *error: //' | sed 's/^ *note: //' | sed 's/"/\\"/g')
-            echo "{\"tool\":\"mypy\",\"file\":\"$file\",\"line\":$line,\"column\":${col:-0},\"severity\":\"$severity\",\"code\":\"mypy\",\"message\":\"$message\",\"fixable\":false}"
         done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$MYPY_NORM" && "$MYPY_NORM" != "null" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $MYPY_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$MYPY_NORM"
     fi
 fi
 
-# Calculate summary
-ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
-WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
-TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-
-# Convert tools array to JSON (handle empty array safely)
-if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
-    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
-else
-    TOOLS_JSON="[]"
-fi
-
-# Output normalized JSON
-jq -n \
-    --argjson findings "$ALL_FINDINGS" \
-    --argjson errors "$ERROR_COUNT" \
-    --argjson warnings "$WARNING_COUNT" \
-    --argjson total "$TOTAL_COUNT" \
-    --argjson tools "$TOOLS_JSON" \
-    '{
-        success: true,
-        language: "python",
-        summary: {
-            total: $total,
-            errors: $errors,
-            warnings: $warnings,
-            pass: ($errors == 0)
-        },
-        findings: $findings,
-        tools_run: $tools
-    }'
+# Generate output using common function
+generate_output "python"

--- a/.map/static-analysis/handlers/python.sh
+++ b/.map/static-analysis/handlers/python.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Python Static Analysis Handler
+# Tools: ruff (linting), mypy (type checking)
+set -euo pipefail
+
+FILES=""
+CONFIG="{}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# If no files specified, use current directory
+if [[ -z "$FILES" ]]; then
+    FILES="."
+fi
+
+TOOLS_RUN=()
+ALL_FINDINGS="[]"
+
+# Run ruff (if available)
+if command -v ruff &> /dev/null; then
+    TOOLS_RUN+=("ruff")
+    RUFF_OUT=$(timeout 30 ruff check --output-format=json $FILES 2>/dev/null || echo "[]")
+
+    # Normalize ruff output to standard format
+    if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
+        RUFF_NORM=$(echo "$RUFF_OUT" | jq -c '[.[] | {
+            tool: "ruff",
+            file: .filename,
+            line: .location.row,
+            column: .location.column,
+            severity: (if .code | startswith("F") then "error" elif .code | startswith("E") then "error" else "warning" end),
+            code: .code,
+            message: .message,
+            fixable: (.fix != null)
+        }]' 2>/dev/null || echo "[]")
+
+        ALL_FINDINGS=$(echo "$ALL_FINDINGS $RUFF_NORM" | jq -s 'add // []')
+    fi
+fi
+
+# Run mypy (if available)
+if command -v mypy &> /dev/null; then
+    TOOLS_RUN+=("mypy")
+    MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary $FILES 2>&1 || true)
+
+    # Parse mypy text output to JSON
+    if [[ -n "$MYPY_OUT" ]]; then
+        MYPY_NORM=$(echo "$MYPY_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line col rest; do
+            # Determine severity from message
+            if echo "$rest" | grep -q "error:"; then
+                severity="error"
+            else
+                severity="warning"
+            fi
+            message=$(echo "$rest" | sed 's/^ *error: //' | sed 's/^ *note: //' | sed 's/"/\\"/g')
+            echo "{\"tool\":\"mypy\",\"file\":\"$file\",\"line\":$line,\"column\":${col:-0},\"severity\":\"$severity\",\"code\":\"mypy\",\"message\":\"$message\",\"fixable\":false}"
+        done | jq -s '.' 2>/dev/null || echo "[]")
+
+        if [[ -n "$MYPY_NORM" && "$MYPY_NORM" != "null" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $MYPY_NORM" | jq -s 'add // []')
+        fi
+    fi
+fi
+
+# Calculate summary
+ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
+WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
+TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
+
+# Convert tools array to JSON
+TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+
+# Output normalized JSON
+jq -n \
+    --argjson findings "$ALL_FINDINGS" \
+    --argjson errors "$ERROR_COUNT" \
+    --argjson warnings "$WARNING_COUNT" \
+    --argjson total "$TOTAL_COUNT" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+        success: true,
+        language: "python",
+        summary: {
+            total: $total,
+            errors: $errors,
+            warnings: $warnings,
+            pass: ($errors == 0)
+        },
+        findings: $findings,
+        tools_run: $tools
+    }'

--- a/.map/static-analysis/handlers/python.sh
+++ b/.map/static-analysis/handlers/python.sh
@@ -25,7 +25,7 @@ ALL_FINDINGS="[]"
 # Run ruff (if available)
 if command -v ruff &> /dev/null; then
     TOOLS_RUN+=("ruff")
-    RUFF_OUT=$(timeout 30 ruff check --output-format=json $FILES 2>/dev/null || echo "[]")
+    RUFF_OUT=$(timeout 30 ruff check --output-format=json "$FILES" 2>/dev/null || echo "[]")
 
     # Normalize ruff output to standard format
     if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
@@ -47,7 +47,7 @@ fi
 # Run mypy (if available)
 if command -v mypy &> /dev/null; then
     TOOLS_RUN+=("mypy")
-    MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary $FILES 2>&1 || true)
+    MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary "$FILES" 2>&1 || true)
 
     # Parse mypy text output to JSON
     if [[ -n "$MYPY_OUT" ]]; then
@@ -73,8 +73,12 @@ ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | le
 WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
 TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
 
-# Convert tools array to JSON
-TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+# Convert tools array to JSON (handle empty array safely)
+if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+else
+    TOOLS_JSON="[]"
+fi
 
 # Output normalized JSON
 jq -n \

--- a/.map/static-analysis/handlers/typescript.sh
+++ b/.map/static-analysis/handlers/typescript.sh
@@ -30,7 +30,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
     fi
 
     TOOLS_RUN+=("eslint")
-    ESLINT_OUT=$(timeout 60 $ESLINT_CMD --format json $FILES 2>/dev/null || echo "[]")
+    ESLINT_OUT=$(timeout 60 "$ESLINT_CMD" --format json "$FILES" 2>/dev/null || echo "[]")
 
     if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
         ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
@@ -55,9 +55,9 @@ if [[ -f "tsconfig.json" ]]; then
         TSC_CMD="./node_modules/.bin/tsc"
     fi
 
-    if command -v $TSC_CMD &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
+    if command -v "$TSC_CMD" &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
         TOOLS_RUN+=("tsc")
-        TSC_OUT=$(timeout 60 $TSC_CMD --noEmit --pretty false 2>&1 || true)
+        TSC_OUT=$(timeout 60 "$TSC_CMD" --noEmit --pretty false 2>&1 || true)
 
         if [[ -n "$TSC_OUT" ]]; then
             TSC_NORM=$(echo "$TSC_OUT" | grep -E "^[^(]+\([0-9]+,[0-9]+\):" | while read -r line; do

--- a/.map/static-analysis/handlers/typescript.sh
+++ b/.map/static-analysis/handlers/typescript.sh
@@ -3,6 +3,9 @@
 # Tools: eslint, tsc (TypeScript compiler)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 FILES=""
 CONFIG="{}"
 
@@ -20,7 +23,6 @@ if [[ -z "$FILES" ]]; then
 fi
 
 TOOLS_RUN=()
-ALL_FINDINGS="[]"
 
 # Run eslint (if available)
 if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
@@ -44,7 +46,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
             fixable: (.fix != null)
         }]' 2>/dev/null || echo "[]")
 
-        ALL_FINDINGS=$(echo "$ALL_FINDINGS $ESLINT_NORM" | jq -s 'add // []')
+        add_findings "$ESLINT_NORM"
     fi
 fi
 
@@ -60,52 +62,26 @@ if [[ -f "tsconfig.json" ]]; then
         TSC_OUT=$(timeout 60 "$TSC_CMD" --noEmit --pretty false 2>&1 || true)
 
         if [[ -n "$TSC_OUT" ]]; then
-            TSC_NORM=$(echo "$TSC_OUT" | grep -E "^[^(]+\([0-9]+,[0-9]+\):" | while read -r line; do
-                # Parse format: file(line,col): error TSxxxx: message
-                file=$(echo "$line" | sed -E 's/\([0-9]+,[0-9]+\):.*//')
-                linenum=$(echo "$line" | sed -E 's/.*\(([0-9]+),[0-9]+\):.*/\1/')
-                col=$(echo "$line" | sed -E 's/.*\([0-9]+,([0-9]+)\):.*/\1/')
-                code=$(echo "$line" | sed -E 's/.*: (error TS[0-9]+):.*/\1/' | tr -d ' ')
-                message=$(echo "$line" | sed -E 's/.*: error TS[0-9]+: //' | sed 's/"/\\"/g')
+            # Parse format: file(line,col): error TSxxxx: message
+            TSC_NORM=$(echo "$TSC_OUT" | while IFS= read -r line; do
+                if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ error\ (TS[0-9]+):\ (.*)$ ]]; then
+                    local file="${BASH_REMATCH[1]}"
+                    local linenum="${BASH_REMATCH[2]}"
+                    local col="${BASH_REMATCH[3]}"
+                    local code="${BASH_REMATCH[4]}"
+                    local message="${BASH_REMATCH[5]}"
 
-                echo "{\"tool\":\"tsc\",\"file\":\"$file\",\"line\":$linenum,\"column\":$col,\"severity\":\"error\",\"code\":\"$code\",\"message\":\"$message\",\"fixable\":false}"
+                    file=$(json_escape "$file")
+                    message=$(json_escape "$message")
+
+                    echo "{\"tool\":\"tsc\",\"file\":\"$file\",\"line\":$linenum,\"column\":$col,\"severity\":\"error\",\"code\":\"$code\",\"message\":\"$message\",\"fixable\":false}"
+                fi
             done | jq -s '.' 2>/dev/null || echo "[]")
 
-            if [[ -n "$TSC_NORM" && "$TSC_NORM" != "null" ]]; then
-                ALL_FINDINGS=$(echo "$ALL_FINDINGS $TSC_NORM" | jq -s 'add // []')
-            fi
+            add_findings "$TSC_NORM"
         fi
     fi
 fi
 
-# Calculate summary
-ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
-WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
-TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-
-# Convert tools array to JSON
-if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
-    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
-else
-    TOOLS_JSON="[]"
-fi
-
-# Output normalized JSON
-jq -n \
-    --argjson findings "$ALL_FINDINGS" \
-    --argjson errors "$ERROR_COUNT" \
-    --argjson warnings "$WARNING_COUNT" \
-    --argjson total "$TOTAL_COUNT" \
-    --argjson tools "$TOOLS_JSON" \
-    '{
-        success: true,
-        language: "typescript",
-        summary: {
-            total: $total,
-            errors: $errors,
-            warnings: $warnings,
-            pass: ($errors == 0)
-        },
-        findings: $findings,
-        tools_run: $tools
-    }'
+# Generate output using common function
+generate_output "typescript"

--- a/.map/static-analysis/handlers/typescript.sh
+++ b/.map/static-analysis/handlers/typescript.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# TypeScript/JavaScript Static Analysis Handler
+# Tools: eslint, tsc (TypeScript compiler)
+set -euo pipefail
+
+FILES=""
+CONFIG="{}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# If no files specified, use current directory
+if [[ -z "$FILES" ]]; then
+    FILES="."
+fi
+
+TOOLS_RUN=()
+ALL_FINDINGS="[]"
+
+# Run eslint (if available)
+if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
+    ESLINT_CMD="eslint"
+    if [[ -x "./node_modules/.bin/eslint" ]]; then
+        ESLINT_CMD="./node_modules/.bin/eslint"
+    fi
+
+    TOOLS_RUN+=("eslint")
+    ESLINT_OUT=$(timeout 60 $ESLINT_CMD --format json $FILES 2>/dev/null || echo "[]")
+
+    if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
+        ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
+            tool: "eslint",
+            file: $file,
+            line: .line,
+            column: .column,
+            severity: (if .severity == 2 then "error" else "warning" end),
+            code: (.ruleId // "eslint"),
+            message: .message,
+            fixable: (.fix != null)
+        }]' 2>/dev/null || echo "[]")
+
+        ALL_FINDINGS=$(echo "$ALL_FINDINGS $ESLINT_NORM" | jq -s 'add // []')
+    fi
+fi
+
+# Run tsc type checking (if tsconfig.json exists)
+if [[ -f "tsconfig.json" ]]; then
+    TSC_CMD="tsc"
+    if [[ -x "./node_modules/.bin/tsc" ]]; then
+        TSC_CMD="./node_modules/.bin/tsc"
+    fi
+
+    if command -v $TSC_CMD &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
+        TOOLS_RUN+=("tsc")
+        TSC_OUT=$(timeout 60 $TSC_CMD --noEmit --pretty false 2>&1 || true)
+
+        if [[ -n "$TSC_OUT" ]]; then
+            TSC_NORM=$(echo "$TSC_OUT" | grep -E "^[^(]+\([0-9]+,[0-9]+\):" | while read -r line; do
+                # Parse format: file(line,col): error TSxxxx: message
+                file=$(echo "$line" | sed -E 's/\([0-9]+,[0-9]+\):.*//')
+                linenum=$(echo "$line" | sed -E 's/.*\(([0-9]+),[0-9]+\):.*/\1/')
+                col=$(echo "$line" | sed -E 's/.*\([0-9]+,([0-9]+)\):.*/\1/')
+                code=$(echo "$line" | sed -E 's/.*: (error TS[0-9]+):.*/\1/' | tr -d ' ')
+                message=$(echo "$line" | sed -E 's/.*: error TS[0-9]+: //' | sed 's/"/\\"/g')
+
+                echo "{\"tool\":\"tsc\",\"file\":\"$file\",\"line\":$linenum,\"column\":$col,\"severity\":\"error\",\"code\":\"$code\",\"message\":\"$message\",\"fixable\":false}"
+            done | jq -s '.' 2>/dev/null || echo "[]")
+
+            if [[ -n "$TSC_NORM" && "$TSC_NORM" != "null" ]]; then
+                ALL_FINDINGS=$(echo "$ALL_FINDINGS $TSC_NORM" | jq -s 'add // []')
+            fi
+        fi
+    fi
+fi
+
+# Calculate summary
+ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
+WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
+TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
+
+# Convert tools array to JSON
+if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+else
+    TOOLS_JSON="[]"
+fi
+
+# Output normalized JSON
+jq -n \
+    --argjson findings "$ALL_FINDINGS" \
+    --argjson errors "$ERROR_COUNT" \
+    --argjson warnings "$WARNING_COUNT" \
+    --argjson total "$TOTAL_COUNT" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+        success: true,
+        language: "typescript",
+        summary: {
+            total: $total,
+            errors: $errors,
+            warnings: $warnings,
+            pass: ($errors == 0)
+        },
+        findings: $findings,
+        tools_run: $tools
+    }'

--- a/.map/static-analysis/handlers/typescript.sh
+++ b/.map/static-analysis/handlers/typescript.sh
@@ -57,7 +57,7 @@ if [[ -f "tsconfig.json" ]]; then
         TSC_CMD="./node_modules/.bin/tsc"
     fi
 
-    if command -v "$TSC_CMD" &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
+    if [[ -x "./node_modules/.bin/tsc" ]] || command -v tsc &> /dev/null; then
         TOOLS_RUN+=("tsc")
         TSC_OUT=$(timeout 60 "$TSC_CMD" --noEmit --pretty false 2>&1 || true)
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -1181,8 +1181,13 @@ def create_map_tools(project_path: Path) -> int:
         if static_analysis_src.exists():
             static_analysis_dest = map_dir / "static-analysis"
             if static_analysis_dest.exists():
-                shutil.rmtree(static_analysis_dest)
-            shutil.copytree(static_analysis_src, static_analysis_dest)
+                try:
+                    shutil.rmtree(static_analysis_dest)
+                except (OSError, PermissionError) as e:
+                    # Log warning but continue - old scripts may be in use
+                    import sys
+                    print(f"Warning: Could not remove existing {static_analysis_dest}: {e}", file=sys.stderr)
+            shutil.copytree(static_analysis_src, static_analysis_dest, dirs_exist_ok=True)
             # Make scripts executable
             for script in static_analysis_dest.rglob("*.sh"):
                 script.chmod(script.stat().st_mode | 0o755)

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -1163,6 +1163,34 @@ def create_skill_files(project_path: Path) -> int:
     return count
 
 
+def create_map_tools(project_path: Path) -> int:
+    """Create .map/ directory with static analysis tools."""
+    import shutil
+
+    map_dir = project_path / ".map"
+    map_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get templates directory
+    templates_dir = get_templates_dir()
+    map_template_dir = templates_dir / "map"
+
+    count = 0
+    if map_template_dir.exists():
+        # Copy static-analysis directory
+        static_analysis_src = map_template_dir / "static-analysis"
+        if static_analysis_src.exists():
+            static_analysis_dest = map_dir / "static-analysis"
+            if static_analysis_dest.exists():
+                shutil.rmtree(static_analysis_dest)
+            shutil.copytree(static_analysis_src, static_analysis_dest)
+            # Make scripts executable
+            for script in static_analysis_dest.rglob("*.sh"):
+                script.chmod(script.stat().st_mode | 0o755)
+                count += 1
+
+    return count
+
+
 def configure_global_permissions() -> None:
     """Configure global Claude Code permissions for read-only commands"""
     claude_dir = Path.home() / ".claude"
@@ -1934,6 +1962,12 @@ def init(
     skill_count = create_skill_files(project_path)
     skill_word = "skill" if skill_count == 1 else "skills"
     tracker.complete("create-skills", f"{skill_count} {skill_word}")
+
+    tracker.add("create-map-tools", "Create MAP tools")
+    tracker.start("create-map-tools")
+    tool_count = create_map_tools(project_path)
+    tool_word = "script" if tool_count == 1 else "scripts"
+    tracker.complete("create-map-tools", f"{tool_count} {tool_word}")
 
     if selected_mcp_servers:
         # Create internal MCP config (for MAP Framework agent mappings)

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -38,6 +38,8 @@ You are a meticulous code reviewer and security expert with 10+ years of experie
 | `{{playbook_bullets}}` | array | `[]` | Learned patterns from previous reviews |
 | `{{feedback}}` | array | `[]` | Previous review findings to verify |
 | `{{loc_count}}` | number | `null` | Lines of code count (for large change handling) |
+| `{{enable_static_analysis}}` | boolean | `true` | Enable/disable static analysis tool execution |
+| `{{static_analysis_config}}` | object | `{}` | Language-specific static analysis tool options |
 
 ### Missing Placeholder Behavior
 
@@ -65,6 +67,14 @@ IF {{review_mode}} missing:
 IF {{loc_count}} missing:
   → Estimate from {{solution}} line count using rules below
   → Use estimated value for large change threshold checks
+
+IF {{enable_static_analysis}} missing:
+  → Default to true
+  → Execute language-appropriate static analysis tools
+
+IF {{static_analysis_config}} missing:
+  → Default to {} (empty object)
+  → Use language-specific defaults (see Static Analysis Configuration)
 ```
 
 ### LOC Estimation Rules
@@ -99,6 +109,53 @@ ESTIMATION CONFIDENCE:
 - Always round UP to nearest 50 for threshold comparisons
 ```
 
+### Static Analysis (External Scripts)
+
+When `{{enable_static_analysis}} == true`, Monitor invokes external static analysis tools via the dispatcher script. This keeps the agent template lean while supporting multiple languages.
+
+#### Invocation
+
+```bash
+{{#if enable_static_analysis}}
+.map/static-analysis/analyze.sh \
+    --language "{{language}}" \
+    --files "{{changed_files}}" \
+    --config "{{static_analysis_config}}"
+{{/if}}
+```
+
+#### Script Output (Normalized JSON)
+
+All language handlers produce a standardized JSON format:
+
+```json
+{
+  "success": true,
+  "language": "python",
+  "summary": { "total": 5, "errors": 2, "warnings": 3, "pass": false },
+  "findings": [
+    { "tool": "ruff", "file": "src/main.py", "line": 42, "severity": "error", "code": "F821", "message": "Undefined name" }
+  ],
+  "tools_run": ["ruff", "mypy"]
+}
+```
+
+#### Integration with Review
+
+```
+IF script returns summary.pass == false:
+  → Add all findings to issues array with appropriate severity
+  → Set valid = false if errors > 0
+
+IF script returns success == false:
+  → Log warning: "Static analysis failed: {error}"
+  → Continue with manual review (don't block)
+
+IF script not found or {{enable_static_analysis}} == false:
+  → Skip static analysis phase
+  → Note in output: "Static analysis skipped"
+```
+
 ### Configuration Example
 
 ```json
@@ -113,7 +170,15 @@ ESTIMATION CONFIDENCE:
   "playbook_bullets": [
     "Always validate JWT expiry in auth middleware",
     "Use parameterized queries for all database operations"
-  ]
+  ],
+  "enable_static_analysis": true,
+  "static_analysis_config": {
+    "timeout_seconds": 30,
+    "typescript": {
+      "eslint_config": ".eslintrc.json",
+      "tsc_flags": "--noEmit --strict"
+    }
+  }
 }
 ```
 
@@ -128,9 +193,10 @@ Execute review in this exact sequence:
 
 ```
 PHASE 1: BASELINE (ALWAYS)
-1. Read context & requirements completely
-2. Call request_review with summary + focus_areas
-3. Record AI findings as baseline issues
+1. Detect language from {{language}} placeholder or infer from code syntax
+2. Read context & requirements completely
+3. Call request_review with summary + focus_areas
+4. Record AI findings as baseline issues
 
 PHASE 2: AUGMENTATION (CONDITIONAL)
 IF code uses external libraries:
@@ -141,11 +207,14 @@ IF similar code reviewed before:
   → Run cipher_memory_search with pattern query
 IF code modifies shared functions:
   → Run cipher_search_graph + get_neighbors for impact
+IF detected_language != "unknown":
+  → Consider language-specific static analysis tools
 
 PHASE 3: MANUAL VALIDATION (ALWAYS)
 Work through ALL 10 dimensions systematically
 Add issues not caught by MCP tools
 Check dimensions even if early issues found
+Apply language-specific validation rules
 
 PHASE 4: SYNTHESIS
 Deduplicate issues across MCP tools + manual review
@@ -158,6 +227,7 @@ Verify JSON is valid (no syntax errors)
 Confirm all required fields present
 Check valid=true/false matches decision rules
 Ensure no markdown wrapping around JSON
+Include detected_language in metadata
 ```
 
 </review_workflow>

--- a/src/mapify_cli/templates/map/static-analysis/analyze.sh
+++ b/src/mapify_cli/templates/map/static-analysis/analyze.sh
@@ -37,12 +37,12 @@ if [[ -z "$LANGUAGE" || "$LANGUAGE" == "auto" ]]; then
     elif [[ -f "Cargo.toml" ]]; then
         LANGUAGE="rust"
     else
-        # Try to detect from file extensions
-        if ls *.py 2>/dev/null | head -1 >/dev/null; then
+        # Try to detect from file extensions using safer pattern checks
+        if compgen -G "*.py" > /dev/null; then
             LANGUAGE="python"
-        elif ls *.go 2>/dev/null | head -1 >/dev/null; then
+        elif compgen -G "*.go" > /dev/null; then
             LANGUAGE="go"
-        elif ls *.ts 2>/dev/null | head -1 >/dev/null; then
+        elif compgen -G "*.ts" > /dev/null; then
             LANGUAGE="typescript"
         else
             LANGUAGE="unknown"

--- a/src/mapify_cli/templates/map/static-analysis/analyze.sh
+++ b/src/mapify_cli/templates/map/static-analysis/analyze.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Static Analysis Dispatcher
+# Invokes language-specific handlers and returns normalized JSON output
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HANDLERS_DIR="${SCRIPT_DIR}/handlers"
+
+# Default values
+LANGUAGE=""
+FILES=""
+CONFIG="{}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --language) LANGUAGE="$2"; shift 2 ;;
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# Auto-detect language if not provided
+if [[ -z "$LANGUAGE" || "$LANGUAGE" == "auto" ]]; then
+    if [[ -f "pyproject.toml" || -f "requirements.txt" || -f "setup.py" ]]; then
+        LANGUAGE="python"
+    elif [[ -f "go.mod" ]]; then
+        LANGUAGE="go"
+    elif [[ -f "package.json" ]]; then
+        # Check for TypeScript
+        if [[ -f "tsconfig.json" ]]; then
+            LANGUAGE="typescript"
+        else
+            LANGUAGE="javascript"
+        fi
+    elif [[ -f "Cargo.toml" ]]; then
+        LANGUAGE="rust"
+    else
+        # Try to detect from file extensions
+        if ls *.py 2>/dev/null | head -1 >/dev/null; then
+            LANGUAGE="python"
+        elif ls *.go 2>/dev/null | head -1 >/dev/null; then
+            LANGUAGE="go"
+        elif ls *.ts 2>/dev/null | head -1 >/dev/null; then
+            LANGUAGE="typescript"
+        else
+            LANGUAGE="unknown"
+        fi
+    fi
+fi
+
+# Check if handler exists
+HANDLER="${HANDLERS_DIR}/${LANGUAGE}.sh"
+if [[ ! -x "$HANDLER" ]]; then
+    # Return JSON indicating no handler
+    cat <<EOF
+{
+    "success": false,
+    "language": "${LANGUAGE}",
+    "error": "No handler for language: ${LANGUAGE}",
+    "summary": { "total": 0, "errors": 0, "warnings": 0, "pass": true },
+    "findings": [],
+    "tools_run": []
+}
+EOF
+    exit 0
+fi
+
+# Execute handler
+"$HANDLER" --files "$FILES" --config "$CONFIG"

--- a/src/mapify_cli/templates/map/static-analysis/analyze.sh
+++ b/src/mapify_cli/templates/map/static-analysis/analyze.sh
@@ -50,6 +50,16 @@ if [[ -z "$LANGUAGE" || "$LANGUAGE" == "auto" ]]; then
     fi
 fi
 
+# Validate language against whitelist to prevent path traversal
+case "$LANGUAGE" in
+    python|go|javascript|typescript|rust|unknown)
+        # allowed values
+        ;;
+    *)
+        LANGUAGE="unknown"
+        ;;
+esac
+
 # Check if handler exists
 HANDLER="${HANDLERS_DIR}/${LANGUAGE}.sh"
 if [[ ! -x "$HANDLER" ]]; then

--- a/src/mapify_cli/templates/map/static-analysis/handlers/common.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/common.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Common utilities for static analysis handlers
+# Source this file at the beginning of each handler
+
+# Accumulator for findings - use array instead of repeated jq concatenation
+declare -a FINDINGS_ARRAY=()
+
+# Add findings to accumulator (avoids O(n²) concatenation)
+add_findings() {
+    local findings_json="$1"
+    if [[ -n "$findings_json" && "$findings_json" != "[]" && "$findings_json" != "null" ]]; then
+        FINDINGS_ARRAY+=("$findings_json")
+    fi
+}
+
+# Merge all findings into single JSON array
+merge_findings() {
+    if [[ ${#FINDINGS_ARRAY[@]} -eq 0 ]]; then
+        echo "[]"
+        return
+    fi
+
+    # Concatenate all arrays efficiently with jq
+    printf '%s\n' "${FINDINGS_ARRAY[@]}" | jq -s 'add // []' 2>/dev/null || echo "[]"
+}
+
+# Generate summary and output final JSON
+# Usage: generate_output "language"
+generate_output() {
+    local language="$1"
+    local all_findings
+    all_findings=$(merge_findings)
+
+    # Calculate summary
+    local error_count warning_count total_count tools_json
+    error_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
+    warning_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
+    total_count=$(echo "$all_findings" | jq 'length')
+
+    # Convert tools array to JSON (handle empty array safely)
+    if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+        tools_json=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+    else
+        tools_json="[]"
+    fi
+
+    # Output normalized JSON
+    jq -n \
+        --argjson findings "$all_findings" \
+        --argjson errors "$error_count" \
+        --argjson warnings "$warning_count" \
+        --argjson total "$total_count" \
+        --argjson tools "$tools_json" \
+        --arg language "$language" \
+        '{
+            success: true,
+            language: $language,
+            summary: {
+                total: $total,
+                errors: $errors,
+                warnings: $warnings,
+                pass: ($errors == 0)
+            },
+            findings: $findings,
+            tools_run: $tools
+        }'
+}
+
+# Safe JSON string escaping
+json_escape() {
+    local str="$1"
+    # Escape backslashes first, then quotes
+    str="${str//\\/\\\\}"
+    str="${str//\"/\\\"}"
+    str="${str//$'\t'/\\t}"
+    str="${str//$'\r'/\\r}"
+    str="${str//$'\n'/\\n}"
+    echo "$str"
+}
+
+# Parse tool output line with robust handling of colons in filenames
+# Usage: parse_line "file:line:col:message" -> sets FILE, LINE, COL, MESSAGE
+parse_colon_delimited() {
+    local input="$1"
+    local -n out_file="$2"
+    local -n out_line="$3"
+    local -n out_col="$4"
+    local -n out_msg="$5"
+
+    # Try file:line:col:message pattern first
+    if [[ "$input" =~ ^(.+):([0-9]+):([0-9]+):(.*)$ ]]; then
+        out_file="${BASH_REMATCH[1]}"
+        out_line="${BASH_REMATCH[2]}"
+        out_col="${BASH_REMATCH[3]}"
+        out_msg="${BASH_REMATCH[4]}"
+        return 0
+    fi
+
+    # Fallback to file:line:message (no column)
+    if [[ "$input" =~ ^(.+):([0-9]+):(.*)$ ]]; then
+        out_file="${BASH_REMATCH[1]}"
+        out_line="${BASH_REMATCH[2]}"
+        out_col=0
+        out_msg="${BASH_REMATCH[3]}"
+        return 0
+    fi
+
+    return 1
+}

--- a/src/mapify_cli/templates/map/static-analysis/handlers/common.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/common.sh
@@ -79,7 +79,7 @@ json_escape() {
 }
 
 # Parse tool output line with robust handling of colons in filenames
-# Usage: parse_line "file:line:col:message" -> sets FILE, LINE, COL, MESSAGE
+# Usage: parse_colon_delimited "file:line:col:message" -> sets FILE, LINE, COL, MESSAGE
 parse_colon_delimited() {
     local input="$1"
     local -n out_file="$2"

--- a/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Go Static Analysis Handler
+# Tools: go vet, gofmt, staticcheck (if available)
+set -euo pipefail
+
+FILES=""
+CONFIG="{}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# If no files specified, use current directory
+if [[ -z "$FILES" ]]; then
+    FILES="./..."
+fi
+
+TOOLS_RUN=()
+ALL_FINDINGS="[]"
+
+# Run go vet
+if command -v go &> /dev/null; then
+    TOOLS_RUN+=("go vet")
+    VET_OUT=$(timeout 30 go vet $FILES 2>&1 || true)
+
+    if [[ -n "$VET_OUT" ]]; then
+        VET_NORM=$(echo "$VET_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line rest; do
+            message=$(echo "$rest" | sed 's/"/\\"/g' | xargs)
+            echo "{\"tool\":\"go vet\",\"file\":\"$file\",\"line\":$line,\"column\":0,\"severity\":\"error\",\"code\":\"vet\",\"message\":\"$message\",\"fixable\":false}"
+        done | jq -s '.' 2>/dev/null || echo "[]")
+
+        if [[ -n "$VET_NORM" && "$VET_NORM" != "null" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $VET_NORM" | jq -s 'add // []')
+        fi
+    fi
+fi
+
+# Run gofmt check
+if command -v gofmt &> /dev/null; then
+    TOOLS_RUN+=("gofmt")
+    # gofmt -l lists files that need formatting
+    if [[ "$FILES" == "./..." ]]; then
+        FMT_FILES=$(find . -name "*.go" -not -path "./vendor/*" 2>/dev/null || true)
+    else
+        FMT_FILES="$FILES"
+    fi
+
+    if [[ -n "$FMT_FILES" ]]; then
+        FMT_OUT=$(echo "$FMT_FILES" | xargs gofmt -l 2>/dev/null || true)
+
+        if [[ -n "$FMT_OUT" ]]; then
+            FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+                echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
+            done | jq -s '.' 2>/dev/null || echo "[]")
+
+            if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
+                ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
+            fi
+        fi
+    fi
+fi
+
+# Run staticcheck (if available)
+if command -v staticcheck &> /dev/null; then
+    TOOLS_RUN+=("staticcheck")
+    SC_OUT=$(timeout 60 staticcheck -f json $FILES 2>/dev/null || echo "")
+
+    if [[ -n "$SC_OUT" ]]; then
+        SC_NORM=$(echo "$SC_OUT" | jq -c '{
+            tool: "staticcheck",
+            file: .location.file,
+            line: .location.line,
+            column: .location.column,
+            severity: (if .severity == "error" then "error" else "warning" end),
+            code: .code,
+            message: .message,
+            fixable: false
+        }' 2>/dev/null | jq -s '.' || echo "[]")
+
+        if [[ -n "$SC_NORM" && "$SC_NORM" != "null" && "$SC_NORM" != "[]" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $SC_NORM" | jq -s 'add // []')
+        fi
+    fi
+fi
+
+# Calculate summary
+ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
+WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
+TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
+
+# Convert tools array to JSON
+TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+
+# Output normalized JSON
+jq -n \
+    --argjson findings "$ALL_FINDINGS" \
+    --argjson errors "$ERROR_COUNT" \
+    --argjson warnings "$WARNING_COUNT" \
+    --argjson total "$TOTAL_COUNT" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+        success: true,
+        language: "go",
+        summary: {
+            total: $total,
+            errors: $errors,
+            warnings: $warnings,
+            pass: ($errors == 0)
+        },
+        findings: $findings,
+        tools_run: $tools
+    }'

--- a/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
@@ -25,7 +25,7 @@ ALL_FINDINGS="[]"
 # Run go vet
 if command -v go &> /dev/null; then
     TOOLS_RUN+=("go vet")
-    VET_OUT=$(timeout 30 go vet $FILES 2>&1 || true)
+    VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
         VET_NORM=$(echo "$VET_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line rest; do
@@ -44,22 +44,19 @@ if command -v gofmt &> /dev/null; then
     TOOLS_RUN+=("gofmt")
     # gofmt -l lists files that need formatting
     if [[ "$FILES" == "./..." ]]; then
-        FMT_FILES=$(find . -name "*.go" -not -path "./vendor/*" 2>/dev/null || true)
+        # Use null-delimited output from find to safely handle filenames with spaces
+        FMT_OUT=$(find . -name "*.go" -not -path "./vendor/*" -print0 2>/dev/null | xargs -0 gofmt -l 2>/dev/null || true)
     else
-        FMT_FILES="$FILES"
+        FMT_OUT=$(gofmt -l "$FILES" 2>/dev/null || true)
     fi
 
-    if [[ -n "$FMT_FILES" ]]; then
-        FMT_OUT=$(echo "$FMT_FILES" | xargs gofmt -l 2>/dev/null || true)
+    if [[ -n "$FMT_OUT" ]]; then
+        FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+            echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
+        done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$FMT_OUT" ]]; then
-            FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
-                echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
-            done | jq -s '.' 2>/dev/null || echo "[]")
-
-            if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
-                ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
-            fi
+        if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
         fi
     fi
 fi
@@ -67,10 +64,12 @@ fi
 # Run staticcheck (if available)
 if command -v staticcheck &> /dev/null; then
     TOOLS_RUN+=("staticcheck")
-    SC_OUT=$(timeout 60 staticcheck -f json $FILES 2>/dev/null || echo "")
+    SC_OUT=$(timeout 60 staticcheck -f json "$FILES" 2>/dev/null || echo "")
 
     if [[ -n "$SC_OUT" ]]; then
-        SC_NORM=$(echo "$SC_OUT" | jq -c '{
+        # staticcheck outputs NDJSON (one JSON object per line)
+        # Use jq -s to slurp all objects into an array, then transform each
+        SC_NORM=$(echo "$SC_OUT" | jq -s '[.[] | {
             tool: "staticcheck",
             file: .location.file,
             line: .location.line,
@@ -79,7 +78,7 @@ if command -v staticcheck &> /dev/null; then
             code: .code,
             message: .message,
             fixable: false
-        }' 2>/dev/null | jq -s '.' || echo "[]")
+        }]' 2>/dev/null || echo "[]")
 
         if [[ -n "$SC_NORM" && "$SC_NORM" != "null" && "$SC_NORM" != "[]" ]]; then
             ALL_FINDINGS=$(echo "$ALL_FINDINGS $SC_NORM" | jq -s 'add // []')
@@ -92,8 +91,12 @@ ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | le
 WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
 TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
 
-# Convert tools array to JSON
-TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+# Convert tools array to JSON (handle empty array safely)
+if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+else
+    TOOLS_JSON="[]"
+fi
 
 # Output normalized JSON
 jq -n \

--- a/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
@@ -56,7 +56,7 @@ if command -v gofmt &> /dev/null; then
     fi
 
     if [[ -n "$FMT_OUT" ]]; then
-        FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+        FMT_NORM=$(echo "$FMT_OUT" | while IFS= read -r file; do
             file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")

--- a/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
@@ -3,6 +3,9 @@
 # Tools: go vet, gofmt, staticcheck (if available)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 FILES=""
 CONFIG="{}"
 
@@ -20,7 +23,6 @@ if [[ -z "$FILES" ]]; then
 fi
 
 TOOLS_RUN=()
-ALL_FINDINGS="[]"
 
 # Run go vet
 if command -v go &> /dev/null; then
@@ -28,14 +30,17 @@ if command -v go &> /dev/null; then
     VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
-        VET_NORM=$(echo "$VET_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line rest; do
-            message=$(echo "$rest" | sed 's/"/\\"/g' | xargs)
-            echo "{\"tool\":\"go vet\",\"file\":\"$file\",\"line\":$line,\"column\":0,\"severity\":\"error\",\"code\":\"vet\",\"message\":\"$message\",\"fixable\":false}"
+        VET_NORM=$(echo "$VET_OUT" | while IFS= read -r line; do
+            local file lineno col msg
+            if parse_colon_delimited "$line" file lineno col msg; then
+                msg="${msg# }"
+                msg=$(json_escape "$msg")
+                file=$(json_escape "$file")
+                echo "{\"tool\":\"go vet\",\"file\":\"$file\",\"line\":$lineno,\"column\":$col,\"severity\":\"error\",\"code\":\"vet\",\"message\":\"$msg\",\"fixable\":false}"
+            fi
         done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$VET_NORM" && "$VET_NORM" != "null" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $VET_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$VET_NORM"
     fi
 fi
 
@@ -52,12 +57,11 @@ if command -v gofmt &> /dev/null; then
 
     if [[ -n "$FMT_OUT" ]]; then
         FMT_NORM=$(echo "$FMT_OUT" | while read -r file; do
+            file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$FMT_NORM" && "$FMT_NORM" != "null" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $FMT_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$FMT_NORM"
     fi
 fi
 
@@ -80,40 +84,9 @@ if command -v staticcheck &> /dev/null; then
             fixable: false
         }]' 2>/dev/null || echo "[]")
 
-        if [[ -n "$SC_NORM" && "$SC_NORM" != "null" && "$SC_NORM" != "[]" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $SC_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$SC_NORM"
     fi
 fi
 
-# Calculate summary
-ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
-WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
-TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-
-# Convert tools array to JSON (handle empty array safely)
-if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
-    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
-else
-    TOOLS_JSON="[]"
-fi
-
-# Output normalized JSON
-jq -n \
-    --argjson findings "$ALL_FINDINGS" \
-    --argjson errors "$ERROR_COUNT" \
-    --argjson warnings "$WARNING_COUNT" \
-    --argjson total "$TOTAL_COUNT" \
-    --argjson tools "$TOOLS_JSON" \
-    '{
-        success: true,
-        language: "go",
-        summary: {
-            total: $total,
-            errors: $errors,
-            warnings: $warnings,
-            pass: ($errors == 0)
-        },
-        findings: $findings,
-        tools_run: $tools
-    }'
+# Generate output using common function
+generate_output "go"

--- a/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
@@ -3,6 +3,9 @@
 # Tools: ruff (linting), mypy (type checking)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 FILES=""
 CONFIG="{}"
 
@@ -20,7 +23,6 @@ if [[ -z "$FILES" ]]; then
 fi
 
 TOOLS_RUN=()
-ALL_FINDINGS="[]"
 
 # Run ruff (if available)
 if command -v ruff &> /dev/null; then
@@ -40,7 +42,7 @@ if command -v ruff &> /dev/null; then
             fixable: (.fix != null)
         }]' 2>/dev/null || echo "[]")
 
-        ALL_FINDINGS=$(echo "$ALL_FINDINGS $RUFF_NORM" | jq -s 'add // []')
+        add_findings "$RUFF_NORM"
     fi
 fi
 
@@ -49,53 +51,30 @@ if command -v mypy &> /dev/null; then
     TOOLS_RUN+=("mypy")
     MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary "$FILES" 2>&1 || true)
 
-    # Parse mypy text output to JSON
+    # Parse mypy text output to JSON using robust parsing
     if [[ -n "$MYPY_OUT" ]]; then
-        MYPY_NORM=$(echo "$MYPY_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line col rest; do
-            # Determine severity from message
-            if echo "$rest" | grep -q "error:"; then
-                severity="error"
-            else
-                severity="warning"
+        MYPY_NORM=$(echo "$MYPY_OUT" | while IFS= read -r line; do
+            local file lineno col msg
+            if parse_colon_delimited "$line" file lineno col msg; then
+                # Determine severity from message
+                local severity="warning"
+                if [[ "$msg" == *"error:"* ]]; then
+                    severity="error"
+                fi
+                # Clean up message
+                msg="${msg# }"
+                msg="${msg#error: }"
+                msg="${msg#note: }"
+                msg=$(json_escape "$msg")
+                file=$(json_escape "$file")
+
+                echo "{\"tool\":\"mypy\",\"file\":\"$file\",\"line\":$lineno,\"column\":$col,\"severity\":\"$severity\",\"code\":\"mypy\",\"message\":\"$msg\",\"fixable\":false}"
             fi
-            message=$(echo "$rest" | sed 's/^ *error: //' | sed 's/^ *note: //' | sed 's/"/\\"/g')
-            echo "{\"tool\":\"mypy\",\"file\":\"$file\",\"line\":$line,\"column\":${col:-0},\"severity\":\"$severity\",\"code\":\"mypy\",\"message\":\"$message\",\"fixable\":false}"
         done | jq -s '.' 2>/dev/null || echo "[]")
 
-        if [[ -n "$MYPY_NORM" && "$MYPY_NORM" != "null" ]]; then
-            ALL_FINDINGS=$(echo "$ALL_FINDINGS $MYPY_NORM" | jq -s 'add // []')
-        fi
+        add_findings "$MYPY_NORM"
     fi
 fi
 
-# Calculate summary
-ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
-WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
-TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-
-# Convert tools array to JSON (handle empty array safely)
-if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
-    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
-else
-    TOOLS_JSON="[]"
-fi
-
-# Output normalized JSON
-jq -n \
-    --argjson findings "$ALL_FINDINGS" \
-    --argjson errors "$ERROR_COUNT" \
-    --argjson warnings "$WARNING_COUNT" \
-    --argjson total "$TOTAL_COUNT" \
-    --argjson tools "$TOOLS_JSON" \
-    '{
-        success: true,
-        language: "python",
-        summary: {
-            total: $total,
-            errors: $errors,
-            warnings: $warnings,
-            pass: ($errors == 0)
-        },
-        findings: $findings,
-        tools_run: $tools
-    }'
+# Generate output using common function
+generate_output "python"

--- a/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Python Static Analysis Handler
+# Tools: ruff (linting), mypy (type checking)
+set -euo pipefail
+
+FILES=""
+CONFIG="{}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# If no files specified, use current directory
+if [[ -z "$FILES" ]]; then
+    FILES="."
+fi
+
+TOOLS_RUN=()
+ALL_FINDINGS="[]"
+
+# Run ruff (if available)
+if command -v ruff &> /dev/null; then
+    TOOLS_RUN+=("ruff")
+    RUFF_OUT=$(timeout 30 ruff check --output-format=json $FILES 2>/dev/null || echo "[]")
+
+    # Normalize ruff output to standard format
+    if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
+        RUFF_NORM=$(echo "$RUFF_OUT" | jq -c '[.[] | {
+            tool: "ruff",
+            file: .filename,
+            line: .location.row,
+            column: .location.column,
+            severity: (if .code | startswith("F") then "error" elif .code | startswith("E") then "error" else "warning" end),
+            code: .code,
+            message: .message,
+            fixable: (.fix != null)
+        }]' 2>/dev/null || echo "[]")
+
+        ALL_FINDINGS=$(echo "$ALL_FINDINGS $RUFF_NORM" | jq -s 'add // []')
+    fi
+fi
+
+# Run mypy (if available)
+if command -v mypy &> /dev/null; then
+    TOOLS_RUN+=("mypy")
+    MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary $FILES 2>&1 || true)
+
+    # Parse mypy text output to JSON
+    if [[ -n "$MYPY_OUT" ]]; then
+        MYPY_NORM=$(echo "$MYPY_OUT" | grep -E "^[^:]+:[0-9]+:" | while IFS=: read -r file line col rest; do
+            # Determine severity from message
+            if echo "$rest" | grep -q "error:"; then
+                severity="error"
+            else
+                severity="warning"
+            fi
+            message=$(echo "$rest" | sed 's/^ *error: //' | sed 's/^ *note: //' | sed 's/"/\\"/g')
+            echo "{\"tool\":\"mypy\",\"file\":\"$file\",\"line\":$line,\"column\":${col:-0},\"severity\":\"$severity\",\"code\":\"mypy\",\"message\":\"$message\",\"fixable\":false}"
+        done | jq -s '.' 2>/dev/null || echo "[]")
+
+        if [[ -n "$MYPY_NORM" && "$MYPY_NORM" != "null" ]]; then
+            ALL_FINDINGS=$(echo "$ALL_FINDINGS $MYPY_NORM" | jq -s 'add // []')
+        fi
+    fi
+fi
+
+# Calculate summary
+ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
+WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
+TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
+
+# Convert tools array to JSON
+TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+
+# Output normalized JSON
+jq -n \
+    --argjson findings "$ALL_FINDINGS" \
+    --argjson errors "$ERROR_COUNT" \
+    --argjson warnings "$WARNING_COUNT" \
+    --argjson total "$TOTAL_COUNT" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+        success: true,
+        language: "python",
+        summary: {
+            total: $total,
+            errors: $errors,
+            warnings: $warnings,
+            pass: ($errors == 0)
+        },
+        findings: $findings,
+        tools_run: $tools
+    }'

--- a/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
@@ -25,7 +25,7 @@ ALL_FINDINGS="[]"
 # Run ruff (if available)
 if command -v ruff &> /dev/null; then
     TOOLS_RUN+=("ruff")
-    RUFF_OUT=$(timeout 30 ruff check --output-format=json $FILES 2>/dev/null || echo "[]")
+    RUFF_OUT=$(timeout 30 ruff check --output-format=json "$FILES" 2>/dev/null || echo "[]")
 
     # Normalize ruff output to standard format
     if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
@@ -47,7 +47,7 @@ fi
 # Run mypy (if available)
 if command -v mypy &> /dev/null; then
     TOOLS_RUN+=("mypy")
-    MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary $FILES 2>&1 || true)
+    MYPY_OUT=$(timeout 30 mypy --no-color-output --no-error-summary "$FILES" 2>&1 || true)
 
     # Parse mypy text output to JSON
     if [[ -n "$MYPY_OUT" ]]; then
@@ -73,8 +73,12 @@ ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | le
 WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
 TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
 
-# Convert tools array to JSON
-TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+# Convert tools array to JSON (handle empty array safely)
+if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+else
+    TOOLS_JSON="[]"
+fi
 
 # Output normalized JSON
 jq -n \

--- a/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
@@ -30,7 +30,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
     fi
 
     TOOLS_RUN+=("eslint")
-    ESLINT_OUT=$(timeout 60 $ESLINT_CMD --format json $FILES 2>/dev/null || echo "[]")
+    ESLINT_OUT=$(timeout 60 "$ESLINT_CMD" --format json "$FILES" 2>/dev/null || echo "[]")
 
     if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
         ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
@@ -55,9 +55,9 @@ if [[ -f "tsconfig.json" ]]; then
         TSC_CMD="./node_modules/.bin/tsc"
     fi
 
-    if command -v $TSC_CMD &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
+    if command -v "$TSC_CMD" &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
         TOOLS_RUN+=("tsc")
-        TSC_OUT=$(timeout 60 $TSC_CMD --noEmit --pretty false 2>&1 || true)
+        TSC_OUT=$(timeout 60 "$TSC_CMD" --noEmit --pretty false 2>&1 || true)
 
         if [[ -n "$TSC_OUT" ]]; then
             TSC_NORM=$(echo "$TSC_OUT" | grep -E "^[^(]+\([0-9]+,[0-9]+\):" | while read -r line; do

--- a/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
@@ -3,6 +3,9 @@
 # Tools: eslint, tsc (TypeScript compiler)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 FILES=""
 CONFIG="{}"
 
@@ -20,7 +23,6 @@ if [[ -z "$FILES" ]]; then
 fi
 
 TOOLS_RUN=()
-ALL_FINDINGS="[]"
 
 # Run eslint (if available)
 if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
@@ -44,7 +46,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
             fixable: (.fix != null)
         }]' 2>/dev/null || echo "[]")
 
-        ALL_FINDINGS=$(echo "$ALL_FINDINGS $ESLINT_NORM" | jq -s 'add // []')
+        add_findings "$ESLINT_NORM"
     fi
 fi
 
@@ -60,52 +62,26 @@ if [[ -f "tsconfig.json" ]]; then
         TSC_OUT=$(timeout 60 "$TSC_CMD" --noEmit --pretty false 2>&1 || true)
 
         if [[ -n "$TSC_OUT" ]]; then
-            TSC_NORM=$(echo "$TSC_OUT" | grep -E "^[^(]+\([0-9]+,[0-9]+\):" | while read -r line; do
-                # Parse format: file(line,col): error TSxxxx: message
-                file=$(echo "$line" | sed -E 's/\([0-9]+,[0-9]+\):.*//')
-                linenum=$(echo "$line" | sed -E 's/.*\(([0-9]+),[0-9]+\):.*/\1/')
-                col=$(echo "$line" | sed -E 's/.*\([0-9]+,([0-9]+)\):.*/\1/')
-                code=$(echo "$line" | sed -E 's/.*: (error TS[0-9]+):.*/\1/' | tr -d ' ')
-                message=$(echo "$line" | sed -E 's/.*: error TS[0-9]+: //' | sed 's/"/\\"/g')
+            # Parse format: file(line,col): error TSxxxx: message
+            TSC_NORM=$(echo "$TSC_OUT" | while IFS= read -r line; do
+                if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ error\ (TS[0-9]+):\ (.*)$ ]]; then
+                    local file="${BASH_REMATCH[1]}"
+                    local linenum="${BASH_REMATCH[2]}"
+                    local col="${BASH_REMATCH[3]}"
+                    local code="${BASH_REMATCH[4]}"
+                    local message="${BASH_REMATCH[5]}"
 
-                echo "{\"tool\":\"tsc\",\"file\":\"$file\",\"line\":$linenum,\"column\":$col,\"severity\":\"error\",\"code\":\"$code\",\"message\":\"$message\",\"fixable\":false}"
+                    file=$(json_escape "$file")
+                    message=$(json_escape "$message")
+
+                    echo "{\"tool\":\"tsc\",\"file\":\"$file\",\"line\":$linenum,\"column\":$col,\"severity\":\"error\",\"code\":\"$code\",\"message\":\"$message\",\"fixable\":false}"
+                fi
             done | jq -s '.' 2>/dev/null || echo "[]")
 
-            if [[ -n "$TSC_NORM" && "$TSC_NORM" != "null" ]]; then
-                ALL_FINDINGS=$(echo "$ALL_FINDINGS $TSC_NORM" | jq -s 'add // []')
-            fi
+            add_findings "$TSC_NORM"
         fi
     fi
 fi
 
-# Calculate summary
-ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
-WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
-TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
-
-# Convert tools array to JSON
-if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
-    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
-else
-    TOOLS_JSON="[]"
-fi
-
-# Output normalized JSON
-jq -n \
-    --argjson findings "$ALL_FINDINGS" \
-    --argjson errors "$ERROR_COUNT" \
-    --argjson warnings "$WARNING_COUNT" \
-    --argjson total "$TOTAL_COUNT" \
-    --argjson tools "$TOOLS_JSON" \
-    '{
-        success: true,
-        language: "typescript",
-        summary: {
-            total: $total,
-            errors: $errors,
-            warnings: $warnings,
-            pass: ($errors == 0)
-        },
-        findings: $findings,
-        tools_run: $tools
-    }'
+# Generate output using common function
+generate_output "typescript"

--- a/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# TypeScript/JavaScript Static Analysis Handler
+# Tools: eslint, tsc (TypeScript compiler)
+set -euo pipefail
+
+FILES=""
+CONFIG="{}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --files) FILES="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# If no files specified, use current directory
+if [[ -z "$FILES" ]]; then
+    FILES="."
+fi
+
+TOOLS_RUN=()
+ALL_FINDINGS="[]"
+
+# Run eslint (if available)
+if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
+    ESLINT_CMD="eslint"
+    if [[ -x "./node_modules/.bin/eslint" ]]; then
+        ESLINT_CMD="./node_modules/.bin/eslint"
+    fi
+
+    TOOLS_RUN+=("eslint")
+    ESLINT_OUT=$(timeout 60 $ESLINT_CMD --format json $FILES 2>/dev/null || echo "[]")
+
+    if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
+        ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
+            tool: "eslint",
+            file: $file,
+            line: .line,
+            column: .column,
+            severity: (if .severity == 2 then "error" else "warning" end),
+            code: (.ruleId // "eslint"),
+            message: .message,
+            fixable: (.fix != null)
+        }]' 2>/dev/null || echo "[]")
+
+        ALL_FINDINGS=$(echo "$ALL_FINDINGS $ESLINT_NORM" | jq -s 'add // []')
+    fi
+fi
+
+# Run tsc type checking (if tsconfig.json exists)
+if [[ -f "tsconfig.json" ]]; then
+    TSC_CMD="tsc"
+    if [[ -x "./node_modules/.bin/tsc" ]]; then
+        TSC_CMD="./node_modules/.bin/tsc"
+    fi
+
+    if command -v $TSC_CMD &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
+        TOOLS_RUN+=("tsc")
+        TSC_OUT=$(timeout 60 $TSC_CMD --noEmit --pretty false 2>&1 || true)
+
+        if [[ -n "$TSC_OUT" ]]; then
+            TSC_NORM=$(echo "$TSC_OUT" | grep -E "^[^(]+\([0-9]+,[0-9]+\):" | while read -r line; do
+                # Parse format: file(line,col): error TSxxxx: message
+                file=$(echo "$line" | sed -E 's/\([0-9]+,[0-9]+\):.*//')
+                linenum=$(echo "$line" | sed -E 's/.*\(([0-9]+),[0-9]+\):.*/\1/')
+                col=$(echo "$line" | sed -E 's/.*\([0-9]+,([0-9]+)\):.*/\1/')
+                code=$(echo "$line" | sed -E 's/.*: (error TS[0-9]+):.*/\1/' | tr -d ' ')
+                message=$(echo "$line" | sed -E 's/.*: error TS[0-9]+: //' | sed 's/"/\\"/g')
+
+                echo "{\"tool\":\"tsc\",\"file\":\"$file\",\"line\":$linenum,\"column\":$col,\"severity\":\"error\",\"code\":\"$code\",\"message\":\"$message\",\"fixable\":false}"
+            done | jq -s '.' 2>/dev/null || echo "[]")
+
+            if [[ -n "$TSC_NORM" && "$TSC_NORM" != "null" ]]; then
+                ALL_FINDINGS=$(echo "$ALL_FINDINGS $TSC_NORM" | jq -s 'add // []')
+            fi
+        fi
+    fi
+fi
+
+# Calculate summary
+ERROR_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="error")] | length')
+WARNING_COUNT=$(echo "$ALL_FINDINGS" | jq '[.[] | select(.severity=="warning")] | length')
+TOTAL_COUNT=$(echo "$ALL_FINDINGS" | jq 'length')
+
+# Convert tools array to JSON
+if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then
+    TOOLS_JSON=$(printf '%s\n' "${TOOLS_RUN[@]}" | jq -R . | jq -s .)
+else
+    TOOLS_JSON="[]"
+fi
+
+# Output normalized JSON
+jq -n \
+    --argjson findings "$ALL_FINDINGS" \
+    --argjson errors "$ERROR_COUNT" \
+    --argjson warnings "$WARNING_COUNT" \
+    --argjson total "$TOTAL_COUNT" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+        success: true,
+        language: "typescript",
+        summary: {
+            total: $total,
+            errors: $errors,
+            warnings: $warnings,
+            pass: ($errors == 0)
+        },
+        findings: $findings,
+        tools_run: $tools
+    }'

--- a/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
@@ -57,7 +57,7 @@ if [[ -f "tsconfig.json" ]]; then
         TSC_CMD="./node_modules/.bin/tsc"
     fi
 
-    if command -v "$TSC_CMD" &> /dev/null || [[ -x "./node_modules/.bin/tsc" ]]; then
+    if [[ -x "./node_modules/.bin/tsc" ]] || command -v tsc &> /dev/null; then
         TOOLS_RUN+=("tsc")
         TSC_OUT=$(timeout 60 "$TSC_CMD" --noEmit --pretty false 2>&1 || true)
 

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -20,6 +20,7 @@ from mapify_cli import (
     create_agent_files,
     create_command_files,
     create_commands_dir,
+    create_map_tools,
     create_or_merge_project_mcp_json,
     create_ssl_context,
     get_latest_release,
@@ -1086,3 +1087,109 @@ class TestMcpJsonConfig:
         assert "mcpServers" in config
         # docs = context7 + deepwiki
         assert "context7" in config["mcpServers"] or "deepwiki" in config["mcpServers"]
+
+
+class TestCreateMapTools:
+    """Test create_map_tools() function for static analysis tools."""
+
+    def test_create_map_tools_creates_directory(self, tmp_path):
+        """Test that create_map_tools creates .map directory with static-analysis."""
+        count = create_map_tools(tmp_path)
+
+        map_dir = tmp_path / ".map"
+        static_analysis_dir = map_dir / "static-analysis"
+
+        assert map_dir.exists()
+        assert static_analysis_dir.exists()
+        assert count > 0  # Should have created some scripts
+
+    def test_create_map_tools_copies_scripts(self, tmp_path):
+        """Test that static analysis scripts are copied correctly."""
+        create_map_tools(tmp_path)
+
+        static_analysis_dir = tmp_path / ".map" / "static-analysis"
+        handlers_dir = static_analysis_dir / "handlers"
+
+        # Verify main script exists
+        assert (static_analysis_dir / "analyze.sh").exists()
+
+        # Verify handlers exist
+        assert handlers_dir.exists()
+        assert (handlers_dir / "python.sh").exists()
+        assert (handlers_dir / "go.sh").exists()
+        assert (handlers_dir / "typescript.sh").exists()
+        assert (handlers_dir / "common.sh").exists()
+
+    def test_create_map_tools_makes_scripts_executable(self, tmp_path):
+        """Test that scripts are made executable."""
+        create_map_tools(tmp_path)
+
+        static_analysis_dir = tmp_path / ".map" / "static-analysis"
+        handlers_dir = static_analysis_dir / "handlers"
+
+        # Check main script is executable
+        analyze_script = static_analysis_dir / "analyze.sh"
+        assert analyze_script.stat().st_mode & 0o111  # Has execute bit
+
+        # Check handler scripts are executable
+        for script in handlers_dir.glob("*.sh"):
+            assert script.stat().st_mode & 0o111, f"{script.name} should be executable"
+
+    def test_create_map_tools_overwrites_existing(self, tmp_path):
+        """Test that existing static-analysis directory is replaced."""
+        # Create existing .map structure with a marker file
+        map_dir = tmp_path / ".map" / "static-analysis"
+        map_dir.mkdir(parents=True)
+        marker_file = map_dir / "old_marker.txt"
+        marker_file.write_text("old content")
+
+        # Run create_map_tools
+        create_map_tools(tmp_path)
+
+        # Marker file should be gone (directory was replaced)
+        assert not marker_file.exists()
+
+        # New scripts should exist
+        assert (tmp_path / ".map" / "static-analysis" / "analyze.sh").exists()
+
+    def test_create_map_tools_returns_script_count(self, tmp_path):
+        """Test that function returns correct count of scripts."""
+        count = create_map_tools(tmp_path)
+
+        # Count actual .sh files created
+        static_analysis_dir = tmp_path / ".map" / "static-analysis"
+        actual_count = len(list(static_analysis_dir.rglob("*.sh")))
+
+        assert count == actual_count
+        assert count >= 5  # analyze.sh + common.sh + python.sh + go.sh + typescript.sh
+
+    @mock.patch("mapify_cli.get_templates_dir")
+    def test_create_map_tools_no_templates(self, mock_get_templates, tmp_path):
+        """Test handling when templates directory doesn't have map subdirectory."""
+        # Mock empty templates directory
+        mock_templates = tmp_path / "empty_templates"
+        mock_templates.mkdir()
+        mock_get_templates.return_value = mock_templates
+
+        count = create_map_tools(tmp_path)
+
+        # Should return 0 when no map templates exist
+        assert count == 0
+
+    def test_create_map_tools_preserves_other_map_contents(self, tmp_path):
+        """Test that other files in .map are preserved."""
+        # Create .map with other content
+        map_dir = tmp_path / ".map"
+        map_dir.mkdir()
+        other_file = map_dir / "other_data.json"
+        other_file.write_text('{"key": "value"}')
+
+        # Run create_map_tools
+        create_map_tools(tmp_path)
+
+        # Other file should still exist
+        assert other_file.exists()
+        assert other_file.read_text() == '{"key": "value"}'
+
+        # New scripts should also exist
+        assert (map_dir / "static-analysis" / "analyze.sh").exists()

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -1176,6 +1176,25 @@ class TestCreateMapTools:
         # Should return 0 when no map templates exist
         assert count == 0
 
+    @mock.patch("mapify_cli.get_templates_dir")
+    def test_create_map_tools_map_exists_but_no_static_analysis(
+        self, mock_get_templates, tmp_path
+    ):
+        """Test when templates_dir/map exists but static-analysis subdirectory doesn't."""
+        # Create templates/map without static-analysis
+        mock_templates = tmp_path / "templates"
+        mock_templates.mkdir()
+        (mock_templates / "map").mkdir()
+        # Don't create static-analysis subdirectory
+        mock_get_templates.return_value = mock_templates
+
+        count = create_map_tools(tmp_path)
+
+        # Should return 0 when static-analysis doesn't exist
+        assert count == 0
+        # .map directory should still be created
+        assert (tmp_path / ".map").exists()
+
     def test_create_map_tools_preserves_other_map_contents(self, tmp_path):
         """Test that other files in .map are preserved."""
         # Create .map with other content


### PR DESCRIPTION
## Summary

- Implement modular static analysis integration for Monitor agent
- Follow LLM Council recommendation to keep agent templates lean
- Add external scripts in `.map/static-analysis/` with per-language handlers

## Changes

### New Files
- `.map/static-analysis/analyze.sh` — Main dispatcher with auto-detection
- `.map/static-analysis/handlers/python.sh` — ruff + mypy
- `.map/static-analysis/handlers/go.sh` — go vet + gofmt + staticcheck  
- `.map/static-analysis/handlers/typescript.sh` — eslint + tsc
- Templates copied to `src/mapify_cli/templates/map/` for `mapify init`

### Modified Files
- `.claude/agents/monitor.md` — Reduced ~380 lines, added minimal invocation section
- `src/mapify_cli/__init__.py` — Added `create_map_tools()` for init workflow
- `.gitignore` — Track `.map/static-analysis/` only

## Architecture

```
.map/
└── static-analysis/
    ├── analyze.sh           # Dispatcher (auto-detects language)
    └── handlers/
        ├── python.sh        # ruff + mypy
        ├── go.sh            # go vet + gofmt + staticcheck
        └── typescript.sh    # eslint + tsc
```

All handlers produce normalized JSON output:
```json
{
  "success": true,
  "language": "python",
  "summary": { "total": 5, "errors": 2, "warnings": 3, "pass": false },
  "findings": [...],
  "tools_run": ["ruff", "mypy"]
}
```

## Benefits

| Before | After |
|--------|-------|
| ~400 lines inline in monitor.md | ~45 lines (script invocation) |
| Hard to extend | New language = new handler script |
| Not testable | Scripts testable independently |
| Single language focus | Multi-language by design |

## Test plan

- [x] All 474 tests pass
- [x] Template sync tests pass
- [x] Python handler tested on real files
- [x] Auto-detection works correctly