### PR TITLE
Fix init counts; make map-fast actually cheap

### DIFF
--- a/.claude/commands/map-fast.md
+++ b/.claude/commands/map-fast.md
@@ -10,6 +10,17 @@ Minimal agent sequence (40-50% token savings). Skips: Predictor, Evaluator, Refl
 
 **Consequences:** No impact analysis, no quality scoring, no learning, playbook never improves.
 
+## Safety Guardrails (Keep It Cheap, Avoid Disasters)
+
+If the task involves ANY of the following, STOP and use `/map-efficient` instead (or `/map-efficient --self-moa` for security-critical work):
+
+- auth/session/JWT/OAuth/passwords/permissions
+- payments/billing/invoicing/PCI
+- secrets/crypto/encryption/signing/keys
+- data migrations/schema changes
+- infra/CI/CD/deploy/release changes (use `/map-release` for mapify-cli itself)
+- anything where a bug is expensive
+
 Implement the following:
 
 **Task:** $ARGUMENTS
@@ -43,7 +54,7 @@ Break down the task into subtasks:
 Task(
   subagent_type="task-decomposer",
   description="Decompose task into subtasks",
-  prompt="Break down this task into atomic subtasks (≤8):
+  prompt="Break down this task into atomic subtasks (≤4). If you need more than 4, recommend switching to /map-efficient:
 
 Task: $ARGUMENTS
 
@@ -74,11 +85,13 @@ Task(
 
 Output JSON with:
 - approach: string (implementation strategy)
-- code_changes: array of {file_path, change_type, content, rationale}
+- code_changes: array of {file_path, change_type, patch_or_snippet, rationale}
 - trade_offs: array of strings
 - testing_approach: string
 
-Provide FULL file content for each change, not diffs."
+Keep it token-cheap:
+- Prefer minimal patch/snippet over FULL file content
+- Only include FULL file content when creating a new file or when the file is very small"
 )
 ```
 
@@ -120,8 +133,8 @@ Output JSON with:
 After all subtasks completed:
 
 1. Run basic tests (if applicable)
-2. Create commit with message
-3. Summarize what was implemented
+2. Summarize what was implemented
+3. If this is no longer throwaway: rerun with `/map-efficient` and optionally `/map-learn`
 
 **Note:** No playbook updates, no cipher patterns stored (learning disabled).
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -510,8 +510,12 @@ def get_templates_dir() -> Path:
     raise RuntimeError("Templates directory not found. Please reinstall mapify-cli.")
 
 
-def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
-    """Create MAP agent files in .claude/agents/"""
+def create_agent_files(project_path: Path, mcp_servers: List[str]) -> int:
+    """Create MAP agent files in .claude/agents/
+
+    Returns:
+        Number of agent files installed
+    """
     agents_dir = project_path / ".claude" / "agents"
     agents_dir.mkdir(parents=True, exist_ok=True)
 
@@ -526,12 +530,15 @@ def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
         # Files to exclude from agent directory (documentation, not agents)
         exclude_files = {"README.md", "CHANGELOG.md", "MCP-PATTERNS.md"}
 
+        count = 0
         for agent_template in agents_template_dir.glob("*.md"):
             # Skip documentation files - they're not agents
             if agent_template.name in exclude_files:
                 continue
             dest_file = agents_dir / agent_template.name
             shutil.copy2(agent_template, dest_file)
+            count += 1
+        return count
     else:
         # Fallback: generate simplified versions if templates not found
         # NOTE: orchestrator removed (moved to slash commands in production architecture)
@@ -551,6 +558,7 @@ def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
         for name, content in agents.items():
             agent_file = agents_dir / f"{name}.md"
             agent_file.write_text(content)
+        return len(agents)
 
 
 def create_task_decomposer_content(mcp_servers: List[str]) -> str:
@@ -1083,8 +1091,12 @@ def create_reference_files(project_path: Path) -> int:
     return count
 
 
-def create_command_files(project_path: Path) -> None:
-    """Create MAP slash commands in .claude/commands/"""
+def create_command_files(project_path: Path) -> int:
+    """Create MAP slash commands in .claude/commands/
+
+    Returns:
+        Number of command files installed
+    """
     commands_dir = project_path / ".claude" / "commands"
     commands_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1138,18 +1150,48 @@ $ARGUMENTS
 
 Call Reflector to extract patterns, then Curator to update playbook.
 """,
+            "map-review": """---
+description: Comprehensive MAP review of changes
+---
+
+Review current git changes using Monitor, Predictor, and Evaluator:
+
+$ARGUMENTS
+""",
+            "map-debate": """---
+description: Debate-based multi-variant synthesis (advanced)
+---
+
+Use multi-variant debate workflow for:
+
+$ARGUMENTS
+""",
+            "map-release": """---
+description: Package release runbook (maintainers)
+---
+
+Follow the release checklist for:
+
+$ARGUMENTS
+""",
         }
 
+        count = 0
         for name, content in commands.items():
             command_file = commands_dir / f"{name}.md"
             command_file.write_text(content)
+            count += 1
+        return count
     else:
         # Copy templates from bundled directory
         import shutil
 
+        count = 0
         for command_template in commands_template_dir.glob("*.md"):
             dest_file = commands_dir / command_template.name
             shutil.copy2(command_template, dest_file)
+            count += 1
+        return count
 
 
 def create_skill_files(project_path: Path) -> int:
@@ -1800,6 +1842,9 @@ def create_commands_dir(project_path: Path) -> None:
     commands_dir.mkdir(parents=True, exist_ok=True)
 
     readme = commands_dir / "README.md"
+    if readme.exists():
+        return
+
     readme.write_text(
         """# Claude Code Commands
 
@@ -1810,8 +1855,10 @@ This directory contains custom slash commands for Claude Code.
 - `/map-efficient` - Implement features with optimized workflow (recommended)
 - `/map-debug` - Debug issues using MAP analysis
 - `/map-fast` - Quick implementation with minimal validation
-- `/map-learn` - Extract lessons from completed workflows
-- `/map-release` - Execute MAP Framework package release workflow
+- `/map-review` - Review changes (Monitor + Predictor + Evaluator)
+- `/map-learn` - Extract lessons from completed workflows (optional)
+- `/map-debate` - Multi-variant with Opus arbiter (advanced)
+- `/map-release` - MAP Framework package release workflow (maintainers)
 
 ## Creating Custom Commands
 
@@ -1985,13 +2032,14 @@ def init(
     # Create MAP files
     tracker.add("create-agents", "Create MAP agents")
     tracker.start("create-agents")
-    create_agent_files(project_path, selected_mcp_servers)
-    tracker.complete("create-agents", "8 agents")
+    agent_count = create_agent_files(project_path, selected_mcp_servers)
+    tracker.complete("create-agents", f"{agent_count} agents")
 
     tracker.add("create-commands", "Create slash commands")
     tracker.start("create-commands")
-    create_command_files(project_path)
-    tracker.complete("create-commands", "4 commands")
+    create_commands_dir(project_path)
+    command_count = create_command_files(project_path)
+    tracker.complete("create-commands", f"{command_count} commands")
 
     tracker.add("create-skills", "Create skills")
     tracker.start("create-skills")
@@ -2141,16 +2189,16 @@ def init(
         step_num = 2
 
     steps_lines.append(f"{step_num}. Start using MAP commands with Claude Code:")
-    steps_lines.append(
-        "   • [cyan]/map-efficient[/] - Implement features with optimized workflow (recommended)"
+    installed = sorted(
+        p.stem
+        for p in (project_path / ".claude" / "commands").glob("*.md")
+        if p.name != "README.md"
     )
-    steps_lines.append("   • [cyan]/map-debug[/] - Debug issue using MAP analysis")
-    steps_lines.append(
-        "   • [cyan]/map-fast[/] - Quick implementation with minimal validation"
-    )
-    steps_lines.append(
-        "   • [cyan]/map-learn[/] - Extract lessons from completed workflows"
-    )
+    if not installed:
+        steps_lines.append("   • [yellow](no slash commands installed)[/yellow]")
+    else:
+        for cmd in installed:
+            steps_lines.append(f"   • [cyan]/{cmd}[/]")
 
     steps_panel = Panel(
         "\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1, 2)

--- a/src/mapify_cli/templates/commands/map-fast.md
+++ b/src/mapify_cli/templates/commands/map-fast.md
@@ -10,6 +10,17 @@ Minimal agent sequence (40-50% token savings). Skips: Predictor, Evaluator, Refl
 
 **Consequences:** No impact analysis, no quality scoring, no learning, playbook never improves.
 
+## Safety Guardrails (Keep It Cheap, Avoid Disasters)
+
+If the task involves ANY of the following, STOP and use `/map-efficient` instead (or `/map-efficient --self-moa` for security-critical work):
+
+- auth/session/JWT/OAuth/passwords/permissions
+- payments/billing/invoicing/PCI
+- secrets/crypto/encryption/signing/keys
+- data migrations/schema changes
+- infra/CI/CD/deploy/release changes (use `/map-release` for mapify-cli itself)
+- anything where a bug is expensive
+
 Implement the following:
 
 **Task:** $ARGUMENTS
@@ -43,7 +54,7 @@ Break down the task into subtasks:
 Task(
   subagent_type="task-decomposer",
   description="Decompose task into subtasks",
-  prompt="Break down this task into atomic subtasks (≤8):
+  prompt="Break down this task into atomic subtasks (≤4). If you need more than 4, recommend switching to /map-efficient:
 
 Task: $ARGUMENTS
 
@@ -74,11 +85,13 @@ Task(
 
 Output JSON with:
 - approach: string (implementation strategy)
-- code_changes: array of {file_path, change_type, content, rationale}
+- code_changes: array of {file_path, change_type, patch_or_snippet, rationale}
 - trade_offs: array of strings
 - testing_approach: string
 
-Provide FULL file content for each change, not diffs."
+Keep it token-cheap:
+- Prefer minimal patch/snippet over FULL file content
+- Only include FULL file content when creating a new file or when the file is very small"
 )
 ```
 
@@ -120,8 +133,8 @@ Output JSON with:
 After all subtasks completed:
 
 1. Run basic tests (if applicable)
-2. Create commit with message
-3. Summarize what was implemented
+2. Summarize what was implemented
+3. If this is no longer throwaway: rerun with `/map-efficient` and optionally `/map-learn`
 
 **Note:** No playbook updates, no cipher patterns stored (learning disabled).
 


### PR DESCRIPTION
- mapify init: report actual installed agent/command counts and list installed slash commands
- /map-fast: add guardrails and reduce token spend by avoiding FULL file content requirement

Files:
- src/mapify_cli/__init__.py
- src/mapify_cli/templates/commands/map-fast.md
- .claude/commands/map-fast.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added safety guardrails to `/map-fast` command with automatic routing for security-sensitive operations
  * Tightened subtask limit from 8 to 4 for improved task scoping and control
  * Optimized code change output format for better token efficiency
  * Dynamic "Next Steps" section now displays currently installed commands based on your setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->