### PR TITLE
feat: add TDD workflow and enhanced SPEC phase

### DIFF
--- a/.claude/agents/actor.md
+++ b/.claude/agents/actor.md
@@ -227,6 +227,52 @@ UserService -> register(email, password) -> creates user, returns 201 with JWT
 
 ---
 
+## TDD Mode Support
+
+Actor supports two TDD modes, activated by the `<TDD_Mode>` tag in the prompt:
+
+### TDD Mode: `test_writer`
+
+When `<TDD_Mode>test_writer</TDD_Mode>` is present:
+
+**You write ONLY test files.** No implementation code.
+
+Rules:
+1. Derive tests from the AAG contract, validation_criteria, and test_strategy — NOT from any implementation.
+2. You have NO knowledge of the implementation. Do not assume internal structure, class names, or method signatures beyond what the contract specifies.
+3. Test the PUBLIC interface/behavior described in the contract.
+4. Each `VCn:` validation criterion must have at least one corresponding test.
+5. Include edge cases from the spec's `## Edge Cases` section if available in the packet.
+6. Use standard test patterns for the project's language and framework.
+7. Tests SHOULD fail when run (implementation doesn't exist yet). This is expected.
+
+Output:
+- Test files created via Write tool
+- Evidence file: `.map/<branch>/evidence/test_writer_<subtask_id>.json`
+
+### TDD Mode: `code_only`
+
+When `<TDD_Mode>code_only</TDD_Mode>` is present:
+
+**You write ONLY implementation code.** Test files are READ-ONLY.
+
+Rules:
+1. Read the test files listed in `<TDD_Tests>` FIRST to understand expected behavior.
+2. Do NOT modify, delete, or rename any test file.
+3. Implement the minimum code needed to make ALL existing tests pass.
+4. Follow the AAG contract as your specification.
+5. If a test seems wrong (testing impossible behavior), flag it in trade-offs but still implement to satisfy it. Monitor will catch true test issues.
+
+Output:
+- Implementation files created/modified via Edit/Write tools
+- Standard Actor evidence file
+
+### No TDD Mode (default)
+
+When no `<TDD_Mode>` tag is present, Actor operates in standard mode: write both implementation and tests as described in sections 3-7 below.
+
+---
+
 ## 2. Approach
 Explain solution strategy in 2-3 sentences. Include:
 - Core idea and why this approach

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -244,6 +244,7 @@ Return **ONLY** valid JSON in this exact structure:
   - `scope`: "function" | "endpoint" | "module"
   - Include when: security_critical OR complexity_score ≥ 5 OR API contracts
   - Omit when: simple CRUD, internal helpers, complexity_score < 5
+  - **Spec invariant linkage**: If a `spec_<branch>.md` file exists with an `## Invariants` section, each contract MUST trace back to at least one spec invariant. Add `"source": "spec-invariant-N"` to link the contract to the invariant it enforces. This ensures no spec invariant is left unguarded by contracts.
 **subtasks[].aag_contract**: REQUIRED one-line contract in `Actor -> Action(params) -> Goal` format
   - This is the primary handoff artifact to the Actor agent
   - Actor "compiles" this contract into code; Monitor verifies against it
@@ -542,6 +543,11 @@ If circular dependency detected (e.g., A→B→C→A):
 - [ ] For complexity_score ≥ 7, verify at least one entry in `risks` (or explicitly state `[]` if none)
 - [ ] All assumptions documented that could affect implementation
 - [ ] Open questions flagged that need clarification before proceeding
+
+**Spec Invariant Coverage** (when spec exists):
+- [ ] Read `spec_<branch>.md` if present — check for `## Invariants` section
+- [ ] Each spec invariant is covered by at least one contract across subtasks
+- [ ] Edge cases from spec's `## Edge Cases` section are reflected in validation_criteria
 
 **MCP Tool Usage Verification**:
 - [ ] Did you use insights from MCP tools in your decomposition?

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -61,6 +61,29 @@ Both files must stay in sync. The orchestrator updates `step_state.json` on ever
 
 **Task:** $ARGUMENTS
 
+## Flag Parsing
+
+Parse optional flags from `$ARGUMENTS`:
+
+- **`--tdd`**: Enable TDD mode (test-first workflow). Inserts TEST_WRITER and TEST_FAIL_GATE phases before ACTOR. Tests are written from spec before implementation.
+
+```bash
+# Extract flags and clean task description
+TASK_ARGS="$ARGUMENTS"
+TDD_FLAG=false
+if echo "$TASK_ARGS" | grep -q -- '--tdd'; then
+  TDD_FLAG=true
+  TASK_ARGS=$(echo "$TASK_ARGS" | sed 's/--tdd//g' | xargs)
+fi
+```
+
+If `--tdd` is detected, enable TDD mode after state initialization:
+```bash
+if [ "$TDD_FLAG" = "true" ]; then
+  python3 .map/scripts/map_orchestrator.py set_tdd_mode true
+fi
+```
+
 ## Step 0: Detect Existing Plan from /map-plan
 
 Before starting the state machine, check if `/map-plan` already produced artifacts for this branch:
@@ -322,7 +345,53 @@ This file is the SOLE research artifact passed to Actor and future steps."""
     )
 ```
 
+### Phase: TEST_WRITER (2.25) — TDD Mode Only
+
+Auto-skipped when TDD mode is disabled. When active:
+
+```python
+Task(
+  subagent_type="actor",
+  description="TDD: Write tests for subtask [ID]",
+  prompt=f"""You are in TDD TEST_WRITER mode.
+
+<MAP_Packet subtask="[ID]" v="1.0" risk="[risk_level]">
+[paste from .map/<branch>/current_packet.xml]
+</MAP_Packet>
+
+<MAP_Contract>
+[AAG contract from decomposition]
+</MAP_Contract>
+
+<TDD_Mode>test_writer</TDD_Mode>
+
+STRICT RULES:
+1. Write ONLY test files. Do NOT create or modify implementation files.
+2. Tests must be derived from the SPECIFICATION (AAG contract + validation_criteria).
+3. You have NO knowledge of the implementation.
+4. Each VCn: validation criterion must have at least one corresponding test.
+5. Tests SHOULD fail when run (implementation doesn't exist yet).
+
+Write evidence: .map/<branch>/evidence/test_writer_<subtask_id>.json"""
+)
+```
+
+### Phase: TEST_FAIL_GATE (2.26) — TDD Mode Only
+
+Auto-skipped when TDD mode is disabled. When active, run the tests — they MUST fail:
+
+```bash
+# Run tests — expect failures (Red phase)
+pytest --tb=short 2>&1 || true
+# If tests PASS → go back to TEST_WRITER (tests are trivial)
+# If tests FAIL with assertion errors → proceed to ACTOR (expected TDD state)
+```
+
+Write evidence: `.map/<branch>/evidence/test_fail_gate_<subtask_id>.json`
+
 ### Phase: ACTOR (2.3)
+
+When TDD mode is active, Actor receives `<TDD_Mode>code_only</TDD_Mode>` and must NOT modify test files. When TDD is off, standard behavior.
 
 ```python
 Task(

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -59,8 +59,6 @@ Both files must stay in sync. The orchestrator updates `step_state.json` on ever
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Task:** $ARGUMENTS
-
 ## Flag Parsing
 
 Parse optional flags from `$ARGUMENTS`:
@@ -76,6 +74,10 @@ if echo "$TASK_ARGS" | grep -q -- '--tdd'; then
   TASK_ARGS=$(echo "$TASK_ARGS" | sed 's/--tdd//g' | xargs)
 fi
 ```
+
+**Task:** $TASK_ARGS
+
+**IMPORTANT:** Use `$TASK_ARGS` (not `$ARGUMENTS`) in all agent prompts below. The `--tdd` flag has been stripped from `$TASK_ARGS` so it won't leak into task descriptions.
 
 If `--tdd` is detected, enable TDD mode after state initialization:
 ```bash
@@ -128,7 +130,7 @@ Task(
   description="Decompose task into subtasks",
   prompt=f"""Break down into ≤20 atomic subtasks and RETURN ONLY JSON.
 
-Task: $ARGUMENTS
+Task: $TASK_ARGS
 
 Hard requirements:
 - Use `blueprint.subtasks[].validation_criteria` (2-4 testable outcomes)
@@ -277,6 +279,14 @@ loop:
     # Phase A: Prep (sequential per subtask - lightweight)
     for each subtask in WAVE.subtasks:
       build XML_PACKET, run CONTEXT_SEARCH, optional RESEARCH
+
+    # Phase A.5: TDD phases (if --tdd mode)
+    # When TDD is enabled, run TEST_WRITER + TEST_FAIL_GATE per subtask
+    # BEFORE launching Actors. These run sequentially per subtask.
+    if TDD_FLAG:
+      for each subtask in WAVE.subtasks:
+        run TEST_WRITER (2.25) → validate_wave_step SUBTASK_ID "2.25"
+        run TEST_FAIL_GATE (2.26) → validate_wave_step SUBTASK_ID "2.26"
 
     # Phase B: Parallel Actors
     # Launch ALL Task(subagent_type="actor") calls in ONE message

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -596,10 +596,16 @@ Question 2: For EACH subtask, did I:
   - Run linter gate? [YES/NO per subtask]
 Answer: [List each subtask and answers]
 
-Question 3: Did I ever write code directly without Actor?
+Question 3: (TDD mode only) For EACH subtask, did I:
+  - Call TEST_WRITER before Actor? [YES/NO/N/A per subtask]
+  - Verify tests failed at TEST_FAIL_GATE? [YES/NO/N/A per subtask]
+  - Use code_only mode for Actor (no test modifications)? [YES/NO/N/A]
+Answer: [List answers, or N/A if TDD mode is not active]
+
+Question 4: Did I ever write code directly without Actor?
 Answer: [YES/NO - if YES, this is a VIOLATION]
 
-Question 4: Did I output CHECKPOINT blocks before agent calls?
+Question 5: Did I output CHECKPOINT blocks before agent calls?
 Answer: [YES/NO - if NO, add them now]
 
 EVALUATION: [PASSED/FAILED]

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -371,6 +371,8 @@ STRICT RULES:
 3. You have NO knowledge of the implementation.
 4. Each VCn: validation criterion must have at least one corresponding test.
 5. Tests SHOULD fail when run (implementation doesn't exist yet).
+6. Test files MUST be lint-clean. Use proper imports at the top of the file
+   (not inside type annotations). Run the project linter on test files before finishing.
 
 Write evidence: .map/<branch>/evidence/test_writer_<subtask_id>.json"""
 )
@@ -378,8 +380,16 @@ Write evidence: .map/<branch>/evidence/test_writer_<subtask_id>.json"""
 
 ### Phase: TEST_FAIL_GATE (2.26) — TDD Mode Only
 
-Auto-skipped when TDD mode is disabled. When active, run the tests — they MUST fail:
+Auto-skipped when TDD mode is disabled. When active:
 
+**First:** lint-check test files (ACTOR cannot fix them later):
+```bash
+# Lint ONLY the test files from TEST_WRITER evidence
+ruff check <test_files> 2>&1 || true
+# If lint errors → go back to TEST_WRITER with feedback to fix lint
+```
+
+**Then:** run the tests — they MUST fail:
 ```bash
 # Run tests — expect failures (Red phase)
 pytest --tb=short 2>&1 || true

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -106,7 +106,7 @@ Read the user's requirements and decide if deep interview is needed.
 - Small isolated change (single bug fix, test update)
 - User explicitly provided a spec or detailed description
 
-If interview is not needed, skip to Step 3.
+If interview is not needed, skip to Step 2a (write spec without interview).
 
 ### Step 2: Deep Interview (Spec Discovery)
 
@@ -217,9 +217,22 @@ Formal, testable conditions that define "done". Each criterion must be verifiabl
 - [Anything still unresolved]
 ```
 
+### Step 2a: Write Spec (when interview was skipped)
+
+If interview was skipped (task is well-defined), still write `spec_<branch>.md` using the same template as Step 2. Populate it from the user's requirements and discovery findings:
+
+- **Decisions Made**: extract from user's request (may be short or N/A)
+- **Invariants**: derive from existing code patterns found in discovery
+- **Edge Cases**: identify from the task description and affected code
+- **Acceptance Criteria**: REQUIRED — must be testable conditions that define "done"
+- **Security Boundaries**: include if task touches auth/validation/user input
+- **Out of Scope**: explicitly state what is NOT being changed
+
+This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
+
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
-**Skip if:** complexity < 5 (simple, well-defined tasks) or interview was skipped.
+**Skip if:** complexity < 5 (simple, well-defined tasks).
 
 After writing the spec, invoke Monitor agent to adversarially review it. The goal is to surface gaps, contradictions, and missing edge cases BEFORE decomposition.
 

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -169,6 +169,45 @@ AskUserQuestion(questions=[
 | 1 | Token storage | Server-side (Redis) | Need revocation support |
 | 2 | Session expiry UX | Silent refresh | Better UX, no data loss |
 
+## Invariants
+
+Conditions that MUST remain true throughout implementation and after deployment.
+These are hard constraints — violating any invariant is a blocker.
+
+- [e.g., "All API endpoints require authentication except /health and /login"]
+- [e.g., "Database migrations must be backward-compatible (no column drops)"]
+- [e.g., "Response time for any endpoint must stay under 500ms p95"]
+
+## Edge Cases
+
+Enumerate boundary conditions and unusual inputs that implementation must handle.
+
+| # | Edge Case | Expected Behavior | Priority |
+|---|-----------|-------------------|----------|
+| 1 | [e.g., Empty input array] | [Return empty result, not error] | must-handle |
+| 2 | [e.g., Concurrent updates to same resource] | [Last-write-wins with conflict detection] | must-handle |
+| 3 | [e.g., Unicode in usernames] | [Accept, normalize to NFC] | should-handle |
+
+Priority levels: `must-handle` (blocks release), `should-handle` (best effort), `won't-handle` (documented limitation).
+
+## Acceptance Criteria
+
+Formal, testable conditions that define "done". Each criterion must be verifiable by automated test or manual check.
+
+| ID | Criterion | Verification Method |
+|----|-----------|-------------------|
+| AC-1 | [e.g., User can log in with valid credentials] | `pytest tests/test_auth.py::test_login` |
+| AC-2 | [e.g., Invalid token returns 401] | `pytest tests/test_auth.py::test_invalid_token` |
+
+## Security Boundaries
+
+*(Include for security-critical tasks; omit for purely internal/cosmetic changes)*
+
+- **Trust boundary:** [e.g., "All user input is untrusted; validate at API layer"]
+- **Auth model:** [e.g., "RBAC with role checks at service layer, not just route level"]
+- **Data sensitivity:** [e.g., "PII fields encrypted at rest, never logged"]
+- **Attack surface:** [e.g., "Public API exposed to internet; internal services behind VPN"]
+
 ## Out of Scope
 
 - [Explicitly excluded items]
@@ -177,6 +216,41 @@ AskUserQuestion(questions=[
 
 - [Anything still unresolved]
 ```
+
+### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+
+**Skip if:** complexity < 5 (simple, well-defined tasks) or interview was skipped.
+
+After writing the spec, invoke Monitor agent to adversarially review it. The goal is to surface gaps, contradictions, and missing edge cases BEFORE decomposition.
+
+```
+Task(
+  subagent_type="monitor",
+  description="Devil's Advocate spec review",
+  prompt=f"""You are reviewing a SPECIFICATION (not code). Act as Devil's Advocate.
+
+Read the spec file: .map/<branch>/spec_<branch>.md
+
+Check for:
+1. **Race conditions / concurrency gaps**: Are there shared resources without defined conflict resolution?
+2. **Ownership ambiguity**: Are responsibilities clearly assigned? Could two components both assume the other handles something?
+3. **Missing edge cases**: Compare the Edge Cases section against Invariants — are there invariant violations not covered by edge cases?
+4. **Contradictions**: Do any decisions contradict invariants or acceptance criteria?
+5. **Security gaps**: Are trust boundaries complete? Are there injection vectors not addressed?
+6. **Implicit assumptions**: What is assumed but not stated?
+
+Output format:
+- For each finding: severity (HIGH/MEDIUM/LOW), category, description, suggested fix
+- If NO high-severity issues found: output "SPEC APPROVED"
+- If HIGH-severity issues found: list them clearly for user resolution
+"""
+)
+```
+
+**After Devil's Advocate review:**
+- If **SPEC APPROVED** (no HIGH-severity findings): proceed to Step 3.
+- If **HIGH-severity findings**: present them to the user via AskUserQuestion. Update the spec with resolutions before proceeding. Do NOT silently proceed past HIGH findings.
+- MEDIUM/LOW findings: note them in the spec's Open Questions section but proceed.
 
 ### Step 3: Create Branch Directory
 

--- a/.claude/commands/map-resume.md
+++ b/.claude/commands/map-resume.md
@@ -21,9 +21,11 @@ description: Resume incomplete MAP workflow from checkpoint
 6. Continues from the last incomplete step via the state machine
 
 **State files used:**
-- **`step_state.json`** — Orchestrator canonical state. Source of truth for resumption. Tracks current step, retry counts, circuit breaker status.
+- **`step_state.json`** — Orchestrator canonical state. Source of truth for resumption. Tracks current step, retry counts, circuit breaker status. Includes `tdd_mode` field (persisted across sessions).
 - **`workflow_state.json`** — Enforcement gates. Tracks subtask completion for workflow-gate.py hook.
 - **`task_plan_<branch>.md`** — Full task decomposition with validation criteria and AAG contracts.
+
+**TDD mode note:** If the interrupted workflow was using `/map-tdd` or `--tdd` flag, `tdd_mode: true` is preserved in `step_state.json`. The TDD phases (TEST_WRITER, TEST_FAIL_GATE) will be correctly included in the resumed workflow. No manual re-enablement is needed when resuming from `step_state.json`.
 
 ---
 

--- a/.claude/commands/map-task.md
+++ b/.claude/commands/map-task.md
@@ -1,0 +1,168 @@
+---
+description: Execute a single subtask from an existing plan
+---
+
+# /map-task — Single Subtask Execution
+
+**Purpose:** Execute one specific subtask from an existing plan, without running the full workflow.
+
+**When to use:**
+- After `/map-plan` has created a decomposition — pick and run one subtask
+- When you want fine-grained control over execution order
+- When resuming work on a specific subtask after context reset
+- When parallelizing subtasks across multiple sessions
+
+**Prerequisites:** A plan must exist (`.map/<branch>/task_plan_<branch>.md`). Run `/map-plan` first if needed.
+
+**Task:** $ARGUMENTS
+
+---
+
+## Step 0: Parse Arguments
+
+Extract the subtask ID from `$ARGUMENTS`:
+
+```bash
+SUBTASK_ID=$(echo "$ARGUMENTS" | grep -oE 'ST-[0-9]+' | head -1)
+if [ -z "$SUBTASK_ID" ]; then
+  echo "ERROR: No subtask ID found. Usage: /map-task ST-001"
+  exit 1
+fi
+```
+
+## Step 1: Initialize Single Subtask
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+
+# Set up state for single subtask execution
+RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID")
+STATUS=$(echo "$RESULT" | jq -r '.status')
+
+if [ "$STATUS" = "error" ]; then
+  echo "$RESULT" | jq -r '.message'
+  exit 1
+fi
+```
+
+**If error mentions "No plan found":** Run `/map-plan` first to create a decomposition.
+**If error mentions "not found in plan":** The output lists available subtask IDs — pick one.
+
+## Step 2: Load Subtask Context
+
+Read the plan to get the subtask's details:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+# Read: .map/${BRANCH}/task_plan_${BRANCH}.md — find the ### ${SUBTASK_ID} section
+# Read: .map/${BRANCH}/blueprint.json — get AAG contract, validation_criteria, dependencies
+```
+
+Display a brief summary:
+
+```text
+═══════════════════════════════════════════════════
+SINGLE SUBTASK EXECUTION
+═══════════════════════════════════════════════════
+Subtask: ${SUBTASK_ID}
+Title: <from plan>
+AAG Contract: <from blueprint>
+Risk: <from blueprint>
+Dependencies: <from blueprint>
+═══════════════════════════════════════════════════
+```
+
+## Step 3: State Machine Loop
+
+Follow the same state machine loop as `/map-efficient`. Call `get_next_step` and execute based on the returned phase.
+
+```bash
+NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
+PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+```
+
+Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
+
+- **XML_PACKET (2.0)** — Build XML packet for this subtask
+- **CONTEXT_SEARCH (2.1)** — Search for relevant patterns
+- **RESEARCH (2.2)** — Call research-agent if needed
+- **ACTOR (2.3)** — Implement the subtask
+- **MONITOR (2.4)** — Validate implementation
+- **PREDICTOR (2.6)** — Impact analysis (conditional)
+- **UPDATE_STATE (2.7)** — Mark progress
+- **TESTS_GATE (2.8)** — Run tests
+- **LINTER_GATE (2.9)** — Run linter
+- **VERIFY_ADHERENCE (2.10)** — Self-audit
+
+For each step:
+1. Get next step from orchestrator
+2. Execute the phase (same handlers as map-efficient)
+3. Validate: `python3 .map/scripts/map_orchestrator.py validate_step "$STEP_ID"`
+4. Continue to next step until complete
+
+**If Monitor returns `valid: false`:**
+- Retry Actor with feedback (max 5 iterations)
+
+## Step 4: Completion
+
+When `get_next_step` returns `is_complete: true`:
+
+```text
+═══════════════════════════════════════════════════
+SUBTASK COMPLETE
+═══════════════════════════════════════════════════
+Subtask: ${SUBTASK_ID}
+Title: <title>
+Status: COMPLETE
+
+Files Modified:
+  - <list of changed files>
+
+Next steps:
+  - Run /map-task ST-XXX for the next subtask
+  - Run tests to verify: pytest / npm test / go test
+  - Run /map-check for full verification
+═══════════════════════════════════════════════════
+```
+
+Update the plan status:
+```bash
+python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "complete"
+```
+
+---
+
+## Error Handling
+
+### No Plan Exists
+
+```text
+No plan found. Run /map-plan first to create a task decomposition,
+then use /map-task ST-001 to execute individual subtasks.
+```
+
+### Subtask Not in Plan
+
+```text
+Subtask ST-999 not found in plan.
+Available subtasks: ST-001, ST-002, ST-003
+```
+
+### Dependencies Not Met
+
+Check blueprint for dependencies. If the subtask depends on unfinished work, warn:
+
+```text
+WARNING: ${SUBTASK_ID} depends on ${DEP_ID} which may not be complete.
+Proceed anyway? (The Actor will work with whatever state exists.)
+```
+
+---
+
+## Related Commands
+
+- **/map-plan** — Create task decomposition (prerequisite)
+- **/map-efficient** — Run full workflow (all subtasks)
+- **/map-tdd ST-001** — Write tests for a specific subtask (TDD mode)
+- **/map-resume** — Resume interrupted workflow from checkpoint
+- **/map-check** — Verify all acceptance criteria

--- a/.claude/commands/map-task.md
+++ b/.claude/commands/map-task.md
@@ -103,9 +103,25 @@ For each step:
 **If Monitor returns `valid: false`:**
 - Retry Actor with feedback (max 5 iterations)
 
-## Step 4: Completion
+## Step 4: Completion and Progress Report
 
 When `get_next_step` returns `is_complete: true`:
+
+1. Update the plan status:
+```bash
+python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "complete"
+```
+
+2. Get overall plan progress:
+```bash
+PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
+TOTAL=$(echo "$PROGRESS" | jq -r '.total')
+DONE=$(echo "$PROGRESS" | jq -r '.completed_count')
+REMAINING=$(echo "$PROGRESS" | jq -r '.pending_count')
+SUGGESTED=$(echo "$PROGRESS" | jq -r '.suggested_next')
+```
+
+3. Display completion report with remaining subtasks:
 
 ```text
 ═══════════════════════════════════════════════════
@@ -118,16 +134,46 @@ Status: COMPLETE
 Files Modified:
   - <list of changed files>
 
-Next steps:
-  - Run /map-task ST-XXX for the next subtask
-  - Run tests to verify: pytest / npm test / go test
-  - Run /map-check for full verification
+───────────────────────────────────────────────────
+PLAN PROGRESS: ${DONE}/${TOTAL} subtasks complete
+───────────────────────────────────────────────────
+
+Completed:
+  ✓ ST-001: <title>
+  ✓ ST-002: <title>  ← just completed
+
+Remaining:
+  ○ ST-003: <title> (pending)
+  ○ ST-004: <title> (pending)
+
 ═══════════════════════════════════════════════════
 ```
 
-Update the plan status:
-```bash
-python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "complete"
+4. **Suggest next subtask** using AskUserQuestion:
+
+```
+AskUserQuestion(questions=[
+  {
+    "question": "What would you like to do next?",
+    "header": "Next subtask",
+    "options": [
+      {"label": "/map-task ${SUGGESTED}", "description": "Execute next subtask: <title>"},
+      {"label": "/map-tdd ${SUGGESTED}", "description": "TDD for next subtask: <title>"},
+      {"label": "Done for now", "description": "Stop here, continue later with /map-task"}
+    ],
+    "multiSelect": false
+  }
+])
+```
+
+**If all subtasks are complete** (REMAINING == 0), skip the question and show:
+
+```text
+═══════════════════════════════════════════════════
+ALL SUBTASKS COMPLETE (${TOTAL}/${TOTAL})
+═══════════════════════════════════════════════════
+
+Run /map-check for final verification, or /map-learn to extract patterns.
 ```
 
 ---

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -1,0 +1,240 @@
+---
+description: TDD workflow — test-first development with spec-driven tests written before implementation
+---
+
+# /map-tdd — Test-Driven Development Workflow
+
+**Purpose:** Enforce test-first development where tests are written from the SPECIFICATION (not from implementation), ensuring tests validate intent rather than confirming implementation bugs.
+
+**When to use:**
+- Features where correctness is critical (auth, payments, data integrity)
+- When you want tests that truly validate behavior, not mirror implementation
+- When AI-written tests tend to pass trivially (testing what was written, not what was specified)
+
+**Key insight:** If implementation is in context when writing tests, AI writes tests that confirm the implementation — including its bugs. By writing tests FIRST from the spec only, tests become an independent correctness oracle.
+
+**What this command does NOT do:**
+- Does NOT replace /map-efficient — it augments the Actor/Monitor loop with test-first phases
+- Does NOT work without a spec or plan — requires spec_<branch>.md or clear acceptance criteria
+
+---
+
+## Execution Flow
+
+```
+Standard:  DECOMPOSE → ACTOR (code+tests) → MONITOR
+TDD:       DECOMPOSE → TEST_WRITER → TEST_FAIL_GATE → ACTOR (code only) → MONITOR
+```
+
+**Task:** $ARGUMENTS
+
+---
+
+## Step 0: Prerequisites
+
+Verify that a plan or spec exists for this branch:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "step_state:  $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+```
+
+- If **no spec and no task_plan**: Run `/map-plan` first. TDD requires clear acceptance criteria.
+- If **step_state.json EXISTS**: Resume from checkpoint (same as /map-efficient resume logic).
+- If **task_plan EXISTS but no step_state**: Run `python3 .map/scripts/map_orchestrator.py resume_from_plan` then enable TDD mode.
+
+### Enable TDD Mode
+
+After state is initialized (either fresh or resumed):
+
+```bash
+python3 .map/scripts/map_orchestrator.py set_tdd_mode true
+```
+
+This inserts TEST_WRITER (2.25) and TEST_FAIL_GATE (2.26) phases before ACTOR (2.3) in the step sequence.
+
+---
+
+## Step 1: State Machine Loop
+
+Follow the same state machine loop as /map-efficient. The orchestrator handles phase routing.
+Call `get_next_step` and execute based on the returned phase.
+
+```bash
+NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
+PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+```
+
+Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.
+The two NEW phases are described below.
+
+---
+
+## Phase: TEST_WRITER (2.25)
+
+Write tests ONLY — no implementation code. Tests are derived from the SPECIFICATION.
+
+```python
+Task(
+  subagent_type="actor",
+  description="TDD: Write tests for subtask [ID]",
+  prompt=f"""You are in TDD TEST_WRITER mode.
+
+<MAP_Packet subtask="[ID]" v="1.0" risk="[risk_level]">
+[paste from .map/<branch>/current_packet.xml]
+</MAP_Packet>
+
+<MAP_Contract>
+[AAG contract from decomposition]
+</MAP_Contract>
+
+<TDD_Mode>test_writer</TDD_Mode>
+
+STRICT RULES:
+1. Write ONLY test files. Do NOT create or modify implementation files.
+2. Tests must be derived from the SPECIFICATION (AAG contract + validation_criteria + test_strategy).
+3. You have NO knowledge of the implementation. Do not assume implementation details.
+4. Tests should assert BEHAVIOR described in the contract, not implementation structure.
+5. Use standard test patterns for the project's language/framework.
+6. Each validation_criteria item (VCn:) must have at least one corresponding test.
+7. Include edge cases from the spec's Edge Cases section if available.
+
+Output:
+- Test files written via Edit/Write tools
+- Evidence file: .map/<branch>/evidence/test_writer_<subtask_id>.json
+
+Evidence JSON must include:
+  "phase": "TEST_WRITER",
+  "subtask_id": "<id>",
+  "timestamp": "<ISO 8601>",
+  "test_files_created": ["path/to/test_file.py"],
+  "validation_criteria_covered": ["VC1", "VC2", "VC3"],
+  "status": "applied"
+"""
+)
+```
+
+After TEST_WRITER returns:
+```bash
+python3 .map/scripts/map_orchestrator.py validate_step "2.25"
+```
+
+---
+
+## Phase: TEST_FAIL_GATE (2.26)
+
+Run the tests written by TEST_WRITER. They MUST fail (implementation doesn't exist yet).
+
+```bash
+# Run tests — expect failures
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+
+if [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
+  TEST_OUTPUT=$(pytest --tb=short 2>&1) || true
+elif [ -f "package.json" ]; then
+  TEST_OUTPUT=$(npm test 2>&1) || true
+elif [ -f "go.mod" ]; then
+  TEST_OUTPUT=$(go test ./... 2>&1) || true
+elif [ -f "Cargo.toml" ]; then
+  TEST_OUTPUT=$(cargo test 2>&1) || true
+fi
+```
+
+**Evaluate results:**
+
+- **Tests FAIL with assertion/import errors** → GOOD. This is the expected TDD state ("Red" phase). Proceed to ACTOR.
+- **Tests PASS** → PROBLEM. Tests are trivial or not testing real behavior. Go back to TEST_WRITER with feedback: "Tests pass without implementation. Tests must assert behavior that requires code to be written."
+- **Tests have syntax errors** → Go back to TEST_WRITER with feedback to fix syntax.
+
+Write evidence file:
+
+```json
+{
+  "phase": "TEST_FAIL_GATE",
+  "subtask_id": "<id>",
+  "timestamp": "<ISO 8601>",
+  "tests_ran": true,
+  "tests_failed": true,
+  "failure_type": "assertion_errors",
+  "status": "gate_passed"
+}
+```
+
+```bash
+python3 .map/scripts/map_orchestrator.py validate_step "2.26"
+```
+
+---
+
+## Phase: ACTOR in TDD Mode (2.3)
+
+When TDD mode is active, Actor receives a modified prompt:
+
+```python
+Task(
+  subagent_type="actor",
+  description="TDD: Implement subtask [ID] to make tests green",
+  prompt=f"""You are in TDD CODE_ONLY mode.
+
+<MAP_Packet subtask="[ID]" v="1.0" risk="[risk_level]">
+[paste from .map/<branch>/current_packet.xml]
+</MAP_Packet>
+
+<MAP_Contract>
+[AAG contract from decomposition]
+</MAP_Contract>
+
+<TDD_Mode>code_only</TDD_Mode>
+
+<TDD_Tests>
+[List test files created by TEST_WRITER]
+</TDD_Tests>
+
+STRICT RULES:
+1. Write ONLY implementation code. Do NOT modify test files.
+2. Your goal: make ALL existing tests pass (turn Red → Green).
+3. Read the test files first to understand what behavior is expected.
+4. Implement the minimum code needed to satisfy the tests.
+5. Follow the AAG contract as your specification.
+
+Test files (READ-ONLY):
+{test_files_list}
+
+Output: standard Actor output (approach + code + trade-offs)
+Evidence file: .map/<branch>/evidence/actor_<subtask_id>.json"""
+)
+```
+
+After ACTOR, proceed to MONITOR as usual. Monitor verifies both implementation AND that tests pass.
+
+---
+
+## Differences from /map-efficient
+
+| Aspect | /map-efficient | /map-tdd |
+|--------|---------------|----------|
+| Test authoring | Actor writes code + tests together | TEST_WRITER writes tests first, Actor writes code only |
+| Test independence | Tests may mirror implementation | Tests derived from spec only |
+| Phase count | 16 phases | 18 phases (+TEST_WRITER, +TEST_FAIL_GATE) |
+| Token cost | Lower | ~20-30% higher (extra Actor call for tests) |
+| Best for | General development | Correctness-critical features |
+
+---
+
+## When NOT to use /map-tdd
+
+- Simple refactoring (no new behavior to test)
+- Documentation-only changes
+- Config/infrastructure changes without testable behavior
+- When test framework doesn't exist and adding one is out of scope
+
+---
+
+## Related Commands
+
+- **/map-plan** — Create spec with invariants and acceptance criteria (recommended before /map-tdd)
+- **/map-efficient** — Standard workflow without test-first constraint
+- **/map-check** — Final verification after all subtasks complete
+- **/map-learn** — Extract lessons from completed TDD workflow

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -256,7 +256,16 @@ Evidence file: .map/<branch>/evidence/actor_<subtask_id>.json"""
 )
 ```
 
-After ACTOR, proceed to MONITOR as usual. Monitor verifies both implementation AND that tests pass.
+**CRITICAL: After ACTOR returns, you MUST call Monitor (2.4). Do NOT skip Monitor. Do NOT mark the subtask complete without Monitor validation.** This is not optional — Monitor is a mandatory phase in every workflow, including TDD.
+
+```bash
+# Validate Actor step, then get_next_step will return MONITOR (2.4)
+python3 .map/scripts/map_orchestrator.py validate_step "2.3"
+NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
+# NEXT_STEP.phase MUST be "MONITOR" — execute it before proceeding
+```
+
+Monitor verifies both implementation correctness AND that all tests pass.
 
 ---
 

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -127,6 +127,9 @@ STRICT RULES:
 5. Use standard test patterns for the project's language/framework.
 6. Each validation_criteria item (VCn:) must have at least one corresponding test.
 7. Include edge cases from the spec's Edge Cases section if available.
+8. Test files MUST be lint-clean. Use proper imports at the top of the file
+   (not inside type annotations). Run the project linter (ruff/eslint/golangci-lint)
+   on test files before finishing. Fix any lint errors in your test files.
 
 Output:
 - Test files written via Edit/Write tools
@@ -172,7 +175,23 @@ else
 fi
 ```
 
-**Evaluate results:**
+**First: lint-check test files.** ACTOR cannot fix test files later, so they must be clean now.
+
+```bash
+# Lint-check ONLY the test files created by TEST_WRITER
+# (read test_files_created from evidence/test_writer_<subtask_id>.json)
+if command -v ruff &> /dev/null; then
+  LINT_OUTPUT=$(ruff check <test_files> 2>&1) || true
+elif command -v eslint &> /dev/null; then
+  LINT_OUTPUT=$(eslint <test_files> 2>&1) || true
+elif command -v golangci-lint &> /dev/null; then
+  LINT_OUTPUT=$(golangci-lint run <test_files> 2>&1) || true
+fi
+```
+
+- **Lint errors found** → Go back to TEST_WRITER with feedback: "Fix lint errors in test files: <errors>. ACTOR cannot modify test files, so they must be lint-clean now."
+
+**Then evaluate test results:**
 
 - **Tests FAIL with assertion/import errors** → GOOD. This is the expected TDD state ("Red" phase). Proceed to ACTOR.
 - **Tests PASS** → PROBLEM. Tests are trivial or not testing real behavior. Go back to TEST_WRITER with feedback: "Tests pass without implementation. Tests must assert behavior that requires code to be written."

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -30,12 +30,39 @@ TDD:       DECOMPOSE → TEST_WRITER → TEST_FAIL_GATE → ACTOR (code only) �
 
 ---
 
-## Step 0: Prerequisites
+## Step 0: Parse Arguments and Detect Mode
+
+```bash
+TASK_ARGS="$ARGUMENTS"
+SUBTASK_ID=$(echo "$TASK_ARGS" | grep -oE 'ST-[0-9]+' | head -1)
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+```
+
+**Two modes:**
+- **Single-subtask mode** (`/map-tdd ST-001`): Write tests + implement for ONE subtask only
+- **Full workflow mode** (`/map-tdd "task description"`): TDD for all subtasks
+
+### Single-Subtask Mode (when `$SUBTASK_ID` is detected)
+
+```bash
+RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID" --tdd)
+STATUS=$(echo "$RESULT" | jq -r '.status')
+
+if [ "$STATUS" = "error" ]; then
+  echo "$RESULT" | jq -r '.message'
+  # If no plan: "Run /map-plan first"
+  # If subtask not found: shows available IDs
+  exit 1
+fi
+```
+
+Then proceed directly to **Step 1: State Machine Loop** below.
+
+### Full Workflow Mode (no subtask ID)
 
 Verify that a plan or spec exists for this branch:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "step_state:  $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
@@ -45,7 +72,7 @@ echo "step_state:  $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || ec
 - If **step_state.json EXISTS**: Resume from checkpoint (same as /map-efficient resume logic).
 - If **task_plan EXISTS but no step_state**: Run `python3 .map/scripts/map_orchestrator.py resume_from_plan` then enable TDD mode.
 
-### Enable TDD Mode
+### Enable TDD Mode (full workflow only)
 
 After state is initialized (either fresh or resumed):
 
@@ -68,7 +95,7 @@ PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.
-The two NEW phases are described below.
+The two TDD-specific phases are described below.
 
 ---
 
@@ -238,6 +265,7 @@ After ACTOR, proceed to MONITOR as usual. Monitor verifies both implementation A
 ## Related Commands
 
 - **/map-plan** — Create spec with invariants and acceptance criteria (recommended before /map-tdd)
+- **/map-task ST-001** — Execute a single subtask without TDD (implementation only)
 - **/map-efficient** — Standard workflow without test-first constraint
 - **/map-check** — Final verification after all subtasks complete
 - **/map-learn** — Extract lessons from completed TDD workflow

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -139,6 +139,9 @@ elif [ -f "go.mod" ]; then
   TEST_OUTPUT=$(go test ./... 2>&1) || true
 elif [ -f "Cargo.toml" ]; then
   TEST_OUTPUT=$(cargo test 2>&1) || true
+else
+  echo "WARNING: No test runner detected. Set TEST_OUTPUT manually for your project."
+  TEST_OUTPUT="NO_TEST_RUNNER_FOUND"
 fi
 ```
 

--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -99,11 +99,13 @@ def is_exempt_path(file_path: str) -> bool:
         else (Path.cwd().resolve() / candidate).resolve(strict=False)
     )
 
-    # Allow Claude auto-memory and settings (~/.claude/)
-    claude_dir = Path.home() / ".claude"
+    # Allow Claude auto-memory writes (~/.claude/projects/*/memory/)
+    claude_memory_dir = Path.home() / ".claude" / "projects"
     try:
-        resolved.relative_to(claude_dir.resolve())
-        return True
+        rel = resolved.relative_to(claude_memory_dir.resolve())
+        # Only allow paths that include a "memory" component
+        if "memory" in rel.parts:
+            return True
     except ValueError:
         pass
 

--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -14,6 +14,7 @@ ENFORCEMENT RULES:
   - Blocks if current subtask hasn't completed required steps: ['actor', 'monitor']
   - Allows tools if all required steps are completed
   - Always allows edits under .map/ (workflow artifacts/state) to prevent deadlocks
+  - Always allows edits under ~/.claude/ (auto-memory, project settings)
   - Allows Read, Bash, and other non-editing tools always
 
 WORKFLOW STATE FILE:
@@ -80,24 +81,34 @@ def extract_target_file_paths(tool_call: Dict) -> list[str]:
     return paths
 
 
-def is_map_artifact_path(file_path: str) -> bool:
+def is_exempt_path(file_path: str) -> bool:
     """
-    Return True if file_path resolves under the current working directory's .map/.
+    Return True if file_path is exempt from workflow enforcement.
 
-    This allowlist prevents the workflow gate from deadlocking itself by blocking
-    updates to workflow artifacts (including workflow_state.json).
+    Exempt paths:
+    - .map/ artifacts (workflow state, plans, findings) -- prevents deadlocks
+    - ~/.claude/ (auto-memory, project settings) -- Claude's own persistence
     """
     if not isinstance(file_path, str) or not file_path.strip():
         return False
 
-    repo_root = Path.cwd().resolve()
     candidate = Path(file_path)
     resolved = (
         candidate.resolve(strict=False)
         if candidate.is_absolute()
-        else (repo_root / candidate).resolve(strict=False)
+        else (Path.cwd().resolve() / candidate).resolve(strict=False)
     )
 
+    # Allow Claude auto-memory and settings (~/.claude/)
+    claude_dir = Path.home() / ".claude"
+    try:
+        resolved.relative_to(claude_dir.resolve())
+        return True
+    except ValueError:
+        pass
+
+    # Allow .map/ artifacts
+    repo_root = Path.cwd().resolve()
     try:
         rel = resolved.relative_to(repo_root)
     except ValueError:
@@ -221,7 +232,7 @@ def main():
 
         # Always allow edits to MAP workflow artifacts under .map/
         target_paths = extract_target_file_paths(tool_call)
-        if target_paths and all(is_map_artifact_path(p) for p in target_paths):
+        if target_paths and all(is_exempt_path(p) for p in target_paths):
             print("{}")
             sys.exit(0)
 

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -1166,6 +1166,88 @@ def resume_from_plan(branch: str) -> Dict:
     }
 
 
+def resume_single_subtask(subtask_id: str, branch: str, tdd_mode: bool = False) -> Dict:
+    """Set up state to execute a single subtask from an existing plan.
+
+    Requires task_plan_<branch>.md to exist (created by /map-plan or decomposer).
+    Validates that the requested subtask ID exists in the plan.
+    Creates state starting from XML_PACKET (2.0) for just that one subtask.
+
+    Args:
+        subtask_id: The subtask to execute (e.g., "ST-001")
+        branch: Git branch name (sanitized)
+        tdd_mode: Whether to enable TDD mode for this subtask
+
+    Returns:
+        Dict with status and state info
+    """
+    plan_dir = Path(f".map/{branch}")
+    plan_file = plan_dir / f"task_plan_{branch}.md"
+
+    if not plan_file.exists():
+        return {
+            "status": "error",
+            "message": f"No plan found at {plan_file}. Run /map-plan first.",
+        }
+
+    import re
+
+    plan_content = plan_file.read_text(encoding="utf-8")
+    all_subtask_ids = re.findall(r"###\s+(ST-\d+)", plan_content)
+
+    if not all_subtask_ids:
+        return {
+            "status": "error",
+            "message": f"No subtask IDs (ST-XXX) found in {plan_file}.",
+        }
+
+    if subtask_id not in all_subtask_ids:
+        return {
+            "status": "error",
+            "message": (
+                f"Subtask {subtask_id} not found in plan. "
+                f"Available: {', '.join(all_subtask_ids)}"
+            ),
+        }
+
+    # Build state for single subtask execution
+    step_order = _get_step_order(tdd_mode)
+    xml_packet_idx = step_order.index("2.0")
+    subtask_steps = step_order[xml_packet_idx:]
+
+    state_file = plan_dir / "step_state.json"
+    state = StepState(
+        current_subtask_id=subtask_id,
+        subtask_index=0,
+        subtask_sequence=[subtask_id],  # Only this one subtask
+        current_step_id="2.0",
+        current_step_phase="XML_PACKET",
+        completed_steps=["1.0", "1.5", "1.55", "1.56", "1.6"],
+        pending_steps=subtask_steps,
+        plan_approved=True,
+        execution_mode="batch",
+        tdd_mode=tdd_mode,
+    )
+    state.save(state_file)
+
+    # Ensure evidence directory exists
+    evidence_dir = plan_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    return {
+        "status": "success",
+        "message": (
+            f"Single subtask mode: {subtask_id}. "
+            f"TDD: {'enabled' if tdd_mode else 'disabled'}. "
+            f"Starting from XML_PACKET."
+        ),
+        "subtask_id": subtask_id,
+        "tdd_mode": tdd_mode,
+        "all_subtasks_in_plan": all_subtask_ids,
+        "next_phase": "XML_PACKET",
+    }
+
+
 def main():
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -1188,6 +1270,7 @@ def main():
             "get_wave_step",
             "validate_wave_step",
             "advance_wave",
+            "resume_single_subtask",
         ],
         help="Command to execute",
     )
@@ -1200,6 +1283,9 @@ def main():
     parser.add_argument("--branch", help="Git branch (auto-detected if omitted)")
     parser.add_argument(
         "--blueprint", help="Path to blueprint JSON (for set_waves command)"
+    )
+    parser.add_argument(
+        "--tdd", action="store_true", help="Enable TDD mode (for resume_single_subtask)"
     )
 
     args = parser.parse_args()
@@ -1322,6 +1408,18 @@ def main():
 
         elif args.command == "advance_wave":
             result = advance_wave(branch)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "resume_single_subtask":
+            if not args.task_or_step:
+                print(
+                    json.dumps(
+                        {"error": "subtask_id required. Usage: resume_single_subtask ST-001 [--tdd]"}
+                    ),
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            result = resume_single_subtask(args.task_or_step, branch, tdd_mode=args.tdd)
             print(json.dumps(result, indent=2))
 
     except Exception as e:

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -35,7 +35,7 @@ STATE FILE:
       "pending_steps": ["2.1_CONTEXT_SEARCH", "2.3_ACTOR", "2.4_MONITOR", ...]
     }
 
-STEP PHASES (16 total):
+STEP PHASES (18 total, 16 standard + 2 TDD):
   1.0  DECOMPOSE          - task-decomposer agent
   1.5  INIT_PLAN          - Generate task_plan.md
   1.55 REVIEW_PLAN        - User review + explicit approval checkpoint
@@ -44,6 +44,8 @@ STEP PHASES (16 total):
   2.0  XML_PACKET         - Build AI-friendly subtask packet
   2.1  CONTEXT_SEARCH     - Context search
   2.2  RESEARCH           - research-agent (conditional)
+  2.25 TEST_WRITER        - TDD: write tests from spec (TDD mode only)
+  2.26 TEST_FAIL_GATE     - TDD: verify tests fail without impl (TDD mode only)
   2.3  ACTOR              - Actor agent implementation
   2.4  MONITOR            - Monitor validation
   2.6  PREDICTOR          - Impact analysis (conditional)
@@ -109,6 +111,8 @@ STEP_PHASES = {
     "2.0": "XML_PACKET",
     "2.1": "CONTEXT_SEARCH",
     "2.2": "RESEARCH",
+    "2.25": "TEST_WRITER",
+    "2.26": "TEST_FAIL_GATE",
     "2.3": "ACTOR",
     "2.4": "MONITOR",
     "2.6": "PREDICTOR",
@@ -119,7 +123,7 @@ STEP_PHASES = {
     "2.11": "SUBTASK_APPROVAL",
 }
 
-# Step execution order
+# Step execution order (standard — without TDD phases)
 STEP_ORDER = [
     "1.0",
     "1.5",
@@ -139,11 +143,35 @@ STEP_ORDER = [
     "2.11",
 ]
 
+# TDD step order — includes TEST_WRITER and TEST_FAIL_GATE before ACTOR
+TDD_STEP_ORDER = [
+    "1.0",
+    "1.5",
+    "1.55",
+    "1.56",
+    "1.6",
+    "2.0",
+    "2.1",
+    "2.2",
+    "2.25",
+    "2.26",
+    "2.3",
+    "2.4",
+    "2.6",
+    "2.7",
+    "2.8",
+    "2.9",
+    "2.10",
+    "2.11",
+]
+
 # Steps that require evidence files from agents before validation.
 # Format: step_id -> (agent_phase, always_required)
 # If always_required is False, evidence is only checked when the step
 # appears in pending_steps (i.e., it wasn't skipped).
 EVIDENCE_REQUIRED = {
+    "2.25": ("test_writer", False),  # Only in TDD mode
+    "2.26": ("test_fail_gate", False),  # Only in TDD mode
     "2.3": ("actor", True),  # Always required
     "2.4": ("monitor", True),  # Always required
     "2.6": ("predictor", False),  # Only when 2.6 is in pending_steps
@@ -167,6 +195,8 @@ class StepState:
     max_retries: int = 5
     plan_approved: bool = False
     execution_mode: str = "batch"  # batch|step_by_step
+    # TDD mode: inserts TEST_WRITER and TEST_FAIL_GATE before ACTOR
+    tdd_mode: bool = False
     # Wave-based parallel execution fields
     execution_waves: List[List[str]] = field(default_factory=list)
     current_wave_index: int = 0
@@ -189,6 +219,7 @@ class StepState:
             "max_retries": self.max_retries,
             "plan_approved": self.plan_approved,
             "execution_mode": self.execution_mode,
+            "tdd_mode": self.tdd_mode,
             "execution_waves": self.execution_waves,
             "current_wave_index": self.current_wave_index,
             "subtask_phases": self.subtask_phases,
@@ -212,6 +243,7 @@ class StepState:
             max_retries=data.get("max_retries", 5),
             plan_approved=data.get("plan_approved", False),
             execution_mode=data.get("execution_mode", "batch"),
+            tdd_mode=data.get("tdd_mode", False),
             execution_waves=data.get("execution_waves", []),
             current_wave_index=data.get("current_wave_index", 0),
             subtask_phases=data.get("subtask_phases", {}),
@@ -238,6 +270,11 @@ class StepState:
             encoding="utf-8",
         )
         tmp_file.replace(state_file)
+
+
+def _get_step_order(tdd_mode: bool = False) -> List[str]:
+    """Return the appropriate step order based on TDD mode."""
+    return TDD_STEP_ORDER if tdd_mode else STEP_ORDER
 
 
 def get_branch_name() -> str:
@@ -312,10 +349,31 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             "Call Task(subagent_type='research-agent') if refactoring or "
             "touching 3+ files. Pass findings to Actor."
         ),
+        "2.25": (
+            f"TDD TEST_WRITER: Call Task(subagent_type='actor') with "
+            f"<TDD_Mode>test_writer</TDD_Mode> to write ONLY tests for subtask "
+            f"{state.current_subtask_id}. Tests must be derived from spec/contract, "
+            f"NOT from implementation. "
+            f"Actor MUST write evidence file: "
+            f".map/<branch>/evidence/test_writer_{state.current_subtask_id}.json"
+        ),
+        "2.26": (
+            f"TDD TEST_FAIL_GATE: Run tests written by TEST_WRITER. "
+            f"Tests MUST fail (no implementation exists yet). "
+            f"If tests pass → problem (trivial tests), go back to TEST_WRITER. "
+            f"If tests fail with assertion errors → proceed to ACTOR. "
+            f"Write evidence: .map/<branch>/evidence/test_fail_gate_{state.current_subtask_id}.json"
+        ),
         "2.3": (
             f"Call Task(subagent_type='actor') to implement subtask "
-            f"{state.current_subtask_id}. Pass XML packet and context patterns. "
-            f"Actor MUST write evidence file: "
+            f"{state.current_subtask_id}. "
+            + (
+                "TDD CODE_ONLY mode: pass <TDD_Mode>code_only</TDD_Mode>. "
+                "Actor must make existing tests green without modifying test files. "
+                if state.tdd_mode
+                else "Pass XML packet and context patterns. "
+            )
+            + f"Actor MUST write evidence file: "
             f".map/<branch>/evidence/actor_{state.current_subtask_id}.json"
         ),
         "2.4": (
@@ -376,6 +434,15 @@ def get_next_step(branch: str) -> Dict:
         state.pending_steps.pop(0)
         state.save(state_file)
 
+    # Auto-skip TDD phases when tdd_mode is disabled
+    while (
+        state.pending_steps
+        and state.pending_steps[0] in ("2.25", "2.26")
+        and not state.tdd_mode
+    ):
+        state.completed_steps.append(state.pending_steps.pop(0))
+        state.save(state_file)
+
     # Auto-skip steps that are conditional in batch mode
     while (
         state.pending_steps
@@ -396,8 +463,9 @@ def get_next_step(branch: str) -> Dict:
             state.current_step_id = "2.0"
             state.current_step_phase = "XML_PACKET"
             # Reset to subtask-level steps (skip global setup steps)
-            xml_packet_idx = STEP_ORDER.index("2.0")
-            state.pending_steps = STEP_ORDER[xml_packet_idx:]  # Start from 2.0
+            step_order = _get_step_order(state.tdd_mode)
+            xml_packet_idx = step_order.index("2.0")
+            state.pending_steps = step_order[xml_packet_idx:]  # Start from 2.0
             state.completed_steps = []
             state.retry_count = 0
             state.save(state_file)
@@ -601,6 +669,41 @@ def set_execution_mode(mode: str, branch: str) -> Dict:
     state.execution_mode = normalized
     state.save(state_file)
     return {"status": "success", "execution_mode": state.execution_mode}
+
+
+def set_tdd_mode(value: str, branch: str) -> Dict:
+    """Enable or disable TDD mode (test-first workflow).
+
+    When enabled, inserts TEST_WRITER (2.25) and TEST_FAIL_GATE (2.26)
+    phases before ACTOR (2.3) in the step sequence.
+
+    Args:
+        value: "true" or "false"
+        branch: Git branch name (sanitized)
+
+    Returns:
+        Dict with status and tdd_mode value
+    """
+    state_file = Path(f".map/{branch}/step_state.json")
+    state = StepState.load(state_file)
+    normalized = (value or "").strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        state.tdd_mode = True
+    elif normalized in {"0", "false", "no", "n"}:
+        state.tdd_mode = False
+    else:
+        return {
+            "status": "error",
+            "message": f"Invalid value for tdd_mode: {value}",
+        }
+
+    # Rebuild pending_steps with correct order for TDD mode
+    step_order = _get_step_order(state.tdd_mode)
+    completed_set = set(state.completed_steps)
+    state.pending_steps = [s for s in step_order if s not in completed_set]
+
+    state.save(state_file)
+    return {"status": "success", "tdd_mode": state.tdd_mode}
 
 
 def set_waves(branch: str, blueprint_path: Optional[str] = None) -> Dict:
@@ -857,7 +960,7 @@ def advance_wave(branch: str) -> Dict:
     }
 
 
-SKIPPABLE_STEPS = {"2.2", "2.6", "2.11"}
+SKIPPABLE_STEPS = {"2.2", "2.25", "2.26", "2.6", "2.11"}
 
 
 def skip_step(step_id: str, branch: str) -> Dict:
@@ -1063,6 +1166,7 @@ def main():
             "initialize",
             "set_plan_approved",
             "set_execution_mode",
+            "set_tdd_mode",
             "skip_step",
             "set_subtasks",
             "resume_from_plan",
@@ -1130,6 +1234,17 @@ def main():
                 )
                 sys.exit(1)
             result = set_execution_mode(mode, branch)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "set_tdd_mode":
+            value = args.task_or_step
+            if value is None:
+                print(
+                    json.dumps({"error": "value required for set_tdd_mode"}),
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            result = set_tdd_mode(value, branch)
             print(json.dumps(result, indent=2))
 
         elif args.command == "skip_step":

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -301,6 +301,24 @@ def get_branch_name() -> str:
         return "default"
 
 
+def _actor_step_instruction(state: StepState) -> str:
+    """Build instruction string for the ACTOR step, TDD-aware."""
+    subtask = state.current_subtask_id
+    if state.tdd_mode:
+        context = (
+            "TDD CODE_ONLY mode: pass <TDD_Mode>code_only</TDD_Mode>. "
+            "Actor must make existing tests green without modifying test files. "
+        )
+    else:
+        context = "Pass XML packet and context patterns. "
+    return (
+        f"Call Task(subagent_type='actor') to implement subtask {subtask}. "
+        f"{context}"
+        f"Actor MUST write evidence file: "
+        f".map/<branch>/evidence/actor_{subtask}.json"
+    )
+
+
 def get_step_instruction(step_id: str, state: StepState) -> str:
     """
     Get instruction for executing a specific step.
@@ -364,18 +382,7 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             f"If tests fail with assertion errors → proceed to ACTOR. "
             f"Write evidence: .map/<branch>/evidence/test_fail_gate_{state.current_subtask_id}.json"
         ),
-        "2.3": (
-            f"Call Task(subagent_type='actor') to implement subtask "
-            f"{state.current_subtask_id}. "
-            + (
-                "TDD CODE_ONLY mode: pass <TDD_Mode>code_only</TDD_Mode>. "
-                "Actor must make existing tests green without modifying test files. "
-                if state.tdd_mode
-                else "Pass XML packet and context patterns. "
-            )
-            + f"Actor MUST write evidence file: "
-            f".map/<branch>/evidence/actor_{state.current_subtask_id}.json"
-        ),
+        "2.3": _actor_step_instruction(state),
         "2.4": (
             "Call Task(subagent_type='monitor') to validate Actor output. "
             "Check correctness, security, standards, and tests. "
@@ -883,16 +890,23 @@ def validate_wave_step(subtask_id: str, step_id: str, branch: str) -> Dict:
     if step_id in EVIDENCE_REQUIRED:
         phase_name, _always_required = EVIDENCE_REQUIRED[step_id]
         evidence_dir = Path(f".map/{branch}/evidence")
-        if evidence_dir.is_dir():
-            evidence_file = evidence_dir / f"{phase_name}_{subtask_id}.json"
-            if not evidence_file.exists():
-                return {
-                    "valid": False,
-                    "message": (
-                        f"Evidence file missing: {evidence_file}. "
-                        f"The {phase_name} agent must write this file."
-                    ),
-                }
+        if not evidence_dir.is_dir():
+            return {
+                "valid": False,
+                "message": (
+                    f"Evidence directory missing: {evidence_dir}. "
+                    f"Create it before running agent steps."
+                ),
+            }
+        evidence_file = evidence_dir / f"{phase_name}_{subtask_id}.json"
+        if not evidence_file.exists():
+            return {
+                "valid": False,
+                "message": (
+                    f"Evidence file missing: {evidence_file}. "
+                    f"The {phase_name} agent must write this file."
+                ),
+            }
 
     # Determine next phase for this subtask
     subtask_step_order = [s for s in _get_step_order(state.tdd_mode) if s.startswith("2.")]

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -1166,6 +1166,60 @@ def resume_from_plan(branch: str) -> Dict:
     }
 
 
+def get_plan_progress(branch: str) -> Dict:
+    """Return status of all subtasks from the task plan.
+
+    Reads task_plan_<branch>.md and extracts subtask IDs with their statuses.
+    Identifies the next pending subtask (respecting dependency order from blueprint).
+
+    Args:
+        branch: Git branch name (sanitized)
+
+    Returns:
+        Dict with subtask statuses, completed/pending counts, and suggested next
+    """
+    import re
+
+    plan_dir = Path(f".map/{branch}")
+    plan_file = plan_dir / f"task_plan_{branch}.md"
+
+    if not plan_file.exists():
+        return {"status": "error", "message": f"No plan found at {plan_file}."}
+
+    content = plan_file.read_text(encoding="utf-8")
+
+    # Extract subtask IDs and statuses: ### ST-XXX ... \n- **Status:** <status>
+    subtasks = []
+    for match in re.finditer(
+        r"###\s+(ST-\d+)[^\n]*\n(?:.*?\n)*?- \*\*Status:\*\*\s+(\w+)",
+        content,
+    ):
+        subtasks.append({"id": match.group(1), "status": match.group(2)})
+
+    if not subtasks:
+        # Fallback: just extract IDs without status
+        ids = re.findall(r"###\s+(ST-\d+)", content)
+        subtasks = [{"id": sid, "status": "unknown"} for sid in ids]
+
+    completed = [s for s in subtasks if s["status"] == "complete"]
+    pending = [s for s in subtasks if s["status"] != "complete"]
+
+    # Determine suggested next subtask
+    # Prefer first pending subtask (plan order respects dependencies)
+    suggested_next = pending[0]["id"] if pending else None
+
+    return {
+        "status": "success",
+        "total": len(subtasks),
+        "completed_count": len(completed),
+        "pending_count": len(pending),
+        "subtasks": subtasks,
+        "completed": [s["id"] for s in completed],
+        "pending": [s["id"] for s in pending],
+        "suggested_next": suggested_next,
+    }
+
+
 def resume_single_subtask(subtask_id: str, branch: str, tdd_mode: bool = False) -> Dict:
     """Set up state to execute a single subtask from an existing plan.
 
@@ -1271,6 +1325,7 @@ def main():
             "validate_wave_step",
             "advance_wave",
             "resume_single_subtask",
+            "get_plan_progress",
         ],
         help="Command to execute",
     )
@@ -1420,6 +1475,10 @@ def main():
                 )
                 sys.exit(1)
             result = resume_single_subtask(args.task_or_step, branch, tdd_mode=args.tdd)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "get_plan_progress":
+            result = get_plan_progress(branch)
             print(json.dumps(result, indent=2))
 
     except Exception as e:

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -721,7 +721,6 @@ def set_waves(branch: str, blueprint_path: Optional[str] = None) -> Dict:
         Dict with status and computed waves
     """
     # Import here to avoid circular deps at module level
-    sys_path_added = False
     try:
         from mapify_cli.dependency_graph import DependencyGraph, SubtaskNode
     except ImportError:
@@ -741,8 +740,8 @@ def set_waves(branch: str, blueprint_path: Optional[str] = None) -> Dict:
                 if spec and spec.loader:
                     mod = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(mod)
-                    DependencyGraph = mod.DependencyGraph  # noqa: N806
-                    SubtaskNode = mod.SubtaskNode  # noqa: N806
+                    DependencyGraph = mod.DependencyGraph  # type: ignore[misc]  # noqa: N806
+                    SubtaskNode = mod.SubtaskNode  # type: ignore[misc]  # noqa: N806
                     loaded = True
                     break
         if not loaded:
@@ -896,7 +895,7 @@ def validate_wave_step(subtask_id: str, step_id: str, branch: str) -> Dict:
                 }
 
     # Determine next phase for this subtask
-    subtask_step_order = [s for s in STEP_ORDER if s.startswith("2.")]
+    subtask_step_order = [s for s in _get_step_order(state.tdd_mode) if s.startswith("2.")]
     current_idx = subtask_step_order.index(step_id) if step_id in subtask_step_order else -1
 
     if current_idx >= 0 and current_idx + 1 < len(subtask_step_order):
@@ -1036,7 +1035,7 @@ def check_circuit_breaker(branch: str) -> Dict:
     state = StepState.load(state_file)
 
     tool_count = len(state.completed_steps)
-    max_iterations = len(state.subtask_sequence) * len(STEP_ORDER)
+    max_iterations = len(state.subtask_sequence) * len(_get_step_order(state.tdd_mode))
 
     return {
         "tool_count": tool_count,

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -197,6 +197,9 @@ class StepState:
     execution_mode: str = "batch"  # batch|step_by_step
     # TDD mode: inserts TEST_WRITER and TEST_FAIL_GATE before ACTOR
     tdd_mode: bool = False
+    # Steps skipped (not executed) — tracked separately from completed_steps
+    # so that re-enabling TDD can re-introduce skipped TDD steps
+    skipped_steps: List[str] = field(default_factory=list)
     # Wave-based parallel execution fields
     execution_waves: List[List[str]] = field(default_factory=list)
     current_wave_index: int = 0
@@ -220,6 +223,7 @@ class StepState:
             "plan_approved": self.plan_approved,
             "execution_mode": self.execution_mode,
             "tdd_mode": self.tdd_mode,
+            "skipped_steps": self.skipped_steps,
             "execution_waves": self.execution_waves,
             "current_wave_index": self.current_wave_index,
             "subtask_phases": self.subtask_phases,
@@ -244,6 +248,7 @@ class StepState:
             plan_approved=data.get("plan_approved", False),
             execution_mode=data.get("execution_mode", "batch"),
             tdd_mode=data.get("tdd_mode", False),
+            skipped_steps=data.get("skipped_steps", []),
             execution_waves=data.get("execution_waves", []),
             current_wave_index=data.get("current_wave_index", 0),
             subtask_phases=data.get("subtask_phases", {}),
@@ -447,7 +452,8 @@ def get_next_step(branch: str) -> Dict:
         and state.pending_steps[0] in ("2.25", "2.26")
         and not state.tdd_mode
     ):
-        state.completed_steps.append(state.pending_steps.pop(0))
+        skipped = state.pending_steps.pop(0)
+        state.skipped_steps.append(skipped)
         state.save(state_file)
 
     # Auto-skip steps that are conditional in batch mode
@@ -474,6 +480,7 @@ def get_next_step(branch: str) -> Dict:
             xml_packet_idx = step_order.index("2.0")
             state.pending_steps = step_order[xml_packet_idx:]  # Start from 2.0
             state.completed_steps = []
+            state.skipped_steps = []
             state.retry_count = 0
             state.save(state_file)
         else:
@@ -704,10 +711,47 @@ def set_tdd_mode(value: str, branch: str) -> Dict:
             "message": f"Invalid value for tdd_mode: {value}",
         }
 
-    # Rebuild pending_steps with correct order for TDD mode
+    # Rebuild pending_steps relative to current position (not from scratch)
+    # to avoid re-introducing already-completed global steps (1.x)
     step_order = _get_step_order(state.tdd_mode)
-    completed_set = set(state.completed_steps)
-    state.pending_steps = [s for s in step_order if s not in completed_set]
+
+    # When re-enabling TDD, remove 2.25/2.26 from skipped so they can run
+    if state.tdd_mode:
+        state.skipped_steps = [
+            s for s in state.skipped_steps if s not in ("2.25", "2.26")
+        ]
+
+    done_and_skipped = set(state.completed_steps) | set(state.skipped_steps)
+
+    if state.pending_steps:
+        # Find position of first pending step in the new order
+        first_pending = state.pending_steps[0]
+        if first_pending in step_order:
+            pos = step_order.index(first_pending)
+            # When enabling TDD, also include TDD steps that come
+            # just before the current position (2.25/2.26 before 2.3)
+            if state.tdd_mode:
+                # Find the earliest TDD step not yet done
+                tdd_steps = {"2.25", "2.26"}
+                earliest_tdd = None
+                for i, s in enumerate(step_order):
+                    if s in tdd_steps and s not in done_and_skipped and i < pos:
+                        if earliest_tdd is None or i < earliest_tdd:
+                            earliest_tdd = i
+                if earliest_tdd is not None:
+                    pos = earliest_tdd
+            # Rebuild from position onwards, excluding done/skipped
+            state.pending_steps = [
+                s for s in step_order[pos:] if s not in done_and_skipped
+            ]
+        else:
+            state.pending_steps = [
+                s for s in step_order if s not in done_and_skipped
+            ]
+    else:
+        state.pending_steps = [
+            s for s in step_order if s not in done_and_skipped
+        ]
 
     state.save(state_file)
     return {"status": "success", "tdd_mode": state.tdd_mode}
@@ -853,9 +897,11 @@ def get_wave_step(branch: str) -> Dict:
     mode = "sequential" if len(wave) == 1 else "parallel"
 
     # Build subtask info with current phases
+    # Default start phase depends on TDD mode
+    default_phase = "2.25" if state.tdd_mode else "2.3"
     subtask_infos = []
     for st_id in wave:
-        phase = state.subtask_phases.get(st_id, "2.3")
+        phase = state.subtask_phases.get(st_id, default_phase)
         phase_name = STEP_PHASES.get(phase, "ACTOR")
         subtask_infos.append({
             "subtask_id": st_id,
@@ -981,6 +1027,8 @@ def skip_step(step_id: str, branch: str) -> Dict:
 
     Only steps that are defined as conditional can be skipped:
       - 2.2 (RESEARCH): conditional on refactoring or 3+ files
+      - 2.25 (TEST_WRITER): TDD mode only, auto-skipped otherwise
+      - 2.26 (TEST_FAIL_GATE): TDD mode only, auto-skipped otherwise
       - 2.6 (PREDICTOR): conditional on medium/high risk
       - 2.11 (SUBTASK_APPROVAL): conditional on step_by_step mode
 
@@ -1204,8 +1252,7 @@ def get_plan_progress(branch: str) -> Dict:
     completed = [s for s in subtasks if s["status"] == "complete"]
     pending = [s for s in subtasks if s["status"] != "complete"]
 
-    # Determine suggested next subtask
-    # Prefer first pending subtask (plan order respects dependencies)
+    # Determine suggested next subtask (first pending in plan order)
     suggested_next = pending[0]["id"] if pending else None
 
     return {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Enhanced SPEC phase in `/map-plan`**: Structured spec template with Invariants, Edge Cases, Acceptance Criteria, and Security Boundaries sections
 - **Devil's Advocate review step**: After spec creation, Monitor agent adversarially reviews the spec for race conditions, ownership ambiguity, missing edge cases, contradictions, and security gaps (skipped for complexity < 5)
 - **Spec invariant linkage in task-decomposer**: Contracts must trace back to spec invariants when spec exists; checklist enforces coverage
+- **`skipped_steps` tracking**: TDD steps skipped when TDD is disabled are tracked separately from completed steps, making TDD toggle reversible
+- **Plan progress tracking (`get_plan_progress`)**: Shows completed/pending subtask counts and suggests next subtask
+
+### Fixed
+- **`--tdd` flag leak**: Flag was leaking into agent prompts via `$ARGUMENTS`; now stripped into `$TASK_ARGS`
+- **Wave-mode TDD support**: Waves now start subtasks at TEST_WRITER (2.25) instead of ACTOR (2.3) when TDD is enabled
+- **`set_tdd_mode` restart bug**: Toggling TDD after first subtask no longer re-introduces completed global steps (1.x)
+- **TDD toggle reversibility**: Re-enabling TDD correctly re-introduces TEST_WRITER/TEST_FAIL_GATE phases even when they come before the current position
+- **ARCHITECTURE.md phase list**: Added missing `2.1 CONTEXT_SEARCH`, fixed `CHOOSE_MODE` description
+- **SKIPPABLE_STEPS docstring**: Added 2.25/2.26 to documented skippable steps
+- **`get_plan_progress` docstring**: Removed incorrect claim about dependency-aware ordering
+- **Workflow gate `~/.claude/` scope**: Narrowed exemption from entire `~/.claude/` to only `~/.claude/projects/*/memory/`
 
 ## [3.4.1] - 2026-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`--tdd` flag for `/map-efficient`**: Enables TDD mode within the standard efficient workflow
 - **TDD support in Actor agent**: Two new modes — `test_writer` (write only tests from spec) and `code_only` (implement to make tests green, no test modifications)
 - **`set_tdd_mode` orchestrator command**: Enable/disable TDD phases in the state machine
+- **Single subtask execution (`/map-task ST-001`)**: Execute one specific subtask from an existing plan without running the full workflow. Requires `/map-plan` first
+- **Single subtask TDD (`/map-tdd ST-001`)**: Write TDD tests and implement a specific subtask. Combines single-subtask execution with test-first development
+- **`resume_single_subtask` orchestrator command**: Sets up state for executing a single subtask with optional `--tdd` flag
 - **Enhanced SPEC phase in `/map-plan`**: Structured spec template with Invariants, Edge Cases, Acceptance Criteria, and Security Boundaries sections
 - **Devil's Advocate review step**: After spec creation, Monitor agent adversarially reviews the spec for race conditions, ownership ambiguity, missing edge cases, contradictions, and security gaps (skipped for complexity < 5)
 - **Spec invariant linkage in task-decomposer**: Contracts must trace back to spec invariants when spec exists; checklist enforces coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **TDD workflow (`/map-tdd`)**: Test-first development mode where tests are written from specification before implementation. Includes TEST_WRITER (2.25) and TEST_FAIL_GATE (2.26) phases
+- **`--tdd` flag for `/map-efficient`**: Enables TDD mode within the standard efficient workflow
+- **TDD support in Actor agent**: Two new modes — `test_writer` (write only tests from spec) and `code_only` (implement to make tests green, no test modifications)
+- **`set_tdd_mode` orchestrator command**: Enable/disable TDD phases in the state machine
+- **Enhanced SPEC phase in `/map-plan`**: Structured spec template with Invariants, Edge Cases, Acceptance Criteria, and Security Boundaries sections
+- **Devil's Advocate review step**: After spec creation, Monitor agent adversarially reviews the spec for race conditions, ownership ambiguity, missing edge cases, contradictions, and security gaps (skipped for complexity < 5)
+- **Spec invariant linkage in task-decomposer**: Contracts must trace back to spec invariants when spec exists; checklist enforces coverage
+
 ## [3.4.1] - 2026-03-09
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,6 +56,14 @@ MAP Framework implements cognitive architecture inspired by prefrontal cortex fu
 │  │   TEST_WRITER (tests from spec) → TEST_FAIL_GATE (Red)  │   │
 │  │   → Actor (code_only) → Monitor → [Predictor if risky]  │   │
 │  │ Tests written BEFORE implementation. 18 phases.          │   │
+│  │ Single-subtask: /map-tdd ST-001 (TDD for one subtask)   │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+│  /map-task (single subtask execution):                           │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ Runs one subtask from existing plan (no decomposition).  │   │
+│  │ Usage: /map-task ST-001                                  │   │
+│  │ Requires: /map-plan completed first.                     │   │
 │  └──────────────────────────────────────────────────────────┘   │
 │                                                                  │
 │  /map-debug (debugging-specific):                               │

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -674,7 +674,7 @@ See [USAGE.md - Workflow Variants](./USAGE.md#workflow-variants) for detailed de
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
 │  State Machine (.map/scripts/map_orchestrator.py)                │
-│  • 17 step phases (DECOMPOSE → SUBTASK_APPROVAL)            │
+│  • 18 step phases (DECOMPOSE → SUBTASK_APPROVAL + 2 TDD)     │
 │  • State file: .map/<branch>/step_state.json                │
 │  • Enforces: Sequential execution, no step skipping         │
 │  • CLI: get_next_step, validate_step, initialize            │
@@ -720,7 +720,7 @@ See [USAGE.md - Workflow Variants](./USAGE.md#workflow-variants) for detailed de
 
 #### Implementation Details
 
-**17 Step Phases:**
+**18 Step Phases (16 standard + 2 TDD):**
 1. `1.0 DECOMPOSE` - task-decomposer agent
 2. `1.5 INIT_PLAN` - Generate task_plan.md
 3. `1.55 REVIEW_PLAN` - User approval checkpoint
@@ -728,14 +728,16 @@ See [USAGE.md - Workflow Variants](./USAGE.md#workflow-variants) for detailed de
 5. `1.6 INIT_STATE` - Create workflow_state.json
 6. `2.0 XML_PACKET` - Build AI-friendly subtask packet
 7. `2.2 RESEARCH` - research-agent (conditional)
-9. `2.3 ACTOR` - Actor agent implementation
-10. `2.4 MONITOR` - Monitor validation (retry up to 5 times)
-11. `2.6 PREDICTOR` - Impact analysis (conditional)
-12. `2.7 UPDATE_STATE` - Update workflow_state.json
-13. `2.8 TESTS_GATE` - Run tests
-14. `2.9 LINTER_GATE` - Run linter
-15. `2.10 VERIFY_ADHERENCE` - Self-audit checkpoint
-16. `2.11 SUBTASK_APPROVAL` - Pause between subtasks (step_by_step only)
+8. `2.25 TEST_WRITER` - TDD: write tests from spec (TDD mode only, auto-skipped otherwise)
+9. `2.26 TEST_FAIL_GATE` - TDD: verify tests fail without impl (TDD mode only)
+10. `2.3 ACTOR` - Actor agent implementation (code-only in TDD mode)
+11. `2.4 MONITOR` - Monitor validation (retry up to 5 times)
+12. `2.6 PREDICTOR` - Impact analysis (conditional)
+13. `2.7 UPDATE_STATE` - Update workflow_state.json
+14. `2.8 TESTS_GATE` - Run tests
+15. `2.9 LINTER_GATE` - Run linter
+16. `2.10 VERIFY_ADHERENCE` - Self-audit checkpoint
+17. `2.11 SUBTASK_APPROVAL` - Pause between subtasks (step_by_step only)
 
 **State Files:**
 - `step_state.json` - Hook injection source (current step phase)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,11 +33,11 @@ MAP Framework implements cognitive architecture inspired by prefrontal cortex fu
     ┌───────────────┼───────────────────────────────────────┐
     │               │               │               │        │
     ▼               ▼               ▼               ▼        ▼
-┌────────┐    ┌────────┐    ┌────────┐    ┌────────┐  ┌────────┐
-│EFFICIENT│    │ DEBUG  │    │ DEBATE │    │ REVIEW │  │  FAST  │
-└────┬────┘    └────┬────┘   └────┬────┘   └────┬────┘  └────┬────┘
-     │              │             │              │            │
-     ▼              ▼             ▼              ▼            ▼
+┌────────┐    ┌────────┐    ┌────────┐    ┌────────┐  ┌────────┐  ┌────────┐
+│EFFICIENT│    │  TDD   │    │ DEBUG  │    │ DEBATE │  │ REVIEW │  │  FAST  │
+└────┬────┘    └────┬────┘   └────┬────┘   └────┬────┘  └────┬────┘  └────┬────┘
+     │              │             │              │            │            │
+     ▼              ▼             ▼              ▼            ▼            ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                   WORKFLOW-SPECIFIC SEQUENCES                    │
 ├─────────────────────────────────────────────────────────────────┤
@@ -48,6 +48,14 @@ MAP Framework implements cognitive architecture inspired by prefrontal cortex fu
 │  │   ├─ Standard: Actor → Monitor → [Predictor if risky]    │   │
 │  │   └─ Self-MoA: 3×Actor → 3×Monitor → Synthesizer → Mon.  │   │
 │  │ No Evaluator. Learning via /map-learn (optional)         │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+│  /map-tdd (test-first development):                              │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ TaskDecomposer → For each subtask:                       │   │
+│  │   TEST_WRITER (tests from spec) → TEST_FAIL_GATE (Red)  │   │
+│  │   → Actor (code_only) → Monitor → [Predictor if risky]  │   │
+│  │ Tests written BEFORE implementation. 18 phases.          │   │
 │  └──────────────────────────────────────────────────────────┘   │
 │                                                                  │
 │  /map-debug (debugging-specific):                               │

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -740,20 +740,21 @@ See [USAGE.md - Workflow Variants](./USAGE.md#workflow-variants) for detailed de
 1. `1.0 DECOMPOSE` - task-decomposer agent
 2. `1.5 INIT_PLAN` - Generate task_plan.md
 3. `1.55 REVIEW_PLAN` - User approval checkpoint
-4. `1.56 CHOOSE_MODE` - Select execution mode (step_by_step|batch)
+4. `1.56 CHOOSE_MODE` - Auto-skipped (always batch mode)
 5. `1.6 INIT_STATE` - Create workflow_state.json
 6. `2.0 XML_PACKET` - Build AI-friendly subtask packet
-7. `2.2 RESEARCH` - research-agent (conditional)
-8. `2.25 TEST_WRITER` - TDD: write tests from spec (TDD mode only, auto-skipped otherwise)
-9. `2.26 TEST_FAIL_GATE` - TDD: verify tests fail without impl (TDD mode only)
-10. `2.3 ACTOR` - Actor agent implementation (code-only in TDD mode)
-11. `2.4 MONITOR` - Monitor validation (retry up to 5 times)
-12. `2.6 PREDICTOR` - Impact analysis (conditional)
-13. `2.7 UPDATE_STATE` - Update workflow_state.json
-14. `2.8 TESTS_GATE` - Run tests
-15. `2.9 LINTER_GATE` - Run linter
-16. `2.10 VERIFY_ADHERENCE` - Self-audit checkpoint
-17. `2.11 SUBTASK_APPROVAL` - Pause between subtasks (step_by_step only)
+7. `2.1 CONTEXT_SEARCH` - Context search for relevant patterns
+8. `2.2 RESEARCH` - research-agent (conditional)
+9. `2.25 TEST_WRITER` - TDD: write tests from spec (TDD mode only, auto-skipped otherwise)
+10. `2.26 TEST_FAIL_GATE` - TDD: verify tests fail without impl (TDD mode only)
+11. `2.3 ACTOR` - Actor agent implementation (code-only in TDD mode)
+12. `2.4 MONITOR` - Monitor validation (retry up to 5 times)
+13. `2.6 PREDICTOR` - Impact analysis (conditional)
+14. `2.7 UPDATE_STATE` - Update workflow_state.json
+15. `2.8 TESTS_GATE` - Run tests
+16. `2.9 LINTER_GATE` - Run linter
+17. `2.10 VERIFY_ADHERENCE` - Self-audit checkpoint
+18. `2.11 SUBTASK_APPROVAL` - Pause between subtasks (step_by_step only, auto-skipped in batch)
 
 **State Files:**
 - `step_state.json` - Hook injection source (current step phase)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -803,7 +803,7 @@ Summary:
 
 ## 🔀 Workflow Variants
 
-MAP Framework offers three primary implementation workflows with different trade-offs between token usage, quality assurance, and learning. Additional supporting workflows (`/map-debug`, `/map-review`, `/map-check`, `/map-plan`, `/map-release`, `/map-resume`, `/map-learn`) are documented in their respective sections.
+MAP Framework offers three primary implementation workflows with different trade-offs between token usage, quality assurance, and learning. A fourth workflow (`/map-tdd`) adds test-first development. Additional supporting workflows (`/map-debug`, `/map-review`, `/map-check`, `/map-plan`, `/map-release`, `/map-resume`, `/map-learn`) are documented in their respective sections.
 
 ### Comparison Table
 
@@ -955,6 +955,33 @@ MAP Framework offers three primary implementation workflows with different trade
 # Minor docs automation
 /map-fast Update CLI help text formatting
 ```
+
+#### Use `/map-tdd` (Test-Driven Development)
+
+**When:** Correctness-critical features where you need tests to validate behavior independently of implementation.
+
+**Key insight:** When AI writes tests alongside code, tests tend to confirm the implementation (including its bugs) rather than validate the specification. TDD mode separates test authoring from implementation.
+
+**Flow:**
+```
+DECOMPOSE → TEST_WRITER (tests from spec) → TEST_FAIL_GATE (verify Red) → ACTOR (code only) → MONITOR
+```
+
+**Usage:**
+```bash
+# Standalone TDD workflow
+/map-tdd Add payment processing with refund support
+
+# Or via --tdd flag on /map-efficient
+/map-efficient --tdd Add JWT authentication with refresh tokens
+```
+
+**Best for:**
+- Auth, payments, data integrity features
+- Features with clear acceptance criteria in the spec
+- When previous AI-generated tests missed real bugs
+
+**Token cost:** ~20-30% higher than /map-efficient (extra Actor call for test-writing phase).
 
 ### Real-World Token Usage Examples
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -803,7 +803,7 @@ Summary:
 
 ## 🔀 Workflow Variants
 
-MAP Framework offers three primary implementation workflows with different trade-offs between token usage, quality assurance, and learning. A fourth workflow (`/map-tdd`) adds test-first development. Additional supporting workflows (`/map-debug`, `/map-review`, `/map-check`, `/map-plan`, `/map-release`, `/map-resume`, `/map-learn`) are documented in their respective sections.
+MAP Framework offers three primary implementation workflows with different trade-offs between token usage, quality assurance, and learning. A fourth workflow (`/map-tdd`) adds test-first development. A fifth (`/map-task`) executes a single subtask from an existing plan. Additional supporting workflows (`/map-debug`, `/map-review`, `/map-check`, `/map-plan`, `/map-release`, `/map-resume`, `/map-learn`) are documented in their respective sections.
 
 ### Comparison Table
 
@@ -982,6 +982,33 @@ DECOMPOSE → TEST_WRITER (tests from spec) → TEST_FAIL_GATE (verify Red) → 
 - When previous AI-generated tests missed real bugs
 
 **Token cost:** ~20-30% higher than /map-efficient (extra Actor call for test-writing phase).
+
+#### Use `/map-task` (Single Subtask Execution)
+
+**When:** You have a plan from `/map-plan` and want to execute just one specific subtask.
+
+**Prerequisites:** Run `/map-plan` first to create a task decomposition.
+
+**Usage:**
+```bash
+# Execute a single subtask from the plan
+/map-task ST-001
+
+# Write TDD tests for a specific subtask
+/map-tdd ST-001
+
+# Typical workflow: plan first, then pick subtasks
+/map-plan Add user authentication
+/map-task ST-001   # implement first subtask
+/map-tdd ST-002    # TDD for second subtask
+/map-task ST-003   # implement third subtask
+```
+
+**Best for:**
+- Fine-grained control over execution order
+- Parallelizing subtasks across multiple sessions
+- Resuming work on a specific subtask after context reset
+- Cherry-picking which subtasks to implement now vs. later
 
 ### Real-World Token Usage Examples
 

--- a/src/mapify_cli/templates/agents/actor.md
+++ b/src/mapify_cli/templates/agents/actor.md
@@ -227,6 +227,52 @@ UserService -> register(email, password) -> creates user, returns 201 with JWT
 
 ---
 
+## TDD Mode Support
+
+Actor supports two TDD modes, activated by the `<TDD_Mode>` tag in the prompt:
+
+### TDD Mode: `test_writer`
+
+When `<TDD_Mode>test_writer</TDD_Mode>` is present:
+
+**You write ONLY test files.** No implementation code.
+
+Rules:
+1. Derive tests from the AAG contract, validation_criteria, and test_strategy — NOT from any implementation.
+2. You have NO knowledge of the implementation. Do not assume internal structure, class names, or method signatures beyond what the contract specifies.
+3. Test the PUBLIC interface/behavior described in the contract.
+4. Each `VCn:` validation criterion must have at least one corresponding test.
+5. Include edge cases from the spec's `## Edge Cases` section if available in the packet.
+6. Use standard test patterns for the project's language and framework.
+7. Tests SHOULD fail when run (implementation doesn't exist yet). This is expected.
+
+Output:
+- Test files created via Write tool
+- Evidence file: `.map/<branch>/evidence/test_writer_<subtask_id>.json`
+
+### TDD Mode: `code_only`
+
+When `<TDD_Mode>code_only</TDD_Mode>` is present:
+
+**You write ONLY implementation code.** Test files are READ-ONLY.
+
+Rules:
+1. Read the test files listed in `<TDD_Tests>` FIRST to understand expected behavior.
+2. Do NOT modify, delete, or rename any test file.
+3. Implement the minimum code needed to make ALL existing tests pass.
+4. Follow the AAG contract as your specification.
+5. If a test seems wrong (testing impossible behavior), flag it in trade-offs but still implement to satisfy it. Monitor will catch true test issues.
+
+Output:
+- Implementation files created/modified via Edit/Write tools
+- Standard Actor evidence file
+
+### No TDD Mode (default)
+
+When no `<TDD_Mode>` tag is present, Actor operates in standard mode: write both implementation and tests as described in sections 3-7 below.
+
+---
+
 ## 2. Approach
 Explain solution strategy in 2-3 sentences. Include:
 - Core idea and why this approach

--- a/src/mapify_cli/templates/agents/task-decomposer.md
+++ b/src/mapify_cli/templates/agents/task-decomposer.md
@@ -244,6 +244,7 @@ Return **ONLY** valid JSON in this exact structure:
   - `scope`: "function" | "endpoint" | "module"
   - Include when: security_critical OR complexity_score ≥ 5 OR API contracts
   - Omit when: simple CRUD, internal helpers, complexity_score < 5
+  - **Spec invariant linkage**: If a `spec_<branch>.md` file exists with an `## Invariants` section, each contract MUST trace back to at least one spec invariant. Add `"source": "spec-invariant-N"` to link the contract to the invariant it enforces. This ensures no spec invariant is left unguarded by contracts.
 **subtasks[].aag_contract**: REQUIRED one-line contract in `Actor -> Action(params) -> Goal` format
   - This is the primary handoff artifact to the Actor agent
   - Actor "compiles" this contract into code; Monitor verifies against it
@@ -542,6 +543,11 @@ If circular dependency detected (e.g., A→B→C→A):
 - [ ] For complexity_score ≥ 7, verify at least one entry in `risks` (or explicitly state `[]` if none)
 - [ ] All assumptions documented that could affect implementation
 - [ ] Open questions flagged that need clarification before proceeding
+
+**Spec Invariant Coverage** (when spec exists):
+- [ ] Read `spec_<branch>.md` if present — check for `## Invariants` section
+- [ ] Each spec invariant is covered by at least one contract across subtasks
+- [ ] Edge cases from spec's `## Edge Cases` section are reflected in validation_criteria
 
 **MCP Tool Usage Verification**:
 - [ ] Did you use insights from MCP tools in your decomposition?

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -61,6 +61,29 @@ Both files must stay in sync. The orchestrator updates `step_state.json` on ever
 
 **Task:** $ARGUMENTS
 
+## Flag Parsing
+
+Parse optional flags from `$ARGUMENTS`:
+
+- **`--tdd`**: Enable TDD mode (test-first workflow). Inserts TEST_WRITER and TEST_FAIL_GATE phases before ACTOR. Tests are written from spec before implementation.
+
+```bash
+# Extract flags and clean task description
+TASK_ARGS="$ARGUMENTS"
+TDD_FLAG=false
+if echo "$TASK_ARGS" | grep -q -- '--tdd'; then
+  TDD_FLAG=true
+  TASK_ARGS=$(echo "$TASK_ARGS" | sed 's/--tdd//g' | xargs)
+fi
+```
+
+If `--tdd` is detected, enable TDD mode after state initialization:
+```bash
+if [ "$TDD_FLAG" = "true" ]; then
+  python3 .map/scripts/map_orchestrator.py set_tdd_mode true
+fi
+```
+
 ## Step 0: Detect Existing Plan from /map-plan
 
 Before starting the state machine, check if `/map-plan` already produced artifacts for this branch:
@@ -322,7 +345,53 @@ This file is the SOLE research artifact passed to Actor and future steps."""
     )
 ```
 
+### Phase: TEST_WRITER (2.25) — TDD Mode Only
+
+Auto-skipped when TDD mode is disabled. When active:
+
+```python
+Task(
+  subagent_type="actor",
+  description="TDD: Write tests for subtask [ID]",
+  prompt=f"""You are in TDD TEST_WRITER mode.
+
+<MAP_Packet subtask="[ID]" v="1.0" risk="[risk_level]">
+[paste from .map/<branch>/current_packet.xml]
+</MAP_Packet>
+
+<MAP_Contract>
+[AAG contract from decomposition]
+</MAP_Contract>
+
+<TDD_Mode>test_writer</TDD_Mode>
+
+STRICT RULES:
+1. Write ONLY test files. Do NOT create or modify implementation files.
+2. Tests must be derived from the SPECIFICATION (AAG contract + validation_criteria).
+3. You have NO knowledge of the implementation.
+4. Each VCn: validation criterion must have at least one corresponding test.
+5. Tests SHOULD fail when run (implementation doesn't exist yet).
+
+Write evidence: .map/<branch>/evidence/test_writer_<subtask_id>.json"""
+)
+```
+
+### Phase: TEST_FAIL_GATE (2.26) — TDD Mode Only
+
+Auto-skipped when TDD mode is disabled. When active, run the tests — they MUST fail:
+
+```bash
+# Run tests — expect failures (Red phase)
+pytest --tb=short 2>&1 || true
+# If tests PASS → go back to TEST_WRITER (tests are trivial)
+# If tests FAIL with assertion errors → proceed to ACTOR (expected TDD state)
+```
+
+Write evidence: `.map/<branch>/evidence/test_fail_gate_<subtask_id>.json`
+
 ### Phase: ACTOR (2.3)
+
+When TDD mode is active, Actor receives `<TDD_Mode>code_only</TDD_Mode>` and must NOT modify test files. When TDD is off, standard behavior.
 
 ```python
 Task(

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -59,8 +59,6 @@ Both files must stay in sync. The orchestrator updates `step_state.json` on ever
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Task:** $ARGUMENTS
-
 ## Flag Parsing
 
 Parse optional flags from `$ARGUMENTS`:
@@ -76,6 +74,10 @@ if echo "$TASK_ARGS" | grep -q -- '--tdd'; then
   TASK_ARGS=$(echo "$TASK_ARGS" | sed 's/--tdd//g' | xargs)
 fi
 ```
+
+**Task:** $TASK_ARGS
+
+**IMPORTANT:** Use `$TASK_ARGS` (not `$ARGUMENTS`) in all agent prompts below. The `--tdd` flag has been stripped from `$TASK_ARGS` so it won't leak into task descriptions.
 
 If `--tdd` is detected, enable TDD mode after state initialization:
 ```bash
@@ -128,7 +130,7 @@ Task(
   description="Decompose task into subtasks",
   prompt=f"""Break down into ≤20 atomic subtasks and RETURN ONLY JSON.
 
-Task: $ARGUMENTS
+Task: $TASK_ARGS
 
 Hard requirements:
 - Use `blueprint.subtasks[].validation_criteria` (2-4 testable outcomes)
@@ -277,6 +279,14 @@ loop:
     # Phase A: Prep (sequential per subtask - lightweight)
     for each subtask in WAVE.subtasks:
       build XML_PACKET, run CONTEXT_SEARCH, optional RESEARCH
+
+    # Phase A.5: TDD phases (if --tdd mode)
+    # When TDD is enabled, run TEST_WRITER + TEST_FAIL_GATE per subtask
+    # BEFORE launching Actors. These run sequentially per subtask.
+    if TDD_FLAG:
+      for each subtask in WAVE.subtasks:
+        run TEST_WRITER (2.25) → validate_wave_step SUBTASK_ID "2.25"
+        run TEST_FAIL_GATE (2.26) → validate_wave_step SUBTASK_ID "2.26"
 
     # Phase B: Parallel Actors
     # Launch ALL Task(subagent_type="actor") calls in ONE message

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -596,10 +596,16 @@ Question 2: For EACH subtask, did I:
   - Run linter gate? [YES/NO per subtask]
 Answer: [List each subtask and answers]
 
-Question 3: Did I ever write code directly without Actor?
+Question 3: (TDD mode only) For EACH subtask, did I:
+  - Call TEST_WRITER before Actor? [YES/NO/N/A per subtask]
+  - Verify tests failed at TEST_FAIL_GATE? [YES/NO/N/A per subtask]
+  - Use code_only mode for Actor (no test modifications)? [YES/NO/N/A]
+Answer: [List answers, or N/A if TDD mode is not active]
+
+Question 4: Did I ever write code directly without Actor?
 Answer: [YES/NO - if YES, this is a VIOLATION]
 
-Question 4: Did I output CHECKPOINT blocks before agent calls?
+Question 5: Did I output CHECKPOINT blocks before agent calls?
 Answer: [YES/NO - if NO, add them now]
 
 EVALUATION: [PASSED/FAILED]

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -371,6 +371,8 @@ STRICT RULES:
 3. You have NO knowledge of the implementation.
 4. Each VCn: validation criterion must have at least one corresponding test.
 5. Tests SHOULD fail when run (implementation doesn't exist yet).
+6. Test files MUST be lint-clean. Use proper imports at the top of the file
+   (not inside type annotations). Run the project linter on test files before finishing.
 
 Write evidence: .map/<branch>/evidence/test_writer_<subtask_id>.json"""
 )
@@ -378,8 +380,16 @@ Write evidence: .map/<branch>/evidence/test_writer_<subtask_id>.json"""
 
 ### Phase: TEST_FAIL_GATE (2.26) — TDD Mode Only
 
-Auto-skipped when TDD mode is disabled. When active, run the tests — they MUST fail:
+Auto-skipped when TDD mode is disabled. When active:
 
+**First:** lint-check test files (ACTOR cannot fix them later):
+```bash
+# Lint ONLY the test files from TEST_WRITER evidence
+ruff check <test_files> 2>&1 || true
+# If lint errors → go back to TEST_WRITER with feedback to fix lint
+```
+
+**Then:** run the tests — they MUST fail:
 ```bash
 # Run tests — expect failures (Red phase)
 pytest --tb=short 2>&1 || true

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -106,7 +106,7 @@ Read the user's requirements and decide if deep interview is needed.
 - Small isolated change (single bug fix, test update)
 - User explicitly provided a spec or detailed description
 
-If interview is not needed, skip to Step 3.
+If interview is not needed, skip to Step 2a (write spec without interview).
 
 ### Step 2: Deep Interview (Spec Discovery)
 
@@ -217,9 +217,22 @@ Formal, testable conditions that define "done". Each criterion must be verifiabl
 - [Anything still unresolved]
 ```
 
+### Step 2a: Write Spec (when interview was skipped)
+
+If interview was skipped (task is well-defined), still write `spec_<branch>.md` using the same template as Step 2. Populate it from the user's requirements and discovery findings:
+
+- **Decisions Made**: extract from user's request (may be short or N/A)
+- **Invariants**: derive from existing code patterns found in discovery
+- **Edge Cases**: identify from the task description and affected code
+- **Acceptance Criteria**: REQUIRED — must be testable conditions that define "done"
+- **Security Boundaries**: include if task touches auth/validation/user input
+- **Out of Scope**: explicitly state what is NOT being changed
+
+This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
+
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
-**Skip if:** complexity < 5 (simple, well-defined tasks) or interview was skipped.
+**Skip if:** complexity < 5 (simple, well-defined tasks).
 
 After writing the spec, invoke Monitor agent to adversarially review it. The goal is to surface gaps, contradictions, and missing edge cases BEFORE decomposition.
 

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -169,6 +169,45 @@ AskUserQuestion(questions=[
 | 1 | Token storage | Server-side (Redis) | Need revocation support |
 | 2 | Session expiry UX | Silent refresh | Better UX, no data loss |
 
+## Invariants
+
+Conditions that MUST remain true throughout implementation and after deployment.
+These are hard constraints — violating any invariant is a blocker.
+
+- [e.g., "All API endpoints require authentication except /health and /login"]
+- [e.g., "Database migrations must be backward-compatible (no column drops)"]
+- [e.g., "Response time for any endpoint must stay under 500ms p95"]
+
+## Edge Cases
+
+Enumerate boundary conditions and unusual inputs that implementation must handle.
+
+| # | Edge Case | Expected Behavior | Priority |
+|---|-----------|-------------------|----------|
+| 1 | [e.g., Empty input array] | [Return empty result, not error] | must-handle |
+| 2 | [e.g., Concurrent updates to same resource] | [Last-write-wins with conflict detection] | must-handle |
+| 3 | [e.g., Unicode in usernames] | [Accept, normalize to NFC] | should-handle |
+
+Priority levels: `must-handle` (blocks release), `should-handle` (best effort), `won't-handle` (documented limitation).
+
+## Acceptance Criteria
+
+Formal, testable conditions that define "done". Each criterion must be verifiable by automated test or manual check.
+
+| ID | Criterion | Verification Method |
+|----|-----------|-------------------|
+| AC-1 | [e.g., User can log in with valid credentials] | `pytest tests/test_auth.py::test_login` |
+| AC-2 | [e.g., Invalid token returns 401] | `pytest tests/test_auth.py::test_invalid_token` |
+
+## Security Boundaries
+
+*(Include for security-critical tasks; omit for purely internal/cosmetic changes)*
+
+- **Trust boundary:** [e.g., "All user input is untrusted; validate at API layer"]
+- **Auth model:** [e.g., "RBAC with role checks at service layer, not just route level"]
+- **Data sensitivity:** [e.g., "PII fields encrypted at rest, never logged"]
+- **Attack surface:** [e.g., "Public API exposed to internet; internal services behind VPN"]
+
 ## Out of Scope
 
 - [Explicitly excluded items]
@@ -177,6 +216,41 @@ AskUserQuestion(questions=[
 
 - [Anything still unresolved]
 ```
+
+### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+
+**Skip if:** complexity < 5 (simple, well-defined tasks) or interview was skipped.
+
+After writing the spec, invoke Monitor agent to adversarially review it. The goal is to surface gaps, contradictions, and missing edge cases BEFORE decomposition.
+
+```
+Task(
+  subagent_type="monitor",
+  description="Devil's Advocate spec review",
+  prompt=f"""You are reviewing a SPECIFICATION (not code). Act as Devil's Advocate.
+
+Read the spec file: .map/<branch>/spec_<branch>.md
+
+Check for:
+1. **Race conditions / concurrency gaps**: Are there shared resources without defined conflict resolution?
+2. **Ownership ambiguity**: Are responsibilities clearly assigned? Could two components both assume the other handles something?
+3. **Missing edge cases**: Compare the Edge Cases section against Invariants — are there invariant violations not covered by edge cases?
+4. **Contradictions**: Do any decisions contradict invariants or acceptance criteria?
+5. **Security gaps**: Are trust boundaries complete? Are there injection vectors not addressed?
+6. **Implicit assumptions**: What is assumed but not stated?
+
+Output format:
+- For each finding: severity (HIGH/MEDIUM/LOW), category, description, suggested fix
+- If NO high-severity issues found: output "SPEC APPROVED"
+- If HIGH-severity issues found: list them clearly for user resolution
+"""
+)
+```
+
+**After Devil's Advocate review:**
+- If **SPEC APPROVED** (no HIGH-severity findings): proceed to Step 3.
+- If **HIGH-severity findings**: present them to the user via AskUserQuestion. Update the spec with resolutions before proceeding. Do NOT silently proceed past HIGH findings.
+- MEDIUM/LOW findings: note them in the spec's Open Questions section but proceed.
 
 ### Step 3: Create Branch Directory
 

--- a/src/mapify_cli/templates/commands/map-resume.md
+++ b/src/mapify_cli/templates/commands/map-resume.md
@@ -21,9 +21,11 @@ description: Resume incomplete MAP workflow from checkpoint
 6. Continues from the last incomplete step via the state machine
 
 **State files used:**
-- **`step_state.json`** — Orchestrator canonical state. Source of truth for resumption. Tracks current step, retry counts, circuit breaker status.
+- **`step_state.json`** — Orchestrator canonical state. Source of truth for resumption. Tracks current step, retry counts, circuit breaker status. Includes `tdd_mode` field (persisted across sessions).
 - **`workflow_state.json`** — Enforcement gates. Tracks subtask completion for workflow-gate.py hook.
 - **`task_plan_<branch>.md`** — Full task decomposition with validation criteria and AAG contracts.
+
+**TDD mode note:** If the interrupted workflow was using `/map-tdd` or `--tdd` flag, `tdd_mode: true` is preserved in `step_state.json`. The TDD phases (TEST_WRITER, TEST_FAIL_GATE) will be correctly included in the resumed workflow. No manual re-enablement is needed when resuming from `step_state.json`.
 
 ---
 

--- a/src/mapify_cli/templates/commands/map-task.md
+++ b/src/mapify_cli/templates/commands/map-task.md
@@ -1,0 +1,168 @@
+---
+description: Execute a single subtask from an existing plan
+---
+
+# /map-task — Single Subtask Execution
+
+**Purpose:** Execute one specific subtask from an existing plan, without running the full workflow.
+
+**When to use:**
+- After `/map-plan` has created a decomposition — pick and run one subtask
+- When you want fine-grained control over execution order
+- When resuming work on a specific subtask after context reset
+- When parallelizing subtasks across multiple sessions
+
+**Prerequisites:** A plan must exist (`.map/<branch>/task_plan_<branch>.md`). Run `/map-plan` first if needed.
+
+**Task:** $ARGUMENTS
+
+---
+
+## Step 0: Parse Arguments
+
+Extract the subtask ID from `$ARGUMENTS`:
+
+```bash
+SUBTASK_ID=$(echo "$ARGUMENTS" | grep -oE 'ST-[0-9]+' | head -1)
+if [ -z "$SUBTASK_ID" ]; then
+  echo "ERROR: No subtask ID found. Usage: /map-task ST-001"
+  exit 1
+fi
+```
+
+## Step 1: Initialize Single Subtask
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+
+# Set up state for single subtask execution
+RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID")
+STATUS=$(echo "$RESULT" | jq -r '.status')
+
+if [ "$STATUS" = "error" ]; then
+  echo "$RESULT" | jq -r '.message'
+  exit 1
+fi
+```
+
+**If error mentions "No plan found":** Run `/map-plan` first to create a decomposition.
+**If error mentions "not found in plan":** The output lists available subtask IDs — pick one.
+
+## Step 2: Load Subtask Context
+
+Read the plan to get the subtask's details:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+# Read: .map/${BRANCH}/task_plan_${BRANCH}.md — find the ### ${SUBTASK_ID} section
+# Read: .map/${BRANCH}/blueprint.json — get AAG contract, validation_criteria, dependencies
+```
+
+Display a brief summary:
+
+```text
+═══════════════════════════════════════════════════
+SINGLE SUBTASK EXECUTION
+═══════════════════════════════════════════════════
+Subtask: ${SUBTASK_ID}
+Title: <from plan>
+AAG Contract: <from blueprint>
+Risk: <from blueprint>
+Dependencies: <from blueprint>
+═══════════════════════════════════════════════════
+```
+
+## Step 3: State Machine Loop
+
+Follow the same state machine loop as `/map-efficient`. Call `get_next_step` and execute based on the returned phase.
+
+```bash
+NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
+PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+```
+
+Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
+
+- **XML_PACKET (2.0)** — Build XML packet for this subtask
+- **CONTEXT_SEARCH (2.1)** — Search for relevant patterns
+- **RESEARCH (2.2)** — Call research-agent if needed
+- **ACTOR (2.3)** — Implement the subtask
+- **MONITOR (2.4)** — Validate implementation
+- **PREDICTOR (2.6)** — Impact analysis (conditional)
+- **UPDATE_STATE (2.7)** — Mark progress
+- **TESTS_GATE (2.8)** — Run tests
+- **LINTER_GATE (2.9)** — Run linter
+- **VERIFY_ADHERENCE (2.10)** — Self-audit
+
+For each step:
+1. Get next step from orchestrator
+2. Execute the phase (same handlers as map-efficient)
+3. Validate: `python3 .map/scripts/map_orchestrator.py validate_step "$STEP_ID"`
+4. Continue to next step until complete
+
+**If Monitor returns `valid: false`:**
+- Retry Actor with feedback (max 5 iterations)
+
+## Step 4: Completion
+
+When `get_next_step` returns `is_complete: true`:
+
+```text
+═══════════════════════════════════════════════════
+SUBTASK COMPLETE
+═══════════════════════════════════════════════════
+Subtask: ${SUBTASK_ID}
+Title: <title>
+Status: COMPLETE
+
+Files Modified:
+  - <list of changed files>
+
+Next steps:
+  - Run /map-task ST-XXX for the next subtask
+  - Run tests to verify: pytest / npm test / go test
+  - Run /map-check for full verification
+═══════════════════════════════════════════════════
+```
+
+Update the plan status:
+```bash
+python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "complete"
+```
+
+---
+
+## Error Handling
+
+### No Plan Exists
+
+```text
+No plan found. Run /map-plan first to create a task decomposition,
+then use /map-task ST-001 to execute individual subtasks.
+```
+
+### Subtask Not in Plan
+
+```text
+Subtask ST-999 not found in plan.
+Available subtasks: ST-001, ST-002, ST-003
+```
+
+### Dependencies Not Met
+
+Check blueprint for dependencies. If the subtask depends on unfinished work, warn:
+
+```text
+WARNING: ${SUBTASK_ID} depends on ${DEP_ID} which may not be complete.
+Proceed anyway? (The Actor will work with whatever state exists.)
+```
+
+---
+
+## Related Commands
+
+- **/map-plan** — Create task decomposition (prerequisite)
+- **/map-efficient** — Run full workflow (all subtasks)
+- **/map-tdd ST-001** — Write tests for a specific subtask (TDD mode)
+- **/map-resume** — Resume interrupted workflow from checkpoint
+- **/map-check** — Verify all acceptance criteria

--- a/src/mapify_cli/templates/commands/map-task.md
+++ b/src/mapify_cli/templates/commands/map-task.md
@@ -103,9 +103,25 @@ For each step:
 **If Monitor returns `valid: false`:**
 - Retry Actor with feedback (max 5 iterations)
 
-## Step 4: Completion
+## Step 4: Completion and Progress Report
 
 When `get_next_step` returns `is_complete: true`:
+
+1. Update the plan status:
+```bash
+python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "complete"
+```
+
+2. Get overall plan progress:
+```bash
+PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
+TOTAL=$(echo "$PROGRESS" | jq -r '.total')
+DONE=$(echo "$PROGRESS" | jq -r '.completed_count')
+REMAINING=$(echo "$PROGRESS" | jq -r '.pending_count')
+SUGGESTED=$(echo "$PROGRESS" | jq -r '.suggested_next')
+```
+
+3. Display completion report with remaining subtasks:
 
 ```text
 ═══════════════════════════════════════════════════
@@ -118,16 +134,46 @@ Status: COMPLETE
 Files Modified:
   - <list of changed files>
 
-Next steps:
-  - Run /map-task ST-XXX for the next subtask
-  - Run tests to verify: pytest / npm test / go test
-  - Run /map-check for full verification
+───────────────────────────────────────────────────
+PLAN PROGRESS: ${DONE}/${TOTAL} subtasks complete
+───────────────────────────────────────────────────
+
+Completed:
+  ✓ ST-001: <title>
+  ✓ ST-002: <title>  ← just completed
+
+Remaining:
+  ○ ST-003: <title> (pending)
+  ○ ST-004: <title> (pending)
+
 ═══════════════════════════════════════════════════
 ```
 
-Update the plan status:
-```bash
-python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "complete"
+4. **Suggest next subtask** using AskUserQuestion:
+
+```
+AskUserQuestion(questions=[
+  {
+    "question": "What would you like to do next?",
+    "header": "Next subtask",
+    "options": [
+      {"label": "/map-task ${SUGGESTED}", "description": "Execute next subtask: <title>"},
+      {"label": "/map-tdd ${SUGGESTED}", "description": "TDD for next subtask: <title>"},
+      {"label": "Done for now", "description": "Stop here, continue later with /map-task"}
+    ],
+    "multiSelect": false
+  }
+])
+```
+
+**If all subtasks are complete** (REMAINING == 0), skip the question and show:
+
+```text
+═══════════════════════════════════════════════════
+ALL SUBTASKS COMPLETE (${TOTAL}/${TOTAL})
+═══════════════════════════════════════════════════
+
+Run /map-check for final verification, or /map-learn to extract patterns.
 ```
 
 ---

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -1,0 +1,240 @@
+---
+description: TDD workflow — test-first development with spec-driven tests written before implementation
+---
+
+# /map-tdd — Test-Driven Development Workflow
+
+**Purpose:** Enforce test-first development where tests are written from the SPECIFICATION (not from implementation), ensuring tests validate intent rather than confirming implementation bugs.
+
+**When to use:**
+- Features where correctness is critical (auth, payments, data integrity)
+- When you want tests that truly validate behavior, not mirror implementation
+- When AI-written tests tend to pass trivially (testing what was written, not what was specified)
+
+**Key insight:** If implementation is in context when writing tests, AI writes tests that confirm the implementation — including its bugs. By writing tests FIRST from the spec only, tests become an independent correctness oracle.
+
+**What this command does NOT do:**
+- Does NOT replace /map-efficient — it augments the Actor/Monitor loop with test-first phases
+- Does NOT work without a spec or plan — requires spec_<branch>.md or clear acceptance criteria
+
+---
+
+## Execution Flow
+
+```
+Standard:  DECOMPOSE → ACTOR (code+tests) → MONITOR
+TDD:       DECOMPOSE → TEST_WRITER → TEST_FAIL_GATE → ACTOR (code only) → MONITOR
+```
+
+**Task:** $ARGUMENTS
+
+---
+
+## Step 0: Prerequisites
+
+Verify that a plan or spec exists for this branch:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
+echo "step_state:  $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+```
+
+- If **no spec and no task_plan**: Run `/map-plan` first. TDD requires clear acceptance criteria.
+- If **step_state.json EXISTS**: Resume from checkpoint (same as /map-efficient resume logic).
+- If **task_plan EXISTS but no step_state**: Run `python3 .map/scripts/map_orchestrator.py resume_from_plan` then enable TDD mode.
+
+### Enable TDD Mode
+
+After state is initialized (either fresh or resumed):
+
+```bash
+python3 .map/scripts/map_orchestrator.py set_tdd_mode true
+```
+
+This inserts TEST_WRITER (2.25) and TEST_FAIL_GATE (2.26) phases before ACTOR (2.3) in the step sequence.
+
+---
+
+## Step 1: State Machine Loop
+
+Follow the same state machine loop as /map-efficient. The orchestrator handles phase routing.
+Call `get_next_step` and execute based on the returned phase.
+
+```bash
+NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
+PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+```
+
+Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.
+The two NEW phases are described below.
+
+---
+
+## Phase: TEST_WRITER (2.25)
+
+Write tests ONLY — no implementation code. Tests are derived from the SPECIFICATION.
+
+```python
+Task(
+  subagent_type="actor",
+  description="TDD: Write tests for subtask [ID]",
+  prompt=f"""You are in TDD TEST_WRITER mode.
+
+<MAP_Packet subtask="[ID]" v="1.0" risk="[risk_level]">
+[paste from .map/<branch>/current_packet.xml]
+</MAP_Packet>
+
+<MAP_Contract>
+[AAG contract from decomposition]
+</MAP_Contract>
+
+<TDD_Mode>test_writer</TDD_Mode>
+
+STRICT RULES:
+1. Write ONLY test files. Do NOT create or modify implementation files.
+2. Tests must be derived from the SPECIFICATION (AAG contract + validation_criteria + test_strategy).
+3. You have NO knowledge of the implementation. Do not assume implementation details.
+4. Tests should assert BEHAVIOR described in the contract, not implementation structure.
+5. Use standard test patterns for the project's language/framework.
+6. Each validation_criteria item (VCn:) must have at least one corresponding test.
+7. Include edge cases from the spec's Edge Cases section if available.
+
+Output:
+- Test files written via Edit/Write tools
+- Evidence file: .map/<branch>/evidence/test_writer_<subtask_id>.json
+
+Evidence JSON must include:
+  "phase": "TEST_WRITER",
+  "subtask_id": "<id>",
+  "timestamp": "<ISO 8601>",
+  "test_files_created": ["path/to/test_file.py"],
+  "validation_criteria_covered": ["VC1", "VC2", "VC3"],
+  "status": "applied"
+"""
+)
+```
+
+After TEST_WRITER returns:
+```bash
+python3 .map/scripts/map_orchestrator.py validate_step "2.25"
+```
+
+---
+
+## Phase: TEST_FAIL_GATE (2.26)
+
+Run the tests written by TEST_WRITER. They MUST fail (implementation doesn't exist yet).
+
+```bash
+# Run tests — expect failures
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+
+if [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
+  TEST_OUTPUT=$(pytest --tb=short 2>&1) || true
+elif [ -f "package.json" ]; then
+  TEST_OUTPUT=$(npm test 2>&1) || true
+elif [ -f "go.mod" ]; then
+  TEST_OUTPUT=$(go test ./... 2>&1) || true
+elif [ -f "Cargo.toml" ]; then
+  TEST_OUTPUT=$(cargo test 2>&1) || true
+fi
+```
+
+**Evaluate results:**
+
+- **Tests FAIL with assertion/import errors** → GOOD. This is the expected TDD state ("Red" phase). Proceed to ACTOR.
+- **Tests PASS** → PROBLEM. Tests are trivial or not testing real behavior. Go back to TEST_WRITER with feedback: "Tests pass without implementation. Tests must assert behavior that requires code to be written."
+- **Tests have syntax errors** → Go back to TEST_WRITER with feedback to fix syntax.
+
+Write evidence file:
+
+```json
+{
+  "phase": "TEST_FAIL_GATE",
+  "subtask_id": "<id>",
+  "timestamp": "<ISO 8601>",
+  "tests_ran": true,
+  "tests_failed": true,
+  "failure_type": "assertion_errors",
+  "status": "gate_passed"
+}
+```
+
+```bash
+python3 .map/scripts/map_orchestrator.py validate_step "2.26"
+```
+
+---
+
+## Phase: ACTOR in TDD Mode (2.3)
+
+When TDD mode is active, Actor receives a modified prompt:
+
+```python
+Task(
+  subagent_type="actor",
+  description="TDD: Implement subtask [ID] to make tests green",
+  prompt=f"""You are in TDD CODE_ONLY mode.
+
+<MAP_Packet subtask="[ID]" v="1.0" risk="[risk_level]">
+[paste from .map/<branch>/current_packet.xml]
+</MAP_Packet>
+
+<MAP_Contract>
+[AAG contract from decomposition]
+</MAP_Contract>
+
+<TDD_Mode>code_only</TDD_Mode>
+
+<TDD_Tests>
+[List test files created by TEST_WRITER]
+</TDD_Tests>
+
+STRICT RULES:
+1. Write ONLY implementation code. Do NOT modify test files.
+2. Your goal: make ALL existing tests pass (turn Red → Green).
+3. Read the test files first to understand what behavior is expected.
+4. Implement the minimum code needed to satisfy the tests.
+5. Follow the AAG contract as your specification.
+
+Test files (READ-ONLY):
+{test_files_list}
+
+Output: standard Actor output (approach + code + trade-offs)
+Evidence file: .map/<branch>/evidence/actor_<subtask_id>.json"""
+)
+```
+
+After ACTOR, proceed to MONITOR as usual. Monitor verifies both implementation AND that tests pass.
+
+---
+
+## Differences from /map-efficient
+
+| Aspect | /map-efficient | /map-tdd |
+|--------|---------------|----------|
+| Test authoring | Actor writes code + tests together | TEST_WRITER writes tests first, Actor writes code only |
+| Test independence | Tests may mirror implementation | Tests derived from spec only |
+| Phase count | 16 phases | 18 phases (+TEST_WRITER, +TEST_FAIL_GATE) |
+| Token cost | Lower | ~20-30% higher (extra Actor call for tests) |
+| Best for | General development | Correctness-critical features |
+
+---
+
+## When NOT to use /map-tdd
+
+- Simple refactoring (no new behavior to test)
+- Documentation-only changes
+- Config/infrastructure changes without testable behavior
+- When test framework doesn't exist and adding one is out of scope
+
+---
+
+## Related Commands
+
+- **/map-plan** — Create spec with invariants and acceptance criteria (recommended before /map-tdd)
+- **/map-efficient** — Standard workflow without test-first constraint
+- **/map-check** — Final verification after all subtasks complete
+- **/map-learn** — Extract lessons from completed TDD workflow

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -256,7 +256,16 @@ Evidence file: .map/<branch>/evidence/actor_<subtask_id>.json"""
 )
 ```
 
-After ACTOR, proceed to MONITOR as usual. Monitor verifies both implementation AND that tests pass.
+**CRITICAL: After ACTOR returns, you MUST call Monitor (2.4). Do NOT skip Monitor. Do NOT mark the subtask complete without Monitor validation.** This is not optional — Monitor is a mandatory phase in every workflow, including TDD.
+
+```bash
+# Validate Actor step, then get_next_step will return MONITOR (2.4)
+python3 .map/scripts/map_orchestrator.py validate_step "2.3"
+NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
+# NEXT_STEP.phase MUST be "MONITOR" — execute it before proceeding
+```
+
+Monitor verifies both implementation correctness AND that all tests pass.
 
 ---
 

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -127,6 +127,9 @@ STRICT RULES:
 5. Use standard test patterns for the project's language/framework.
 6. Each validation_criteria item (VCn:) must have at least one corresponding test.
 7. Include edge cases from the spec's Edge Cases section if available.
+8. Test files MUST be lint-clean. Use proper imports at the top of the file
+   (not inside type annotations). Run the project linter (ruff/eslint/golangci-lint)
+   on test files before finishing. Fix any lint errors in your test files.
 
 Output:
 - Test files written via Edit/Write tools
@@ -172,7 +175,23 @@ else
 fi
 ```
 
-**Evaluate results:**
+**First: lint-check test files.** ACTOR cannot fix test files later, so they must be clean now.
+
+```bash
+# Lint-check ONLY the test files created by TEST_WRITER
+# (read test_files_created from evidence/test_writer_<subtask_id>.json)
+if command -v ruff &> /dev/null; then
+  LINT_OUTPUT=$(ruff check <test_files> 2>&1) || true
+elif command -v eslint &> /dev/null; then
+  LINT_OUTPUT=$(eslint <test_files> 2>&1) || true
+elif command -v golangci-lint &> /dev/null; then
+  LINT_OUTPUT=$(golangci-lint run <test_files> 2>&1) || true
+fi
+```
+
+- **Lint errors found** → Go back to TEST_WRITER with feedback: "Fix lint errors in test files: <errors>. ACTOR cannot modify test files, so they must be lint-clean now."
+
+**Then evaluate test results:**
 
 - **Tests FAIL with assertion/import errors** → GOOD. This is the expected TDD state ("Red" phase). Proceed to ACTOR.
 - **Tests PASS** → PROBLEM. Tests are trivial or not testing real behavior. Go back to TEST_WRITER with feedback: "Tests pass without implementation. Tests must assert behavior that requires code to be written."

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -30,12 +30,39 @@ TDD:       DECOMPOSE → TEST_WRITER → TEST_FAIL_GATE → ACTOR (code only) �
 
 ---
 
-## Step 0: Prerequisites
+## Step 0: Parse Arguments and Detect Mode
+
+```bash
+TASK_ARGS="$ARGUMENTS"
+SUBTASK_ID=$(echo "$TASK_ARGS" | grep -oE 'ST-[0-9]+' | head -1)
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+```
+
+**Two modes:**
+- **Single-subtask mode** (`/map-tdd ST-001`): Write tests + implement for ONE subtask only
+- **Full workflow mode** (`/map-tdd "task description"`): TDD for all subtasks
+
+### Single-Subtask Mode (when `$SUBTASK_ID` is detected)
+
+```bash
+RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID" --tdd)
+STATUS=$(echo "$RESULT" | jq -r '.status')
+
+if [ "$STATUS" = "error" ]; then
+  echo "$RESULT" | jq -r '.message'
+  # If no plan: "Run /map-plan first"
+  # If subtask not found: shows available IDs
+  exit 1
+fi
+```
+
+Then proceed directly to **Step 1: State Machine Loop** below.
+
+### Full Workflow Mode (no subtask ID)
 
 Verify that a plan or spec exists for this branch:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "step_state:  $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
@@ -45,7 +72,7 @@ echo "step_state:  $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || ec
 - If **step_state.json EXISTS**: Resume from checkpoint (same as /map-efficient resume logic).
 - If **task_plan EXISTS but no step_state**: Run `python3 .map/scripts/map_orchestrator.py resume_from_plan` then enable TDD mode.
 
-### Enable TDD Mode
+### Enable TDD Mode (full workflow only)
 
 After state is initialized (either fresh or resumed):
 
@@ -68,7 +95,7 @@ PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.
-The two NEW phases are described below.
+The two TDD-specific phases are described below.
 
 ---
 
@@ -238,6 +265,7 @@ After ACTOR, proceed to MONITOR as usual. Monitor verifies both implementation A
 ## Related Commands
 
 - **/map-plan** — Create spec with invariants and acceptance criteria (recommended before /map-tdd)
+- **/map-task ST-001** — Execute a single subtask without TDD (implementation only)
 - **/map-efficient** — Standard workflow without test-first constraint
 - **/map-check** — Final verification after all subtasks complete
 - **/map-learn** — Extract lessons from completed TDD workflow

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -139,6 +139,9 @@ elif [ -f "go.mod" ]; then
   TEST_OUTPUT=$(go test ./... 2>&1) || true
 elif [ -f "Cargo.toml" ]; then
   TEST_OUTPUT=$(cargo test 2>&1) || true
+else
+  echo "WARNING: No test runner detected. Set TEST_OUTPUT manually for your project."
+  TEST_OUTPUT="NO_TEST_RUNNER_FOUND"
 fi
 ```
 

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -99,11 +99,13 @@ def is_exempt_path(file_path: str) -> bool:
         else (Path.cwd().resolve() / candidate).resolve(strict=False)
     )
 
-    # Allow Claude auto-memory and settings (~/.claude/)
-    claude_dir = Path.home() / ".claude"
+    # Allow Claude auto-memory writes (~/.claude/projects/*/memory/)
+    claude_memory_dir = Path.home() / ".claude" / "projects"
     try:
-        resolved.relative_to(claude_dir.resolve())
-        return True
+        rel = resolved.relative_to(claude_memory_dir.resolve())
+        # Only allow paths that include a "memory" component
+        if "memory" in rel.parts:
+            return True
     except ValueError:
         pass
 

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -14,6 +14,7 @@ ENFORCEMENT RULES:
   - Blocks if current subtask hasn't completed required steps: ['actor', 'monitor']
   - Allows tools if all required steps are completed
   - Always allows edits under .map/ (workflow artifacts/state) to prevent deadlocks
+  - Always allows edits under ~/.claude/ (auto-memory, project settings)
   - Allows Read, Bash, and other non-editing tools always
 
 WORKFLOW STATE FILE:
@@ -80,24 +81,34 @@ def extract_target_file_paths(tool_call: Dict) -> list[str]:
     return paths
 
 
-def is_map_artifact_path(file_path: str) -> bool:
+def is_exempt_path(file_path: str) -> bool:
     """
-    Return True if file_path resolves under the current working directory's .map/.
+    Return True if file_path is exempt from workflow enforcement.
 
-    This allowlist prevents the workflow gate from deadlocking itself by blocking
-    updates to workflow artifacts (including workflow_state.json).
+    Exempt paths:
+    - .map/ artifacts (workflow state, plans, findings) -- prevents deadlocks
+    - ~/.claude/ (auto-memory, project settings) -- Claude's own persistence
     """
     if not isinstance(file_path, str) or not file_path.strip():
         return False
 
-    repo_root = Path.cwd().resolve()
     candidate = Path(file_path)
     resolved = (
         candidate.resolve(strict=False)
         if candidate.is_absolute()
-        else (repo_root / candidate).resolve(strict=False)
+        else (Path.cwd().resolve() / candidate).resolve(strict=False)
     )
 
+    # Allow Claude auto-memory and settings (~/.claude/)
+    claude_dir = Path.home() / ".claude"
+    try:
+        resolved.relative_to(claude_dir.resolve())
+        return True
+    except ValueError:
+        pass
+
+    # Allow .map/ artifacts
+    repo_root = Path.cwd().resolve()
     try:
         rel = resolved.relative_to(repo_root)
     except ValueError:
@@ -221,7 +232,7 @@ def main():
 
         # Always allow edits to MAP workflow artifacts under .map/
         target_paths = extract_target_file_paths(tool_call)
-        if target_paths and all(is_map_artifact_path(p) for p in target_paths):
+        if target_paths and all(is_exempt_path(p) for p in target_paths):
             print("{}")
             sys.exit(0)
 

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -35,15 +35,17 @@ STATE FILE:
       "pending_steps": ["2.1_CONTEXT_SEARCH", "2.3_ACTOR", "2.4_MONITOR", ...]
     }
 
-STEP PHASES (16 total):
+STEP PHASES (18 total, 16 standard + 2 TDD):
   1.0  DECOMPOSE          - task-decomposer agent
   1.5  INIT_PLAN          - Generate task_plan.md
   1.55 REVIEW_PLAN        - User review + explicit approval checkpoint
-  1.56 CHOOSE_MODE        - Choose execution mode (step_by_step|batch)
+  1.56 CHOOSE_MODE        - Auto-skipped (always batch mode)
   1.6  INIT_STATE         - Create workflow_state.json
   2.0  XML_PACKET         - Build AI-friendly subtask packet
   2.1  CONTEXT_SEARCH     - Context search
   2.2  RESEARCH           - research-agent (conditional)
+  2.25 TEST_WRITER        - TDD: write tests from spec (TDD mode only)
+  2.26 TEST_FAIL_GATE     - TDD: verify tests fail without impl (TDD mode only)
   2.3  ACTOR              - Actor agent implementation
   2.4  MONITOR            - Monitor validation
   2.6  PREDICTOR          - Impact analysis (conditional)
@@ -51,7 +53,7 @@ STEP PHASES (16 total):
   2.8  TESTS_GATE         - Run tests
   2.9  LINTER_GATE        - Run linter
   2.10 VERIFY_ADHERENCE   - Self-audit checkpoint
-  2.11 SUBTASK_APPROVAL   - Optional pause between subtasks (step_by_step)
+  2.11 SUBTASK_APPROVAL   - Auto-skipped in batch mode
 
 CLI INTERFACE:
   python3 map_orchestrator.py get_next_step [--branch BRANCH]
@@ -109,6 +111,8 @@ STEP_PHASES = {
     "2.0": "XML_PACKET",
     "2.1": "CONTEXT_SEARCH",
     "2.2": "RESEARCH",
+    "2.25": "TEST_WRITER",
+    "2.26": "TEST_FAIL_GATE",
     "2.3": "ACTOR",
     "2.4": "MONITOR",
     "2.6": "PREDICTOR",
@@ -119,7 +123,7 @@ STEP_PHASES = {
     "2.11": "SUBTASK_APPROVAL",
 }
 
-# Step execution order
+# Step execution order (standard — without TDD phases)
 STEP_ORDER = [
     "1.0",
     "1.5",
@@ -139,11 +143,35 @@ STEP_ORDER = [
     "2.11",
 ]
 
+# TDD step order — includes TEST_WRITER and TEST_FAIL_GATE before ACTOR
+TDD_STEP_ORDER = [
+    "1.0",
+    "1.5",
+    "1.55",
+    "1.56",
+    "1.6",
+    "2.0",
+    "2.1",
+    "2.2",
+    "2.25",
+    "2.26",
+    "2.3",
+    "2.4",
+    "2.6",
+    "2.7",
+    "2.8",
+    "2.9",
+    "2.10",
+    "2.11",
+]
+
 # Steps that require evidence files from agents before validation.
 # Format: step_id -> (agent_phase, always_required)
 # If always_required is False, evidence is only checked when the step
 # appears in pending_steps (i.e., it wasn't skipped).
 EVIDENCE_REQUIRED = {
+    "2.25": ("test_writer", False),  # Only in TDD mode
+    "2.26": ("test_fail_gate", False),  # Only in TDD mode
     "2.3": ("actor", True),  # Always required
     "2.4": ("monitor", True),  # Always required
     "2.6": ("predictor", False),  # Only when 2.6 is in pending_steps
@@ -167,6 +195,8 @@ class StepState:
     max_retries: int = 5
     plan_approved: bool = False
     execution_mode: str = "batch"  # batch|step_by_step
+    # TDD mode: inserts TEST_WRITER and TEST_FAIL_GATE before ACTOR
+    tdd_mode: bool = False
     # Wave-based parallel execution fields
     execution_waves: List[List[str]] = field(default_factory=list)
     current_wave_index: int = 0
@@ -189,6 +219,7 @@ class StepState:
             "max_retries": self.max_retries,
             "plan_approved": self.plan_approved,
             "execution_mode": self.execution_mode,
+            "tdd_mode": self.tdd_mode,
             "execution_waves": self.execution_waves,
             "current_wave_index": self.current_wave_index,
             "subtask_phases": self.subtask_phases,
@@ -212,6 +243,7 @@ class StepState:
             max_retries=data.get("max_retries", 5),
             plan_approved=data.get("plan_approved", False),
             execution_mode=data.get("execution_mode", "batch"),
+            tdd_mode=data.get("tdd_mode", False),
             execution_waves=data.get("execution_waves", []),
             current_wave_index=data.get("current_wave_index", 0),
             subtask_phases=data.get("subtask_phases", {}),
@@ -238,6 +270,11 @@ class StepState:
             encoding="utf-8",
         )
         tmp_file.replace(state_file)
+
+
+def _get_step_order(tdd_mode: bool = False) -> List[str]:
+    """Return the appropriate step order based on TDD mode."""
+    return TDD_STEP_ORDER if tdd_mode else STEP_ORDER
 
 
 def get_branch_name() -> str:
@@ -292,9 +329,8 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             "python3 .map/scripts/map_orchestrator.py set_plan_approved true"
         ),
         "1.56": (
-            "Ask user to choose execution mode: step_by_step (pause between subtasks) "
-            "or batch (run through). Persist choice in step_state.json: "
-            "python3 .map/scripts/map_orchestrator.py set_execution_mode step_by_step|batch"
+            "Execution mode is batch (auto-set). No user action needed. "
+            "Advance to next step: python3 .map/scripts/map_orchestrator.py get_next_step"
         ),
         "1.6": (
             "Create .map/<branch>/workflow_state.json with initial state. "
@@ -313,10 +349,31 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             "Call Task(subagent_type='research-agent') if refactoring or "
             "touching 3+ files. Pass findings to Actor."
         ),
+        "2.25": (
+            f"TDD TEST_WRITER: Call Task(subagent_type='actor') with "
+            f"<TDD_Mode>test_writer</TDD_Mode> to write ONLY tests for subtask "
+            f"{state.current_subtask_id}. Tests must be derived from spec/contract, "
+            f"NOT from implementation. "
+            f"Actor MUST write evidence file: "
+            f".map/<branch>/evidence/test_writer_{state.current_subtask_id}.json"
+        ),
+        "2.26": (
+            f"TDD TEST_FAIL_GATE: Run tests written by TEST_WRITER. "
+            f"Tests MUST fail (no implementation exists yet). "
+            f"If tests pass → problem (trivial tests), go back to TEST_WRITER. "
+            f"If tests fail with assertion errors → proceed to ACTOR. "
+            f"Write evidence: .map/<branch>/evidence/test_fail_gate_{state.current_subtask_id}.json"
+        ),
         "2.3": (
             f"Call Task(subagent_type='actor') to implement subtask "
-            f"{state.current_subtask_id}. Pass XML packet and context patterns. "
-            f"Actor MUST write evidence file: "
+            f"{state.current_subtask_id}. "
+            + (
+                "TDD CODE_ONLY mode: pass <TDD_Mode>code_only</TDD_Mode>. "
+                "Actor must make existing tests green without modifying test files. "
+                if state.tdd_mode
+                else "Pass XML packet and context patterns. "
+            )
+            + f"Actor MUST write evidence file: "
             f".map/<branch>/evidence/actor_{state.current_subtask_id}.json"
         ),
         "2.4": (
@@ -370,6 +427,22 @@ def get_next_step(branch: str) -> Dict:
     state_file = Path(f".map/{branch}/step_state.json")
     state = StepState.load(state_file)
 
+    # Auto-skip CHOOSE_MODE: always batch, set mode automatically
+    while state.pending_steps and state.pending_steps[0] == "1.56":
+        state.execution_mode = "batch"
+        state.completed_steps.append("1.56")
+        state.pending_steps.pop(0)
+        state.save(state_file)
+
+    # Auto-skip TDD phases when tdd_mode is disabled
+    while (
+        state.pending_steps
+        and state.pending_steps[0] in ("2.25", "2.26")
+        and not state.tdd_mode
+    ):
+        state.completed_steps.append(state.pending_steps.pop(0))
+        state.save(state_file)
+
     # Auto-skip steps that are conditional in batch mode
     while (
         state.pending_steps
@@ -390,8 +463,9 @@ def get_next_step(branch: str) -> Dict:
             state.current_step_id = "2.0"
             state.current_step_phase = "XML_PACKET"
             # Reset to subtask-level steps (skip global setup steps)
-            xml_packet_idx = STEP_ORDER.index("2.0")
-            state.pending_steps = STEP_ORDER[xml_packet_idx:]  # Start from 2.0
+            step_order = _get_step_order(state.tdd_mode)
+            xml_packet_idx = step_order.index("2.0")
+            state.pending_steps = step_order[xml_packet_idx:]  # Start from 2.0
             state.completed_steps = []
             state.retry_count = 0
             state.save(state_file)
@@ -450,11 +524,7 @@ def validate_step(step_id: str, branch: str) -> Dict:
             "valid": False,
             "message": "Plan not approved. Set approval first: python3 .map/scripts/map_orchestrator.py set_plan_approved true",
         }
-    if step_id == "1.56" and state.execution_mode not in {"batch", "step_by_step"}:
-        return {
-            "valid": False,
-            "message": "Invalid execution_mode. Set mode first: python3 .map/scripts/map_orchestrator.py set_execution_mode step_by_step|batch",
-        }
+    # CHOOSE_MODE is auto-skipped; execution_mode is always "batch"
 
     # Evidence-gated validation: require agent evidence files for key steps
     if step_id in EVIDENCE_REQUIRED:
@@ -601,6 +671,41 @@ def set_execution_mode(mode: str, branch: str) -> Dict:
     return {"status": "success", "execution_mode": state.execution_mode}
 
 
+def set_tdd_mode(value: str, branch: str) -> Dict:
+    """Enable or disable TDD mode (test-first workflow).
+
+    When enabled, inserts TEST_WRITER (2.25) and TEST_FAIL_GATE (2.26)
+    phases before ACTOR (2.3) in the step sequence.
+
+    Args:
+        value: "true" or "false"
+        branch: Git branch name (sanitized)
+
+    Returns:
+        Dict with status and tdd_mode value
+    """
+    state_file = Path(f".map/{branch}/step_state.json")
+    state = StepState.load(state_file)
+    normalized = (value or "").strip().lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        state.tdd_mode = True
+    elif normalized in {"0", "false", "no", "n"}:
+        state.tdd_mode = False
+    else:
+        return {
+            "status": "error",
+            "message": f"Invalid value for tdd_mode: {value}",
+        }
+
+    # Rebuild pending_steps with correct order for TDD mode
+    step_order = _get_step_order(state.tdd_mode)
+    completed_set = set(state.completed_steps)
+    state.pending_steps = [s for s in step_order if s not in completed_set]
+
+    state.save(state_file)
+    return {"status": "success", "tdd_mode": state.tdd_mode}
+
+
 def set_waves(branch: str, blueprint_path: Optional[str] = None) -> Dict:
     """Compute execution waves from blueprint DAG and store in step_state.json.
 
@@ -626,17 +731,12 @@ def set_waves(branch: str, blueprint_path: Optional[str] = None) -> Dict:
 
         dg_candidates = [
             Path("src/mapify_cli/dependency_graph.py"),
-            Path(__file__).resolve().parents[3]
-            / "src"
-            / "mapify_cli"
-            / "dependency_graph.py",
+            Path(__file__).resolve().parents[3] / "src" / "mapify_cli" / "dependency_graph.py",
         ]
         loaded = False
         for candidate in dg_candidates:
             if candidate.exists():
-                spec = importlib.util.spec_from_file_location(
-                    "dependency_graph", candidate
-                )
+                spec = importlib.util.spec_from_file_location("dependency_graph", candidate)
                 if spec and spec.loader:
                     mod = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(mod)
@@ -750,13 +850,11 @@ def get_wave_step(branch: str) -> Dict:
     for st_id in wave:
         phase = state.subtask_phases.get(st_id, "2.3")
         phase_name = STEP_PHASES.get(phase, "ACTOR")
-        subtask_infos.append(
-            {
-                "subtask_id": st_id,
-                "phase": phase_name,
-                "step_id": phase,
-            }
-        )
+        subtask_infos.append({
+            "subtask_id": st_id,
+            "phase": phase_name,
+            "step_id": phase,
+        })
 
     return {
         "mode": mode,
@@ -797,10 +895,8 @@ def validate_wave_step(subtask_id: str, step_id: str, branch: str) -> Dict:
                 }
 
     # Determine next phase for this subtask
-    subtask_step_order = [s for s in STEP_ORDER if s.startswith("2.")]
-    current_idx = (
-        subtask_step_order.index(step_id) if step_id in subtask_step_order else -1
-    )
+    subtask_step_order = [s for s in _get_step_order(state.tdd_mode) if s.startswith("2.")]
+    current_idx = subtask_step_order.index(step_id) if step_id in subtask_step_order else -1
 
     if current_idx >= 0 and current_idx + 1 < len(subtask_step_order):
         next_phase = subtask_step_order[current_idx + 1]
@@ -863,7 +959,7 @@ def advance_wave(branch: str) -> Dict:
     }
 
 
-SKIPPABLE_STEPS = {"2.2", "2.6", "2.11"}
+SKIPPABLE_STEPS = {"2.2", "2.25", "2.26", "2.6", "2.11"}
 
 
 def skip_step(step_id: str, branch: str) -> Dict:
@@ -939,7 +1035,7 @@ def check_circuit_breaker(branch: str) -> Dict:
     state = StepState.load(state_file)
 
     tool_count = len(state.completed_steps)
-    max_iterations = len(state.subtask_sequence) * len(STEP_ORDER)
+    max_iterations = len(state.subtask_sequence) * len(_get_step_order(state.tdd_mode))
 
     return {
         "tool_count": tool_count,
@@ -983,7 +1079,7 @@ def resume_from_plan(branch: str) -> Dict:
 
     Detects task_plan_<branch>.md and workflow_state.json created by /map-plan.
     Extracts subtask IDs from the plan, marks init phases as completed, and
-    starts execution from CHOOSE_MODE (user still picks step_by_step vs batch).
+    starts execution from INIT_STATE (batch mode auto-set).
 
     Args:
         branch: Git branch name (sanitized)
@@ -1023,9 +1119,9 @@ def resume_from_plan(branch: str) -> Dict:
         except (json.JSONDecodeError, KeyError):
             pass
 
-    # Create state that skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN (plan already approved)
-    # Start from CHOOSE_MODE so user can still pick execution mode
-    skipped_phases = ["1.0", "1.5", "1.55"]
+    # Create state that skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN, CHOOSE_MODE
+    # (plan already approved, execution mode is always batch)
+    skipped_phases = ["1.0", "1.5", "1.55", "1.56"]
     execution_start = [s for s in STEP_ORDER if s not in skipped_phases]
 
     state_file = plan_dir / "step_state.json"
@@ -1033,11 +1129,12 @@ def resume_from_plan(branch: str) -> Dict:
         current_subtask_id=subtask_ids[0],
         subtask_index=0,
         subtask_sequence=subtask_ids,
-        current_step_id="1.56",
-        current_step_phase="CHOOSE_MODE",
+        current_step_id=execution_start[0] if execution_start else "1.6",
+        current_step_phase=STEP_PHASES.get(execution_start[0], "INIT_STATE") if execution_start else "INIT_STATE",
         completed_steps=skipped_phases,
         pending_steps=execution_start,
         plan_approved=True,
+        execution_mode="batch",
     )
     state.save(state_file)
 
@@ -1047,11 +1144,11 @@ def resume_from_plan(branch: str) -> Dict:
 
     return {
         "status": "success",
-        "message": "Resumed from /map-plan. Skipped DECOMPOSE, INIT_PLAN, REVIEW_PLAN.",
+        "message": "Resumed from /map-plan. Skipped DECOMPOSE, INIT_PLAN, REVIEW_PLAN, CHOOSE_MODE. Mode: batch.",
         "subtask_sequence": subtask_ids,
         "current_subtask_id": subtask_ids[0],
         "aag_contracts_found": len(aag_contracts),
-        "next_phase": "CHOOSE_MODE",
+        "next_phase": "INIT_STATE",
     }
 
 
@@ -1068,6 +1165,7 @@ def main():
             "initialize",
             "set_plan_approved",
             "set_execution_mode",
+            "set_tdd_mode",
             "skip_step",
             "set_subtasks",
             "resume_from_plan",
@@ -1137,6 +1235,17 @@ def main():
             result = set_execution_mode(mode, branch)
             print(json.dumps(result, indent=2))
 
+        elif args.command == "set_tdd_mode":
+            value = args.task_or_step
+            if value is None:
+                print(
+                    json.dumps({"error": "value required for set_tdd_mode"}),
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            result = set_tdd_mode(value, branch)
+            print(json.dumps(result, indent=2))
+
         elif args.command == "skip_step":
             if not args.task_or_step:
                 print(
@@ -1172,9 +1281,7 @@ def main():
             print(json.dumps(result, indent=2))
 
         elif args.command == "set_waves":
-            blueprint_path = (
-                args.blueprint or args.task_or_step
-            )  # --blueprint or positional
+            blueprint_path = args.blueprint or args.task_or_step  # --blueprint or positional
             result = set_waves(branch, blueprint_path)
             print(json.dumps(result, indent=2))
 

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -1166,6 +1166,88 @@ def resume_from_plan(branch: str) -> Dict:
     }
 
 
+def resume_single_subtask(subtask_id: str, branch: str, tdd_mode: bool = False) -> Dict:
+    """Set up state to execute a single subtask from an existing plan.
+
+    Requires task_plan_<branch>.md to exist (created by /map-plan or decomposer).
+    Validates that the requested subtask ID exists in the plan.
+    Creates state starting from XML_PACKET (2.0) for just that one subtask.
+
+    Args:
+        subtask_id: The subtask to execute (e.g., "ST-001")
+        branch: Git branch name (sanitized)
+        tdd_mode: Whether to enable TDD mode for this subtask
+
+    Returns:
+        Dict with status and state info
+    """
+    plan_dir = Path(f".map/{branch}")
+    plan_file = plan_dir / f"task_plan_{branch}.md"
+
+    if not plan_file.exists():
+        return {
+            "status": "error",
+            "message": f"No plan found at {plan_file}. Run /map-plan first.",
+        }
+
+    import re
+
+    plan_content = plan_file.read_text(encoding="utf-8")
+    all_subtask_ids = re.findall(r"###\s+(ST-\d+)", plan_content)
+
+    if not all_subtask_ids:
+        return {
+            "status": "error",
+            "message": f"No subtask IDs (ST-XXX) found in {plan_file}.",
+        }
+
+    if subtask_id not in all_subtask_ids:
+        return {
+            "status": "error",
+            "message": (
+                f"Subtask {subtask_id} not found in plan. "
+                f"Available: {', '.join(all_subtask_ids)}"
+            ),
+        }
+
+    # Build state for single subtask execution
+    step_order = _get_step_order(tdd_mode)
+    xml_packet_idx = step_order.index("2.0")
+    subtask_steps = step_order[xml_packet_idx:]
+
+    state_file = plan_dir / "step_state.json"
+    state = StepState(
+        current_subtask_id=subtask_id,
+        subtask_index=0,
+        subtask_sequence=[subtask_id],  # Only this one subtask
+        current_step_id="2.0",
+        current_step_phase="XML_PACKET",
+        completed_steps=["1.0", "1.5", "1.55", "1.56", "1.6"],
+        pending_steps=subtask_steps,
+        plan_approved=True,
+        execution_mode="batch",
+        tdd_mode=tdd_mode,
+    )
+    state.save(state_file)
+
+    # Ensure evidence directory exists
+    evidence_dir = plan_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    return {
+        "status": "success",
+        "message": (
+            f"Single subtask mode: {subtask_id}. "
+            f"TDD: {'enabled' if tdd_mode else 'disabled'}. "
+            f"Starting from XML_PACKET."
+        ),
+        "subtask_id": subtask_id,
+        "tdd_mode": tdd_mode,
+        "all_subtasks_in_plan": all_subtask_ids,
+        "next_phase": "XML_PACKET",
+    }
+
+
 def main():
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -1188,6 +1270,7 @@ def main():
             "get_wave_step",
             "validate_wave_step",
             "advance_wave",
+            "resume_single_subtask",
         ],
         help="Command to execute",
     )
@@ -1200,6 +1283,9 @@ def main():
     parser.add_argument("--branch", help="Git branch (auto-detected if omitted)")
     parser.add_argument(
         "--blueprint", help="Path to blueprint JSON (for set_waves command)"
+    )
+    parser.add_argument(
+        "--tdd", action="store_true", help="Enable TDD mode (for resume_single_subtask)"
     )
 
     args = parser.parse_args()
@@ -1322,6 +1408,18 @@ def main():
 
         elif args.command == "advance_wave":
             result = advance_wave(branch)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "resume_single_subtask":
+            if not args.task_or_step:
+                print(
+                    json.dumps(
+                        {"error": "subtask_id required. Usage: resume_single_subtask ST-001 [--tdd]"}
+                    ),
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            result = resume_single_subtask(args.task_or_step, branch, tdd_mode=args.tdd)
             print(json.dumps(result, indent=2))
 
     except Exception as e:

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -301,6 +301,24 @@ def get_branch_name() -> str:
         return "default"
 
 
+def _actor_step_instruction(state: StepState) -> str:
+    """Build instruction string for the ACTOR step, TDD-aware."""
+    subtask = state.current_subtask_id
+    if state.tdd_mode:
+        context = (
+            "TDD CODE_ONLY mode: pass <TDD_Mode>code_only</TDD_Mode>. "
+            "Actor must make existing tests green without modifying test files. "
+        )
+    else:
+        context = "Pass XML packet and context patterns. "
+    return (
+        f"Call Task(subagent_type='actor') to implement subtask {subtask}. "
+        f"{context}"
+        f"Actor MUST write evidence file: "
+        f".map/<branch>/evidence/actor_{subtask}.json"
+    )
+
+
 def get_step_instruction(step_id: str, state: StepState) -> str:
     """
     Get instruction for executing a specific step.
@@ -364,18 +382,7 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             f"If tests fail with assertion errors → proceed to ACTOR. "
             f"Write evidence: .map/<branch>/evidence/test_fail_gate_{state.current_subtask_id}.json"
         ),
-        "2.3": (
-            f"Call Task(subagent_type='actor') to implement subtask "
-            f"{state.current_subtask_id}. "
-            + (
-                "TDD CODE_ONLY mode: pass <TDD_Mode>code_only</TDD_Mode>. "
-                "Actor must make existing tests green without modifying test files. "
-                if state.tdd_mode
-                else "Pass XML packet and context patterns. "
-            )
-            + f"Actor MUST write evidence file: "
-            f".map/<branch>/evidence/actor_{state.current_subtask_id}.json"
-        ),
+        "2.3": _actor_step_instruction(state),
         "2.4": (
             "Call Task(subagent_type='monitor') to validate Actor output. "
             "Check correctness, security, standards, and tests. "
@@ -883,16 +890,23 @@ def validate_wave_step(subtask_id: str, step_id: str, branch: str) -> Dict:
     if step_id in EVIDENCE_REQUIRED:
         phase_name, _always_required = EVIDENCE_REQUIRED[step_id]
         evidence_dir = Path(f".map/{branch}/evidence")
-        if evidence_dir.is_dir():
-            evidence_file = evidence_dir / f"{phase_name}_{subtask_id}.json"
-            if not evidence_file.exists():
-                return {
-                    "valid": False,
-                    "message": (
-                        f"Evidence file missing: {evidence_file}. "
-                        f"The {phase_name} agent must write this file."
-                    ),
-                }
+        if not evidence_dir.is_dir():
+            return {
+                "valid": False,
+                "message": (
+                    f"Evidence directory missing: {evidence_dir}. "
+                    f"Create it before running agent steps."
+                ),
+            }
+        evidence_file = evidence_dir / f"{phase_name}_{subtask_id}.json"
+        if not evidence_file.exists():
+            return {
+                "valid": False,
+                "message": (
+                    f"Evidence file missing: {evidence_file}. "
+                    f"The {phase_name} agent must write this file."
+                ),
+            }
 
     # Determine next phase for this subtask
     subtask_step_order = [s for s in _get_step_order(state.tdd_mode) if s.startswith("2.")]

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -1166,6 +1166,60 @@ def resume_from_plan(branch: str) -> Dict:
     }
 
 
+def get_plan_progress(branch: str) -> Dict:
+    """Return status of all subtasks from the task plan.
+
+    Reads task_plan_<branch>.md and extracts subtask IDs with their statuses.
+    Identifies the next pending subtask (respecting dependency order from blueprint).
+
+    Args:
+        branch: Git branch name (sanitized)
+
+    Returns:
+        Dict with subtask statuses, completed/pending counts, and suggested next
+    """
+    import re
+
+    plan_dir = Path(f".map/{branch}")
+    plan_file = plan_dir / f"task_plan_{branch}.md"
+
+    if not plan_file.exists():
+        return {"status": "error", "message": f"No plan found at {plan_file}."}
+
+    content = plan_file.read_text(encoding="utf-8")
+
+    # Extract subtask IDs and statuses: ### ST-XXX ... \n- **Status:** <status>
+    subtasks = []
+    for match in re.finditer(
+        r"###\s+(ST-\d+)[^\n]*\n(?:.*?\n)*?- \*\*Status:\*\*\s+(\w+)",
+        content,
+    ):
+        subtasks.append({"id": match.group(1), "status": match.group(2)})
+
+    if not subtasks:
+        # Fallback: just extract IDs without status
+        ids = re.findall(r"###\s+(ST-\d+)", content)
+        subtasks = [{"id": sid, "status": "unknown"} for sid in ids]
+
+    completed = [s for s in subtasks if s["status"] == "complete"]
+    pending = [s for s in subtasks if s["status"] != "complete"]
+
+    # Determine suggested next subtask
+    # Prefer first pending subtask (plan order respects dependencies)
+    suggested_next = pending[0]["id"] if pending else None
+
+    return {
+        "status": "success",
+        "total": len(subtasks),
+        "completed_count": len(completed),
+        "pending_count": len(pending),
+        "subtasks": subtasks,
+        "completed": [s["id"] for s in completed],
+        "pending": [s["id"] for s in pending],
+        "suggested_next": suggested_next,
+    }
+
+
 def resume_single_subtask(subtask_id: str, branch: str, tdd_mode: bool = False) -> Dict:
     """Set up state to execute a single subtask from an existing plan.
 
@@ -1271,6 +1325,7 @@ def main():
             "validate_wave_step",
             "advance_wave",
             "resume_single_subtask",
+            "get_plan_progress",
         ],
         help="Command to execute",
     )
@@ -1420,6 +1475,10 @@ def main():
                 )
                 sys.exit(1)
             result = resume_single_subtask(args.task_or_step, branch, tdd_mode=args.tdd)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "get_plan_progress":
+            result = get_plan_progress(branch)
             print(json.dumps(result, indent=2))
 
     except Exception as e:

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -197,6 +197,9 @@ class StepState:
     execution_mode: str = "batch"  # batch|step_by_step
     # TDD mode: inserts TEST_WRITER and TEST_FAIL_GATE before ACTOR
     tdd_mode: bool = False
+    # Steps skipped (not executed) — tracked separately from completed_steps
+    # so that re-enabling TDD can re-introduce skipped TDD steps
+    skipped_steps: List[str] = field(default_factory=list)
     # Wave-based parallel execution fields
     execution_waves: List[List[str]] = field(default_factory=list)
     current_wave_index: int = 0
@@ -220,6 +223,7 @@ class StepState:
             "plan_approved": self.plan_approved,
             "execution_mode": self.execution_mode,
             "tdd_mode": self.tdd_mode,
+            "skipped_steps": self.skipped_steps,
             "execution_waves": self.execution_waves,
             "current_wave_index": self.current_wave_index,
             "subtask_phases": self.subtask_phases,
@@ -244,6 +248,7 @@ class StepState:
             plan_approved=data.get("plan_approved", False),
             execution_mode=data.get("execution_mode", "batch"),
             tdd_mode=data.get("tdd_mode", False),
+            skipped_steps=data.get("skipped_steps", []),
             execution_waves=data.get("execution_waves", []),
             current_wave_index=data.get("current_wave_index", 0),
             subtask_phases=data.get("subtask_phases", {}),
@@ -447,7 +452,8 @@ def get_next_step(branch: str) -> Dict:
         and state.pending_steps[0] in ("2.25", "2.26")
         and not state.tdd_mode
     ):
-        state.completed_steps.append(state.pending_steps.pop(0))
+        skipped = state.pending_steps.pop(0)
+        state.skipped_steps.append(skipped)
         state.save(state_file)
 
     # Auto-skip steps that are conditional in batch mode
@@ -474,6 +480,7 @@ def get_next_step(branch: str) -> Dict:
             xml_packet_idx = step_order.index("2.0")
             state.pending_steps = step_order[xml_packet_idx:]  # Start from 2.0
             state.completed_steps = []
+            state.skipped_steps = []
             state.retry_count = 0
             state.save(state_file)
         else:
@@ -704,10 +711,47 @@ def set_tdd_mode(value: str, branch: str) -> Dict:
             "message": f"Invalid value for tdd_mode: {value}",
         }
 
-    # Rebuild pending_steps with correct order for TDD mode
+    # Rebuild pending_steps relative to current position (not from scratch)
+    # to avoid re-introducing already-completed global steps (1.x)
     step_order = _get_step_order(state.tdd_mode)
-    completed_set = set(state.completed_steps)
-    state.pending_steps = [s for s in step_order if s not in completed_set]
+
+    # When re-enabling TDD, remove 2.25/2.26 from skipped so they can run
+    if state.tdd_mode:
+        state.skipped_steps = [
+            s for s in state.skipped_steps if s not in ("2.25", "2.26")
+        ]
+
+    done_and_skipped = set(state.completed_steps) | set(state.skipped_steps)
+
+    if state.pending_steps:
+        # Find position of first pending step in the new order
+        first_pending = state.pending_steps[0]
+        if first_pending in step_order:
+            pos = step_order.index(first_pending)
+            # When enabling TDD, also include TDD steps that come
+            # just before the current position (2.25/2.26 before 2.3)
+            if state.tdd_mode:
+                # Find the earliest TDD step not yet done
+                tdd_steps = {"2.25", "2.26"}
+                earliest_tdd = None
+                for i, s in enumerate(step_order):
+                    if s in tdd_steps and s not in done_and_skipped and i < pos:
+                        if earliest_tdd is None or i < earliest_tdd:
+                            earliest_tdd = i
+                if earliest_tdd is not None:
+                    pos = earliest_tdd
+            # Rebuild from position onwards, excluding done/skipped
+            state.pending_steps = [
+                s for s in step_order[pos:] if s not in done_and_skipped
+            ]
+        else:
+            state.pending_steps = [
+                s for s in step_order if s not in done_and_skipped
+            ]
+    else:
+        state.pending_steps = [
+            s for s in step_order if s not in done_and_skipped
+        ]
 
     state.save(state_file)
     return {"status": "success", "tdd_mode": state.tdd_mode}
@@ -853,9 +897,11 @@ def get_wave_step(branch: str) -> Dict:
     mode = "sequential" if len(wave) == 1 else "parallel"
 
     # Build subtask info with current phases
+    # Default start phase depends on TDD mode
+    default_phase = "2.25" if state.tdd_mode else "2.3"
     subtask_infos = []
     for st_id in wave:
-        phase = state.subtask_phases.get(st_id, "2.3")
+        phase = state.subtask_phases.get(st_id, default_phase)
         phase_name = STEP_PHASES.get(phase, "ACTOR")
         subtask_infos.append({
             "subtask_id": st_id,
@@ -981,6 +1027,8 @@ def skip_step(step_id: str, branch: str) -> Dict:
 
     Only steps that are defined as conditional can be skipped:
       - 2.2 (RESEARCH): conditional on refactoring or 3+ files
+      - 2.25 (TEST_WRITER): TDD mode only, auto-skipped otherwise
+      - 2.26 (TEST_FAIL_GATE): TDD mode only, auto-skipped otherwise
       - 2.6 (PREDICTOR): conditional on medium/high risk
       - 2.11 (SUBTASK_APPROVAL): conditional on step_by_step mode
 
@@ -1204,8 +1252,7 @@ def get_plan_progress(branch: str) -> Dict:
     completed = [s for s in subtasks if s["status"] == "complete"]
     pending = [s for s in subtasks if s["status"] != "complete"]
 
-    # Determine suggested next subtask
-    # Prefer first pending subtask (plan order respects dependencies)
+    # Determine suggested next subtask (first pending in plan order)
     suggested_next = pending[0]["id"] if pending else None
 
     return {

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -658,5 +658,72 @@ class TestResumeSingleSubtask:
         assert result["current_subtask"] == "ST-002"
 
 
+class TestGetPlanProgress:
+    """Tests for get_plan_progress — plan status overview."""
+
+    def _create_plan_with_statuses(self, tmp_path, branch, subtasks):
+        """Helper: subtasks is list of (id, status) tuples."""
+        plan_dir = tmp_path / ".map" / branch
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        content = "# Task Plan\n\n"
+        for sid, status in subtasks:
+            content += f"### {sid}: Some title\n- **Status:** {status}\n\n"
+        (plan_dir / f"task_plan_{branch}.md").write_text(content)
+
+    def test_all_pending(self, branch_dir, tmp_path):
+        """All subtasks pending — suggested_next is first one."""
+        self._create_plan_with_statuses(
+            tmp_path, branch_dir,
+            [("ST-001", "pending"), ("ST-002", "pending"), ("ST-003", "pending")],
+        )
+        result = map_orchestrator.get_plan_progress(branch_dir)
+        assert result["status"] == "success"
+        assert result["total"] == 3
+        assert result["completed_count"] == 0
+        assert result["pending_count"] == 3
+        assert result["suggested_next"] == "ST-001"
+
+    def test_some_complete(self, branch_dir, tmp_path):
+        """Mix of complete and pending — suggested_next skips completed."""
+        self._create_plan_with_statuses(
+            tmp_path, branch_dir,
+            [("ST-001", "complete"), ("ST-002", "complete"), ("ST-003", "pending")],
+        )
+        result = map_orchestrator.get_plan_progress(branch_dir)
+        assert result["completed_count"] == 2
+        assert result["pending_count"] == 1
+        assert result["completed"] == ["ST-001", "ST-002"]
+        assert result["pending"] == ["ST-003"]
+        assert result["suggested_next"] == "ST-003"
+
+    def test_all_complete(self, branch_dir, tmp_path):
+        """All subtasks complete — suggested_next is None."""
+        self._create_plan_with_statuses(
+            tmp_path, branch_dir,
+            [("ST-001", "complete"), ("ST-002", "complete")],
+        )
+        result = map_orchestrator.get_plan_progress(branch_dir)
+        assert result["completed_count"] == 2
+        assert result["pending_count"] == 0
+        assert result["suggested_next"] is None
+
+    def test_no_plan(self, branch_dir):
+        """Error when no plan exists."""
+        result = map_orchestrator.get_plan_progress(branch_dir)
+        assert result["status"] == "error"
+        assert "No plan found" in result["message"]
+
+    def test_in_progress_counts_as_pending(self, branch_dir, tmp_path):
+        """in_progress subtask counts as pending (not complete)."""
+        self._create_plan_with_statuses(
+            tmp_path, branch_dir,
+            [("ST-001", "complete"), ("ST-002", "in_progress"), ("ST-003", "pending")],
+        )
+        result = map_orchestrator.get_plan_progress(branch_dir)
+        assert result["completed_count"] == 1
+        assert result["pending_count"] == 2
+        assert result["suggested_next"] == "ST-002"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -572,5 +572,91 @@ class TestTDDMode:
         assert "Evidence directory missing" in result["message"]
 
 
+class TestResumeSingleSubtask:
+    """Tests for resume_single_subtask — single subtask execution."""
+
+    def _create_plan(self, tmp_path, branch, subtask_ids):
+        """Helper to create a task plan with given subtask IDs."""
+        plan_dir = tmp_path / ".map" / branch
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        plan_content = "# Task Plan\n\n"
+        for st_id in subtask_ids:
+            plan_content += f"### {st_id}\n- **Status:** pending\n\n"
+        plan_file = plan_dir / f"task_plan_{branch}.md"
+        plan_file.write_text(plan_content)
+        return plan_dir
+
+    def test_resume_single_subtask_success(self, branch_dir, tmp_path):
+        """Basic single subtask setup creates correct state."""
+        self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002", "ST-003"])
+        result = map_orchestrator.resume_single_subtask("ST-002", branch_dir)
+        assert result["status"] == "success"
+        assert result["subtask_id"] == "ST-002"
+        assert result["tdd_mode"] is False
+
+        # Verify state file
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state = map_orchestrator.StepState.load(state_file)
+        assert state.subtask_sequence == ["ST-002"]
+        assert state.current_subtask_id == "ST-002"
+        assert state.current_step_id == "2.0"
+        assert state.plan_approved is True
+        assert "1.0" in state.completed_steps
+        assert "2.0" in state.pending_steps
+
+    def test_resume_single_subtask_with_tdd(self, branch_dir, tmp_path):
+        """TDD mode adds TEST_WRITER and TEST_FAIL_GATE to pending steps."""
+        self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002"])
+        result = map_orchestrator.resume_single_subtask("ST-001", branch_dir, tdd_mode=True)
+        assert result["status"] == "success"
+        assert result["tdd_mode"] is True
+
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state = map_orchestrator.StepState.load(state_file)
+        assert state.tdd_mode is True
+        assert "2.25" in state.pending_steps
+        assert "2.26" in state.pending_steps
+
+    def test_resume_single_subtask_no_plan(self, branch_dir):
+        """Error when no plan file exists."""
+        result = map_orchestrator.resume_single_subtask("ST-001", branch_dir)
+        assert result["status"] == "error"
+        assert "No plan found" in result["message"]
+
+    def test_resume_single_subtask_not_in_plan(self, branch_dir, tmp_path):
+        """Error when subtask ID is not in the plan."""
+        self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002"])
+        result = map_orchestrator.resume_single_subtask("ST-999", branch_dir)
+        assert result["status"] == "error"
+        assert "ST-999 not found" in result["message"]
+        assert "ST-001" in result["message"]
+
+    def test_resume_single_subtask_creates_evidence_dir(self, branch_dir, tmp_path):
+        """Evidence directory is created automatically."""
+        # Remove the evidence dir created by fixture
+        import shutil
+        evidence_dir = tmp_path / ".map" / branch_dir / "evidence"
+        if evidence_dir.exists():
+            shutil.rmtree(evidence_dir)
+
+        self._create_plan(tmp_path, branch_dir, ["ST-001"])
+        map_orchestrator.resume_single_subtask("ST-001", branch_dir)
+        assert evidence_dir.exists()
+
+    def test_resume_single_subtask_lists_all_subtasks(self, branch_dir, tmp_path):
+        """Response includes all subtask IDs from the plan."""
+        self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002", "ST-003"])
+        result = map_orchestrator.resume_single_subtask("ST-001", branch_dir)
+        assert result["all_subtasks_in_plan"] == ["ST-001", "ST-002", "ST-003"]
+
+    def test_resume_single_subtask_then_get_next_step(self, branch_dir, tmp_path):
+        """After resume_single_subtask, get_next_step returns XML_PACKET."""
+        self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002"])
+        map_orchestrator.resume_single_subtask("ST-002", branch_dir)
+        result = map_orchestrator.get_next_step(branch_dir)
+        assert result["phase"] == "XML_PACKET"
+        assert result["current_subtask"] == "ST-002"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -193,6 +193,21 @@ class TestGetWaveStep:
         assert result["is_complete"] is True
         assert result["mode"] == "sequential"
 
+    def test_tdd_mode_default_phase_is_test_writer(
+        self, branch_dir, sample_blueprint
+    ):
+        """In TDD mode, wave subtasks default to TEST_WRITER (2.25) not ACTOR."""
+        map_orchestrator.set_waves(branch_dir, sample_blueprint)
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state = map_orchestrator.StepState.load(state_file)
+        state.tdd_mode = True
+        state.save(state_file)
+
+        result = map_orchestrator.get_wave_step(branch_dir)
+        for subtask in result["subtasks"]:
+            assert subtask["step_id"] == "2.25"
+            assert subtask["phase"] == "TEST_WRITER"
+
 
 class TestValidateWaveStep:
     """Tests for validate_wave_step command."""
@@ -552,6 +567,85 @@ class TestTDDMode:
         )
         assert "2.25" not in loaded.pending_steps
         assert "2.25" in loaded.completed_steps
+
+    def test_auto_skip_tdd_uses_skipped_steps(self, branch_dir):
+        """Auto-skipped TDD phases go to skipped_steps, not completed_steps."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = False
+        state.subtask_sequence = ["ST-001"]
+        state.current_subtask_id = "ST-001"
+        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
+                               "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        map_orchestrator.get_next_step(branch_dir)
+
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert "2.25" in loaded.skipped_steps
+        assert "2.26" in loaded.skipped_steps
+        assert "2.25" not in loaded.completed_steps
+        assert "2.26" not in loaded.completed_steps
+
+    def test_tdd_toggle_reversible(self, branch_dir):
+        """Disabling then re-enabling TDD re-introduces TDD phases."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = True
+        state.subtask_sequence = ["ST-001"]
+        state.current_subtask_id = "ST-001"
+        state.completed_steps = ["1.0", "1.5", "1.55", "1.56", "1.6",
+                                 "2.0", "2.1", "2.2"]
+        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
+                               "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        # Disable TDD
+        map_orchestrator.set_tdd_mode("false", branch_dir)
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert "2.25" not in loaded.pending_steps
+
+        # Re-enable TDD
+        map_orchestrator.set_tdd_mode("true", branch_dir)
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert "2.25" in loaded.pending_steps
+        assert "2.26" in loaded.pending_steps
+
+    def test_set_tdd_mode_no_global_steps_after_subtask(self, branch_dir):
+        """set_tdd_mode after first subtask doesn't re-introduce 1.x steps."""
+        state = map_orchestrator.StepState()
+        state.subtask_sequence = ["ST-001", "ST-002"]
+        state.subtask_index = 1
+        state.current_subtask_id = "ST-002"
+        state.completed_steps = []  # Reset after subtask transition
+        state.pending_steps = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.6",
+                               "2.7", "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        map_orchestrator.set_tdd_mode("true", branch_dir)
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        # Must NOT have 1.x steps
+        for step in loaded.pending_steps:
+            assert not step.startswith("1."), f"Global step {step} re-introduced"
+        # Must have TDD steps
+        assert "2.25" in loaded.pending_steps
+        assert "2.26" in loaded.pending_steps
+
+    def test_skipped_steps_serialization(self, branch_dir):
+        """skipped_steps field serializes and deserializes correctly."""
+        state = map_orchestrator.StepState()
+        state.skipped_steps = ["2.25", "2.26"]
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state.save(state_file)
+
+        loaded = map_orchestrator.StepState.load(state_file)
+        assert loaded.skipped_steps == ["2.25", "2.26"]
 
     def test_validate_wave_step_missing_evidence_dir(self, branch_dir, sample_blueprint):
         """validate_wave_step returns error when evidence directory is missing."""

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -457,7 +457,8 @@ class TestTDDMode:
 
     def test_validate_wave_step_with_tdd_mode(self, branch_dir, sample_blueprint):
         """validate_wave_step uses TDD step order when tdd_mode is enabled."""
-        map_orchestrator.set_waves(branch_dir)
+        result = map_orchestrator.set_waves(branch_dir, sample_blueprint)
+        assert result["status"] == "success"
         state_file = Path(f".map/{branch_dir}/step_state.json")
         state = map_orchestrator.StepState.load(state_file)
         state.tdd_mode = True
@@ -505,6 +506,70 @@ class TestTDDMode:
     def test_tdd_step_order_has_more_steps(self):
         """TDD_STEP_ORDER has exactly 2 more steps than STEP_ORDER."""
         assert len(map_orchestrator.TDD_STEP_ORDER) == len(map_orchestrator.STEP_ORDER) + 2
+
+    def test_set_tdd_mode_accepts_various_falsy_values(self, branch_dir):
+        """set_tdd_mode accepts 'no', 'n', '0', 'false' as falsy."""
+        for value in ["no", "n", "0", "false", "FALSE", " False "]:
+            state = map_orchestrator.StepState()
+            state.tdd_mode = True
+            state.save(Path(f".map/{branch_dir}/step_state.json"))
+            result = map_orchestrator.set_tdd_mode(value, branch_dir)
+            assert result["tdd_mode"] is False, f"Failed for value: {value!r}"
+
+    def test_get_next_step_after_mid_workflow_tdd_toggle(self, branch_dir):
+        """get_next_step returns TEST_WRITER after enabling TDD mid-workflow."""
+        state = map_orchestrator.StepState()
+        state.subtask_sequence = ["ST-001"]
+        state.current_subtask_id = "ST-001"
+        state.completed_steps = ["1.0", "1.5", "1.55", "1.56", "1.6",
+                                 "2.0", "2.1", "2.2"]
+        state.pending_steps = ["2.3", "2.4", "2.6", "2.7", "2.8",
+                               "2.9", "2.10", "2.11"]
+        state.current_step_id = "2.2"
+        state.current_step_phase = "RESEARCH"
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        map_orchestrator.set_tdd_mode("true", branch_dir)
+        result = map_orchestrator.get_next_step(branch_dir)
+        assert result["step_id"] == "2.25"
+        assert result["phase"] == "TEST_WRITER"
+
+    def test_skip_step_works_for_tdd_phases(self, branch_dir):
+        """skip_step('2.25') succeeds when tdd_mode is True."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = True
+        state.current_step_id = "2.25"
+        state.current_step_phase = "TEST_WRITER"
+        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
+                               "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.skip_step("2.25", branch_dir)
+        assert result["status"] == "success"
+
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert "2.25" not in loaded.pending_steps
+        assert "2.25" in loaded.completed_steps
+
+    def test_validate_wave_step_missing_evidence_dir(self, branch_dir, sample_blueprint):
+        """validate_wave_step returns error when evidence directory is missing."""
+        result = map_orchestrator.set_waves(branch_dir, sample_blueprint)
+        assert result["status"] == "success"
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state = map_orchestrator.StepState.load(state_file)
+        state.subtask_phases = {"ST-001": "2.3"}
+        # Remove evidence directory
+        evidence_dir = Path(f".map/{branch_dir}/evidence")
+        if evidence_dir.exists():
+            import shutil
+            shutil.rmtree(evidence_dir)
+        state.save(state_file)
+
+        result = map_orchestrator.validate_wave_step("ST-001", "2.3", branch_dir)
+        assert result["valid"] is False
+        assert "Evidence directory missing" in result["message"]
 
 
 if __name__ == "__main__":

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -310,5 +310,202 @@ class TestBackwardCompat:
         assert loaded.subtask_retry_counts == {}
 
 
+class TestTDDMode:
+    """Tests for TDD mode: set_tdd_mode, _get_step_order, auto-skip, and TDD-aware phases."""
+
+    def test_get_step_order_default(self):
+        """_get_step_order returns STEP_ORDER when tdd_mode=False."""
+        order = map_orchestrator._get_step_order(False)
+        assert order is map_orchestrator.STEP_ORDER
+        assert "2.25" not in order
+        assert "2.26" not in order
+
+    def test_get_step_order_tdd(self):
+        """_get_step_order returns TDD_STEP_ORDER when tdd_mode=True."""
+        order = map_orchestrator._get_step_order(True)
+        assert order is map_orchestrator.TDD_STEP_ORDER
+        assert "2.25" in order
+        assert "2.26" in order
+        # TDD phases must come before ACTOR (2.3)
+        assert order.index("2.25") < order.index("2.3")
+        assert order.index("2.26") < order.index("2.3")
+        assert order.index("2.25") < order.index("2.26")
+
+    def test_set_tdd_mode_enables(self, branch_dir):
+        """set_tdd_mode('true') enables TDD and rebuilds pending_steps with TDD phases."""
+        state = map_orchestrator.StepState()
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.set_tdd_mode("true", branch_dir)
+        assert result["status"] == "success"
+        assert result["tdd_mode"] is True
+
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert loaded.tdd_mode is True
+        assert "2.25" in loaded.pending_steps
+        assert "2.26" in loaded.pending_steps
+
+    def test_set_tdd_mode_disables(self, branch_dir):
+        """set_tdd_mode('false') disables TDD and removes TDD phases from pending_steps."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = True
+        state.pending_steps = map_orchestrator.TDD_STEP_ORDER.copy()
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.set_tdd_mode("false", branch_dir)
+        assert result["status"] == "success"
+        assert result["tdd_mode"] is False
+
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert loaded.tdd_mode is False
+        assert "2.25" not in loaded.pending_steps
+        assert "2.26" not in loaded.pending_steps
+
+    def test_set_tdd_mode_invalid_value(self, branch_dir):
+        """set_tdd_mode with invalid value returns error."""
+        state = map_orchestrator.StepState()
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.set_tdd_mode("maybe", branch_dir)
+        assert result["status"] == "error"
+        assert "Invalid" in result["message"]
+
+    def test_set_tdd_mode_preserves_completed_steps(self, branch_dir):
+        """Enabling TDD mode doesn't re-add already completed steps."""
+        state = map_orchestrator.StepState()
+        state.completed_steps = ["1.0", "1.5"]
+        state.pending_steps = ["1.55", "1.56", "1.6", "2.0", "2.1", "2.2", "2.3",
+                               "2.4", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        map_orchestrator.set_tdd_mode("true", branch_dir)
+
+        loaded = map_orchestrator.StepState.load(
+            Path(f".map/{branch_dir}/step_state.json")
+        )
+        assert "1.0" not in loaded.pending_steps
+        assert "1.5" not in loaded.pending_steps
+        assert "2.25" in loaded.pending_steps
+        assert "2.26" in loaded.pending_steps
+
+    def test_set_tdd_mode_accepts_various_truthy_values(self, branch_dir):
+        """set_tdd_mode accepts 'yes', 'y', '1', 'true' as truthy."""
+        for value in ["yes", "y", "1", "true", "TRUE", " True "]:
+            state = map_orchestrator.StepState()
+            state.save(Path(f".map/{branch_dir}/step_state.json"))
+            result = map_orchestrator.set_tdd_mode(value, branch_dir)
+            assert result["tdd_mode"] is True, f"Failed for value: {value!r}"
+
+    def test_auto_skip_tdd_phases_when_disabled(self, branch_dir):
+        """get_next_step auto-skips 2.25 and 2.26 when tdd_mode=False."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = False
+        state.subtask_sequence = ["ST-001"]
+        state.current_subtask_id = "ST-001"
+        state.current_step_id = "2.2"
+        state.current_step_phase = "AAG_CONTRACT"
+        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
+                               "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.get_next_step(branch_dir)
+        assert result["step_id"] == "2.3"
+        assert result["phase"] == "ACTOR"
+
+    def test_tdd_phases_not_skipped_when_enabled(self, branch_dir):
+        """get_next_step does NOT skip 2.25 when tdd_mode=True."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = True
+        state.subtask_sequence = ["ST-001"]
+        state.current_subtask_id = "ST-001"
+        state.current_step_id = "2.2"
+        state.current_step_phase = "AAG_CONTRACT"
+        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
+                               "2.8", "2.9", "2.10", "2.11"]
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.get_next_step(branch_dir)
+        assert result["step_id"] == "2.25"
+        assert result["phase"] == "TEST_WRITER"
+
+    def test_tdd_state_serialization(self, branch_dir):
+        """tdd_mode field serializes and deserializes correctly."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = True
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state.save(state_file)
+
+        loaded = map_orchestrator.StepState.load(state_file)
+        assert loaded.tdd_mode is True
+
+    def test_old_state_without_tdd_mode_defaults_false(self, branch_dir):
+        """State file without tdd_mode field defaults to False."""
+        old_state = {
+            "workflow": "map-efficient",
+            "current_step_id": "1.0",
+            "current_step_phase": "DECOMPOSE",
+        }
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state_file.write_text(json.dumps(old_state), encoding="utf-8")
+
+        loaded = map_orchestrator.StepState.load(state_file)
+        assert loaded.tdd_mode is False
+
+    def test_validate_wave_step_with_tdd_mode(self, branch_dir, sample_blueprint):
+        """validate_wave_step uses TDD step order when tdd_mode is enabled."""
+        map_orchestrator.set_waves(branch_dir)
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+        state = map_orchestrator.StepState.load(state_file)
+        state.tdd_mode = True
+        state.subtask_phases = {"ST-001": "2.25"}
+
+        evidence = {
+            "phase": "TEST_WRITER",
+            "subtask_id": "ST-001",
+            "status": "applied",
+        }
+        evidence_file = Path(f".map/{branch_dir}/evidence/test_writer_ST-001.json")
+        evidence_file.write_text(json.dumps(evidence), encoding="utf-8")
+
+        state.save(state_file)
+        result = map_orchestrator.validate_wave_step("ST-001", "2.25", branch_dir)
+        assert result["valid"] is True
+        loaded = map_orchestrator.StepState.load(state_file)
+        assert loaded.subtask_phases["ST-001"] == "2.26"
+
+    def test_circuit_breaker_uses_tdd_step_count(self, branch_dir):
+        """check_circuit_breaker uses TDD step count when tdd_mode is enabled."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = True
+        state.subtask_sequence = ["ST-001"]
+        state.completed_steps = []
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.check_circuit_breaker(branch_dir)
+        expected_max = len(map_orchestrator.TDD_STEP_ORDER)
+        assert result["max_iterations"] == expected_max
+        assert result["triggered"] is False
+
+    def test_circuit_breaker_standard_step_count(self, branch_dir):
+        """check_circuit_breaker uses standard step count when tdd_mode is disabled."""
+        state = map_orchestrator.StepState()
+        state.tdd_mode = False
+        state.subtask_sequence = ["ST-001"]
+        state.completed_steps = []
+        state.save(Path(f".map/{branch_dir}/step_state.json"))
+
+        result = map_orchestrator.check_circuit_breaker(branch_dir)
+        expected_max = len(map_orchestrator.STEP_ORDER)
+        assert result["max_iterations"] == expected_max
+
+    def test_tdd_step_order_has_more_steps(self):
+        """TDD_STEP_ORDER has exactly 2 more steps than STEP_ORDER."""
+        assert len(map_orchestrator.TDD_STEP_ORDER) == len(map_orchestrator.STEP_ORDER) + 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- **New `/map-tdd` workflow** for test-first development: tests are written from specification before implementation, preventing AI from writing tests that confirm implementation bugs rather than validating behavior
- **Enhanced SPEC phase** in `/map-plan` with structured Invariants, Edge Cases, Acceptance Criteria, Security Boundaries sections and Devil's Advocate review step
- **`--tdd` flag** for `/map-efficient` to enable TDD mode within the standard workflow

## Changes

### TDD Workflow (High Priority)
- New `/map-tdd` command with `TEST_WRITER → TEST_FAIL_GATE → ACTOR (code-only)` flow
- Actor agent gains two TDD modes: `test_writer` (only tests from spec) and `code_only` (make tests green, don't modify test files)
- Orchestrator: new phases 2.25 (TEST_WRITER) and 2.26 (TEST_FAIL_GATE), `set_tdd_mode` command, auto-skip when TDD disabled
- `/map-efficient` parses `--tdd` flag from arguments

### SPEC Phase Enhancement (Medium Priority)
- Structured spec template with 4 new sections: Invariants, Edge Cases, Acceptance Criteria, Security Boundaries
- Devil's Advocate review step: Monitor agent adversarially reviews spec for race conditions, ownership ambiguity, missing edge cases (skipped for complexity < 5)
- Task-decomposer contracts now link to spec invariants via `"source": "spec-invariant-N"`

### Docs & Sync
- Templates synced via `make sync-templates`
- ARCHITECTURE.md updated (18 phases)
- USAGE.md updated with `/map-tdd` section
- CHANGELOG.md updated

## Test plan

- [x] `pytest tests/test_template_sync.py -v` — 24 passed (templates in sync)
- [x] `pytest` — 599 passed, 0 failed
- [x] `make lint` — all checks passed
- [x] `python3 .map/scripts/map_orchestrator.py --help` — `set_tdd_mode` command available
- [ ] Manual: run `/map-tdd` on a test task to verify end-to-end TDD flow