### PR TITLE
feat: TDD workflow, spec improvements, review fixes

### DIFF
--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -246,11 +246,18 @@ This is not optional — wave computation must run after every INIT_STATE.
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 
 ```bash
-python3 .map/scripts/map_orchestrator.py set_waves --blueprint .map/${BRANCH}/blueprint.json
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+if [ -f ".map/${BRANCH}/blueprint.json" ]; then
+  python3 .map/scripts/map_orchestrator.py set_waves --blueprint .map/${BRANCH}/blueprint.json
+else
+  echo "WARNING: blueprint.json not found. Running subtasks sequentially."
+  echo "To enable parallel waves, re-run /map-plan (saves blueprint.json since v3.5)."
+fi
 ```
 
 This reads the blueprint, builds a dependency graph, computes topological waves,
 and splits waves by file conflicts. The result is stored in `step_state.json`.
+If `blueprint.json` is missing (e.g., plan was created before v3.5), subtasks execute sequentially — this is safe but slower.
 
 **Wave execution**: If waves are computed, subtasks within a wave run their Actor
 and Monitor phases in parallel. Check wave status with:

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -325,6 +325,32 @@ Output requirements:
 )
 ```
 
+### Step 5.5: Save Blueprint JSON
+
+Save the raw decomposer output as `.map/<branch>/blueprint.json` using the **Write** tool. This file is required by `/map-efficient` for wave computation (`set_waves`).
+
+The blueprint JSON must include at minimum:
+```json
+{
+  "summary": "<goal description>",
+  "subtasks": [
+    {
+      "id": "ST-001",
+      "title": "<title>",
+      "aag_contract": "Actor -> Action(params) -> Goal",
+      "dependencies": [],
+      "affected_files": ["path/to/file.py"],
+      "complexity_score": 5,
+      "risk_level": "medium",
+      "validation_criteria": ["VC1: ...", "VC2: ..."],
+      "test_strategy": {"unit": ["test description"]}
+    }
+  ]
+}
+```
+
+If the decomposer returned structured JSON, save it directly. If it returned markdown, construct the JSON from the decomposed subtasks. **This step is mandatory** — without `blueprint.json`, `/map-efficient` cannot compute parallel execution waves.
+
 ### Step 6: Create Human-Readable Plan
 
 Write the plan to `.map/<branch>/task_plan_<branch>.md` using the **Write** tool. Wrap content in `<MAP_Plan_v1_0>` semantic brackets for machine-parseable handoff to executors.
@@ -419,6 +445,7 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Deep interview completed (N decisions captured)
 ✅ Architecture graph written to spec_${BRANCH}.md
 ✅ Task decomposed into N subtasks with AAG contracts
+✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ workflow_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
 ✅ Context distilled (plan files ≤4000 tokens per subtask)

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -246,11 +246,18 @@ This is not optional — wave computation must run after every INIT_STATE.
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 
 ```bash
-python3 .map/scripts/map_orchestrator.py set_waves --blueprint .map/${BRANCH}/blueprint.json
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+if [ -f ".map/${BRANCH}/blueprint.json" ]; then
+  python3 .map/scripts/map_orchestrator.py set_waves --blueprint .map/${BRANCH}/blueprint.json
+else
+  echo "WARNING: blueprint.json not found. Running subtasks sequentially."
+  echo "To enable parallel waves, re-run /map-plan (saves blueprint.json since v3.5)."
+fi
 ```
 
 This reads the blueprint, builds a dependency graph, computes topological waves,
 and splits waves by file conflicts. The result is stored in `step_state.json`.
+If `blueprint.json` is missing (e.g., plan was created before v3.5), subtasks execute sequentially — this is safe but slower.
 
 **Wave execution**: If waves are computed, subtasks within a wave run their Actor
 and Monitor phases in parallel. Check wave status with:

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -325,6 +325,32 @@ Output requirements:
 )
 ```
 
+### Step 5.5: Save Blueprint JSON
+
+Save the raw decomposer output as `.map/<branch>/blueprint.json` using the **Write** tool. This file is required by `/map-efficient` for wave computation (`set_waves`).
+
+The blueprint JSON must include at minimum:
+```json
+{
+  "summary": "<goal description>",
+  "subtasks": [
+    {
+      "id": "ST-001",
+      "title": "<title>",
+      "aag_contract": "Actor -> Action(params) -> Goal",
+      "dependencies": [],
+      "affected_files": ["path/to/file.py"],
+      "complexity_score": 5,
+      "risk_level": "medium",
+      "validation_criteria": ["VC1: ...", "VC2: ..."],
+      "test_strategy": {"unit": ["test description"]}
+    }
+  ]
+}
+```
+
+If the decomposer returned structured JSON, save it directly. If it returned markdown, construct the JSON from the decomposed subtasks. **This step is mandatory** — without `blueprint.json`, `/map-efficient` cannot compute parallel execution waves.
+
 ### Step 6: Create Human-Readable Plan
 
 Write the plan to `.map/<branch>/task_plan_<branch>.md` using the **Write** tool. Wrap content in `<MAP_Plan_v1_0>` semantic brackets for machine-parseable handoff to executors.
@@ -419,6 +445,7 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Deep interview completed (N decisions captured)
 ✅ Architecture graph written to spec_${BRANCH}.md
 ✅ Task decomposed into N subtasks with AAG contracts
+✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ workflow_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
 ✅ Context distilled (plan files ≤4000 tokens per subtask)


### PR DESCRIPTION
## Summary
- TDD workflow (`/map-tdd`) with TEST_WRITER and TEST_FAIL_GATE phases
- Single subtask execution (`/map-task`, `/map-tdd ST-001`)
- Mandatory spec in `/map-plan` with Devil's Advocate review
- Blueprint.json saved by `/map-plan` for wave computation
- All Copilot review comments addressed (9 fixes)

## Changes
- `skipped_steps` tracking for reversible TDD toggle
- Position-aware `set_tdd_mode()` (no 1.x step re-introduction)
- Wave-mode TDD support (default phase = TEST_WRITER)
- Narrowed `~/.claude/` workflow-gate exemption to memory/ only
- Graceful fallback when blueprint.json missing

## Test plan
- [x] 635 tests pass, 5 new tests added
- [x] `make check` (lint + mypy + pytest) green
- [x] CI passed on all commits