### PR TITLE
fix: workflow enforcement to prevent Actor→Monitor skip

### DIFF
--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -11,6 +11,42 @@ description: Token-efficient MAP workflow with conditional optimizations
 3. Call each agent individually — no combining or skipping steps
 4. Max 5 retry iterations per subtask
 
+## ⛔ WORKFLOW ENFORCEMENT (Read Every Subtask)
+
+**CRITICAL ANTI-DRIFT RULE:**
+
+Before writing ANY implementation code, you MUST verify:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚠️  SELF-CHECK: Am I about to write code myself?               │
+│                                                                  │
+│  If YES → STOP! You are violating workflow.                     │
+│           Use Task(subagent_type="actor") instead.              │
+│                                                                  │
+│  If calling Task tool → Continue.                               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**BEFORE each Agent call, output this checkpoint:**
+```
+CHECKPOINT: Calling [agent_name] for ST-XXX
+```
+
+**VIOLATION INDICATORS (If you see yourself doing these, STOP):**
+- Writing code blocks without calling Actor first
+- Describing implementation approach without Actor
+- Saying "Let me implement..." without Task tool
+- Writing function/class definitions directly
+
+**CORRECT PATTERN:**
+1. Output: `CHECKPOINT: Calling actor for ST-001`
+2. Call: `Task(subagent_type="actor", ...)`
+3. Wait for Actor output
+4. Output: `CHECKPOINT: Calling monitor for ST-001`
+5. Call: `Task(subagent_type="monitor", ...)`
+6. Wait for Monitor output
+
 **Task:** $ARGUMENTS
 
 ## Workflow Overview
@@ -320,7 +356,20 @@ Validate synthesized code. If invalid: retry synthesis (max 2 iterations).
 
 ## Standard Path
 
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  ⚠️ REMINDER: You are the ORCHESTRATOR, not the implementer.    │
+│                                                                   │
+│  DO NOT write implementation code yourself.                       │
+│  DO call Task(subagent_type="actor") to get implementation.      │
+│                                                                   │
+│  This reminder appears because drift commonly occurs here.        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
 ### 2.3 Actor
+
+**PRE-STEP:** Output `CHECKPOINT: Calling actor for ST-XXX`
 
 ```
 Task(
@@ -336,6 +385,8 @@ Follow the Actor agent protocol output format."
 ```
 
 ### 2.4 Monitor (with Contract Validation)
+
+**PRE-STEP:** Output `CHECKPOINT: Calling monitor for ST-XXX`
 
 ```
 Task(
@@ -357,6 +408,8 @@ If validation_criteria present, include contract_compliance + contract_compliant
 ```
 
 ### 2.5 Retry Loop (3-Strike Protocol)
+
+**⚠️ ANTI-DRIFT CHECKPOINT:** On retry, you MUST still call Task(actor), NOT implement yourself!
 
 If `valid === false`: provide feedback, retry Actor (max 5 iterations).
 

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -11,6 +11,42 @@ description: Token-efficient MAP workflow with conditional optimizations
 3. Call each agent individually — no combining or skipping steps
 4. Max 5 retry iterations per subtask
 
+## ⛔ WORKFLOW ENFORCEMENT (Read Every Subtask)
+
+**CRITICAL ANTI-DRIFT RULE:**
+
+Before writing ANY implementation code, you MUST verify:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚠️  SELF-CHECK: Am I about to write code myself?               │
+│                                                                  │
+│  If YES → STOP! You are violating workflow.                     │
+│           Use Task(subagent_type="actor") instead.              │
+│                                                                  │
+│  If calling Task tool → Continue.                               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**BEFORE each Agent call, output this checkpoint:**
+```
+CHECKPOINT: Calling [agent_name] for ST-XXX
+```
+
+**VIOLATION INDICATORS (If you see yourself doing these, STOP):**
+- Writing code blocks without calling Actor first
+- Describing implementation approach without Actor
+- Saying "Let me implement..." without Task tool
+- Writing function/class definitions directly
+
+**CORRECT PATTERN:**
+1. Output: `CHECKPOINT: Calling actor for ST-001`
+2. Call: `Task(subagent_type="actor", ...)`
+3. Wait for Actor output
+4. Output: `CHECKPOINT: Calling monitor for ST-001`
+5. Call: `Task(subagent_type="monitor", ...)`
+6. Wait for Monitor output
+
 **Task:** $ARGUMENTS
 
 ## Workflow Overview
@@ -320,7 +356,20 @@ Validate synthesized code. If invalid: retry synthesis (max 2 iterations).
 
 ## Standard Path
 
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  ⚠️ REMINDER: You are the ORCHESTRATOR, not the implementer.    │
+│                                                                   │
+│  DO NOT write implementation code yourself.                       │
+│  DO call Task(subagent_type="actor") to get implementation.      │
+│                                                                   │
+│  This reminder appears because drift commonly occurs here.        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
 ### 2.3 Actor
+
+**PRE-STEP:** Output `CHECKPOINT: Calling actor for ST-XXX`
 
 ```
 Task(
@@ -336,6 +385,8 @@ Follow the Actor agent protocol output format."
 ```
 
 ### 2.4 Monitor (with Contract Validation)
+
+**PRE-STEP:** Output `CHECKPOINT: Calling monitor for ST-XXX`
 
 ```
 Task(
@@ -357,6 +408,8 @@ If validation_criteria present, include contract_compliance + contract_compliant
 ```
 
 ### 2.5 Retry Loop (3-Strike Protocol)
+
+**⚠️ ANTI-DRIFT CHECKPOINT:** On retry, you MUST still call Task(actor), NOT implement yourself!
 
 If `valid === false`: provide feedback, retry Actor (max 5 iterations).
 


### PR DESCRIPTION
## Summary

- Add anti-drift enforcement mechanisms to `map-efficient.md` to prevent Claude from skipping `Task(actor)`→`Task(monitor)` cycle
- Include research documents from claude-code-templates and PAI analysis

## Problem

When running `/map-efficient`, Claude often starts writing implementation code directly after 2-3 subtasks instead of calling `Task(subagent_type="actor")`. This violates the MAP workflow and bypasses Actor/Monitor validation.

## Solution

Added explicit enforcement mechanisms:
- **WORKFLOW ENFORCEMENT** section with visual self-check prompt
- **CHECKPOINT markers** before Actor/Monitor calls (`CHECKPOINT: Calling actor for ST-XXX`)
- **ORCHESTRATOR reminder** in Standard Path where drift commonly occurs
- **Anti-drift checkpoint** in Retry Loop

## Test plan

- [ ] Run `/map-efficient` on a task with 3+ subtasks
- [ ] Verify `CHECKPOINT: Calling actor...` appears before each implementation
- [ ] Verify no direct code writing without Actor call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced workflow enforcement documentation with explicit checkpoints and guidelines to improve orchestration consistency and process reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->