### PR TITLE
Remove unused MCP servers, improve workflow execution

### DIFF
--- a/.claude-plugin/PLUGIN.md
+++ b/.claude-plugin/PLUGIN.md
@@ -90,7 +90,6 @@ cp map-framework/.claude/settings.hooks.json your-project/.claude/
 
 **Recommended MCP Servers:**
 - `sequential-thinking` — chain-of-thought reasoning
-- `context7` — library documentation
 - `deepwiki` — GitHub repository analysis
 
 ## Quick Start

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,8 +40,8 @@
       "requirements": {
         "claude_code": ">=1.0.0",
         "mcp_servers": [
-          "claude-reviewer",
-          "sequential-thinking"
+          "sequential-thinking",
+          "deepwiki"
         ]
       },
       "installation": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,11 +24,7 @@
   "requirements": {
     "claude_code_version": ">=1.0.0",
     "mcp_servers": [
-      "claude-reviewer",
-      "sequential-thinking"
-    ],
-    "recommended_mcp_servers": [
-      "context7",
+      "sequential-thinking",
       "deepwiki"
     ]
   },
@@ -36,7 +32,6 @@
     "11 specialized MAP agents (TaskDecomposer, Actor, Monitor, Predictor, Evaluator, Reflector, DocumentationReviewer, Debate-Arbiter, Synthesizer, Research-Agent, Final-Verifier)",
     "5 Claude Code hooks for automation (validate-agent-templates, auto-store-knowledge, enrich-context, session-init, track-metrics)",
     "10 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-review, /map-check, /map-plan, /map-release, /map-resume, /map-learn)",
-    "Professional code review with claude-reviewer MCP",
     "Chain-of-thought reasoning with sequential-thinking MCP",
     "Semantic pattern search with embeddings cache",
     "Cost optimization with per-agent model selection (haiku/sonnet/opus)"

--- a/.claude/agents/actor.md
+++ b/.claude/agents/actor.md
@@ -87,14 +87,12 @@ This enables Synthesizer to extract and resolve decisions across variants.
 
 | Trigger | Tool | Purpose |
 |---------|------|---------|
-| External library API | context7 | Current documentation |
 | Architecture patterns | deepwiki | Production examples |
 
 ### Tool Selection Flowchart
 
 ```
 START → Using external library?
-    YES → context7: resolve-library-id → get-library-docs
     NO  → Continue
     ↓
 Need production architecture example?
@@ -112,7 +110,6 @@ Monitor will validate written code
 
 ## Handling MCP Tool Responses
 
-### context7 / deepwiki Results
 
 **Unclear or incomplete docs**:
 - Cross-reference with deepwiki for usage examples
@@ -122,7 +119,6 @@ Monitor will validate written code
 **Tool unavailable or timeout**:
 ```yaml
 status: RESEARCH_FALLBACK
-tool: context7
 fallback: "Using training data (Jan 2025), may need verification"
 mitigation: "Added version check, comprehensive tests"
 ```
@@ -131,7 +127,6 @@ mitigation: "Added version check, comprehensive tests"
 
 **Library Implementation**:
 ```
-context7: get-library-docs
     → (if architecture unclear) deepwiki: ask_question
     → implement
 ```
@@ -144,7 +139,6 @@ When multiple sources provide conflicting guidance, follow this priority (highes
 
 1. **Explicit human instruction** in subtask description
 2. **Security constraints** (NEVER override)
-3. **Research tools** (context7, deepwiki)
 4. **Training data** (fallback)
 
 </Actor_MCP_Protocol>
@@ -375,7 +369,6 @@ Only include if changes affect:
 - [ ] **Dependencies**: Known vulnerabilities checked (if new deps)
 
 ### MCP Compliance
-- [ ] Research tools used if knowledge gap existed (context7, deepwiki)
 - [ ] Fallback documented if tools unavailable
 
 ### Output Completeness
@@ -594,7 +587,6 @@ If all research tools fail:
 output:
   status: DEGRADED_MODE
   limitations:
-    - "context7: service unavailable"
     - "deepwiki: connection refused"
   confidence: LOW
   approach: "Implementing from training data only"
@@ -937,12 +929,10 @@ recommendation: "Option 1 - clean solution worth scope expansion"
 
 **Subtask**: "Implement WebSocket reconnection logic"
 
-**Approach**: Exponential backoff reconnection. context7 timed out. Implemented standard pattern with documented fallback.
 
 **Code Changes**:
 ```typescript
 // ===== File: lib/websocket.ts =====
-// Standard exponential backoff pattern (context7 unavailable)
 
 export class ReconnectingWebSocket {
   private ws: WebSocket | null = null;
@@ -976,7 +966,6 @@ export class ReconnectingWebSocket {
 
 **Trade-offs**:
 - **Decision**: Standard exponential backoff pattern
-- **Fallback**: context7 unavailable for socket.io v4 verification
 - **Mitigation**: Added comprehensive tests, runtime version check
 - **Risk**: May use outdated API - flagged for manual review
 

--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -107,11 +107,9 @@ You are a technical documentation expert specialized in architecture reviews and
 
 ## Optional MCP Tools (with fallbacks)
 ```
-IF mcp__context7__* available:
   → Use for library documentation verification
 ELSE:
   → Use Fetch to get raw documentation from official sources
-  → Log: "context7 unavailable, using direct fetch"
 
 IF mcp__deepwiki__* available:
   → Use for GitHub repository architecture questions
@@ -409,7 +407,6 @@ For External URL "https://project.io/":
            │
            └─ FAILURE (timeout/404/error)
                Is known library (npm/pypi/k8s)?
-               ├─ YES → mcp__context7__resolve_library_id → get_library_docs
                └─ NO → Mark as "verification_needed", severity per criticality
 ```
 
@@ -423,9 +420,6 @@ Fetch(
 )
 
 # 2. Verify library integration
-mcp__context7__resolve_library_id(libraryName="kyverno")
-mcp__context7__get_library_docs(
-    context7CompatibleLibraryID="/kyverno/kyverno",
     topic="CRD installation and webhook requirements",
     tokens=3000
 )

--- a/.claude/agents/evaluator.md
+++ b/.claude/agents/evaluator.md
@@ -376,7 +376,6 @@ Thought 8: Generate recommendation balancing dimensions
 **Thought Structure Example**:
 ```
 Thought 1: Identify knowledge gap areas (post-cutoff APIs, complex algorithms, security patterns)
-Thought 2: Check Actor output for research documentation (context7, deepwiki citations)
 Thought 3: Evaluate if research was appropriate (did gap require external knowledge?)
 Thought 4: Assess implementation correctness against research sources or known patterns
 Thought 5: Determine if research omission caused correctness issues (outdated API, wrong algorithm)
@@ -397,13 +396,11 @@ Thought 7: Generate recommendation with research feedback
 **Initial hypothesis**: Completeness 7/10 (has tests, docs), Functionality 8/10 (works)
 
 **Sequential-thinking discovery**:
-- **Thought 1**: Next.js Server Actions released April 2023 (post-cutoff) → expect context7 research
 - **Thought 2**: No research citations in Approach section → used training data (outdated)
 - **Thought 4**: Implementation uses `getServerSideProps` → deprecated in Next.js 13+ (Functionality 6/10, uses old API)
 - **Thought 5**: Should use async Server Components pattern → research would have caught this
 - **Thought 6**: Completeness 5/10 (missing research step, outdated implementation approach)
 - **Consolidated**: Functionality 6/10 (wrong pattern), Completeness 5/10 (no research), Code_quality 7/10 (clear but outdated)
-- **Recommendation**: "improve" - use mcp__context7 to get Next.js 14 Server Actions docs, refactor to async Server Components pattern
 
 ---
 
@@ -425,11 +422,9 @@ Thought 7: Generate recommendation with research feedback
 
 **Value Add**: Sequential-thinking reveals dimension interactions that single-pass evaluation misses, leading to more accurate scores and actionable recommendations that address root trade-offs (not just symptoms).
 
-### 2. mcp__claude-reviewer__get_review_history
 **Use When**: Check consistency with past implementations
 **Rationale**: Maintain consistent standards (e.g., if past testability scored 8/10, use same criteria). Prevents score inflation/deflation.
 
-### 3. mcp__context7__get-library-docs
 **Use When**: Solution uses external libraries/frameworks
 **Process**: `resolve-library-id` → `get-library-docs(topics: best-practices, performance, security, testing)`
 **Rationale**: Libraries define quality standards (React testing, Django security). Validate solutions follow these.
@@ -648,7 +643,6 @@ Untested code is broken code waiting to happen. Testability indicates design qua
 - [ ] Error handling complete?
 - [ ] Logging added for debugging?
 - [ ] Research performed when appropriate (unfamiliar libraries, complex algorithms)?
-  - IF subtask requires external knowledge (post-cutoff APIs, production patterns): Did Actor use research tools (context7/deepwiki) OR document skip justification?
   - IF research performed: Are sources cited in output (Approach/Trade-offs sections)?
   - Research completeness indicates thoroughness and reduces Monitor rejection risk
 - [ ] Deployment considerations addressed?

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -487,7 +487,6 @@ Test Code:
   → Verify coverage expectations
 ```
 
-### 1. mcp__claude-reviewer__request_review
 **Use When**: Reviewing implementation code (ALWAYS use first)
 **Parameters**: `summary` (1-2 sentences), `focus_areas` (array), `test_command` (optional)
 **Rationale**: AI baseline review + your domain expertise catches more issues
@@ -522,7 +521,6 @@ Thought N+1: Check for unreachable code or logic gaps
 Conclusion: List issues found with line numbers
 ```
 
-### 3. mcp__context7__get-library-docs
 **Use When**: Code uses external libraries/frameworks
 **Process**: `resolve-library-id` → `get-library-docs(library_id, topic)`
 **Topics**: best-practices, security, error-handling, performance, deprecated-apis
@@ -627,10 +625,7 @@ Priority 4: Severity
 
 | Short Name | Full MCP Name | Category |
 |------------|---------------|----------|
-| `request_review` | `mcp__claude-reviewer__request_review` | AI Review |
 | `sequentialthinking` | `mcp__sequential-thinking__sequentialthinking` | Analysis |
-| `get_library_docs` | `mcp__context7__get-library-docs` | Docs |
-| `resolve_library_id` | `mcp__context7__resolve-library-id` | Docs |
 | `deepwiki` | `mcp__deepwiki__ask_question` | Docs |
 | `glob` | Built-in Glob tool | File |
 | `read` | Built-in Read tool | File |

--- a/.claude/agents/predictor.md
+++ b/.claude/agents/predictor.md
@@ -73,7 +73,6 @@ TIER 2 (Standard - 1-2 min):
       - Cross-validate results
 
 TIER 3 (Deep - 3-5 min):
-  └── grep (extended) + deepwiki/context7 as needed
       - Cross-validate all results
       - Flag disagreements
 ```
@@ -218,7 +217,6 @@ Before any analysis, classify the change to select appropriate depth:
 2. Classify risk (usually "low")
 3. Output JSON with confidence 0.9+
 
-**Skip**: deepwiki, context7
 
 ### Tier 2: STANDARD Analysis (1-2 minutes)
 **When to use**:
@@ -399,7 +397,6 @@ Previous analysis identified these concerns:
 <rationale>
 Impact analysis is about pattern recognition. Similar changes have happened before--renaming APIs, refactoring modules, changing schemas. MCP tools let us learn from history:
 - deepwiki shows how mature projects handle similar changes
-- context7 validates library version compatibility
 
 Without these tools, we're guessing. With them, we're predicting based on evidence.
 </rationale>
@@ -427,7 +424,6 @@ ALWAYS → Grep/Glob (manual verification)
      - Manual search catches edge cases
 ```
 
-### 1. mcp__context7__get-library-docs
 **Use When**: Change involves external library or framework
 **Process**:
 1. `resolve-library-id` with library name

--- a/.claude/agents/reflector.md
+++ b/.claude/agents/reflector.md
@@ -27,7 +27,6 @@ You are an expert learning analyst who extracts reusable patterns and insights f
    → sequential-thinking for root cause analysis
 
 2. Error involves library/framework misuse?
-   → context7 (resolve-library-id → get-library-docs)
 
 3. How do production systems handle this?
    → deepwiki (read_wiki_structure → ask_question)
@@ -40,7 +39,6 @@ You are an expert learning analyst who extracts reusable patterns and insights f
 - Query: "Analyze why [error] in [context]. Trace: trigger → conditions → design → principle → lesson"
 - Why: Prevents shallow analysis (symptom vs root cause)
 
-**mcp__context7__resolve-library-id + get-library-docs**
 - Use when: Library API misuse, verify usage patterns, recommend API changes
 - Process: resolve-library-id → get-library-docs with topic
 - Why: Ensure current APIs, avoid deprecated patterns
@@ -51,7 +49,6 @@ You are an expert learning analyst who extracts reusable patterns and insights f
 - Why: Ground recommendations in battle-tested patterns
 
 <critical>
-**ALWAYS**: Use sequential-thinking for complex failures, verify library usage with context7
 **NEVER**: Skip MCP tools, suggest APIs without verifying docs
 </critical>
 
@@ -93,7 +90,6 @@ Execute frameworks in this sequence:
 ┌─────────────────────────────────────────────────────────────┐
 │ 1. MCP TOOLS (First - before analysis)                      │
 │    - sequential-thinking (IF complex failure)               │
-│    - context7 (IF library/API issue)                        │
 ├─────────────────────────────────────────────────────────────┤
 │ 2. CLASSIFICATION (Pattern Extraction Step 1)               │
 │    Output: SUCCESS | FAILURE | PARTIAL                      │
@@ -356,7 +352,6 @@ IF sequential-thinking exceeds 2 minutes:
   → Flag in reasoning: "Analysis incomplete due to complexity"
   → Recommend: "Break into sub-problems for future reflection"
 
-IF context7 cannot resolve library:
   → Fall back to deepwiki for community documentation
   → Note: "Official docs unavailable, used community sources"
 ```
@@ -757,7 +752,6 @@ Use {{language}}/{{framework}} syntax. Show specific library, configuration, exp
 
 ## What Reflector ALWAYS Does
 
-- Use MCP tools (sequential-thinking for complex cases, context7 for libraries)
 - Perform 5 Whys root cause (beyond symptoms)
 - Include code examples (5+ lines, incorrect + correct)
 - Ground in {{language}}/{{framework}} (specific syntax)
@@ -776,7 +770,6 @@ Reflector's job is learning, not doing. Generic advice is unmemorable. Shallow a
 
 Before outputting:
 
-- [ ] MCP Tools: Used sequential-thinking for complex cases? context7 for library issues?
 - [ ] JSON: All fields? No markdown blocks?
 - [ ] Length: reasoning≥200, root_cause≥150, key_insight≥50?
 - [ ] Code: 5+ lines showing incorrect + correct?

--- a/.claude/commands/map-debug.md
+++ b/.claude/commands/map-debug.md
@@ -235,7 +235,6 @@ This is **completely optional**. Run it when debugging patterns are valuable for
 ## MCP Tools for Debugging
 
 - `mcp__sequential-thinking__sequentialthinking` - Complex root cause analysis
-- `mcp__context7__get-library-docs` - Check library documentation for known issues
 - `mcp__deepwiki__ask_question` - Learn from how others solved similar issues
 
 ## Critical Constraints

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -15,7 +15,8 @@ State machine enforces sequencing, Python validates completion, hooks inject rem
 2. Use exact `subagent_type` specified — never substitute
 3. Call each agent individually — no combining or skipping
 4. Max 5 retry iterations per subtask (note: /map-fast uses max 3)
-5. Agent phases (ACTOR 2.3, MONITOR 2.4, PREDICTOR 2.6) require evidence files.
+5. **Always batch mode, always parallel**: execution mode is always `batch` (no pauses). After INIT_STATE, always compute waves and execute independent subtasks in parallel (multiple `Task()` calls in one message). See "Wave Computation" section.
+6. Agent phases (ACTOR 2.3, MONITOR 2.4, PREDICTOR 2.6) require evidence files.
    Each agent writes `.map/<branch>/evidence/<phase>_<subtask_id>.json` after completing work.
    `validate_step` rejects the step if evidence is missing or malformed.
 
@@ -212,7 +213,10 @@ Then use the **Write** tool to create `.map/<branch>/workflow_state.json`:
 }
 ```
 
-### Wave Computation (after INIT_STATE)
+### Wave Computation (after INIT_STATE) — REQUIRED
+
+**IMPORTANT: Always compute waves and execute subtasks in parallel when possible.**
+This is not optional — wave computation must run after every INIT_STATE.
 
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -348,6 +348,12 @@ Protocol (execute in order):
 )
 ```
 
+**CRITICAL: After Actor returns, do NOT debug or fix issues yourself.**
+- If Actor reports diagnostics/errors — proceed directly to MONITOR.
+- LSP diagnostics shown after Actor may be stale (IDE lag). Do NOT read files or attempt manual fixes.
+- Monitor will verify compilation (`go build`, `pytest`, etc.) and report real issues.
+- If Monitor returns `valid=false`, retry via Actor (not manual edits).
+
 ### Phase: MONITOR (2.4)
 
 ```python

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -73,7 +73,7 @@ if [ -f ".map/${BRANCH}/task_plan_${BRANCH}.md" ] && [ ! -f ".map/${BRANCH}/step
 fi
 ```
 
-If `resume_from_plan` succeeds, the orchestrator skips DECOMPOSE, INIT_PLAN, and REVIEW_PLAN (the plan was already approved in /map-plan) and starts from CHOOSE_MODE.
+If `resume_from_plan` succeeds, the orchestrator skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN, and CHOOSE_MODE (plan already approved, batch mode auto-set) and starts from INIT_STATE.
 
 ## Step 1: Get Next Step Instruction
 
@@ -189,20 +189,10 @@ python3 .map/scripts/map_orchestrator.py set_plan_approved true
 
 If not approved, stop (do not proceed).
 
-### Phase: CHOOSE_MODE (1.56)
+### Phase: CHOOSE_MODE (1.56) — Auto-skipped
 
-Ask the user how to run the workflow:
-
-1. `step_by_step` - pause between subtasks for confirmation
-2. `batch` - run through all subtasks without pausing
-
-Persist choice:
-
-```bash
-python3 .map/scripts/map_orchestrator.py set_execution_mode step_by_step  # or batch
-```
-
-Note: In `batch` mode the orchestrator auto-skips the pause step (2.11).
+Execution mode is always `batch` (auto-set by orchestrator). No user interaction needed.
+The orchestrator auto-skips this step and proceeds to INIT_STATE.
 
 ### Phase: INIT_STATE (1.6)
 
@@ -539,13 +529,9 @@ If FAILED: DO NOT PROCEED. Go back and complete missing steps.
 ═══════════════════════════════════════════════════
 ```
 
-### Phase: SUBTASK_APPROVAL (2.11)
+### Phase: SUBTASK_APPROVAL (2.11) — Auto-skipped
 
-Only used when execution_mode is `step_by_step`.
-
-- Show a brief completion checkpoint for the current subtask.
-- Ask the user whether to continue to the next subtask.
-- If execution_mode is `batch`, the orchestrator auto-skips this step.
+Auto-skipped in batch mode (default). The orchestrator proceeds to the next subtask without pausing.
 
 ## Step 2a: Validate Step Completion
 
@@ -589,7 +575,7 @@ else
 fi
 ```
 
-In `step_by_step` mode, the state machine inserts a pause step (2.11) between subtasks.
+Execution mode is always `batch`. The orchestrator auto-skips pause steps (2.11) between subtasks.
 
 ## Step 3: Final Verification (Ralph Loop)
 

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -23,7 +23,43 @@
 
 ## Workflow Steps
 
+### Pre-flight: Resume Detection
+
+Before starting ANY step, check which artifacts already exist for this branch:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "state:       $(test -f .map/${BRANCH}/workflow_state.json && echo EXISTS || echo MISSING)"
+```
+
+**Resume rules:**
+- If `findings` EXISTS → skip Step 0 (discovery), read existing findings instead
+- If `spec` EXISTS → skip Steps 1-2 (interview), read existing spec instead
+- If `task_plan` EXISTS → skip Steps 4-6 (decomposition), read existing plan instead
+- If `workflow_state.json` EXISTS → plan is already complete, print checkpoint and STOP
+
+This prevents redundant work when the user restarts Claude mid-plan.
+
 ### Step 0: Quick Discovery (Optional but Recommended)
+
+**IMPORTANT — Check for existing discovery first:**
+
+Before running discovery, check if `.map/<branch>/findings_<branch>.md` already exists:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+test -f ".map/${BRANCH}/findings_${BRANCH}.md" && echo "EXISTS" || echo "MISSING"
+```
+
+- If **EXISTS**: Read the file, print "Discovery already completed — reusing existing findings", and skip to Step 1.
+- If **MISSING**: Run discovery below.
+
+This prevents redundant discovery when the user restarts a Claude session mid-plan.
+
+---
 
 If the request touches an existing codebase (most do), do a short discovery pass to avoid planning in a vacuum.
 

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -39,7 +39,7 @@ STEP PHASES (16 total):
   1.0  DECOMPOSE          - task-decomposer agent
   1.5  INIT_PLAN          - Generate task_plan.md
   1.55 REVIEW_PLAN        - User review + explicit approval checkpoint
-  1.56 CHOOSE_MODE        - Choose execution mode (step_by_step|batch)
+  1.56 CHOOSE_MODE        - Auto-skipped (always batch mode)
   1.6  INIT_STATE         - Create workflow_state.json
   2.0  XML_PACKET         - Build AI-friendly subtask packet
   2.1  CONTEXT_SEARCH     - Context search
@@ -51,7 +51,7 @@ STEP PHASES (16 total):
   2.8  TESTS_GATE         - Run tests
   2.9  LINTER_GATE        - Run linter
   2.10 VERIFY_ADHERENCE   - Self-audit checkpoint
-  2.11 SUBTASK_APPROVAL   - Optional pause between subtasks (step_by_step)
+  2.11 SUBTASK_APPROVAL   - Auto-skipped in batch mode
 
 CLI INTERFACE:
   python3 map_orchestrator.py get_next_step [--branch BRANCH]
@@ -292,9 +292,8 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             "python3 .map/scripts/map_orchestrator.py set_plan_approved true"
         ),
         "1.56": (
-            "Ask user to choose execution mode: step_by_step (pause between subtasks) "
-            "or batch (run through). Persist choice in step_state.json: "
-            "python3 .map/scripts/map_orchestrator.py set_execution_mode step_by_step|batch"
+            "Execution mode is batch (auto-set). No user action needed. "
+            "Advance to next step: python3 .map/scripts/map_orchestrator.py get_next_step"
         ),
         "1.6": (
             "Create .map/<branch>/workflow_state.json with initial state. "
@@ -369,6 +368,13 @@ def get_next_step(branch: str) -> Dict:
     """
     state_file = Path(f".map/{branch}/step_state.json")
     state = StepState.load(state_file)
+
+    # Auto-skip CHOOSE_MODE: always batch, set mode automatically
+    while state.pending_steps and state.pending_steps[0] == "1.56":
+        state.execution_mode = "batch"
+        state.completed_steps.append("1.56")
+        state.pending_steps.pop(0)
+        state.save(state_file)
 
     # Auto-skip steps that are conditional in batch mode
     while (
@@ -450,11 +456,7 @@ def validate_step(step_id: str, branch: str) -> Dict:
             "valid": False,
             "message": "Plan not approved. Set approval first: python3 .map/scripts/map_orchestrator.py set_plan_approved true",
         }
-    if step_id == "1.56" and state.execution_mode not in {"batch", "step_by_step"}:
-        return {
-            "valid": False,
-            "message": "Invalid execution_mode. Set mode first: python3 .map/scripts/map_orchestrator.py set_execution_mode step_by_step|batch",
-        }
+    # CHOOSE_MODE is auto-skipped; execution_mode is always "batch"
 
     # Evidence-gated validation: require agent evidence files for key steps
     if step_id in EVIDENCE_REQUIRED:
@@ -970,7 +972,7 @@ def resume_from_plan(branch: str) -> Dict:
 
     Detects task_plan_<branch>.md and workflow_state.json created by /map-plan.
     Extracts subtask IDs from the plan, marks init phases as completed, and
-    starts execution from CHOOSE_MODE (user still picks step_by_step vs batch).
+    starts execution from INIT_STATE (batch mode auto-set).
 
     Args:
         branch: Git branch name (sanitized)
@@ -1010,9 +1012,9 @@ def resume_from_plan(branch: str) -> Dict:
         except (json.JSONDecodeError, KeyError):
             pass
 
-    # Create state that skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN (plan already approved)
-    # Start from CHOOSE_MODE so user can still pick execution mode
-    skipped_phases = ["1.0", "1.5", "1.55"]
+    # Create state that skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN, CHOOSE_MODE
+    # (plan already approved, execution mode is always batch)
+    skipped_phases = ["1.0", "1.5", "1.55", "1.56"]
     execution_start = [s for s in STEP_ORDER if s not in skipped_phases]
 
     state_file = plan_dir / "step_state.json"
@@ -1020,11 +1022,12 @@ def resume_from_plan(branch: str) -> Dict:
         current_subtask_id=subtask_ids[0],
         subtask_index=0,
         subtask_sequence=subtask_ids,
-        current_step_id="1.56",
-        current_step_phase="CHOOSE_MODE",
+        current_step_id=execution_start[0] if execution_start else "1.6",
+        current_step_phase=STEP_PHASES.get(execution_start[0], "INIT_STATE") if execution_start else "INIT_STATE",
         completed_steps=skipped_phases,
         pending_steps=execution_start,
         plan_approved=True,
+        execution_mode="batch",
     )
     state.save(state_file)
 
@@ -1034,11 +1037,11 @@ def resume_from_plan(branch: str) -> Dict:
 
     return {
         "status": "success",
-        "message": "Resumed from /map-plan. Skipped DECOMPOSE, INIT_PLAN, REVIEW_PLAN.",
+        "message": "Resumed from /map-plan. Skipped DECOMPOSE, INIT_PLAN, REVIEW_PLAN, CHOOSE_MODE. Mode: batch.",
         "subtask_sequence": subtask_ids,
         "current_subtask_id": subtask_ids[0],
         "aag_contracts_found": len(aag_contracts),
-        "next_phase": "CHOOSE_MODE",
+        "next_phase": "INIT_STATE",
     }
 
 

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -5,22 +5,6 @@
   "_warning": "Project-specific .mcp.json overrides global ~/.claude.json settings. Only use if you need project-specific MCP configuration.",
 
   "mcpServers": {
-    "claude-reviewer": {
-      "_comment": "Code review MCP server - provides professional code review with security analysis",
-      "_note": "This example uses a community server. You may need to adjust the command for your setup.",
-      "_alternatives": [
-        "Custom fork: /path/to/your/mcp-claude-reviewer/mcp-wrapper.sh",
-        "Community server: npx -y @vibesnipe/code-review-mcp"
-      ],
-      "_required_for": "Professional code review integration, MAP /map-review command",
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@vibesnipe/code-review-mcp"],
-      "env": {
-        "OPENAI_API_KEY": "${OPENAI_API_KEY}"
-      }
-    },
-
     "sequential-thinking": {
       "_comment": "Anthropic's Sequential Thinking - Provides structured chain-of-thought reasoning",
       "_install": "Automatically installed via npx",
@@ -29,17 +13,6 @@
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    },
-
-    "context7": {
-      "_comment": "Context7 by Upstash - Up-to-date, version-specific library documentation",
-      "_install": "Automatically installed via npx",
-      "_required_for": "Library documentation lookup (optional but recommended)",
-      "_docs": "https://github.com/upstash/context7",
-      "_usage": "Add 'use context7' to your prompts",
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
     },
 
     "deepwiki": {
@@ -57,11 +30,9 @@
     "global_vs_local": "Most users should configure MCP servers in ~/.claude.json globally. Only use project-specific .mcp.json if you need different configurations per project.",
     "environment_variables": "Environment variables like ${OPENAI_API_KEY} are expanded from your shell environment or .env file.",
     "required_servers": [
-      "claude-reviewer - Essential for code review features",
       "sequential-thinking - Essential for complex reasoning"
     ],
     "optional_servers": [
-      "context7 - Recommended for library documentation",
       "deepwiki - Recommended for GitHub repository analysis"
     ],
     "alternative_installations": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -833,13 +833,13 @@ If you modified `.claude/commands/map-efficient.md`, you must manually integrate
 5. **Used Patterns** (pattern IDs applied)
 
 **Key Behaviors:**
-- Fetches current docs for external libraries (via context7)
+- Fetches current docs for external libraries (via deepwiki)
 - Explicit error handling required (no silent failures)
 - Complete code, not sketches or placeholders
 - Security-first approach for auth/data access
 
 **MCP Tool Usage:**
-- `mcp__context7__get-library-docs`: Get current library documentation
+- `mcp__deepwiki__read_wiki_contents`: Get current library/project documentation
 
 ### 3. Monitor
 
@@ -871,7 +871,6 @@ If you modified `.claude/commands/map-efficient.md`, you must manually integrate
 - ✅ Dependency justification (if new deps added)
 
 **Key Behaviors:**
-- Uses `claude-reviewer` MCP for professional code review
 - Severity classification: critical/major/minor
 - Specific, actionable feedback
 - Checks against project coding standards
@@ -1197,9 +1196,7 @@ MAP uses MCP (Model Context Protocol) servers for enhanced capabilities beyond b
 
 | MCP Server | Purpose | Required For | Performance Notes |
 |------------|---------|--------------|-------------------|
-| **claude-reviewer** | Professional code review | Monitor | Medium latency (~2-5s) |
 | **sequential-thinking** | Chain-of-thought reasoning | Complex problem solving | Medium latency (~1-3s) |
-| **context7** | Up-to-date library documentation | Actor (external libs) | Low latency (<500ms) |
 | **deepwiki** | GitHub repository analysis | Research phase | Medium latency (~3-7s) |
 
 ### Configuration
@@ -1213,12 +1210,13 @@ MCP servers are configured differently depending on the usage context:
 ```json
 {
   "mcp_servers": {
-    "claude-reviewer": {
+    "sequential-thinking": {
       "enabled": true,
-      "description": "Professional code review with security analysis",
-      "config": {
-        "focus_areas": ["security", "performance", "maintainability"]
-      }
+      "description": "Chain-of-thought reasoning for complex problems"
+    },
+    "deepwiki": {
+      "enabled": true,
+      "description": "GitHub repository analysis and documentation"
     }
   }
 }
@@ -1226,18 +1224,18 @@ MCP servers are configured differently depending on the usage context:
 
 ### MCP Tool Usage Patterns
 
-#### Pattern 1: Current Documentation (Actor)
+#### Pattern 1: Documentation Lookup (Actor)
 
 ```markdown
-**WHEN using external libraries:**
+**WHEN using external libraries or researching projects:**
 
-1. Resolve library ID:
-   - Tool: mcp__context7__resolve-library-id
-   - Input: Library name (e.g., "Flask", "Next.js")
+1. Read wiki structure:
+   - Tool: mcp__deepwiki__read_wiki_structure
+   - Input: Repository owner/name (e.g., "pallets/flask")
 
-2. Fetch current docs:
-   - Tool: mcp__context7__get-library-docs
-   - Parameters: library_id, topic, tokens (default: 5000)
+2. Read wiki contents:
+   - Tool: mcp__deepwiki__read_wiki_contents
+   - Parameters: repo_name, page path
 
 3. Use docs for:
    - API signature verification
@@ -1245,61 +1243,12 @@ MCP servers are configured differently depending on the usage context:
    - Deprecation warnings
 ```
 
-#### Pattern 2: Professional Review (Monitor)
-
-```markdown
-**AFTER Actor generates code:**
-
-1. Request code review:
-   - Tool: claude-reviewer__request_review
-   - Parameters: summary, focus_areas, test_command
-
-2. Parse review output:
-   - Critical issues → BLOCK
-   - Major issues → FEEDBACK to Actor
-   - Minor issues → SUGGESTIONS
-
-3. Iterate until approved:
-   - Max 3-5 iterations
-   - Track iteration count in plan
-```
-
-### Configuration Options
-
-#### Context7 Configuration
-
-```json
-{
-  "context7": {
-    "config": {
-      "default_tokens": 5000,          // Default doc size per request
-      "cache_duration": 3600           // Cache docs for 1 hour
-    }
-  }
-}
-```
-
-#### Claude-Reviewer Configuration
-
-```json
-{
-  "claude-reviewer": {
-    "config": {
-      "focus_areas": ["security", "performance", "maintainability"],
-      "auto_mark_complete": false      // Require manual completion
-    }
-  }
-}
-```
-
 ### MCP Server Availability
 
 **Commonly Available:**
-- claude-reviewer (code review)
 - sequential-thinking (reasoning)
 
 **May Require Installation:**
-- context7 (check Claude Code documentation)
 - deepwiki (check Claude Code documentation)
 
 **To verify availability:**
@@ -1311,9 +1260,8 @@ MCP servers are configured differently depending on the usage context:
 ### Performance Considerations
 
 **Latency Budget (per subtask):**
-- context7 docs: ~500ms per fetch (Actor: 1-2 fetches = ~1s)
-- claude-reviewer: ~2-5s per review (Monitor: 1 review)
-- Total overhead: ~2-7s per subtask
+- deepwiki docs: ~3-7s per fetch (Actor: 1-2 fetches)
+- Total overhead: ~3-7s per subtask
 
 **Optimization Strategies:**
 - Batch similar searches where possible
@@ -2167,7 +2115,7 @@ All failures are non-blocking - hook returns `{"continue": true}` and logs error
 
 **Phase 2** (Prioritized):
 1. **Checkpoints** (high impact) — Workflow resumption after interruption
-2. **MCP caching** (medium-high) — Latency reduction for context7
+2. **MCP caching** (medium-high) — Latency reduction for MCP servers
 3. **Keyword+semantic search** (medium) — Hybrid retrieval accuracy
 4. **Pattern variation** (low-medium) — Few-shot bias reduction
 

--- a/docs/CLI_COMMAND_REFERENCE.md
+++ b/docs/CLI_COMMAND_REFERENCE.md
@@ -116,7 +116,7 @@ mapify init . --force
 mapify init my-project --no-git
 
 # Enable specific MCP servers
-mapify init . --mcp context7,deepwiki
+mapify init . --mcp sequential-thinking,deepwiki
 ```
 
 ---

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -162,14 +162,11 @@ Choose which MCP servers to enable:
 # All available MCP servers
 mapify init my-project --mcp all
 
-# Essential servers only (claude-reviewer, sequential-thinking)
+# Essential servers only (sequential-thinking, deepwiki)
 mapify init my-project --mcp essential
 
-# Documentation servers (context7, deepwiki)
-mapify init my-project --mcp docs
-
 # Specific servers
-mapify init my-project --mcp "context7,deepwiki"
+mapify init my-project --mcp "sequential-thinking,deepwiki"
 
 # No MCP servers
 mapify init my-project --mcp none
@@ -308,23 +305,11 @@ MAP Framework uses **slash commands** as entry points that coordinate specialize
 
 If you selected MCP servers during installation, ensure they're configured:
 
-### Claude-Reviewer (Professional Review)
-
-- Automated security and quality analysis
-- Historical review tracking
-- Focused review on specific areas
-
 ### Sequential-Thinking (Chain-of-Thought)
 
 - Complex problem decomposition
 - Iterative refinement of solutions
 - Edge case discovery
-
-### Context7 (Library Documentation)
-
-- Current API references for any library
-- Version-specific documentation
-- Migration guides
 
 ### Deepwiki (GitHub Intelligence)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,7 +79,7 @@ Maintain all existing functionality.
 
 ```bash
 /map-efficient integrate Stripe payment processing.
-Use context7 to get latest Stripe docs.
+Use deepwiki to get latest Stripe docs.
 ```
 
 ### Learning from Open Source
@@ -1082,7 +1082,7 @@ The Actor agent now includes a 10-item Quality Checklist for self-review before 
 2. Explicit error handling (no silent failures)
 3. Security review (SQL injection, XSS, sensitive data)
 4. Test case identification (happy path + edge cases)
-5. MCP tools usage (context7, sequential-thinking)
+5. MCP tools usage (deepwiki, sequential-thinking)
 6. Template variable preservation (orchestration compatibility)
 7. Trade-offs documentation (decision rationale)
 8. Complete implementations (no ellipsis or placeholders)

--- a/scripts/lint-agent-templates.py
+++ b/scripts/lint-agent-templates.py
@@ -236,7 +236,6 @@ class TemplateLinter:
         """Check MCP tool descriptions for consistency"""
         # Common MCP tools that should be consistently described
         mcp_tools = {
-            "context7": ["library", "documentation", "resolve-library-id"],
             "deepwiki": ["wiki", "repository", "production"],
         }
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -83,16 +83,13 @@ ssl_context = create_ssl_context()
 # Constants
 MCP_SERVER_CHOICES = {
     "all": "All available MCP servers",
-    "essential": "Essential (claude-reviewer, sequential-thinking)",
-    "docs": "Documentation (context7, deepwiki)",
+    "essential": "Essential (sequential-thinking, deepwiki)",
     "custom": "Select individually",
     "none": "Skip MCP setup",
 }
 
 INDIVIDUAL_MCP_SERVERS = {
-    "claude-reviewer": "Professional code review",
     "sequential-thinking": "Chain-of-thought reasoning",
-    "context7": "Library documentation",
     "deepwiki": "GitHub repository intelligence",
 }
 
@@ -551,7 +548,7 @@ def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
 def create_task_decomposer_content(mcp_servers: List[str]) -> str:
     """Create task-decomposer agent content"""
     mcp_section = ""
-    if any(s in mcp_servers for s in ["sequential-thinking", "deepwiki", "context7"]):
+    if any(s in mcp_servers for s in ["sequential-thinking", "deepwiki"]):
         mcp_section = """
 ## MCP Integration
 
@@ -566,11 +563,6 @@ def create_task_decomposer_content(mcp_servers: List[str]) -> str:
             mcp_section += """
 2. **mcp__deepwiki__ask_question** - Get insights from GitHub repositories
    - Ask: "How does [repo] implement [feature]?"
-"""
-        if "context7" in mcp_servers:
-            mcp_section += """
-3. **mcp__context7__get-library-docs** - Get up-to-date library documentation
-   - First use resolve-library-id to find the library
 """
 
     return f"""---
@@ -600,20 +592,13 @@ Return a valid JSON document with subtasks, dependencies, and acceptance criteri
 def create_actor_content(mcp_servers: List[str]) -> str:
     """Create actor agent content"""
     mcp_section = ""
-    if any(s in mcp_servers for s in ["context7", "deepwiki"]):
+    if "deepwiki" in mcp_servers:
         mcp_section = """
 # MCP INTEGRATION
 
 **ALWAYS use these MCP tools:**
-"""
-        if "context7" in mcp_servers:
-            mcp_section += """
-1. **mcp__context7__get-library-docs** - Get current library documentation
-   - Essential when using external libraries/frameworks
-"""
-        if "deepwiki" in mcp_servers:
-            mcp_section += """
-2. **mcp__deepwiki__read_wiki_contents** - Study implementation patterns
+
+1. **mcp__deepwiki__read_wiki_contents** - Study implementation patterns
    - Learn from production code examples
 """
 
@@ -683,18 +668,7 @@ Provide implementation with approach, code changes, trade-offs, and testing cons
 
 def create_monitor_content(mcp_servers: List[str]) -> str:
     """Create monitor agent content"""
-    mcp_section = ""
-    if "claude-reviewer" in mcp_servers:
-        mcp_section = """
-# MCP INTEGRATION
-
-**ALWAYS use these MCP tools for comprehensive review:**
-
-1. **mcp__claude-reviewer__request_review** - Get professional AI code review
-   - Use FIRST to get baseline review, then add your analysis
-"""
-
-    return f"""---
+    return """---
 name: monitor
 description: Reviews code for correctness, standards, security, and testability (MAP)
 tools: Read, Grep, Bash, Glob
@@ -704,7 +678,7 @@ model: sonnet
 # IDENTITY
 
 You are a meticulous code reviewer and security expert. Your mission is to catch bugs, vulnerabilities, and violations before code reaches production.
-{mcp_section}
+
 # REVIEW CHECKLIST
 
 Work through: Correctness, Security, Code Quality, Performance, Testability, Maintainability
@@ -751,21 +725,14 @@ Return strictly valid JSON with validation results and specific issues.
 def create_predictor_content(mcp_servers: List[str]) -> str:
     """Create predictor agent content"""
     mcp_section = ""
-    if any(s in mcp_servers for s in ["deepwiki", "context7"]):
+    if "deepwiki" in mcp_servers:
         mcp_section = """
 ## MCP Integration
 
 **ALWAYS use these MCP tools:**
-"""
-        if "deepwiki" in mcp_servers:
-            mcp_section += """
+
 1. **mcp__deepwiki__ask_question** - Check how repos handle similar changes
    - Ask: "What breaks when changing [component]?"
-"""
-        if "context7" in mcp_servers:
-            mcp_section += """
-2. **mcp__context7__get-library-docs** - Check library compatibility
-   - Verify API changes against current documentation
 """
 
     return f"""---
@@ -860,21 +827,13 @@ Return JSON with:
 def create_documentation_reviewer_content(mcp_servers: List[str]) -> str:
     """Create documentation-reviewer agent content"""
     mcp_section = ""
-    if any(s in mcp_servers for s in ["context7", "deepwiki"]):
+    if "deepwiki" in mcp_servers:
         mcp_section = """
 # MCP INTEGRATION
 
 **ALWAYS use these tools for documentation review:**
-"""
-        if "context7" in mcp_servers:
-            mcp_section += """
-1. **mcp__context7__get-library-docs** - Verify library requirements
-   - Check official docs for installation requirements
-   - Validate version compatibility
-"""
-        if "deepwiki" in mcp_servers:
-            mcp_section += """
-2. **mcp__deepwiki__ask_question** - Compare with similar projects
+
+1. **mcp__deepwiki__ask_question** - Compare with similar projects
    - Ask: "How do other projects handle [integration]?"
    - Learn from successful implementations
 """
@@ -1336,15 +1295,6 @@ def create_mcp_config(project_path: Path, mcp_servers: List[str]) -> None:
 
     # Add server configurations
     server_configs = {
-        "claude-reviewer": {
-            "enabled": True,
-            "description": "Professional AI code review",
-            "config": {
-                "auto_review": True,
-                "focus_areas": ["security", "performance", "testing"],
-                "severity_threshold": "medium",
-            },
-        },
         "sequential-thinking": {
             "enabled": True,
             "description": "Chain-of-thought reasoning",
@@ -1353,11 +1303,6 @@ def create_mcp_config(project_path: Path, mcp_servers: List[str]) -> None:
                 "branch_exploration": True,
                 "hypothesis_verification": True,
             },
-        },
-        "context7": {
-            "enabled": True,
-            "description": "Up-to-date library documentation",
-            "config": {"tokens": 5000, "auto_resolve": True, "cache_duration": 3600},
         },
         "deepwiki": {
             "enabled": True,
@@ -1382,15 +1327,6 @@ def create_mcp_config(project_path: Path, mcp_servers: List[str]) -> None:
         ]:
             if agent in config["agent_mcp_mappings"]:
                 config["agent_mcp_mappings"][agent].append("sequential-thinking")
-
-    if "claude-reviewer" in mcp_servers:
-        for agent in ["monitor", "evaluator", "final-verifier"]:
-            if agent in config["agent_mcp_mappings"]:
-                config["agent_mcp_mappings"][agent].append("claude-reviewer")
-
-    if "context7" in mcp_servers:
-        for agent in config["agent_mcp_mappings"]:
-            config["agent_mcp_mappings"][agent].append("context7")
 
     if "deepwiki" in mcp_servers:
         for agent in config["agent_mcp_mappings"]:
@@ -1420,10 +1356,6 @@ def build_standard_mcp_servers() -> Dict[str, Dict[str, Any]]:
         "sequential-thinking": {
             "command": "npx",
             "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
-        },
-        "context7": {
-            "type": "http",
-            "url": "https://mcp.context7.com/mcp",
         },
         "deepwiki": {
             "type": "http",
@@ -1537,7 +1469,7 @@ def create_or_merge_project_mcp_json(
 
     Args:
         project_path: Project root directory
-        mcp_servers: List of MCP server names to configure (e.g., ["context7", "deepwiki"])
+        mcp_servers: List of MCP server names to configure (e.g., ["sequential-thinking", "deepwiki"])
 
     Behavior:
         - If mcp_servers is empty: No file created/modified (early return)
@@ -1890,7 +1822,7 @@ def init(
     mcp: str = typer.Option(
         "all",
         "--mcp",
-        help="MCP server installation (default: all). Options: all, essential, docs, none, or comma-separated list (e.g. context7,deepwiki)",
+        help="MCP server installation (default: all). Options: all, essential, none, or comma-separated list (e.g. sequential-thinking,deepwiki)",
     ),
     no_git: bool = typer.Option(
         False, "--no-git", help="Skip git repository initialization"
@@ -1918,7 +1850,7 @@ def init(
         mapify init my-project              # Installs all MCP servers
         mapify init my-project --mcp none   # Skip MCP installation
         mapify init my-project --mcp essential
-        mapify init my-project --mcp "context7,deepwiki"
+        mapify init my-project --mcp "sequential-thinking,deepwiki"
         mapify init .
         mapify init . --force  # Force init in non-empty current directory
         mapify init --debug  # Enable workflow logging
@@ -2016,9 +1948,7 @@ def init(
     if mcp == "all":
         selected_mcp_servers = list(INDIVIDUAL_MCP_SERVERS.keys())
     elif mcp == "essential":
-        selected_mcp_servers = ["claude-reviewer", "sequential-thinking"]
-    elif mcp == "docs":
-        selected_mcp_servers = ["context7", "deepwiki"]
+        selected_mcp_servers = ["sequential-thinking", "deepwiki"]
     elif mcp == "none":
         selected_mcp_servers = []
     else:

--- a/src/mapify_cli/templates/agents/actor.md
+++ b/src/mapify_cli/templates/agents/actor.md
@@ -87,14 +87,12 @@ This enables Synthesizer to extract and resolve decisions across variants.
 
 | Trigger | Tool | Purpose |
 |---------|------|---------|
-| External library API | context7 | Current documentation |
 | Architecture patterns | deepwiki | Production examples |
 
 ### Tool Selection Flowchart
 
 ```
 START → Using external library?
-    YES → context7: resolve-library-id → get-library-docs
     NO  → Continue
     ↓
 Need production architecture example?
@@ -112,7 +110,6 @@ Monitor will validate written code
 
 ## Handling MCP Tool Responses
 
-### context7 / deepwiki Results
 
 **Unclear or incomplete docs**:
 - Cross-reference with deepwiki for usage examples
@@ -122,7 +119,6 @@ Monitor will validate written code
 **Tool unavailable or timeout**:
 ```yaml
 status: RESEARCH_FALLBACK
-tool: context7
 fallback: "Using training data (Jan 2025), may need verification"
 mitigation: "Added version check, comprehensive tests"
 ```
@@ -131,7 +127,6 @@ mitigation: "Added version check, comprehensive tests"
 
 **Library Implementation**:
 ```
-context7: get-library-docs
     → (if architecture unclear) deepwiki: ask_question
     → implement
 ```
@@ -144,7 +139,6 @@ When multiple sources provide conflicting guidance, follow this priority (highes
 
 1. **Explicit human instruction** in subtask description
 2. **Security constraints** (NEVER override)
-3. **Research tools** (context7, deepwiki)
 4. **Training data** (fallback)
 
 </Actor_MCP_Protocol>
@@ -375,7 +369,6 @@ Only include if changes affect:
 - [ ] **Dependencies**: Known vulnerabilities checked (if new deps)
 
 ### MCP Compliance
-- [ ] Research tools used if knowledge gap existed (context7, deepwiki)
 - [ ] Fallback documented if tools unavailable
 
 ### Output Completeness
@@ -594,7 +587,6 @@ If all research tools fail:
 output:
   status: DEGRADED_MODE
   limitations:
-    - "context7: service unavailable"
     - "deepwiki: connection refused"
   confidence: LOW
   approach: "Implementing from training data only"
@@ -937,12 +929,10 @@ recommendation: "Option 1 - clean solution worth scope expansion"
 
 **Subtask**: "Implement WebSocket reconnection logic"
 
-**Approach**: Exponential backoff reconnection. context7 timed out. Implemented standard pattern with documented fallback.
 
 **Code Changes**:
 ```typescript
 // ===== File: lib/websocket.ts =====
-// Standard exponential backoff pattern (context7 unavailable)
 
 export class ReconnectingWebSocket {
   private ws: WebSocket | null = null;
@@ -976,7 +966,6 @@ export class ReconnectingWebSocket {
 
 **Trade-offs**:
 - **Decision**: Standard exponential backoff pattern
-- **Fallback**: context7 unavailable for socket.io v4 verification
 - **Mitigation**: Added comprehensive tests, runtime version check
 - **Risk**: May use outdated API - flagged for manual review
 

--- a/src/mapify_cli/templates/agents/documentation-reviewer.md
+++ b/src/mapify_cli/templates/agents/documentation-reviewer.md
@@ -107,11 +107,9 @@ You are a technical documentation expert specialized in architecture reviews and
 
 ## Optional MCP Tools (with fallbacks)
 ```
-IF mcp__context7__* available:
   → Use for library documentation verification
 ELSE:
   → Use Fetch to get raw documentation from official sources
-  → Log: "context7 unavailable, using direct fetch"
 
 IF mcp__deepwiki__* available:
   → Use for GitHub repository architecture questions
@@ -409,7 +407,6 @@ For External URL "https://project.io/":
            │
            └─ FAILURE (timeout/404/error)
                Is known library (npm/pypi/k8s)?
-               ├─ YES → mcp__context7__resolve_library_id → get_library_docs
                └─ NO → Mark as "verification_needed", severity per criticality
 ```
 
@@ -423,9 +420,6 @@ Fetch(
 )
 
 # 2. Verify library integration
-mcp__context7__resolve_library_id(libraryName="kyverno")
-mcp__context7__get_library_docs(
-    context7CompatibleLibraryID="/kyverno/kyverno",
     topic="CRD installation and webhook requirements",
     tokens=3000
 )

--- a/src/mapify_cli/templates/agents/evaluator.md
+++ b/src/mapify_cli/templates/agents/evaluator.md
@@ -376,7 +376,6 @@ Thought 8: Generate recommendation balancing dimensions
 **Thought Structure Example**:
 ```
 Thought 1: Identify knowledge gap areas (post-cutoff APIs, complex algorithms, security patterns)
-Thought 2: Check Actor output for research documentation (context7, deepwiki citations)
 Thought 3: Evaluate if research was appropriate (did gap require external knowledge?)
 Thought 4: Assess implementation correctness against research sources or known patterns
 Thought 5: Determine if research omission caused correctness issues (outdated API, wrong algorithm)
@@ -397,13 +396,11 @@ Thought 7: Generate recommendation with research feedback
 **Initial hypothesis**: Completeness 7/10 (has tests, docs), Functionality 8/10 (works)
 
 **Sequential-thinking discovery**:
-- **Thought 1**: Next.js Server Actions released April 2023 (post-cutoff) → expect context7 research
 - **Thought 2**: No research citations in Approach section → used training data (outdated)
 - **Thought 4**: Implementation uses `getServerSideProps` → deprecated in Next.js 13+ (Functionality 6/10, uses old API)
 - **Thought 5**: Should use async Server Components pattern → research would have caught this
 - **Thought 6**: Completeness 5/10 (missing research step, outdated implementation approach)
 - **Consolidated**: Functionality 6/10 (wrong pattern), Completeness 5/10 (no research), Code_quality 7/10 (clear but outdated)
-- **Recommendation**: "improve" - use mcp__context7 to get Next.js 14 Server Actions docs, refactor to async Server Components pattern
 
 ---
 
@@ -425,11 +422,9 @@ Thought 7: Generate recommendation with research feedback
 
 **Value Add**: Sequential-thinking reveals dimension interactions that single-pass evaluation misses, leading to more accurate scores and actionable recommendations that address root trade-offs (not just symptoms).
 
-### 2. mcp__claude-reviewer__get_review_history
 **Use When**: Check consistency with past implementations
 **Rationale**: Maintain consistent standards (e.g., if past testability scored 8/10, use same criteria). Prevents score inflation/deflation.
 
-### 3. mcp__context7__get-library-docs
 **Use When**: Solution uses external libraries/frameworks
 **Process**: `resolve-library-id` → `get-library-docs(topics: best-practices, performance, security, testing)`
 **Rationale**: Libraries define quality standards (React testing, Django security). Validate solutions follow these.
@@ -648,7 +643,6 @@ Untested code is broken code waiting to happen. Testability indicates design qua
 - [ ] Error handling complete?
 - [ ] Logging added for debugging?
 - [ ] Research performed when appropriate (unfamiliar libraries, complex algorithms)?
-  - IF subtask requires external knowledge (post-cutoff APIs, production patterns): Did Actor use research tools (context7/deepwiki) OR document skip justification?
   - IF research performed: Are sources cited in output (Approach/Trade-offs sections)?
   - Research completeness indicates thoroughness and reduces Monitor rejection risk
 - [ ] Deployment considerations addressed?

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -487,7 +487,6 @@ Test Code:
   → Verify coverage expectations
 ```
 
-### 1. mcp__claude-reviewer__request_review
 **Use When**: Reviewing implementation code (ALWAYS use first)
 **Parameters**: `summary` (1-2 sentences), `focus_areas` (array), `test_command` (optional)
 **Rationale**: AI baseline review + your domain expertise catches more issues
@@ -522,7 +521,6 @@ Thought N+1: Check for unreachable code or logic gaps
 Conclusion: List issues found with line numbers
 ```
 
-### 3. mcp__context7__get-library-docs
 **Use When**: Code uses external libraries/frameworks
 **Process**: `resolve-library-id` → `get-library-docs(library_id, topic)`
 **Topics**: best-practices, security, error-handling, performance, deprecated-apis
@@ -627,10 +625,7 @@ Priority 4: Severity
 
 | Short Name | Full MCP Name | Category |
 |------------|---------------|----------|
-| `request_review` | `mcp__claude-reviewer__request_review` | AI Review |
 | `sequentialthinking` | `mcp__sequential-thinking__sequentialthinking` | Analysis |
-| `get_library_docs` | `mcp__context7__get-library-docs` | Docs |
-| `resolve_library_id` | `mcp__context7__resolve-library-id` | Docs |
 | `deepwiki` | `mcp__deepwiki__ask_question` | Docs |
 | `glob` | Built-in Glob tool | File |
 | `read` | Built-in Read tool | File |

--- a/src/mapify_cli/templates/agents/predictor.md
+++ b/src/mapify_cli/templates/agents/predictor.md
@@ -73,7 +73,6 @@ TIER 2 (Standard - 1-2 min):
       - Cross-validate results
 
 TIER 3 (Deep - 3-5 min):
-  └── grep (extended) + deepwiki/context7 as needed
       - Cross-validate all results
       - Flag disagreements
 ```
@@ -218,7 +217,6 @@ Before any analysis, classify the change to select appropriate depth:
 2. Classify risk (usually "low")
 3. Output JSON with confidence 0.9+
 
-**Skip**: deepwiki, context7
 
 ### Tier 2: STANDARD Analysis (1-2 minutes)
 **When to use**:
@@ -399,7 +397,6 @@ Previous analysis identified these concerns:
 <rationale>
 Impact analysis is about pattern recognition. Similar changes have happened before--renaming APIs, refactoring modules, changing schemas. MCP tools let us learn from history:
 - deepwiki shows how mature projects handle similar changes
-- context7 validates library version compatibility
 
 Without these tools, we're guessing. With them, we're predicting based on evidence.
 </rationale>
@@ -427,7 +424,6 @@ ALWAYS → Grep/Glob (manual verification)
      - Manual search catches edge cases
 ```
 
-### 1. mcp__context7__get-library-docs
 **Use When**: Change involves external library or framework
 **Process**:
 1. `resolve-library-id` with library name

--- a/src/mapify_cli/templates/agents/reflector.md
+++ b/src/mapify_cli/templates/agents/reflector.md
@@ -27,7 +27,6 @@ You are an expert learning analyst who extracts reusable patterns and insights f
    → sequential-thinking for root cause analysis
 
 2. Error involves library/framework misuse?
-   → context7 (resolve-library-id → get-library-docs)
 
 3. How do production systems handle this?
    → deepwiki (read_wiki_structure → ask_question)
@@ -40,7 +39,6 @@ You are an expert learning analyst who extracts reusable patterns and insights f
 - Query: "Analyze why [error] in [context]. Trace: trigger → conditions → design → principle → lesson"
 - Why: Prevents shallow analysis (symptom vs root cause)
 
-**mcp__context7__resolve-library-id + get-library-docs**
 - Use when: Library API misuse, verify usage patterns, recommend API changes
 - Process: resolve-library-id → get-library-docs with topic
 - Why: Ensure current APIs, avoid deprecated patterns
@@ -51,7 +49,6 @@ You are an expert learning analyst who extracts reusable patterns and insights f
 - Why: Ground recommendations in battle-tested patterns
 
 <critical>
-**ALWAYS**: Use sequential-thinking for complex failures, verify library usage with context7
 **NEVER**: Skip MCP tools, suggest APIs without verifying docs
 </critical>
 
@@ -93,7 +90,6 @@ Execute frameworks in this sequence:
 ┌─────────────────────────────────────────────────────────────┐
 │ 1. MCP TOOLS (First - before analysis)                      │
 │    - sequential-thinking (IF complex failure)               │
-│    - context7 (IF library/API issue)                        │
 ├─────────────────────────────────────────────────────────────┤
 │ 2. CLASSIFICATION (Pattern Extraction Step 1)               │
 │    Output: SUCCESS | FAILURE | PARTIAL                      │
@@ -356,7 +352,6 @@ IF sequential-thinking exceeds 2 minutes:
   → Flag in reasoning: "Analysis incomplete due to complexity"
   → Recommend: "Break into sub-problems for future reflection"
 
-IF context7 cannot resolve library:
   → Fall back to deepwiki for community documentation
   → Note: "Official docs unavailable, used community sources"
 ```
@@ -757,7 +752,6 @@ Use {{language}}/{{framework}} syntax. Show specific library, configuration, exp
 
 ## What Reflector ALWAYS Does
 
-- Use MCP tools (sequential-thinking for complex cases, context7 for libraries)
 - Perform 5 Whys root cause (beyond symptoms)
 - Include code examples (5+ lines, incorrect + correct)
 - Ground in {{language}}/{{framework}} (specific syntax)
@@ -776,7 +770,6 @@ Reflector's job is learning, not doing. Generic advice is unmemorable. Shallow a
 
 Before outputting:
 
-- [ ] MCP Tools: Used sequential-thinking for complex cases? context7 for library issues?
 - [ ] JSON: All fields? No markdown blocks?
 - [ ] Length: reasoning≥200, root_cause≥150, key_insight≥50?
 - [ ] Code: 5+ lines showing incorrect + correct?

--- a/src/mapify_cli/templates/commands/map-debug.md
+++ b/src/mapify_cli/templates/commands/map-debug.md
@@ -235,7 +235,6 @@ This is **completely optional**. Run it when debugging patterns are valuable for
 ## MCP Tools for Debugging
 
 - `mcp__sequential-thinking__sequentialthinking` - Complex root cause analysis
-- `mcp__context7__get-library-docs` - Check library documentation for known issues
 - `mcp__deepwiki__ask_question` - Learn from how others solved similar issues
 
 ## Critical Constraints

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -15,7 +15,8 @@ State machine enforces sequencing, Python validates completion, hooks inject rem
 2. Use exact `subagent_type` specified — never substitute
 3. Call each agent individually — no combining or skipping
 4. Max 5 retry iterations per subtask (note: /map-fast uses max 3)
-5. Agent phases (ACTOR 2.3, MONITOR 2.4, PREDICTOR 2.6) require evidence files.
+5. **Always batch mode, always parallel**: execution mode is always `batch` (no pauses). After INIT_STATE, always compute waves and execute independent subtasks in parallel (multiple `Task()` calls in one message). See "Wave Computation" section.
+6. Agent phases (ACTOR 2.3, MONITOR 2.4, PREDICTOR 2.6) require evidence files.
    Each agent writes `.map/<branch>/evidence/<phase>_<subtask_id>.json` after completing work.
    `validate_step` rejects the step if evidence is missing or malformed.
 
@@ -212,7 +213,10 @@ Then use the **Write** tool to create `.map/<branch>/workflow_state.json`:
 }
 ```
 
-### Wave Computation (after INIT_STATE)
+### Wave Computation (after INIT_STATE) — REQUIRED
+
+**IMPORTANT: Always compute waves and execute subtasks in parallel when possible.**
+This is not optional — wave computation must run after every INIT_STATE.
 
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -348,6 +348,12 @@ Protocol (execute in order):
 )
 ```
 
+**CRITICAL: After Actor returns, do NOT debug or fix issues yourself.**
+- If Actor reports diagnostics/errors — proceed directly to MONITOR.
+- LSP diagnostics shown after Actor may be stale (IDE lag). Do NOT read files or attempt manual fixes.
+- Monitor will verify compilation (`go build`, `pytest`, etc.) and report real issues.
+- If Monitor returns `valid=false`, retry via Actor (not manual edits).
+
 ### Phase: MONITOR (2.4)
 
 ```python

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -73,7 +73,7 @@ if [ -f ".map/${BRANCH}/task_plan_${BRANCH}.md" ] && [ ! -f ".map/${BRANCH}/step
 fi
 ```
 
-If `resume_from_plan` succeeds, the orchestrator skips DECOMPOSE, INIT_PLAN, and REVIEW_PLAN (the plan was already approved in /map-plan) and starts from CHOOSE_MODE.
+If `resume_from_plan` succeeds, the orchestrator skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN, and CHOOSE_MODE (plan already approved, batch mode auto-set) and starts from INIT_STATE.
 
 ## Step 1: Get Next Step Instruction
 
@@ -189,20 +189,10 @@ python3 .map/scripts/map_orchestrator.py set_plan_approved true
 
 If not approved, stop (do not proceed).
 
-### Phase: CHOOSE_MODE (1.56)
+### Phase: CHOOSE_MODE (1.56) — Auto-skipped
 
-Ask the user how to run the workflow:
-
-1. `step_by_step` - pause between subtasks for confirmation
-2. `batch` - run through all subtasks without pausing
-
-Persist choice:
-
-```bash
-python3 .map/scripts/map_orchestrator.py set_execution_mode step_by_step  # or batch
-```
-
-Note: In `batch` mode the orchestrator auto-skips the pause step (2.11).
+Execution mode is always `batch` (auto-set by orchestrator). No user interaction needed.
+The orchestrator auto-skips this step and proceeds to INIT_STATE.
 
 ### Phase: INIT_STATE (1.6)
 
@@ -539,13 +529,9 @@ If FAILED: DO NOT PROCEED. Go back and complete missing steps.
 ═══════════════════════════════════════════════════
 ```
 
-### Phase: SUBTASK_APPROVAL (2.11)
+### Phase: SUBTASK_APPROVAL (2.11) — Auto-skipped
 
-Only used when execution_mode is `step_by_step`.
-
-- Show a brief completion checkpoint for the current subtask.
-- Ask the user whether to continue to the next subtask.
-- If execution_mode is `batch`, the orchestrator auto-skips this step.
+Auto-skipped in batch mode (default). The orchestrator proceeds to the next subtask without pausing.
 
 ## Step 2a: Validate Step Completion
 
@@ -589,7 +575,7 @@ else
 fi
 ```
 
-In `step_by_step` mode, the state machine inserts a pause step (2.11) between subtasks.
+Execution mode is always `batch`. The orchestrator auto-skips pause steps (2.11) between subtasks.
 
 ## Step 3: Final Verification (Ralph Loop)
 

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -23,7 +23,43 @@
 
 ## Workflow Steps
 
+### Pre-flight: Resume Detection
+
+Before starting ANY step, check which artifacts already exist for this branch:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "state:       $(test -f .map/${BRANCH}/workflow_state.json && echo EXISTS || echo MISSING)"
+```
+
+**Resume rules:**
+- If `findings` EXISTS → skip Step 0 (discovery), read existing findings instead
+- If `spec` EXISTS → skip Steps 1-2 (interview), read existing spec instead
+- If `task_plan` EXISTS → skip Steps 4-6 (decomposition), read existing plan instead
+- If `workflow_state.json` EXISTS → plan is already complete, print checkpoint and STOP
+
+This prevents redundant work when the user restarts Claude mid-plan.
+
 ### Step 0: Quick Discovery (Optional but Recommended)
+
+**IMPORTANT — Check for existing discovery first:**
+
+Before running discovery, check if `.map/<branch>/findings_<branch>.md` already exists:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+test -f ".map/${BRANCH}/findings_${BRANCH}.md" && echo "EXISTS" || echo "MISSING"
+```
+
+- If **EXISTS**: Read the file, print "Discovery already completed — reusing existing findings", and skip to Step 1.
+- If **MISSING**: Run discovery below.
+
+This prevents redundant discovery when the user restarts a Claude session mid-plan.
+
+---
 
 If the request touches an existing codebase (most do), do a short discovery pass to avoid planning in a vacuum.
 

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -275,7 +275,7 @@ class TestInitCommand:
 
         Verifies that:
         - Init succeeds with --mcp essential
-        - Essential MCP servers are configured (claude-reviewer, sequential-thinking)
+        - Essential MCP servers are configured (sequential-thinking, deepwiki)
         - Agent files are created
         """
         os.chdir(tmp_path)
@@ -288,8 +288,8 @@ class TestInitCommand:
 
         # Check MCP config contains essential servers
         mcp_config = json.loads((tmp_path / ".claude" / "mcp_config.json").read_text())
-        assert "claude-reviewer" in mcp_config["mcp_servers"]
         assert "sequential-thinking" in mcp_config["mcp_servers"]
+        assert "deepwiki" in mcp_config["mcp_servers"]
 
     def test_init_with_directory(self, tmp_path):
         """Test init with specific directory name.
@@ -337,7 +337,7 @@ class TestInitCommand:
 
         Verifies that:
         - --mcp essential flag installs essential servers
-        - MCP config contains claude-reviewer, sequential-thinking
+        - MCP config contains sequential-thinking, deepwiki
         """
         os.chdir(tmp_path)
 
@@ -347,8 +347,8 @@ class TestInitCommand:
         assert (tmp_path / ".claude" / "mcp_config.json").exists()
 
         mcp_config = json.loads((tmp_path / ".claude" / "mcp_config.json").read_text())
-        assert "claude-reviewer" in mcp_config["mcp_servers"]
         assert "sequential-thinking" in mcp_config["mcp_servers"]
+        assert "deepwiki" in mcp_config["mcp_servers"]
 
     @pytest.mark.skip(
         reason="Test isolation issue: passes in isolation but fails in full suite after 332 tests due to stdin/stdout state. TODO: Investigate and fix test infrastructure issue."
@@ -359,9 +359,8 @@ class TestInitCommand:
         Regression test for non-interactive init behavior.
         Verifies that:
         - Init completes without interactive prompts
-        - All 4 MCP servers are installed by default (claude-reviewer,
-          sequential-thinking, context7, deepwiki)
-        - mcp_config.json is created with all 4 servers
+        - All 2 MCP servers are installed by default (sequential-thinking, deepwiki)
+        - mcp_config.json is created with all 2 servers
         """
         # Use fresh CliRunner to avoid state pollution from previous tests
         from typer.testing import CliRunner as FreshRunner
@@ -396,9 +395,7 @@ class TestInitCommand:
         # Verify all 4 MCP servers are configured
         mcp_config = json.loads((tmp_path / ".claude" / "mcp_config.json").read_text())
         expected_servers = [
-            "claude-reviewer",
             "sequential-thinking",
-            "context7",
             "deepwiki",
         ]
 
@@ -570,7 +567,7 @@ class TestAgentCreation:
 
     def test_create_agent_files_with_templates(self, tmp_path):
         """Test creating agent files from templates."""
-        create_agent_files(tmp_path, ["claude-reviewer"])
+        create_agent_files(tmp_path, ["deepwiki"])
 
         agents_dir = tmp_path / ".claude" / "agents"
         assert agents_dir.exists()
@@ -599,7 +596,7 @@ class TestAgentCreation:
         mock_get_templates.return_value = mock_templates_path
 
         # Call create_agent_files with MCP servers
-        create_agent_files(tmp_path, ["claude-reviewer"])
+        create_agent_files(tmp_path, ["deepwiki"])
 
         agents_dir = tmp_path / ".claude" / "agents"
         assert agents_dir.exists()
@@ -699,7 +696,6 @@ class TestMcpJsonConfig:
 
         expected_servers = [
             "sequential-thinking",
-            "context7",
             "deepwiki",
         ]
         for server in expected_servers:
@@ -715,7 +711,7 @@ class TestMcpJsonConfig:
             assert "args" in servers[server_name], f"{server_name} missing args"
 
         # http servers should have 'type' and 'url' keys
-        for server_name in ["context7", "deepwiki"]:
+        for server_name in ["deepwiki"]:
             assert (
                 servers[server_name].get("type") == "http"
             ), f"{server_name} should be http"
@@ -791,53 +787,53 @@ class TestMcpJsonConfig:
             }
         }
         new_servers = {
-            "context7": {"type": "http", "url": "https://mcp.context7.com/mcp"},
+            "deepwiki": {"type": "http", "url": "https://mcp.deepwiki.com/mcp"},
         }
 
         result = merge_mcp_json(existing, new_servers)
 
         assert "user-server" in result["mcpServers"]
-        assert "context7" in result["mcpServers"]
+        assert "deepwiki" in result["mcpServers"]
         assert result["mcpServers"]["user-server"]["command"] == "user-cmd"
 
     def test_merge_mcp_json_does_not_overwrite(self):
         """Test that merge does not overwrite existing servers with same name."""
         existing = {
             "mcpServers": {
-                "context7": {
+                "deepwiki": {
                     "type": "http",
                     "url": "https://custom.url",
                 },  # User's custom
             }
         }
         new_servers = {
-            "context7": {
+            "deepwiki": {
                 "type": "http",
-                "url": "https://mcp.context7.com/mcp",
+                "url": "https://mcp.deepwiki.com/mcp",
             },  # Standard
         }
 
         result = merge_mcp_json(existing, new_servers)
 
         # User's custom config should be preserved
-        assert result["mcpServers"]["context7"]["url"] == "https://custom.url"
+        assert result["mcpServers"]["deepwiki"]["url"] == "https://custom.url"
 
     def test_merge_mcp_json_adds_mcpservers_key(self):
         """Test that merge adds mcpServers key if missing."""
         existing = {"other_key": "value"}
         new_servers = {
-            "context7": {"type": "http", "url": "https://mcp.context7.com/mcp"}
+            "deepwiki": {"type": "http", "url": "https://mcp.deepwiki.com/mcp"}
         }
 
         result = merge_mcp_json(existing, new_servers)
 
         assert "mcpServers" in result
-        assert "context7" in result["mcpServers"]
+        assert "deepwiki" in result["mcpServers"]
         assert "other_key" in result  # Other keys preserved
 
     def test_create_or_merge_new_file(self, tmp_path):
         """Test creating new .mcp.json when file doesn't exist."""
-        create_or_merge_project_mcp_json(tmp_path, ["deepwiki", "context7"])
+        create_or_merge_project_mcp_json(tmp_path, ["deepwiki", "sequential-thinking"])
 
         mcp_file = tmp_path / ".mcp.json"
         assert mcp_file.exists()
@@ -845,7 +841,7 @@ class TestMcpJsonConfig:
         config = json.loads(mcp_file.read_text())
         assert "mcpServers" in config
         assert "deepwiki" in config["mcpServers"]
-        assert "context7" in config["mcpServers"]
+        assert "sequential-thinking" in config["mcpServers"]
         assert len(config["mcpServers"]) == 2
 
     def test_create_or_merge_existing_file(self, tmp_path):
@@ -877,21 +873,21 @@ class TestMcpJsonConfig:
     def test_create_or_merge_filters_unknown_servers(self, tmp_path):
         """Test that unknown server names are ignored."""
         create_or_merge_project_mcp_json(
-            tmp_path, ["deepwiki", "unknown-server", "context7"]
+            tmp_path, ["deepwiki", "unknown-server", "sequential-thinking"]
         )
 
         mcp_file = tmp_path / ".mcp.json"
         config = json.loads(mcp_file.read_text())
 
         assert "deepwiki" in config["mcpServers"]
-        assert "context7" in config["mcpServers"]
+        assert "sequential-thinking" in config["mcpServers"]
         assert "unknown-server" not in config["mcpServers"]
 
     def test_init_creates_mcp_json(self, tmp_path):
         """Test that mapify init creates .mcp.json file."""
         os.chdir(tmp_path)
 
-        result = runner.invoke(app, ["init", ".", "--force", "--mcp", "docs"])
+        result = runner.invoke(app, ["init", ".", "--force", "--mcp", "essential"])
 
         # Allow exit code 0 or initialization messages
         mcp_file = tmp_path / ".mcp.json"
@@ -901,8 +897,8 @@ class TestMcpJsonConfig:
 
         config = json.loads(mcp_file.read_text())
         assert "mcpServers" in config
-        # docs = context7 + deepwiki
-        assert "context7" in config["mcpServers"] or "deepwiki" in config["mcpServers"]
+        # essential = sequential-thinking + deepwiki
+        assert "deepwiki" in config["mcpServers"] or "sequential-thinking" in config["mcpServers"]
 
 
 class TestCreateMapTools:


### PR DESCRIPTION
## Summary

- Remove context7 and claude-reviewer MCP servers from all configs, agents, templates, docs, tests, and scripts
- Add resume detection to `/map-plan` — skip already-completed discovery/spec/plan steps on session restart
- Auto-set batch mode in `/map-efficient` — skip CHOOSE_MODE, no more "step-by-step vs batch" prompt
- Enforce parallel wave execution as REQUIRED (not optional) in `/map-efficient`
- After Actor returns, forward to Monitor instead of manually debugging stale LSP diagnostics

## Commits

1. `ca8d749` — Remove context7 and claude-reviewer MCP servers (25 files, -324 lines)
2. `fbd1a8a` — Add resume detection to /map-plan
3. `04172b2` — Auto-set batch mode, skip CHOOSE_MODE
4. `fe46cf2` — Enforce parallel wave execution
5. `29c8a0f` — Don't debug after Actor, forward to Monitor

## Test plan

- [x] `pytest` — 668 passed, 1 skipped, 0 failed
- [x] `make sync-templates` — templates in sync