### PR TITLE
update MAP workflow artifact handoffs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "id": "map-framework",
       "name": "MAP Framework",
       "version": "1.0.0",
-      "description": "Modular Agentic Planner - Cognitive architecture for AI agents inspired by prefrontal cortex functions. Orchestrates 12 specialized agents for development with automatic quality validation.",
+      "description": "Modular Agentic Planner - Cognitive architecture for AI agents inspired by prefrontal cortex functions. Orchestrates 11 specialized agents for development with automatic quality validation.",
       "author": "azalio",
       "license": "MIT",
       "source": "github:azalio/map-framework",
@@ -33,7 +33,7 @@
       "features": [
         "11 specialized agents (TaskDecomposer, Actor, Monitor, Predictor, Evaluator, Reflector, DocumentationReviewer, Debate-Arbiter, Synthesizer, Research-Agent, Final-Verifier)",
         "5 Claude Code hooks for automation",
-        "10 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-review, /map-check, /map-plan, /map-release, /map-resume, /map-learn)",
+        "12 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-review, /map-check, /map-plan, /map-task, /map-tdd, /map-release, /map-resume, /map-learn)",
         "Professional code review integration",
         "Cost optimization (40-60% savings)"
       ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -31,7 +31,7 @@
   "features": [
     "11 specialized MAP agents (TaskDecomposer, Actor, Monitor, Predictor, Evaluator, Reflector, DocumentationReviewer, Debate-Arbiter, Synthesizer, Research-Agent, Final-Verifier)",
     "5 Claude Code hooks for automation (validate-agent-templates, auto-store-knowledge, enrich-context, session-init, track-metrics)",
-    "10 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-review, /map-check, /map-plan, /map-release, /map-resume, /map-learn)",
+    "12 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-review, /map-check, /map-plan, /map-task, /map-tdd, /map-release, /map-resume, /map-learn)",
     "Chain-of-thought reasoning with sequential-thinking MCP",
     "Semantic pattern search with embeddings cache",
     "Cost optimization with per-agent model selection (haiku/sonnet/opus)"

--- a/.claude/commands/map-check.md
+++ b/.claude/commands/map-check.md
@@ -245,6 +245,40 @@ if [[ -n $(git status --porcelain) ]]; then
 fi
 ```
 
+### Step 5b: Record Run Summary and Known Issues
+
+After each major gate (tests, lint, final verifier), write a compact run summary and a timestamped run dossier under `.map/<branch>/runs/<timestamp>/`, and keep accepted blockers in `.map/<branch>/known-issues.json`.
+
+Examples:
+
+```bash
+python3 .map/scripts/diagnostics.py summarize \
+  --tool tests \
+  --command "$TEST_CMD" \
+  --exit-code $? \
+  --summary "Pytest run for branch verification" \
+  --known-issues ".map/${BRANCH}/known-issues.json" \
+  --notes "Capture any deviations, flaky behavior, or environment quirks here"
+
+python3 .map/scripts/map_step_runner.py ensure_known_issues_file
+python3 .map/scripts/map_step_runner.py add_known_issue "Flaky integration test in CI" accepted "Non-blocking for local verification; tracked for follow-up"
+```
+
+Use `known-issues.json` only for issues intentionally accepted or deferred. Do NOT hide new blocking failures there.
+
+Run dossier contract:
+
+- `.map/<branch>/runs/<timestamp>/RESULTS.md` — mandatory
+- `.map/<branch>/runs/<timestamp>/NOTES.md` — optional
+
+`RESULTS.md` should act as the canonical historical record for that verification run and include:
+- setup/context
+- summary verdict
+- test matrix row(s)
+- detailed results
+- bugs/blockers found
+- accepted/deferred issues count
+
 ### Step 6: Update Workflow State (Complete)
 
 If verification passes, mark workflow complete:
@@ -254,6 +288,75 @@ jq '.current_state = "WORKFLOW_COMPLETE" | .completed_at = "'$(date -u +%Y-%m-%d
 ```
 
 ### Step 7: Output Verification Report
+
+Before printing the console report, update `.map/<branch>/verification-summary.md` with:
+
+```bash
+python3 .map/scripts/map_step_runner.py write_verification_summary "READY FOR REVIEW" "<task title>" "- pytest ...,- ruff ..." "- key findings" "- open PR"
+```
+
+This file should be a compact human-readable report with:
+- branch and task title
+- overall verdict (`READY FOR REVIEW` or `NEEDS WORK`)
+- commands/tests run
+- key failures or warnings
+- recommended next step
+
+Then persist canonical verification handoff artifacts:
+
+```bash
+# Machine-readable gate semantics
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  verification \
+  ready \
+  verification-summary.md \
+  "Verification passed and branch is ready for review"
+
+# Current unresolved set for the branch/workflow stage
+python3 .map/scripts/map_step_runner.py ensure_active_issues_file
+python3 .map/scripts/map_step_runner.py replace_active_issues \
+  verification \
+  verification-summary.md \
+  "- [list unresolved verification issues here, or '(None)']"
+```
+
+Use these verdict mappings consistently:
+- `ready` — verification passed, safe to move to `/map-review`
+- `needs-revision` — implementation changes required before review
+- `blocked` — external/tooling/environment issue prevents safe progress
+
+Then build a handoff bundle and update `.map/<branch>/pr-draft.md` from the collected artifacts:
+
+```bash
+BUNDLE=$(python3 .map/scripts/map_step_runner.py build_handoff_bundle)
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+VALIDATION=$(echo "$BUNDLE" | jq -r '.validation')
+RISKS=$(echo "$BUNDLE" | jq -r '.risks_follow_up')
+python3 .map/scripts/map_step_runner.py write_pr_draft "$SUMMARY" "$VALIDATION" "$RISKS"
+```
+
+This ensures `pr-draft.md` is built from actual workflow artifacts instead of freeform memory.
+It also means `/map-review` can consume a single consolidated verification handoff instead of re-deriving the branch state from scratch.
+
+Recommended format:
+
+```markdown
+# Verification Summary
+
+- Branch: <branch>
+- Task: <title>
+- Verdict: READY FOR REVIEW | NEEDS WORK
+
+## Checks Run
+- pytest ...
+- ruff ...
+
+## Findings
+- ...
+
+## Next Action
+- ...
+```
 
 Print detailed verification results:
 

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -36,6 +36,18 @@ This is NOT a violation of MAP agent rules. Learning is decoupled into `/map-lea
 
 Both files must stay in sync. The orchestrator updates `step_state.json` on every step; `workflow_state.json` is updated at phase boundaries (INIT_STATE, UPDATE_STATE).
 
+## Human-Readable Workflow Artifacts
+
+In addition to machine-readable state/evidence, maintain these branch-scoped markdown artifacts in `.map/<branch>/`:
+
+- `devlog-001.md` — implementation trail and notable changes across subtasks
+- `session-log.md` — chronological workflow journal for the current branch/session
+- `code-review-001.md`, `code-review-002.md`, ... — Monitor verdicts and required fixes per execution review iteration
+- `qa-001.md` — final verification and command results in human-readable form
+- `pr-draft.md` — evolving PR summary, updated as execution finishes
+
+These files are the cook-inspired handoff layer. Keep them concise and update them during the workflow instead of deferring to a separate command.
+
 ## Architecture Overview
 
 ```text
@@ -100,6 +112,26 @@ fi
 ```
 
 If `resume_from_plan` succeeds, the orchestrator skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN, and CHOOSE_MODE (plan already approved, batch mode auto-set) and starts from INIT_STATE.
+
+Before continuing execution, ensure the branch workspace contains `session-log.md`, `devlog-001.md`, `qa-001.md`, and `pr-draft.md` by running:
+
+```bash
+python3 .map/scripts/map_step_runner.py ensure_human_artifacts
+```
+
+Create numbered execution review artifacts deterministically with:
+
+```bash
+python3 .map/scripts/map_step_runner.py next_numbered_artifact_path code-review
+```
+
+Use `session-log.md` as the high-level journal:
+- append one entry when a subtask starts
+- append one entry after Actor completes
+- append one entry after Monitor verdict
+- append one entry before final verification
+
+Each entry should include timestamp, subtask ID, phase, outcome, and pointers to related artifacts (`code-review-XXX.md`, `devlog-001.md`, `qa-001.md`, evidence files).
 
 ## Step 1: Get Next Step Instruction
 
@@ -447,6 +479,18 @@ Protocol (execute in order):
 **CRITICAL: After Actor returns, do NOT debug or fix issues yourself.**
 - If Actor reports diagnostics/errors — proceed directly to MONITOR.
 - LSP diagnostics shown after Actor may be stale (IDE lag). Do NOT read files or attempt manual fixes.
+
+After Actor finishes, update `.map/<branch>/devlog-001.md` with:
+- subtask ID
+- files changed
+- implementation approach
+- unresolved concerns handed to Monitor
+
+Also append a short entry to `.map/<branch>/session-log.md` via:
+
+```bash
+python3 .map/scripts/map_step_runner.py append_session_log ACTOR implemented <subtask_id> "files changed + approach" "devlog-001.md,.map/<branch>/evidence/actor_<subtask_id>.json"
+```
 - Monitor will verify compilation (`go build`, `pytest`, etc.) and report real issues.
 - If Monitor returns `valid=false`, retry via Actor (not manual edits).
 
@@ -645,6 +689,24 @@ If FAILED: DO NOT PROCEED. Go back and complete missing steps.
 
 Auto-skipped in batch mode (default). The orchestrator proceeds to the next subtask without pausing.
 
+### Monitor Artifact Rule
+
+After EVERY Monitor run, write a new execution review artifact in `.map/<branch>/code-review-XXX.md`.
+
+- First Monitor result for the workflow: `code-review-001.md`
+- Second: `code-review-002.md`
+- Continue incrementing for each validation iteration, including retries
+
+Each review artifact must include:
+- subtask ID
+- verdict (`valid=true/false`)
+- key findings grouped by severity
+- exact fixes required before retry, if any
+
+Do not overwrite the previous review file; keep the loop history visible.
+
+After writing the execution review artifact, append a matching summary line with `append_session_log` so someone resuming the branch can scan the review history without opening every file.
+
 ## Step 2a: Validate Step Completion
 
 After executing step, validate and update state:
@@ -658,6 +720,11 @@ if [ "$PHASE" = "VERIFY_ADHERENCE" ]; then
   python3 .map/scripts/map_step_runner.py update_plan_status "$SUBTASK_ID" "complete"
 fi
 ```
+
+If `PHASE=VERIFY_ADHERENCE` succeeds, also append to `.map/<branch>/devlog-001.md`:
+- subtask completed
+- verification summary
+- tests/lint run for that subtask
 
 ## Step 2b: Continue or Complete (Context Distillation)
 
@@ -678,6 +745,7 @@ else
   # 2. workflow_state.json — current progress + completed subtask IDs
   # 3. task_plan.md       — plan with updated statuses
   # 4. aag_contract       — one-line contract for NEXT subtask only
+  # 5. session-log.md / latest code-review-XXX.md / devlog-001.md — human-readable loop history
   #
   # The fresh invocation reads these files — it never inherits conversation history.
 
@@ -727,6 +795,32 @@ You MUST:
 Write results to .map/{branch}/final_verification.json"""
 )
 ```
+
+After final verifier returns, update `.map/<branch>/qa-001.md` with:
+- commands run
+- pass/fail summary
+- residual risks
+- rollback notes if applicable
+
+Also write `.map/<branch>/verification-summary.md` with a compact final report using:
+
+```bash
+python3 .map/scripts/map_step_runner.py write_verification_summary "READY FOR REVIEW" "<task title>" "- pytest ...,- ruff ..." "- notable findings" "- open PR"
+```
+
+The summary should include:
+- overall verdict
+- key commands executed
+- notable failures or warnings
+- confidence / risk statement
+- recommended next action (review, rework, release)
+
+Also update `.map/<branch>/pr-draft.md` with:
+- concise summary of delivered behavior
+- validation commands/results
+- notable risks or follow-up work
+
+Finally append a closing entry to `.map/<branch>/session-log.md` that points to `qa-001.md`, `verification-summary.md`, and `pr-draft.md`.
 
 ### 3.3 Evaluate Results
 

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -12,6 +12,7 @@
 - Calls task-decomposer agent to break down the user's request into subtasks
 - Creates `.map/<branch>/task_plan_<branch>.md` with subtask list
 - Initializes `.map/<branch>/workflow_state.json` with subtask sequence
+- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`research.md`, `implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
 - **STOPS** after planning (forces context flush)
 
 **What this command CANNOT do:**
@@ -33,6 +34,10 @@ echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "state:       $(test -f .map/${BRANCH}/workflow_state.json && echo EXISTS || echo MISSING)"
+echo "research:    $(test -f .map/${BRANCH}/research.md && echo EXISTS || echo MISSING)"
+echo "impl_plan:   $(test -f .map/${BRANCH}/implementation-plan.md && echo EXISTS || echo MISSING)"
+echo "decisions:   $(test -f .map/${BRANCH}/decision-log.md && echo EXISTS || echo MISSING)"
+echo "pr_draft:    $(test -f .map/${BRANCH}/pr-draft.md && echo EXISTS || echo MISSING)"
 ```
 
 **Resume rules:**
@@ -95,7 +100,7 @@ User request:
 )
 ```
 
-**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to `.map/<branch>/findings_<branch>.md` so they persist across sessions. Include key file paths, patterns found, and risks.
+**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to both `.map/<branch>/findings_<branch>.md` and `.map/<branch>/research.md` so they persist across sessions. `findings_<branch>.md` stays optimized for executor distillation; `research.md` is the human-readable planning note.
 
 **Discovery output format** (in findings file):
 ```markdown
@@ -254,6 +259,57 @@ If interview was skipped (task is well-defined), still write `spec_<branch>.md` 
 - **Out of Scope**: explicitly state what is NOT being changed
 
 This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
+
+### Step 2c: Write Human-Readable Planning Artifacts
+
+After the spec is finalized, maintain these branch-scoped artifacts in `.map/<branch>/`:
+
+- `implementation-plan.md` — concise goals, non-goals, milestones, validation plan
+- `decision-log.md` — high-signal decisions and rationale from interview/spec review
+- `pr-draft.md` — placeholder PR summary that execution will update later
+
+Use the **Write** tool to create or overwrite them with distilled content from the spec and decomposition. Keep them short and useful for a human resuming work.
+
+Recommended structure:
+
+```markdown
+# Implementation Plan
+
+## Goal
+[1 sentence]
+
+## Non-Goals
+- ...
+
+## Planned Steps
+1. ST-001 — ...
+2. ST-002 — ...
+
+## Validation Plan
+- [command or check]
+```
+
+```markdown
+# Decision Log
+
+## Decision 001
+- Decision: ...
+- Rationale: ...
+- Impacted files: ...
+```
+
+```markdown
+# PR Draft
+
+## Summary
+- Planning completed for [goal]
+
+## Planned Validation
+- ...
+
+## Risks
+- ...
+```
 
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
@@ -473,6 +529,8 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ workflow_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
+✅ Human-readable artifacts updated: research.md, implementation-plan.md, decision-log.md, pr-draft.md
+✅ Planning review recorded: plan-review-00N.md + plan-gate.json
 ✅ Context distilled (plan files ≤4000 tokens per subtask)
 
 Next Steps:
@@ -497,6 +555,12 @@ DISTILLATION CHECKLIST:
   [x] workflow_state.json   — has aag_contracts map + subtask_sequence
   [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
+  [x] research.md           — human-readable discovery and context for resume/handoff
+  [x] implementation-plan.md — concise execution roadmap for humans
+  [x] decision-log.md       — key tradeoffs captured before implementation
+  [x] pr-draft.md           — initial summary + validation + risk notes
+  [x] plan-review-00N.md    — staged planning review with carry-forward concerns
+  [x] plan-gate.json        — machine-readable planning verdict (`ready|needs-revision|blocked`)
 
 TARGET: Executor reads ≤4000 tokens of distilled state to start any subtask.
 If plan files exceed this, condense — remove redundant descriptions, keep AAG contracts + criteria.

--- a/.claude/commands/map-resume.md
+++ b/.claude/commands/map-resume.md
@@ -72,10 +72,11 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 # .map/${BRANCH}/task_plan_${BRANCH}.md — full plan with AAG contracts
 ```
 
-Also query orchestrator plan progress for the canonical resume briefing:
+Also query orchestrator plan progress for the canonical progress payload:
 
 ```bash
 PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
+BRIEF=$(python3 .map/scripts/map_orchestrator.py build_resume_briefing)
 ```
 
 Parse the state and display:
@@ -91,14 +92,14 @@ Parse the state and display:
 
 ### Resume Briefing
 
-- **Suggested next subtask:** [from `suggested_next`]
-- **Latest verification verdict:** [from `resume_briefing.latest_verification_verdict` or "none"]
-- **Latest review artifact:** [from `resume_briefing.latest_review_path` or "none"]
-- **Immediate next action:** [first item from `next_action[]` if present, else "resume current step"]
+- **Suggested next subtask:** [from `PROGRESS.suggested_next`]
+- **Latest verification verdict:** [from `BRIEF.resume_briefing.latest_verification_verdict` or "none"]
+- **Latest review artifact:** [from `BRIEF.resume_briefing.latest_review_path` or "none"]
+- **Immediate next action:** [first item from `BRIEF.next_action[]` if present, else "resume current step"]
 
 ### Requested Fixes / Follow-ups
 
-- [items from `resume_briefing.suggested_fixes[]`, if any]
+- [items from `BRIEF.resume_briefing.suggested_fixes[]`, if any]
 
 ### Recent Session Context
 

--- a/.claude/commands/map-resume.md
+++ b/.claude/commands/map-resume.md
@@ -61,7 +61,7 @@ No recovery needed.
 
 ## Step 2: Load and Display Progress
 
-Read both state files and the task plan to display progress summary:
+Read both state files, the task plan, and branch artifacts to display a briefing:
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
@@ -70,6 +70,12 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 # .map/${BRANCH}/step_state.json — current orchestrator state
 # .map/${BRANCH}/workflow_state.json — subtask completion status
 # .map/${BRANCH}/task_plan_${BRANCH}.md — full plan with AAG contracts
+```
+
+Also query orchestrator plan progress for the canonical resume briefing:
+
+```bash
+PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
 ```
 
 Parse the state and display:
@@ -82,6 +88,23 @@ Parse the state and display:
 **Current Step:** [current_step from step_state.json]
 **Current Phase:** [phase name from step_state.json]
 **Started:** [started_at from workflow_state.json]
+
+### Resume Briefing
+
+- **Suggested next subtask:** [from `suggested_next`]
+- **Latest verification verdict:** [from `resume_briefing.latest_verification_verdict` or "none"]
+- **Latest review artifact:** [from `resume_briefing.latest_review_path` or "none"]
+- **Immediate next action:** [first item from `next_action[]` if present, else "resume current step"]
+
+### Requested Fixes / Follow-ups
+
+- [items from `resume_briefing.suggested_fixes[]`, if any]
+
+### Recent Session Context
+
+```text
+[recent_session_log excerpt]
+```
 
 ### Progress Overview
 
@@ -137,6 +160,8 @@ Before resuming, read:
 1. `.map/<branch>/step_state.json` — current orchestrator state
 2. `.map/<branch>/workflow_state.json` — subtask completion
 3. `.map/<branch>/task_plan_<branch>.md` — full task decomposition with AAG contracts
+4. `python3 .map/scripts/map_orchestrator.py get_plan_progress` — canonical plan + briefing payload
+5. `.map/<branch>/session-log.md` / `.map/<branch>/verification-summary.md` — extra detail if needed
 
 **Resume via orchestrator:**
 
@@ -156,11 +181,14 @@ For each step, route to the appropriate executor based on `$PHASE` (ACTOR, MONIT
 
 **For each remaining subtask:**
 
-1. **Get next step** from orchestrator
-2. **Execute phase** (Actor → Monitor → Predictor → etc.)
-3. **Validate step** via `map_orchestrator.py validate_step`
-4. **Update state** automatically via orchestrator
-5. **Continue** to next step until workflow complete
+1. **Review the briefing first** to see latest verdict, fixes, and next action
+2. **Get next step** from orchestrator
+3. **Execute phase** (Actor → Monitor → Predictor → etc.)
+4. **Validate step** via `map_orchestrator.py validate_step`
+5. **Update state** automatically via orchestrator
+6. **Continue** to next step until workflow complete
+
+Resume should prioritize the explicit next action from the briefing. Do not improvise a new plan if the artifact trail already indicates the required fix or next subtask.
 
 **If Monitor returns `valid: false`:**
 - Retry Actor with feedback (max 5 iterations, tracked in step_state.json)
@@ -387,6 +415,8 @@ When resuming:
 1. Read `step_state.json` for orchestrator position (current step + subtask)
 2. Read `workflow_state.json` for completed/pending subtask list
 3. Read `task_plan_<branch>.md` for AAG contracts and validation criteria
+4. Read `session-log.md` for latest human-readable iteration history before resuming
+5. If present, read `verification-summary.md` to understand the latest final verdict or remaining issues
 4. Call `map_orchestrator.py get_next_step` to determine next action
 5. Continue phase-based execution from that point
 

--- a/.claude/commands/map-review.md
+++ b/.claude/commands/map-review.md
@@ -93,6 +93,24 @@ git status
 
 Save the diff output — it will be passed to all 3 agents.
 
+### Step A.1b: Load canonical review handoff
+
+Before launching agents, load the branch-scoped review handoff so review works from accumulated MAP artifacts instead of reconstructing context ad hoc:
+
+```bash
+HANDOFF=$(python3 .map/scripts/map_step_runner.py build_review_handoff)
+```
+
+This handoff should surface, when present:
+- latest `plan-review-00N.md`
+- latest `code-review-00N.md`
+- `verification-summary.md`
+- `qa-001.md`
+- `pr-draft.md`
+- `active-issues.json`
+
+Use these artifacts as the primary reviewer context before relying on raw diff analysis alone.
+
 ### Step A.2: Launch all parallel calls
 
 In **ONE message**, launch all 3 calls in parallel (no dependencies between them):
@@ -280,6 +298,46 @@ Present the verdict with a summary table:
 - Predictor risk assessment
 - Key issues resolved during interactive review
 - Remaining action items
+
+## Handoff Artifact Update
+
+After the final verdict, update branch-scoped handoff artifacts so review output survives beyond the chat:
+
+1. Write or append the most important review findings into the next `code-review-00N.md`
+2. Persist final review gate + active unresolved set:
+
+```bash
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  ready \
+  code-review-001.md \
+  "Final review passed"
+
+python3 .map/scripts/map_step_runner.py ensure_active_issues_file
+python3 .map/scripts/map_step_runner.py replace_active_issues \
+  review \
+  code-review-001.md \
+  "- [remaining reviewer action items, or '(None)']"
+```
+
+Map verdicts to gate values:
+- `PROCEED` -> `ready`
+- `REVISE` -> `needs-revision`
+- `BLOCK` -> `blocked`
+
+2. Rebuild the PR handoff from current artifacts:
+
+```bash
+BUNDLE=$(python3 .map/scripts/map_step_runner.py build_handoff_bundle)
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+VALIDATION=$(echo "$BUNDLE" | jq -r '.validation')
+RISKS=$(echo "$BUNDLE" | jq -r '.risks_follow_up')
+python3 .map/scripts/map_step_runner.py write_pr_draft "$SUMMARY" "$VALIDATION" "$RISKS"
+```
+
+This keeps `pr-draft.md` aligned with the latest review verdict and follow-up work.
+
+`active-issues.json` is the current unresolved set. Historical issues remain in `plan-review-00N.md`, `code-review-00N.md`, `qa-001.md`, and run dossiers under `.map/<branch>/runs/`.
 
 ## CI/Auto Mode Behavior
 

--- a/.claude/commands/map-task.md
+++ b/.claude/commands/map-task.md
@@ -94,6 +94,16 @@ Route to the appropriate executor based on `$PHASE`. All phases from `/map-effic
 - **LINTER_GATE (2.9)** — Run linter
 - **VERIFY_ADHERENCE (2.10)** — Self-audit
 
+Single-subtask execution must keep using the shared branch workspace artifacts rather than creating task-local side files:
+
+- `session-log.md`
+- `devlog-001.md`
+- `code-review-00N.md`
+- `qa-001.md`
+- `pr-draft.md`
+
+When Monitor runs during `/map-task`, append to the next `code-review-00N.md` so targeted subtask execution stays aligned with the full workflow artifact model.
+
 For each step:
 1. Get next step from orchestrator
 2. Execute the phase (same handlers as map-efficient)

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -279,6 +279,18 @@ Monitor verifies both implementation correctness AND that all tests pass.
 | Token cost | Lower | ~20-30% higher (extra Actor call for tests) |
 | Best for | General development | Correctness-critical features |
 
+## Artifact Model
+
+`/map-tdd` uses the same branch-scoped execution artifacts as `/map-efficient` because it runs through the same orchestrated state machine with extra TDD phases:
+
+- `session-log.md`
+- `devlog-001.md`
+- `code-review-00N.md`
+- `qa-001.md`
+- `pr-draft.md`
+
+In TDD mode, `TEST_WRITER` and `TEST_FAIL_GATE` should append to the same branch workspace instead of creating a separate artifact universe.
+
 ---
 
 ## When NOT to use /map-tdd

--- a/.claude/skills/map-workflows-guide/SKILL.md
+++ b/.claude/skills/map-workflows-guide/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # MAP Workflows Guide
 
-This skill helps you choose the optimal MAP workflow for your development tasks. MAP Framework provides **10 workflow commands**: 4 primary workflows (`/map-fast`, `/map-efficient`, `/map-debug`, `/map-debate`) and 6 supporting commands (`/map-review`, `/map-check`, `/map-plan`, `/map-release`, `/map-resume`, `/map-learn`). Each is optimized for different scenarios with varying token costs, learning capabilities, and quality gates. Two additional workflows (`/map-feature`, `/map-refactor`) are planned but not yet implemented.
+This skill helps you choose the optimal MAP workflow for your development tasks. MAP Framework provides **12 workflow commands**: 4 primary workflows (`/map-fast`, `/map-efficient`, `/map-debug`, `/map-debate`) and 8 supporting commands (`/map-review`, `/map-check`, `/map-plan`, `/map-task`, `/map-tdd`, `/map-release`, `/map-resume`, `/map-learn`). Each is optimized for different scenarios with varying token costs, learning capabilities, and quality gates. Two additional workflows (`/map-feature`, `/map-refactor`) are planned but not yet implemented.
 
 ## Quick Decision Tree
 
@@ -216,7 +216,7 @@ Intended for refactoring with dependency-focused impact analysis and breaking ch
 
 ## Understanding MAP Agents
 
-MAP workflows orchestrate **12 specialized agents**, each with specific responsibilities:
+MAP workflows orchestrate **11 specialized agents**, each with specific responsibilities:
 
 ### Execution & Validation Agents
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Based on [MAP cognitive architecture](https://github.com/Shanka123/MAP) (Nature 
 
 ## Why MAP?
 
-- **Structured workflows** — 12 specialized agents instead of single-prompt chaos
+- **Structured workflows** — 11 specialized agents instead of single-prompt chaos
 - **Quality gates** — automatic validation catches errors before they compound
 - **40-60% cost savings** — prevents circular reasoning and scope creep
 - **Learning system** — captures patterns for reuse across projects
+- **Persistent artifacts** — `/map-plan`, `/map-efficient`, and `/map-check` keep branch-scoped research, session, review, QA, and verification artifacts inside `.map/<branch>/`
 
 ## Quick Start
 
@@ -51,11 +52,21 @@ claude
 | `/map-review` | Pre-commit code review |
 | `/map-check` | Quality gates and verification |
 | `/map-plan` | Task decomposition without implementation |
+| `/map-task` | Execute a single subtask from an existing plan |
+| `/map-tdd` | Test-first implementation workflow |
 | `/map-release` | Package release workflow |
 | `/map-resume` | Resume interrupted workflows |
 | `/map-learn` | Extract lessons after workflow completion |
 
 [Detailed usage and options →](docs/USAGE.md)
+
+Canonical MAP flows:
+
+- Standard: `/map-plan` -> `/map-efficient` -> `/map-check` -> `/map-review`
+- Full TDD: `/map-plan` -> `/map-tdd` -> `/map-check` -> `/map-review`
+- Targeted subtask TDD: `/map-plan` -> `/map-tdd ST-001` -> `/map-task ST-001` -> ... -> `/map-check` -> `/map-review`
+
+These workflows maintain branch-scoped artifacts like `research.md`, `implementation-plan.md`, `code-review-001.md`, `qa-001.md`, `verification-summary.md`, `pr-draft.md`, and run dossiers under `.map/<branch>/`.
 
 ## How It Works
 
@@ -86,7 +97,7 @@ The orchestration lives in `.claude/commands/map-*.md` prompts created by `mapif
 ## Trouble?
 
 - **Command not found** → Run `mapify init` in your project first
-- **Agent errors** → Check `.claude/agents/` has all 12 `.md` files
+- **Agent errors** → Check `.claude/agents/` has all 11 shipped agent `.md` files
 - [More help →](docs/INSTALL.md#troubleshooting)
 
 ## Contributing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Deep technical documentation for MAP (Modular Agentic Planner) implementation.
 
 ### High-Level Design
 
-MAP Framework implements cognitive architecture inspired by prefrontal cortex functions, orchestrating 12 specialized agents for software development with automatic quality validation.
+MAP Framework implements cognitive architecture inspired by prefrontal cortex functions, orchestrating 11 specialized agents for software development with automatic quality validation.
 
 **Key Design Principle:** Each slash command has its own unique workflow with different agent sequences. There is no single "standard" workflow — the orchestration logic is defined in `.claude/commands/map-*.md` files.
 

--- a/docs/CLI_COMMAND_REFERENCE.md
+++ b/docs/CLI_COMMAND_REFERENCE.md
@@ -11,8 +11,8 @@ Complete reference for all mapify CLI commands with correct syntax, parameters, 
 - [Root Commands](#root-commands)
   - [init](#mapify-init)
   - [check](#mapify-check)
-  - [doctor](#mapify-doctor)
   - [upgrade](#mapify-upgrade)
+  - [doctor](#mapify-doctor)
 - [Common Mistakes](#common-mistakes)
 
 ---

--- a/docs/CLI_COMMAND_REFERENCE.md
+++ b/docs/CLI_COMMAND_REFERENCE.md
@@ -11,6 +11,7 @@ Complete reference for all mapify CLI commands with correct syntax, parameters, 
 - [Root Commands](#root-commands)
   - [init](#mapify-init)
   - [check](#mapify-check)
+  - [doctor](#mapify-doctor)
   - [upgrade](#mapify-upgrade)
 - [Common Mistakes](#common-mistakes)
 
@@ -96,7 +97,7 @@ mapify init [PROJECT_NAME] [OPTIONS]
 
 **Parameters:**
 - `PROJECT_NAME` (optional): Directory name (use '.' for current directory)
-- `--mcp [all|essential|docs|none|LIST]`: MCP servers to enable
+- `--mcp [all|essential|none|LIST]`: MCP servers to enable
 - `--no-git`: Skip git initialization
 - `--force`: Force merge/overwrite in non-empty directory
 
@@ -119,11 +120,16 @@ mapify init my-project --no-git
 mapify init . --mcp sequential-thinking,deepwiki
 ```
 
+**Also creates:**
+- `.map/scripts/` workflow runtime helpers
+- `.map/static-analysis/` language-specific analysis helpers
+- branch-scoped workflow state under `.map/<branch>/` as MAP commands run
+
 ---
 
 ### `mapify check`
 
-**Check that all required tools are installed**
+**Quick environment check for tools, MAP initialization, bundled templates, and supported MCP servers**
 
 ```bash
 mapify check [OPTIONS]
@@ -146,13 +152,53 @@ mapify check --debug
 
 ### `mapify upgrade`
 
-**Upgrade MAP agents to the latest version**
+**Refresh MAP Framework files in the current project**
 
 ```bash
 mapify upgrade
 ```
 
-Updates agent templates in `.claude/agents/` to latest versions.
+Refreshes shipped MAP files in the current project:
+- `.claude/agents/`
+- `.claude/commands/`
+- `.claude/skills/`
+- `.claude/references/`
+- `.claude/hooks/`
+- `.claude/settings.json`, `.claude/workflow-rules.json`, `.claude/ralph-loop-config.json`
+
+Preserves project-specific MCP selections in `.mcp.json` and `.claude/mcp_config.json`.
+
+---
+
+### `mapify doctor`
+
+**Run a detailed MAP project readiness diagnosis**
+
+```bash
+mapify doctor [OPTIONS]
+```
+
+**Parameters:**
+- `--debug`: Enable debug logging
+
+**Checks include:**
+- Required tools (`git`, `claude`)
+- Core MAP paths (`.claude/...`, `.map/scripts`)
+- Installed agent/command counts vs bundled templates
+- Current branch workspace availability in `.map/<branch>/`
+- `.mcp.json` readability
+
+**Examples:**
+
+```bash
+# Diagnose current project state
+mapify doctor
+
+# Diagnose with debug logging
+mapify doctor --debug
+```
+
+---
 
 ---
 
@@ -177,8 +223,8 @@ Updates agent templates in `.claude/agents/` to latest versions.
 ## Version Information
 
 **Generated from**: `src/mapify_cli/__init__.py`
-**Framework version**: Based on map-framework 2.3.0
-**Last updated**: 2026-01-11
+**Framework version**: Based on map-framework 3.5.0
+**Last updated**: 2026-03-19
 
 For the most up-to-date command definitions, see the source code decorators:
 - `@app.command()` - Root commands

--- a/docs/CLI_REFERENCE.json
+++ b/docs/CLI_REFERENCE.json
@@ -91,7 +91,7 @@
               "type": "string",
               "required": false,
               "flag": "--mcp",
-              "enum": ["all", "essential", "docs", "none", "comma-separated-list"],
+              "enum": ["all", "essential", "none", "comma-separated-list"],
               "description": "MCP servers to enable"
             },
             "no-git": {
@@ -125,7 +125,7 @@
           ]
         },
         "check": {
-          "description": "Check that all required tools are installed",
+          "description": "Quick environment check for tools, MAP initialization, bundled templates, and supported MCP servers",
           "usage": "mapify check [OPTIONS]",
           "parameters": {
             "debug": {
@@ -139,7 +139,7 @@
           "examples": [
             {
               "command": "mapify check",
-              "description": "Verify all dependencies are installed"
+              "description": "Verify tool availability and MAP project readiness"
             },
             {
               "command": "mapify check --debug",
@@ -147,14 +147,37 @@
             }
           ]
         },
+        "doctor": {
+          "description": "Run a detailed MAP project readiness diagnosis",
+          "usage": "mapify doctor [OPTIONS]",
+          "parameters": {
+            "debug": {
+              "type": "boolean",
+              "required": false,
+              "flag": "--debug",
+              "default": false,
+              "description": "Enable debug logging"
+            }
+          },
+          "examples": [
+            {
+              "command": "mapify doctor",
+              "description": "Diagnose current project state"
+            },
+            {
+              "command": "mapify doctor --debug",
+              "description": "Diagnose with debug logging"
+            }
+          ]
+        },
         "upgrade": {
-          "description": "Upgrade MAP agents to the latest version",
+          "description": "Refresh MAP Framework files in the current project",
           "usage": "mapify upgrade",
           "parameters": {},
           "examples": [
             {
               "command": "mapify upgrade",
-              "description": "Update agent templates to latest version"
+              "description": "Refresh shipped MAP files in the current project"
             }
           ]
         }
@@ -188,8 +211,8 @@
       "@app.command() decorators",
       "@validate_app.command() decorators"
     ],
-    "version": "Based on map-framework 4.0.0",
-    "last_updated": "2026-02-15",
+    "version": "Based on map-framework 3.5.0",
+    "last_updated": "2026-03-19",
     "related_docs": [
       "docs/USAGE.md",
       "docs/ARCHITECTURE.md",

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -148,9 +148,10 @@ This will:
 
 - ✅ Create project directory
 - ✅ Install MAP agents (including Synthesizer, DebateArbiter, ResearchAgent, FinalVerifier)
-- ✅ Add 10 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-learn, /map-review, /map-release, /map-check, /map-plan, /map-resume)
+- ✅ Add 12 slash commands (/map-efficient, /map-debug, /map-fast, /map-debate, /map-learn, /map-review, /map-check, /map-plan, /map-task, /map-tdd, /map-release, /map-resume)
 - ✅ Configure essential MCP servers
 - ✅ Initialize git repository
+- ✅ Install branch-scoped `.map/<branch>/` workflow runtime used by `/map-plan` and `/map-efficient`
 
 **Note:** MAP Framework is designed for Claude Code. All generated agents and commands are optimized for the Claude Code CLI.
 
@@ -214,7 +215,7 @@ If you prefer manual setup:
    ```
    your-project/
    ├── .claude/
-   │   ├── agents/                    # 12 specialized agents
+   │   ├── agents/                    # 11 specialized agents
    │   │   ├── task-decomposer.md     # Decomposes tasks into subtasks
    │   │   ├── actor.md               # Implements code
    │   │   ├── monitor.md             # Validates implementations
@@ -226,7 +227,7 @@ If you prefer manual setup:
    │   │   ├── research-agent.md      # Isolated codebase research
    │   │   ├── final-verifier.md      # Adversarial verification (Ralph Loop)
    │   │   └── documentation-reviewer.md  # Reviews technical docs
-   │   ├── commands/                  # 10 slash commands
+   │   ├── commands/                  # 12 slash commands
    │   │   ├── map-efficient.md       # Optimized workflow (recommended)
    │   │   ├── map-debate.md          # Multi-variant with Opus reasoning
    │   │   ├── map-debug.md           # Debug workflow

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2,6 +2,42 @@
 
 Complete usage examples, best practices, and optimization strategies for the MAP Framework.
 
+For long-running work, the canonical MAP flows maintain branch-scoped artifacts directly inside `.map/<branch>/`, so research, session logs, code-review lineage, verification summaries, PR drafts, and run dossiers survive context resets.
+
+## Canonical Flows
+
+### Standard flow
+
+```bash
+/map-plan clarify scope and decompose the task
+/map-efficient implement the approved plan
+/map-check
+/map-review
+```
+
+### Full TDD flow
+
+```bash
+/map-plan define the behavior and subtasks
+/map-tdd implement with test-first phases enabled
+/map-check
+/map-review
+```
+
+### Targeted subtask TDD flow
+
+```bash
+/map-plan decompose work into subtasks
+/map-tdd ST-001
+/map-task ST-001
+/map-tdd ST-002
+/map-task ST-002
+/map-check
+/map-review
+```
+
+The full TDD flow is the primary test-first path. The targeted subtask flow is the fine-grained variant when you want to drive one subtask at a time.
+
 ## Navigation
 
 - [Usage Examples](#usage-examples)

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -110,9 +110,9 @@ class StepTracker:
 
     def __init__(self, title: str):
         self.title = title
-        self.steps: List[Dict[str, Any]] = (
-            []
-        )  # list of dicts: {key, label, status, detail}
+        self.steps: List[
+            Dict[str, Any]
+        ] = []  # list of dicts: {key, label, status, detail}
         self._refresh_cb = None
 
     def attach_refresh(self, cb):
@@ -452,10 +452,8 @@ def check_tool(tool: str) -> bool:
 
 
 def check_mcp_server(server: str) -> bool:
-    """Check if an MCP server is available/configured"""
-    # For now, we'll assume MCP servers are available if configured
-    # In a real implementation, you'd check actual MCP configuration
-    return True
+    """Check if an MCP server is recognized by this installation."""
+    return server in build_standard_mcp_servers()
 
 
 def is_debug_enabled(debug_flag: Optional[bool] = None) -> bool:
@@ -503,8 +501,220 @@ def get_templates_dir() -> Path:
     raise RuntimeError("Templates directory not found. Please reinstall mapify-cli.")
 
 
-def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
-    """Create MAP agent files in .claude/agents/"""
+def count_template_markdown_files(template_subdir: str) -> int:
+    """Count shipped markdown templates in a subdirectory."""
+    template_dir = get_templates_dir() / template_subdir
+    if not template_dir.exists():
+        return 0
+    return len([path for path in template_dir.glob("*.md") if path.is_file()])
+
+
+def count_agent_templates() -> int:
+    """Count shipped agent templates, excluding documentation files."""
+    template_dir = get_templates_dir() / "agents"
+    if not template_dir.exists():
+        return 0
+
+    exclude_files = {"README.md", "CHANGELOG.md", "MCP-PATTERNS.md"}
+    return len(
+        [
+            path
+            for path in template_dir.glob("*.md")
+            if path.is_file() and path.name not in exclude_files
+        ]
+    )
+
+
+def count_command_templates() -> int:
+    """Count shipped slash command templates."""
+    return count_template_markdown_files("commands")
+
+
+def count_project_markdown_files(
+    directory: Path, exclude_files: Optional[set[str]] = None
+) -> int:
+    """Count markdown files in a project directory."""
+    if not directory.exists():
+        return 0
+    exclude_files = exclude_files or set()
+    return len(
+        [
+            path
+            for path in directory.glob("*.md")
+            if path.is_file() and path.name not in exclude_files
+        ]
+    )
+
+
+def is_map_initialized(project_path: Path) -> bool:
+    """Return True when the current directory looks like a MAP project."""
+    required_paths = [
+        project_path / ".claude" / "agents",
+        project_path / ".claude" / "commands",
+        project_path / ".claude" / "settings.json",
+        project_path / ".claude" / "workflow-rules.json",
+    ]
+    return all(path.exists() for path in required_paths)
+
+
+def get_project_health(project_path: Path) -> Dict[str, Any]:
+    """Collect project health diagnostics for check/doctor commands."""
+    agent_exclude = {"README.md", "CHANGELOG.md", "MCP-PATTERNS.md"}
+    current_branch = sanitize_identifier(get_current_branch_name())
+    branch_dir = project_path / ".map" / current_branch
+    required_paths = {
+        ".claude/agents": project_path / ".claude" / "agents",
+        ".claude/commands": project_path / ".claude" / "commands",
+        ".claude/settings.json": project_path / ".claude" / "settings.json",
+        ".claude/workflow-rules.json": project_path / ".claude" / "workflow-rules.json",
+        ".map/scripts": project_path / ".map" / "scripts",
+    }
+    missing_paths = [name for name, path in required_paths.items() if not path.exists()]
+
+    agents_dir = project_path / ".claude" / "agents"
+    commands_dir = project_path / ".claude" / "commands"
+    mcp_json_path = project_path / ".mcp.json"
+    internal_mcp_path = project_path / ".claude" / "mcp_config.json"
+    branch_artifact_files = [
+        "research.md",
+        "implementation-plan.md",
+        "decision-log.md",
+        "devlog-001.md",
+        "review-001.md",
+        "qa-001.md",
+        "pr-draft.md",
+    ]
+
+    mcp_json_ok = False
+    if mcp_json_path.exists():
+        mcp_json_ok = read_project_mcp_json(mcp_json_path) is not None
+
+    return {
+        "initialized": is_map_initialized(project_path),
+        "missing_paths": missing_paths,
+        "installed_agents": count_project_markdown_files(agents_dir, agent_exclude),
+        "installed_commands": count_project_markdown_files(commands_dir),
+        "expected_agents": count_agent_templates(),
+        "expected_commands": count_command_templates(),
+        "has_project_mcp": mcp_json_path.exists(),
+        "project_mcp_valid": mcp_json_ok,
+        "has_internal_mcp": internal_mcp_path.exists(),
+        "current_branch": current_branch,
+        "branch_workspace_exists": branch_dir.exists(),
+        "branch_workspace_files": (
+            sorted(path.name for path in branch_dir.iterdir() if path.is_file())
+            if branch_dir.exists()
+            else []
+        ),
+        "branch_artifact_files": branch_artifact_files,
+        "branch_artifact_count": (
+            len(
+                [name for name in branch_artifact_files if (branch_dir / name).exists()]
+            )
+            if branch_dir.exists()
+            else 0
+        ),
+    }
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Parse a semantic-ish version string into an integer tuple."""
+    cleaned = version.strip().lstrip("v")
+    parts = []
+    for chunk in cleaned.split("."):
+        digits = "".join(ch for ch in chunk if ch.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def sanitize_identifier(value: str, fallback: str = "main") -> str:
+    """Sanitize a user or branch supplied identifier for filesystem use."""
+    sanitized = value.strip().replace("/", "-")
+    sanitized = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in sanitized)
+    while "--" in sanitized:
+        sanitized = sanitized.replace("--", "-")
+    sanitized = sanitized.strip("-.")
+    return sanitized or fallback
+
+
+def get_current_branch_name() -> str:
+    """Return current git branch name, or 'main' when unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=Path.cwd(),
+        )
+        branch = result.stdout.strip()
+        return branch or "main"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "main"
+
+
+def get_branch_workspace_dir(project_path: Path, branch: Optional[str] = None) -> Path:
+    """Return the branch-scoped MAP workspace directory."""
+    branch_name = sanitize_identifier(branch or get_current_branch_name())
+    return project_path / ".map" / branch_name
+
+
+def get_branch_artifact_templates(branch: str) -> Dict[str, str]:
+    """Return cook-inspired artifact templates aligned to MAP branch workspaces."""
+    return {
+        "research.md": f"# Research\n\n## Branch\n`{branch}`\n\n## Request\n\n## Context\n\n## Constraints\n\n## Related Files\n\n## Prior Art\n\n## Recommendation\n",
+        "implementation-plan.md": f"# Implementation Plan\n\n## Branch\n`{branch}`\n\n## Summary\n\n## Goals\n\n## Non-Goals\n\n## Steps\n1.\n2.\n3.\n\n## Validation Plan\n\n## Risks\n",
+        "decision-log.md": "# Decision Log\n\n## Decision\n\n## Options Considered\n\n## Chosen Approach\n\n## Consequences\n",
+        "devlog-001.md": "# Devlog 001\n\n## Changes\n\n## Notes\n\n## Verification\n",
+        "review-001.md": "# Review 001\n\n## Scope\n\n## Findings\n\n### High\n\n### Medium\n\n### Low\n\n## Verdict\n- [ ] Ready\n- [ ] Needs revision\n",
+        "qa-001.md": "# QA 001\n\n## Commands Run\n\n## Expected Result\n\n## Actual Result\n\n## Follow-ups\n",
+        "pr-draft.md": "# PR Draft\n\n## Summary\n\n## Validation\n\n## Risks / Rollback\n",
+    }
+
+
+def initialize_branch_workspace(
+    project_path: Path, branch: Optional[str] = None
+) -> Path:
+    """Create branch-scoped planning artifacts inside `.map/<branch>/`."""
+    branch_name = sanitize_identifier(branch or get_current_branch_name())
+    workspace_dir = get_branch_workspace_dir(project_path, branch_name)
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    for file_name, content in get_branch_artifact_templates(branch_name).items():
+        destination = workspace_dir / file_name
+        if not destination.exists():
+            destination.write_text(content, encoding="utf-8")
+
+    return workspace_dir
+
+
+def get_branch_workspace_status(
+    project_path: Path, branch: Optional[str] = None
+) -> Dict[str, Any]:
+    """Collect status information for branch-scoped planning artifacts."""
+    branch_name = sanitize_identifier(branch or get_current_branch_name())
+    workspace_dir = get_branch_workspace_dir(project_path, branch_name)
+    expected_files = list(get_branch_artifact_templates(branch_name).keys())
+    existing_files = (
+        sorted(path.name for path in workspace_dir.iterdir())
+        if workspace_dir.exists()
+        else []
+    )
+    missing_files = [name for name in expected_files if name not in existing_files]
+    return {
+        "branch": branch_name,
+        "path": workspace_dir,
+        "exists": workspace_dir.exists(),
+        "existing_files": existing_files,
+        "missing_files": missing_files,
+        "is_complete": workspace_dir.exists() and not missing_files,
+    }
+
+
+def create_agent_files(project_path: Path, mcp_servers: List[str]) -> int:
+    """Create MAP agent files in .claude/agents/."""
     agents_dir = project_path / ".claude" / "agents"
     agents_dir.mkdir(parents=True, exist_ok=True)
 
@@ -518,6 +728,7 @@ def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
 
         # Files to exclude from agent directory (documentation, not agents)
         exclude_files = {"README.md", "CHANGELOG.md", "MCP-PATTERNS.md"}
+        count = 0
 
         for agent_template in agents_template_dir.glob("*.md"):
             # Skip documentation files - they're not agents
@@ -525,6 +736,8 @@ def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
                 continue
             dest_file = agents_dir / agent_template.name
             shutil.copy2(agent_template, dest_file)
+            count += 1
+        return count
     else:
         # Fallback: generate simplified versions if templates not found
         # NOTE: orchestrator removed (moved to slash commands in production architecture)
@@ -543,6 +756,7 @@ def create_agent_files(project_path: Path, mcp_servers: List[str]) -> None:
         for name, content in agents.items():
             agent_file = agents_dir / f"{name}.md"
             agent_file.write_text(content)
+        return len(agents)
 
 
 def create_task_decomposer_content(mcp_servers: List[str]) -> str:
@@ -953,8 +1167,8 @@ def create_reference_files(project_path: Path) -> int:
     return count
 
 
-def create_command_files(project_path: Path) -> None:
-    """Create MAP slash commands in .claude/commands/"""
+def create_command_files(project_path: Path) -> int:
+    """Create MAP slash commands in .claude/commands/."""
     commands_dir = project_path / ".claude" / "commands"
     commands_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1013,13 +1227,17 @@ Call Reflector to extract patterns from recent workflow.
         for name, content in commands.items():
             command_file = commands_dir / f"{name}.md"
             command_file.write_text(content)
+        return len(commands)
     else:
         # Copy templates from bundled directory
         import shutil
 
+        count = 0
         for command_template in commands_template_dir.glob("*.md"):
             dest_file = commands_dir / command_template.name
             shutil.copy2(command_template, dest_file)
+            count += 1
+        return count
 
 
 def create_skill_files(project_path: Path) -> int:
@@ -1058,20 +1276,16 @@ def create_skill_files(project_path: Path) -> int:
     return count
 
 
-def _copy_map_subdir(
-    map_template_dir: Path, map_dir: Path, subdir: str, executable_glob: str
-) -> int:
-    """Copy a subdirectory from map templates to .map/ and make scripts executable."""
+def _copy_map_path(src: Path, dest: Path) -> int:
+    """Copy a path from map templates to .map/ and mark scripts executable."""
     import shutil
 
-    src = map_template_dir / subdir
-    if not src.exists():
-        return 0
-
-    dest = map_dir / subdir
     if dest.exists():
         try:
-            shutil.rmtree(dest)
+            if dest.is_dir():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
         except (OSError, PermissionError) as e:
             import sys
 
@@ -1079,17 +1293,23 @@ def _copy_map_subdir(
                 f"Warning: Could not remove existing {dest}: {e}",
                 file=sys.stderr,
             )
-    shutil.copytree(src, dest, dirs_exist_ok=True)
+    if src.is_dir():
+        shutil.copytree(src, dest, dirs_exist_ok=True)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
 
     count = 0
-    for script in dest.rglob(executable_glob):
-        script.chmod(script.stat().st_mode | 0o755)
-        count += 1
+    script_targets = [dest] if dest.is_file() else list(dest.rglob("*"))
+    for script in script_targets:
+        if script.is_file() and script.suffix in (".sh", ".py"):
+            script.chmod(script.stat().st_mode | 0o755)
+            count += 1
     return count
 
 
 def create_map_tools(project_path: Path) -> int:
-    """Create .map/ directory with static analysis tools and orchestrator scripts."""
+    """Create .map/ directory with shipped MAP runtime and planning assets."""
     map_dir = project_path / ".map"
     map_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1098,8 +1318,8 @@ def create_map_tools(project_path: Path) -> int:
 
     count = 0
     if map_template_dir.exists():
-        count += _copy_map_subdir(map_template_dir, map_dir, "static-analysis", "*.sh")
-        count += _copy_map_subdir(map_template_dir, map_dir, "scripts", "*.py")
+        for item in map_template_dir.iterdir():
+            count += _copy_map_path(item, map_dir / item.name)
 
     return count
 
@@ -1727,10 +1947,17 @@ This directory contains custom slash commands for Claude Code.
 ## Available Commands
 
 - `/map-efficient` - Implement features with optimized workflow (recommended)
+- `/map-plan` - Decompose work without implementing it yet
+- `/map-task` - Execute a single subtask from an existing plan
+- `/map-tdd` - Run a test-first workflow for one task or plan
 - `/map-debug` - Debug issues using MAP analysis
+- `/map-debate` - Generate variants and synthesize the best result
+- `/map-review` - Run a structured review workflow
+- `/map-check` - Run workflow quality gates and verification
 - `/map-fast` - Quick implementation with minimal validation
 - `/map-learn` - Extract lessons from completed workflows
 - `/map-release` - Execute MAP Framework package release workflow
+- `/map-resume` - Resume an interrupted workflow from `.map/`
 
 ## Creating Custom Commands
 
@@ -1906,9 +2133,9 @@ def init(
     else:
         # Type assertion: flow guarantees project_name is not None here
         # (checked at line 1931, and not in use_current_dir branch)
-        assert (
-            project_name is not None
-        ), "project_name must be set in non-current-dir mode"
+        assert project_name is not None, (
+            "project_name must be set in non-current-dir mode"
+        )
         project_path = Path(project_name).resolve()
         if project_path.exists():
             console.print(
@@ -1967,13 +2194,15 @@ def init(
     # Create MAP files
     tracker.add("create-agents", "Create MAP agents")
     tracker.start("create-agents")
-    create_agent_files(project_path, selected_mcp_servers)
-    tracker.complete("create-agents", "12 agents")
+    agent_count = create_agent_files(project_path, selected_mcp_servers)
+    agent_word = "agent" if agent_count == 1 else "agents"
+    tracker.complete("create-agents", f"{agent_count} {agent_word}")
 
     tracker.add("create-commands", "Create slash commands")
     tracker.start("create-commands")
-    create_command_files(project_path)
-    tracker.complete("create-commands", "10 commands")
+    command_count = create_command_files(project_path)
+    command_word = "command" if command_count == 1 else "commands"
+    tracker.complete("create-commands", f"{command_count} {command_word}")
 
     tracker.add("create-skills", "Create skills")
     tracker.start("create-skills")
@@ -2071,6 +2300,9 @@ def init(
     steps_lines.append(
         "   • [cyan]/map-learn[/] - Extract lessons from completed workflows"
     )
+    steps_lines.append(
+        f"{step_num + 1}. Run [cyan]/map-plan[/cyan] first when you want branch-scoped research, spec, and plan artifacts in `.map/<branch>/`"
+    )
 
     steps_panel = Panel(
         "\n".join(steps_lines), title="Next Steps", border_style="cyan", padding=(1, 2)
@@ -2095,7 +2327,7 @@ def check(debug: bool = typer.Option(False, "--debug", help="Enable debug loggin
             "command_start", "mapify check", metadata={"debug": debug}
         )
     show_banner()
-    console.print("[bold]Checking for installed tools...[/bold]\n")
+    console.print("[bold]Checking MAP Framework environment...[/bold]\n")
 
     tracker = StepTracker("Check Available Tools")
 
@@ -2118,36 +2350,259 @@ def check(debug: bool = typer.Option(False, "--debug", help="Enable debug loggin
             tracker.error(tool, "not found")
             results[tool] = False
 
+    health = get_project_health(Path.cwd())
+
+    tracker.add("project", "Detect MAP project")
+    if health["initialized"]:
+        tracker.complete("project", "initialized")
+    else:
+        tracker.error("project", "not initialized")
+
+    tracker.add("templates", "Inspect bundled templates")
+    if health["expected_agents"] and health["expected_commands"]:
+        tracker.complete(
+            "templates",
+            f"{health['expected_agents']} agents, {health['expected_commands']} commands",
+        )
+    else:
+        tracker.error("templates", "missing bundled templates")
+
+    tracker.add("mcp", "Check supported MCP servers")
+    supported_servers = sorted(build_standard_mcp_servers().keys())
+    unsupported_servers = [s for s in supported_servers if not check_mcp_server(s)]
+    if unsupported_servers:
+        tracker.error("mcp", f"unsupported: {', '.join(unsupported_servers)}")
+    else:
+        tracker.complete("mcp", ", ".join(supported_servers) or "none")
+
     console.print(tracker.render())
     console.print()
 
-    if all(results.values()):
+    if all(results.values()) and health["initialized"]:
         console.print(
             "[bold green]All tools are installed! MAP Framework is ready to use.[/bold green]"
         )
     else:
-        console.print("[yellow]Some tools are missing:[/yellow]")
+        console.print("[yellow]MAP environment needs attention:[/yellow]")
         if not results.get("git"):
             console.print("  • Install git: https://git-scm.com/downloads")
         if not results.get("claude"):
             console.print(
                 "  • Install Claude Code: https://docs.anthropic.com/en/docs/claude-code/setup"
             )
+        if not health["initialized"]:
+            console.print("  • Initialize this directory: mapify init .")
+
+
+@app.command()
+def doctor(debug: bool = typer.Option(False, "--debug", help="Enable debug logging")):
+    """Run a detailed MAP project readiness diagnosis."""
+    if is_debug_enabled(debug):
+        from mapify_cli.workflow_logger import MapWorkflowLogger
+
+        workflow_logger = MapWorkflowLogger(Path.cwd(), enabled=True)
+        log_file = workflow_logger.start_session(
+            task_id=f"mapify_doctor_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        )
+        console.print(f"[dim]Debug logging enabled: {log_file}[/dim]")
+        workflow_logger.log_event(
+            "command_start", "mapify doctor", metadata={"debug": debug}
+        )
+
+    show_banner()
+    console.print("[bold]Running MAP doctor...[/bold]\n")
+
+    project_path = Path.cwd()
+    health = get_project_health(project_path)
+    tracker = StepTracker("MAP Doctor")
+
+    for tool_name, description in [
+        ("git", "Git version control"),
+        ("claude", "Claude Code CLI"),
+    ]:
+        tracker.add(tool_name, description)
+        if check_tool(tool_name):
+            tracker.complete(tool_name, "available")
+        else:
+            tracker.error(tool_name, "not found")
+
+    tracker.add("project", "MAP project structure")
+    if not health["missing_paths"]:
+        tracker.complete("project", "all core paths present")
+    else:
+        tracker.error("project", f"missing {len(health['missing_paths'])} path(s)")
+
+    tracker.add("templates", "Installed template counts")
+    if (
+        health["installed_agents"] == health["expected_agents"]
+        and health["installed_commands"] == health["expected_commands"]
+    ):
+        tracker.complete(
+            "templates",
+            f"{health['installed_agents']}/{health['expected_agents']} agents, "
+            f"{health['installed_commands']}/{health['expected_commands']} commands",
+        )
+    else:
+        tracker.error(
+            "templates",
+            f"agents {health['installed_agents']}/{health['expected_agents']}, "
+            f"commands {health['installed_commands']}/{health['expected_commands']}",
+        )
+
+    tracker.add("planning", "Branch workspace artifacts")
+    if health["branch_workspace_exists"]:
+        tracker.complete(
+            "planning",
+            f"branch {health['current_branch']}: {health['branch_artifact_count']}/{len(health['branch_artifact_files'])} artifacts",
+        )
+    else:
+        tracker.error("planning", f"missing .map/{health['current_branch']}")
+
+    tracker.add("mcp", "Project MCP configuration")
+    if health["has_project_mcp"]:
+        if health["project_mcp_valid"]:
+            tracker.complete("mcp", ".mcp.json valid")
+        else:
+            tracker.error("mcp", ".mcp.json unreadable")
+    elif health["has_internal_mcp"]:
+        tracker.complete("mcp", "internal config only")
+    else:
+        tracker.complete("mcp", "no MCP config")
+
+    console.print(tracker.render())
+    console.print()
+
+    details = Table(title="Doctor Details", show_header=True, header_style="bold cyan")
+    details.add_column("Check")
+    details.add_column("Status")
+    details.add_column("Details")
+    details.add_row(
+        "Project",
+        "OK" if health["initialized"] else "Needs init",
+        ".claude + workflow configs detected"
+        if health["initialized"]
+        else "Run `mapify init .`",
+    )
+    details.add_row(
+        "Agents",
+        f"{health['installed_agents']}/{health['expected_agents']}",
+        "Installed vs bundled agent templates",
+    )
+    details.add_row(
+        "Commands",
+        f"{health['installed_commands']}/{health['expected_commands']}",
+        "Installed vs bundled slash commands",
+    )
+    details.add_row(
+        "Planning",
+        (
+            f"{health['branch_artifact_count']}/{len(health['branch_artifact_files'])}"
+            if health["branch_workspace_exists"]
+            else "missing"
+        ),
+        f"Current branch workspace: .map/{health['current_branch']}/",
+    )
+    details.add_row(
+        "MCP",
+        "valid"
+        if health["project_mcp_valid"]
+        else ("present" if health["has_project_mcp"] else "not configured"),
+        ".mcp.json status",
+    )
+    console.print(details)
+
+    if health["missing_paths"]:
+        console.print()
+        console.print("[yellow]Missing core paths:[/yellow]")
+        for path_name in health["missing_paths"]:
+            console.print(f"  • {path_name}")
 
 
 @app.command()
 def upgrade():
     """Upgrade MAP agents to the latest version."""
     show_banner()
+    project_path = Path.cwd()
+
+    if not is_map_initialized(project_path):
+        console.print(
+            "[yellow]MAP Framework not initialized in this directory.[/yellow]"
+        )
+        console.print("Run: [cyan]mapify init .[/cyan]")
+        raise typer.Exit(0)
+
     console.print("[cyan]Checking for updates...[/cyan]")
+    latest_release = get_latest_release("azalio", "map-framework")
+    latest_version = None
 
-    # In a real implementation, this would:
-    # 1. Fetch latest release from GitHub
-    # 2. Compare versions
-    # 3. Update agents if newer version available
+    if latest_release and latest_release.get("tag_name"):
+        latest_version = latest_release["tag_name"].lstrip("v")
+        if parse_version(latest_version) > parse_version(__version__):
+            console.print(
+                f"[yellow]New version available:[/yellow] {latest_version} "
+                f"(installed {__version__})"
+            )
+            if latest_release.get("html_url"):
+                console.print(f"Release: [cyan]{latest_release['html_url']}[/cyan]")
+        else:
+            console.print(
+                f"[green]You are on the latest installed version ({__version__}).[/green]"
+            )
+    else:
+        console.print(
+            "[dim]Could not fetch release metadata; refreshing local templates anyway.[/dim]"
+        )
 
-    console.print("[yellow]Upgrade feature coming soon![/yellow]")
-    console.print("For now, run: [cyan]mapify init . --force[/cyan] to update agents")
+    tracker = StepTracker("Upgrade MAP Framework Files")
+
+    tracker.add("agents", "Refresh agent templates")
+    tracker.start("agents")
+    agent_count = create_agent_files(project_path, [])
+    tracker.complete("agents", f"{agent_count} files")
+
+    tracker.add("commands", "Refresh slash commands")
+    tracker.start("commands")
+    command_count = create_command_files(project_path)
+    tracker.complete("commands", f"{command_count} files")
+
+    tracker.add("skills", "Refresh skills")
+    tracker.start("skills")
+    skill_count = create_skill_files(project_path)
+    tracker.complete("skills", f"{skill_count} folders")
+
+    tracker.add("references", "Refresh reference files")
+    tracker.start("references")
+    ref_count = create_reference_files(project_path)
+    tracker.complete("references", f"{ref_count} files")
+
+    tracker.add("hooks", "Refresh shared hooks")
+    tracker.start("hooks")
+    hook_count = create_hook_files(project_path)
+    tracker.complete("hooks", f"{hook_count} files")
+
+    tracker.add("configs", "Refresh config files")
+    tracker.start("configs")
+    config_count = create_config_files(project_path)
+    tracker.complete("configs", f"{config_count} files")
+
+    tracker.add("permissions", "Merge local approvals")
+    tracker.start("permissions")
+    create_or_merge_project_settings_local(project_path)
+    tracker.complete("permissions", "settings.local.json updated")
+
+    if (project_path / ".claude" / "mcp_config.json").exists() or (
+        project_path / ".mcp.json"
+    ).exists():
+        tracker.add("mcp", "Preserve MCP config")
+        tracker.complete("mcp", "left unchanged")
+
+    console.print()
+    console.print(tracker.render())
+    console.print()
+    console.print("[bold green]Upgrade complete.[/bold green]")
+    console.print(
+        "[dim]Note: upgrade refreshes shipped MAP files but does not overwrite project-specific MCP selections.[/dim]"
+    )
 
 
 # Validate commands

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -579,11 +579,13 @@ def get_project_health(project_path: Path) -> Dict[str, Any]:
         "research.md",
         "implementation-plan.md",
         "decision-log.md",
+        "session-log.md",
         "devlog-001.md",
-        "review-001.md",
         "qa-001.md",
+        "verification-summary.md",
         "pr-draft.md",
     ]
+    numbered_artifact_prefixes = ["plan-review", "code-review"]
 
     mcp_json_ok = False
     if mcp_json_path.exists():
@@ -610,6 +612,11 @@ def get_project_health(project_path: Path) -> Dict[str, Any]:
         "branch_artifact_count": (
             len(
                 [name for name in branch_artifact_files if (branch_dir / name).exists()]
+            )
+            + sum(
+                1
+                for prefix in numbered_artifact_prefixes
+                if any(branch_dir.glob(f"{prefix}-*.md"))
             )
             if branch_dir.exists()
             else 0
@@ -668,7 +675,7 @@ def get_branch_artifact_templates(branch: str) -> Dict[str, str]:
         "implementation-plan.md": f"# Implementation Plan\n\n## Branch\n`{branch}`\n\n## Summary\n\n## Goals\n\n## Non-Goals\n\n## Steps\n1.\n2.\n3.\n\n## Validation Plan\n\n## Risks\n",
         "decision-log.md": "# Decision Log\n\n## Decision\n\n## Options Considered\n\n## Chosen Approach\n\n## Consequences\n",
         "devlog-001.md": "# Devlog 001\n\n## Changes\n\n## Notes\n\n## Verification\n",
-        "review-001.md": "# Review 001\n\n## Scope\n\n## Findings\n\n### High\n\n### Medium\n\n### Low\n\n## Verdict\n- [ ] Ready\n- [ ] Needs revision\n",
+        "code-review-001.md": "# Code Review 001\n\n## Scope\n\n## Findings\n\n### High\n\n### Medium\n\n### Low\n\n## Verdict\n- [ ] Ready\n- [ ] Needs revision\n",
         "qa-001.md": "# QA 001\n\n## Commands Run\n\n## Expected Result\n\n## Actual Result\n\n## Follow-ups\n",
         "pr-draft.md": "# PR Draft\n\n## Summary\n\n## Validation\n\n## Risks / Rollback\n",
     }
@@ -2369,11 +2376,7 @@ def check(debug: bool = typer.Option(False, "--debug", help="Enable debug loggin
 
     tracker.add("mcp", "Check supported MCP servers")
     supported_servers = sorted(build_standard_mcp_servers().keys())
-    unsupported_servers = [s for s in supported_servers if not check_mcp_server(s)]
-    if unsupported_servers:
-        tracker.error("mcp", f"unsupported: {', '.join(unsupported_servers)}")
-    else:
-        tracker.complete("mcp", ", ".join(supported_servers) or "none")
+    tracker.complete("mcp", ", ".join(supported_servers) or "none")
 
     console.print(tracker.render())
     console.print()
@@ -2555,9 +2558,14 @@ def upgrade():
 
     tracker = StepTracker("Upgrade MAP Framework Files")
 
+    existing_project_mcp = read_project_mcp_json(project_path / ".mcp.json")
+    existing_server_names = []
+    if existing_project_mcp:
+        existing_server_names = list(existing_project_mcp.get("mcpServers", {}).keys())
+
     tracker.add("agents", "Refresh agent templates")
     tracker.start("agents")
-    agent_count = create_agent_files(project_path, [])
+    agent_count = create_agent_files(project_path, existing_server_names)
     tracker.complete("agents", f"{agent_count} files")
 
     tracker.add("commands", "Refresh slash commands")

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -609,6 +609,9 @@ def get_project_health(project_path: Path) -> Dict[str, Any]:
             else []
         ),
         "branch_artifact_files": branch_artifact_files,
+        "numbered_artifact_prefixes": numbered_artifact_prefixes,
+        "expected_branch_artifact_count": len(branch_artifact_files)
+        + len(numbered_artifact_prefixes),
         "branch_artifact_count": (
             len(
                 [name for name in branch_artifact_files if (branch_dir / name).exists()]
@@ -2456,7 +2459,7 @@ def doctor(debug: bool = typer.Option(False, "--debug", help="Enable debug loggi
     if health["branch_workspace_exists"]:
         tracker.complete(
             "planning",
-            f"branch {health['current_branch']}: {health['branch_artifact_count']}/{len(health['branch_artifact_files'])} artifacts",
+            f"branch {health['current_branch']}: {health['branch_artifact_count']}/{health['expected_branch_artifact_count']} artifacts",
         )
     else:
         tracker.error("planning", f"missing .map/{health['current_branch']}")
@@ -2499,7 +2502,7 @@ def doctor(debug: bool = typer.Option(False, "--debug", help="Enable debug loggi
     details.add_row(
         "Planning",
         (
-            f"{health['branch_artifact_count']}/{len(health['branch_artifact_files'])}"
+            f"{health['branch_artifact_count']}/{health['expected_branch_artifact_count']}"
             if health["branch_workspace_exists"]
             else "missing"
         ),

--- a/src/mapify_cli/templates/commands/map-check.md
+++ b/src/mapify_cli/templates/commands/map-check.md
@@ -245,6 +245,40 @@ if [[ -n $(git status --porcelain) ]]; then
 fi
 ```
 
+### Step 5b: Record Run Summary and Known Issues
+
+After each major gate (tests, lint, final verifier), write a compact run summary and a timestamped run dossier under `.map/<branch>/runs/<timestamp>/`, and keep accepted blockers in `.map/<branch>/known-issues.json`.
+
+Examples:
+
+```bash
+python3 .map/scripts/diagnostics.py summarize \
+  --tool tests \
+  --command "$TEST_CMD" \
+  --exit-code $? \
+  --summary "Pytest run for branch verification" \
+  --known-issues ".map/${BRANCH}/known-issues.json" \
+  --notes "Capture any deviations, flaky behavior, or environment quirks here"
+
+python3 .map/scripts/map_step_runner.py ensure_known_issues_file
+python3 .map/scripts/map_step_runner.py add_known_issue "Flaky integration test in CI" accepted "Non-blocking for local verification; tracked for follow-up"
+```
+
+Use `known-issues.json` only for issues intentionally accepted or deferred. Do NOT hide new blocking failures there.
+
+Run dossier contract:
+
+- `.map/<branch>/runs/<timestamp>/RESULTS.md` — mandatory
+- `.map/<branch>/runs/<timestamp>/NOTES.md` — optional
+
+`RESULTS.md` should act as the canonical historical record for that verification run and include:
+- setup/context
+- summary verdict
+- test matrix row(s)
+- detailed results
+- bugs/blockers found
+- accepted/deferred issues count
+
 ### Step 6: Update Workflow State (Complete)
 
 If verification passes, mark workflow complete:
@@ -254,6 +288,75 @@ jq '.current_state = "WORKFLOW_COMPLETE" | .completed_at = "'$(date -u +%Y-%m-%d
 ```
 
 ### Step 7: Output Verification Report
+
+Before printing the console report, update `.map/<branch>/verification-summary.md` with:
+
+```bash
+python3 .map/scripts/map_step_runner.py write_verification_summary "READY FOR REVIEW" "<task title>" "- pytest ...,- ruff ..." "- key findings" "- open PR"
+```
+
+This file should be a compact human-readable report with:
+- branch and task title
+- overall verdict (`READY FOR REVIEW` or `NEEDS WORK`)
+- commands/tests run
+- key failures or warnings
+- recommended next step
+
+Then persist canonical verification handoff artifacts:
+
+```bash
+# Machine-readable gate semantics
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  verification \
+  ready \
+  verification-summary.md \
+  "Verification passed and branch is ready for review"
+
+# Current unresolved set for the branch/workflow stage
+python3 .map/scripts/map_step_runner.py ensure_active_issues_file
+python3 .map/scripts/map_step_runner.py replace_active_issues \
+  verification \
+  verification-summary.md \
+  "- [list unresolved verification issues here, or '(None)']"
+```
+
+Use these verdict mappings consistently:
+- `ready` — verification passed, safe to move to `/map-review`
+- `needs-revision` — implementation changes required before review
+- `blocked` — external/tooling/environment issue prevents safe progress
+
+Then build a handoff bundle and update `.map/<branch>/pr-draft.md` from the collected artifacts:
+
+```bash
+BUNDLE=$(python3 .map/scripts/map_step_runner.py build_handoff_bundle)
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+VALIDATION=$(echo "$BUNDLE" | jq -r '.validation')
+RISKS=$(echo "$BUNDLE" | jq -r '.risks_follow_up')
+python3 .map/scripts/map_step_runner.py write_pr_draft "$SUMMARY" "$VALIDATION" "$RISKS"
+```
+
+This ensures `pr-draft.md` is built from actual workflow artifacts instead of freeform memory.
+It also means `/map-review` can consume a single consolidated verification handoff instead of re-deriving the branch state from scratch.
+
+Recommended format:
+
+```markdown
+# Verification Summary
+
+- Branch: <branch>
+- Task: <title>
+- Verdict: READY FOR REVIEW | NEEDS WORK
+
+## Checks Run
+- pytest ...
+- ruff ...
+
+## Findings
+- ...
+
+## Next Action
+- ...
+```
 
 Print detailed verification results:
 

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -36,6 +36,18 @@ This is NOT a violation of MAP agent rules. Learning is decoupled into `/map-lea
 
 Both files must stay in sync. The orchestrator updates `step_state.json` on every step; `workflow_state.json` is updated at phase boundaries (INIT_STATE, UPDATE_STATE).
 
+## Human-Readable Workflow Artifacts
+
+In addition to machine-readable state/evidence, maintain these branch-scoped markdown artifacts in `.map/<branch>/`:
+
+- `devlog-001.md` — implementation trail and notable changes across subtasks
+- `session-log.md` — chronological workflow journal for the current branch/session
+- `code-review-001.md`, `code-review-002.md`, ... — Monitor verdicts and required fixes per execution review iteration
+- `qa-001.md` — final verification and command results in human-readable form
+- `pr-draft.md` — evolving PR summary, updated as execution finishes
+
+These files are the cook-inspired handoff layer. Keep them concise and update them during the workflow instead of deferring to a separate command.
+
 ## Architecture Overview
 
 ```text
@@ -100,6 +112,26 @@ fi
 ```
 
 If `resume_from_plan` succeeds, the orchestrator skips DECOMPOSE, INIT_PLAN, REVIEW_PLAN, and CHOOSE_MODE (plan already approved, batch mode auto-set) and starts from INIT_STATE.
+
+Before continuing execution, ensure the branch workspace contains `session-log.md`, `devlog-001.md`, `qa-001.md`, and `pr-draft.md` by running:
+
+```bash
+python3 .map/scripts/map_step_runner.py ensure_human_artifacts
+```
+
+Create numbered execution review artifacts deterministically with:
+
+```bash
+python3 .map/scripts/map_step_runner.py next_numbered_artifact_path code-review
+```
+
+Use `session-log.md` as the high-level journal:
+- append one entry when a subtask starts
+- append one entry after Actor completes
+- append one entry after Monitor verdict
+- append one entry before final verification
+
+Each entry should include timestamp, subtask ID, phase, outcome, and pointers to related artifacts (`code-review-XXX.md`, `devlog-001.md`, `qa-001.md`, evidence files).
 
 ## Step 1: Get Next Step Instruction
 
@@ -447,6 +479,18 @@ Protocol (execute in order):
 **CRITICAL: After Actor returns, do NOT debug or fix issues yourself.**
 - If Actor reports diagnostics/errors — proceed directly to MONITOR.
 - LSP diagnostics shown after Actor may be stale (IDE lag). Do NOT read files or attempt manual fixes.
+
+After Actor finishes, update `.map/<branch>/devlog-001.md` with:
+- subtask ID
+- files changed
+- implementation approach
+- unresolved concerns handed to Monitor
+
+Also append a short entry to `.map/<branch>/session-log.md` via:
+
+```bash
+python3 .map/scripts/map_step_runner.py append_session_log ACTOR implemented <subtask_id> "files changed + approach" "devlog-001.md,.map/<branch>/evidence/actor_<subtask_id>.json"
+```
 - Monitor will verify compilation (`go build`, `pytest`, etc.) and report real issues.
 - If Monitor returns `valid=false`, retry via Actor (not manual edits).
 
@@ -645,6 +689,24 @@ If FAILED: DO NOT PROCEED. Go back and complete missing steps.
 
 Auto-skipped in batch mode (default). The orchestrator proceeds to the next subtask without pausing.
 
+### Monitor Artifact Rule
+
+After EVERY Monitor run, write a new execution review artifact in `.map/<branch>/code-review-XXX.md`.
+
+- First Monitor result for the workflow: `code-review-001.md`
+- Second: `code-review-002.md`
+- Continue incrementing for each validation iteration, including retries
+
+Each review artifact must include:
+- subtask ID
+- verdict (`valid=true/false`)
+- key findings grouped by severity
+- exact fixes required before retry, if any
+
+Do not overwrite the previous review file; keep the loop history visible.
+
+After writing the execution review artifact, append a matching summary line with `append_session_log` so someone resuming the branch can scan the review history without opening every file.
+
 ## Step 2a: Validate Step Completion
 
 After executing step, validate and update state:
@@ -658,6 +720,11 @@ if [ "$PHASE" = "VERIFY_ADHERENCE" ]; then
   python3 .map/scripts/map_step_runner.py update_plan_status "$SUBTASK_ID" "complete"
 fi
 ```
+
+If `PHASE=VERIFY_ADHERENCE` succeeds, also append to `.map/<branch>/devlog-001.md`:
+- subtask completed
+- verification summary
+- tests/lint run for that subtask
 
 ## Step 2b: Continue or Complete (Context Distillation)
 
@@ -678,6 +745,7 @@ else
   # 2. workflow_state.json — current progress + completed subtask IDs
   # 3. task_plan.md       — plan with updated statuses
   # 4. aag_contract       — one-line contract for NEXT subtask only
+  # 5. session-log.md / latest code-review-XXX.md / devlog-001.md — human-readable loop history
   #
   # The fresh invocation reads these files — it never inherits conversation history.
 
@@ -727,6 +795,32 @@ You MUST:
 Write results to .map/{branch}/final_verification.json"""
 )
 ```
+
+After final verifier returns, update `.map/<branch>/qa-001.md` with:
+- commands run
+- pass/fail summary
+- residual risks
+- rollback notes if applicable
+
+Also write `.map/<branch>/verification-summary.md` with a compact final report using:
+
+```bash
+python3 .map/scripts/map_step_runner.py write_verification_summary "READY FOR REVIEW" "<task title>" "- pytest ...,- ruff ..." "- notable findings" "- open PR"
+```
+
+The summary should include:
+- overall verdict
+- key commands executed
+- notable failures or warnings
+- confidence / risk statement
+- recommended next action (review, rework, release)
+
+Also update `.map/<branch>/pr-draft.md` with:
+- concise summary of delivered behavior
+- validation commands/results
+- notable risks or follow-up work
+
+Finally append a closing entry to `.map/<branch>/session-log.md` that points to `qa-001.md`, `verification-summary.md`, and `pr-draft.md`.
 
 ### 3.3 Evaluate Results
 

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -12,6 +12,7 @@
 - Calls task-decomposer agent to break down the user's request into subtasks
 - Creates `.map/<branch>/task_plan_<branch>.md` with subtask list
 - Initializes `.map/<branch>/workflow_state.json` with subtask sequence
+- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`research.md`, `implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
 - **STOPS** after planning (forces context flush)
 
 **What this command CANNOT do:**
@@ -33,6 +34,10 @@ echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "state:       $(test -f .map/${BRANCH}/workflow_state.json && echo EXISTS || echo MISSING)"
+echo "research:    $(test -f .map/${BRANCH}/research.md && echo EXISTS || echo MISSING)"
+echo "impl_plan:   $(test -f .map/${BRANCH}/implementation-plan.md && echo EXISTS || echo MISSING)"
+echo "decisions:   $(test -f .map/${BRANCH}/decision-log.md && echo EXISTS || echo MISSING)"
+echo "pr_draft:    $(test -f .map/${BRANCH}/pr-draft.md && echo EXISTS || echo MISSING)"
 ```
 
 **Resume rules:**
@@ -95,7 +100,7 @@ User request:
 )
 ```
 
-**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to `.map/<branch>/findings_<branch>.md` so they persist across sessions. Include key file paths, patterns found, and risks.
+**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to both `.map/<branch>/findings_<branch>.md` and `.map/<branch>/research.md` so they persist across sessions. `findings_<branch>.md` stays optimized for executor distillation; `research.md` is the human-readable planning note.
 
 **Discovery output format** (in findings file):
 ```markdown
@@ -254,6 +259,57 @@ If interview was skipped (task is well-defined), still write `spec_<branch>.md` 
 - **Out of Scope**: explicitly state what is NOT being changed
 
 This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
+
+### Step 2c: Write Human-Readable Planning Artifacts
+
+After the spec is finalized, maintain these branch-scoped artifacts in `.map/<branch>/`:
+
+- `implementation-plan.md` — concise goals, non-goals, milestones, validation plan
+- `decision-log.md` — high-signal decisions and rationale from interview/spec review
+- `pr-draft.md` — placeholder PR summary that execution will update later
+
+Use the **Write** tool to create or overwrite them with distilled content from the spec and decomposition. Keep them short and useful for a human resuming work.
+
+Recommended structure:
+
+```markdown
+# Implementation Plan
+
+## Goal
+[1 sentence]
+
+## Non-Goals
+- ...
+
+## Planned Steps
+1. ST-001 — ...
+2. ST-002 — ...
+
+## Validation Plan
+- [command or check]
+```
+
+```markdown
+# Decision Log
+
+## Decision 001
+- Decision: ...
+- Rationale: ...
+- Impacted files: ...
+```
+
+```markdown
+# PR Draft
+
+## Summary
+- Planning completed for [goal]
+
+## Planned Validation
+- ...
+
+## Risks
+- ...
+```
 
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
@@ -473,6 +529,8 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ workflow_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
+✅ Human-readable artifacts updated: research.md, implementation-plan.md, decision-log.md, pr-draft.md
+✅ Planning review recorded: plan-review-00N.md + plan-gate.json
 ✅ Context distilled (plan files ≤4000 tokens per subtask)
 
 Next Steps:
@@ -497,6 +555,12 @@ DISTILLATION CHECKLIST:
   [x] workflow_state.json   — has aag_contracts map + subtask_sequence
   [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
+  [x] research.md           — human-readable discovery and context for resume/handoff
+  [x] implementation-plan.md — concise execution roadmap for humans
+  [x] decision-log.md       — key tradeoffs captured before implementation
+  [x] pr-draft.md           — initial summary + validation + risk notes
+  [x] plan-review-00N.md    — staged planning review with carry-forward concerns
+  [x] plan-gate.json        — machine-readable planning verdict (`ready|needs-revision|blocked`)
 
 TARGET: Executor reads ≤4000 tokens of distilled state to start any subtask.
 If plan files exceed this, condense — remove redundant descriptions, keep AAG contracts + criteria.

--- a/src/mapify_cli/templates/commands/map-resume.md
+++ b/src/mapify_cli/templates/commands/map-resume.md
@@ -72,10 +72,11 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 # .map/${BRANCH}/task_plan_${BRANCH}.md — full plan with AAG contracts
 ```
 
-Also query orchestrator plan progress for the canonical resume briefing:
+Also query orchestrator plan progress for the canonical progress payload:
 
 ```bash
 PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
+BRIEF=$(python3 .map/scripts/map_orchestrator.py build_resume_briefing)
 ```
 
 Parse the state and display:
@@ -91,14 +92,14 @@ Parse the state and display:
 
 ### Resume Briefing
 
-- **Suggested next subtask:** [from `suggested_next`]
-- **Latest verification verdict:** [from `resume_briefing.latest_verification_verdict` or "none"]
-- **Latest review artifact:** [from `resume_briefing.latest_review_path` or "none"]
-- **Immediate next action:** [first item from `next_action[]` if present, else "resume current step"]
+- **Suggested next subtask:** [from `PROGRESS.suggested_next`]
+- **Latest verification verdict:** [from `BRIEF.resume_briefing.latest_verification_verdict` or "none"]
+- **Latest review artifact:** [from `BRIEF.resume_briefing.latest_review_path` or "none"]
+- **Immediate next action:** [first item from `BRIEF.next_action[]` if present, else "resume current step"]
 
 ### Requested Fixes / Follow-ups
 
-- [items from `resume_briefing.suggested_fixes[]`, if any]
+- [items from `BRIEF.resume_briefing.suggested_fixes[]`, if any]
 
 ### Recent Session Context
 

--- a/src/mapify_cli/templates/commands/map-resume.md
+++ b/src/mapify_cli/templates/commands/map-resume.md
@@ -61,7 +61,7 @@ No recovery needed.
 
 ## Step 2: Load and Display Progress
 
-Read both state files and the task plan to display progress summary:
+Read both state files, the task plan, and branch artifacts to display a briefing:
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
@@ -70,6 +70,12 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 # .map/${BRANCH}/step_state.json — current orchestrator state
 # .map/${BRANCH}/workflow_state.json — subtask completion status
 # .map/${BRANCH}/task_plan_${BRANCH}.md — full plan with AAG contracts
+```
+
+Also query orchestrator plan progress for the canonical resume briefing:
+
+```bash
+PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
 ```
 
 Parse the state and display:
@@ -82,6 +88,23 @@ Parse the state and display:
 **Current Step:** [current_step from step_state.json]
 **Current Phase:** [phase name from step_state.json]
 **Started:** [started_at from workflow_state.json]
+
+### Resume Briefing
+
+- **Suggested next subtask:** [from `suggested_next`]
+- **Latest verification verdict:** [from `resume_briefing.latest_verification_verdict` or "none"]
+- **Latest review artifact:** [from `resume_briefing.latest_review_path` or "none"]
+- **Immediate next action:** [first item from `next_action[]` if present, else "resume current step"]
+
+### Requested Fixes / Follow-ups
+
+- [items from `resume_briefing.suggested_fixes[]`, if any]
+
+### Recent Session Context
+
+```text
+[recent_session_log excerpt]
+```
 
 ### Progress Overview
 
@@ -137,6 +160,8 @@ Before resuming, read:
 1. `.map/<branch>/step_state.json` — current orchestrator state
 2. `.map/<branch>/workflow_state.json` — subtask completion
 3. `.map/<branch>/task_plan_<branch>.md` — full task decomposition with AAG contracts
+4. `python3 .map/scripts/map_orchestrator.py get_plan_progress` — canonical plan + briefing payload
+5. `.map/<branch>/session-log.md` / `.map/<branch>/verification-summary.md` — extra detail if needed
 
 **Resume via orchestrator:**
 
@@ -156,11 +181,14 @@ For each step, route to the appropriate executor based on `$PHASE` (ACTOR, MONIT
 
 **For each remaining subtask:**
 
-1. **Get next step** from orchestrator
-2. **Execute phase** (Actor → Monitor → Predictor → etc.)
-3. **Validate step** via `map_orchestrator.py validate_step`
-4. **Update state** automatically via orchestrator
-5. **Continue** to next step until workflow complete
+1. **Review the briefing first** to see latest verdict, fixes, and next action
+2. **Get next step** from orchestrator
+3. **Execute phase** (Actor → Monitor → Predictor → etc.)
+4. **Validate step** via `map_orchestrator.py validate_step`
+5. **Update state** automatically via orchestrator
+6. **Continue** to next step until workflow complete
+
+Resume should prioritize the explicit next action from the briefing. Do not improvise a new plan if the artifact trail already indicates the required fix or next subtask.
 
 **If Monitor returns `valid: false`:**
 - Retry Actor with feedback (max 5 iterations, tracked in step_state.json)
@@ -387,6 +415,8 @@ When resuming:
 1. Read `step_state.json` for orchestrator position (current step + subtask)
 2. Read `workflow_state.json` for completed/pending subtask list
 3. Read `task_plan_<branch>.md` for AAG contracts and validation criteria
+4. Read `session-log.md` for latest human-readable iteration history before resuming
+5. If present, read `verification-summary.md` to understand the latest final verdict or remaining issues
 4. Call `map_orchestrator.py get_next_step` to determine next action
 5. Continue phase-based execution from that point
 

--- a/src/mapify_cli/templates/commands/map-review.md
+++ b/src/mapify_cli/templates/commands/map-review.md
@@ -93,6 +93,24 @@ git status
 
 Save the diff output — it will be passed to all 3 agents.
 
+### Step A.1b: Load canonical review handoff
+
+Before launching agents, load the branch-scoped review handoff so review works from accumulated MAP artifacts instead of reconstructing context ad hoc:
+
+```bash
+HANDOFF=$(python3 .map/scripts/map_step_runner.py build_review_handoff)
+```
+
+This handoff should surface, when present:
+- latest `plan-review-00N.md`
+- latest `code-review-00N.md`
+- `verification-summary.md`
+- `qa-001.md`
+- `pr-draft.md`
+- `active-issues.json`
+
+Use these artifacts as the primary reviewer context before relying on raw diff analysis alone.
+
 ### Step A.2: Launch all parallel calls
 
 In **ONE message**, launch all 3 calls in parallel (no dependencies between them):
@@ -280,6 +298,46 @@ Present the verdict with a summary table:
 - Predictor risk assessment
 - Key issues resolved during interactive review
 - Remaining action items
+
+## Handoff Artifact Update
+
+After the final verdict, update branch-scoped handoff artifacts so review output survives beyond the chat:
+
+1. Write or append the most important review findings into the next `code-review-00N.md`
+2. Persist final review gate + active unresolved set:
+
+```bash
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  ready \
+  code-review-001.md \
+  "Final review passed"
+
+python3 .map/scripts/map_step_runner.py ensure_active_issues_file
+python3 .map/scripts/map_step_runner.py replace_active_issues \
+  review \
+  code-review-001.md \
+  "- [remaining reviewer action items, or '(None)']"
+```
+
+Map verdicts to gate values:
+- `PROCEED` -> `ready`
+- `REVISE` -> `needs-revision`
+- `BLOCK` -> `blocked`
+
+2. Rebuild the PR handoff from current artifacts:
+
+```bash
+BUNDLE=$(python3 .map/scripts/map_step_runner.py build_handoff_bundle)
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+VALIDATION=$(echo "$BUNDLE" | jq -r '.validation')
+RISKS=$(echo "$BUNDLE" | jq -r '.risks_follow_up')
+python3 .map/scripts/map_step_runner.py write_pr_draft "$SUMMARY" "$VALIDATION" "$RISKS"
+```
+
+This keeps `pr-draft.md` aligned with the latest review verdict and follow-up work.
+
+`active-issues.json` is the current unresolved set. Historical issues remain in `plan-review-00N.md`, `code-review-00N.md`, `qa-001.md`, and run dossiers under `.map/<branch>/runs/`.
 
 ## CI/Auto Mode Behavior
 

--- a/src/mapify_cli/templates/commands/map-task.md
+++ b/src/mapify_cli/templates/commands/map-task.md
@@ -94,6 +94,16 @@ Route to the appropriate executor based on `$PHASE`. All phases from `/map-effic
 - **LINTER_GATE (2.9)** — Run linter
 - **VERIFY_ADHERENCE (2.10)** — Self-audit
 
+Single-subtask execution must keep using the shared branch workspace artifacts rather than creating task-local side files:
+
+- `session-log.md`
+- `devlog-001.md`
+- `code-review-00N.md`
+- `qa-001.md`
+- `pr-draft.md`
+
+When Monitor runs during `/map-task`, append to the next `code-review-00N.md` so targeted subtask execution stays aligned with the full workflow artifact model.
+
 For each step:
 1. Get next step from orchestrator
 2. Execute the phase (same handlers as map-efficient)

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -279,6 +279,18 @@ Monitor verifies both implementation correctness AND that all tests pass.
 | Token cost | Lower | ~20-30% higher (extra Actor call for tests) |
 | Best for | General development | Correctness-critical features |
 
+## Artifact Model
+
+`/map-tdd` uses the same branch-scoped execution artifacts as `/map-efficient` because it runs through the same orchestrated state machine with extra TDD phases:
+
+- `session-log.md`
+- `devlog-001.md`
+- `code-review-00N.md`
+- `qa-001.md`
+- `pr-draft.md`
+
+In TDD mode, `TEST_WRITER` and `TEST_FAIL_GATE` should append to the same branch workspace instead of creating a separate artifact universe.
+
 ---
 
 ## When NOT to use /map-tdd

--- a/src/mapify_cli/templates/map/scripts/diagnostics.py
+++ b/src/mapify_cli/templates/map/scripts/diagnostics.py
@@ -8,6 +8,7 @@ present and always keep a raw tail excerpt for debugging.
 
 Output:
   .map/<branch>/diagnostics.json
+  .map/<branch>/run-summary.json
 """
 
 from __future__ import annotations
@@ -50,6 +51,98 @@ def get_branch_name() -> str:
 
 def default_output_path(branch: str) -> Path:
     return Path(f".map/{branch}/diagnostics.json")
+
+
+def default_run_summary_path(branch: str) -> Path:
+    return Path(f".map/{branch}/run-summary.json")
+
+
+def default_runs_dir(branch: str) -> Path:
+    return Path(f".map/{branch}/runs")
+
+
+def make_run_dir(branch: str, base_time: str | None = None) -> Path:
+    """Create a unique timestamped run dossier directory."""
+    stamp = base_time or datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    runs_dir = default_runs_dir(branch)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+
+    candidate = runs_dir / stamp
+    if not candidate.exists():
+        candidate.mkdir(parents=True, exist_ok=False)
+        return candidate
+
+    counter = 1
+    while True:
+        alt = runs_dir / f"{stamp}-{counter:02d}"
+        if not alt.exists():
+            alt.mkdir(parents=True, exist_ok=False)
+            return alt
+        counter += 1
+
+
+def write_run_dossier(
+    branch: str,
+    tool: str,
+    command: str,
+    status: str,
+    summary: str,
+    diagnostics_payload: dict[str, Any],
+    accepted_issue_count: int,
+    notes: str = "",
+) -> dict[str, str]:
+    """Write a timestamped run dossier with RESULTS.md and optional NOTES.md."""
+    run_dir = make_run_dir(branch)
+    results_file = run_dir / "RESULTS.md"
+    notes_file = run_dir / "NOTES.md"
+
+    issues = diagnostics_payload.get("issues", [])
+    diagnostics_path = diagnostics_payload.get(
+        "diagnostics_path"
+    ) or diagnostics_payload.get("log_path")
+    issue_lines = "\n".join(
+        f"- `{issue.get('path', '[unknown]')}:{issue.get('line', '?')}` — {issue.get('message', '')}"
+        for issue in issues[:10]
+    )
+    if not issue_lines:
+        issue_lines = "- (None)"
+
+    content = (
+        "# Testing Results\n\n"
+        "## Setup\n"
+        f"- Branch: {branch}\n"
+        f"- Tool: {tool}\n"
+        f"- Command: `{command or '[not recorded]'}`\n\n"
+        "## Summary\n"
+        f"- Status: {status.upper()}\n"
+        f"- Summary: {summary}\n\n"
+        "## Test Matrix\n"
+        "| Check | Result | Notes |\n"
+        "|---|---|---|\n"
+        f"| {tool} | {status.upper()} | {summary} |\n\n"
+        "## Detailed Results\n"
+        f"- Issue count: {len(issues)}\n"
+        f"- Accepted issue count: {accepted_issue_count}\n"
+        f"- Diagnostics source: {diagnostics_path or '[not recorded]'}\n\n"
+        "## Bugs / Blockers Found\n"
+        f"{issue_lines}\n\n"
+        "## Accepted / Deferred Issues\n"
+        + (
+            f"- {accepted_issue_count} accepted/deferred issue(s) recorded in known-issues.json\n"
+            if accepted_issue_count
+            else "- (None)\n"
+        )
+    )
+    results_file.write_text(content, encoding="utf-8")
+
+    if notes.strip():
+        notes_file.write_text(f"# Notes\n\n{notes.strip()}\n", encoding="utf-8")
+
+    return {
+        "run_dir": str(run_dir),
+        "results_path": str(results_file),
+        "notes_path": str(notes_file) if notes.strip() else "",
+    }
 
 
 @dataclass
@@ -128,6 +221,72 @@ def cmd_parse(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_summarize(args: argparse.Namespace) -> int:
+    branch = args.branch or get_branch_name()
+    out_path = Path(args.out) if args.out else default_run_summary_path(branch)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    diagnostics_path = (
+        Path(args.diagnostics) if args.diagnostics else default_output_path(branch)
+    )
+    diagnostics_payload: dict[str, Any] = {}
+    if diagnostics_path.exists():
+        diagnostics_payload = json.loads(
+            diagnostics_path.read_text(encoding="utf-8", errors="replace")
+        )
+
+    known_issues = []
+    if args.known_issues:
+        known_path = Path(args.known_issues)
+        if known_path.exists():
+            known_payload = json.loads(
+                known_path.read_text(encoding="utf-8", errors="replace")
+            )
+            known_issues = known_payload.get("issues", [])
+
+    issues = diagnostics_payload.get("issues", [])
+    status = "passed" if args.exit_code == 0 else "failed"
+    accepted_issue_count = sum(
+        1 for issue in known_issues if issue.get("status") == "accepted"
+    )
+
+    payload = {
+        "updated_at": utc_now(),
+        "branch": branch,
+        "tool": args.tool,
+        "command": args.command,
+        "exit_code": args.exit_code,
+        "status": status,
+        "issue_count": len(issues),
+        "accepted_issue_count": accepted_issue_count,
+        "summary": args.summary
+        or ("No blocking issues" if status == "passed" else "Blocking issues detected"),
+        "diagnostics_path": str(diagnostics_path)
+        if diagnostics_path.exists()
+        else None,
+    }
+
+    dossier = write_run_dossier(
+        branch=branch,
+        tool=args.tool,
+        command=args.command,
+        status=status,
+        summary=payload["summary"],
+        diagnostics_payload={
+            **diagnostics_payload,
+            "diagnostics_path": payload["diagnostics_path"],
+        },
+        accepted_issue_count=accepted_issue_count,
+        notes=args.notes,
+    )
+    payload.update(dossier)
+
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Record parsed diagnostics")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -150,6 +309,22 @@ def main() -> int:
     )
     p_parse.add_argument("--branch", default="", help="Branch override")
     p_parse.set_defaults(func=cmd_parse)
+
+    p_summary = sub.add_parser("summarize", help="Write compact run summary")
+    p_summary.add_argument("--tool", required=True, help="Tool name")
+    p_summary.add_argument("--command", default="", help="Executed command")
+    p_summary.add_argument("--exit-code", type=int, default=0, help="Exit code")
+    p_summary.add_argument("--summary", default="", help="Short human-readable summary")
+    p_summary.add_argument(
+        "--diagnostics",
+        default="",
+        help="Diagnostics JSON path (default: .map/<branch>/diagnostics.json)",
+    )
+    p_summary.add_argument("--known-issues", default="", help="Known issues JSON path")
+    p_summary.add_argument("--notes", default="", help="Optional NOTES.md content")
+    p_summary.add_argument("--out", default="", help="Output path")
+    p_summary.add_argument("--branch", default="", help="Branch override")
+    p_summary.set_defaults(func=cmd_summarize)
 
     args = parser.parse_args()
     return int(args.func(args))

--- a/src/mapify_cli/templates/map/scripts/diagnostics.py
+++ b/src/mapify_cli/templates/map/scripts/diagnostics.py
@@ -89,6 +89,7 @@ def write_run_dossier(
     summary: str,
     diagnostics_payload: dict[str, Any],
     accepted_issue_count: int,
+    deferred_issue_count: int,
     notes: str = "",
 ) -> dict[str, str]:
     """Write a timestamped run dossier with RESULTS.md and optional NOTES.md."""
@@ -108,7 +109,7 @@ def write_run_dossier(
         issue_lines = "- (None)"
 
     content = (
-        "# Testing Results\n\n"
+        "# Run Results\n\n"
         "## Setup\n"
         f"- Branch: {branch}\n"
         f"- Tool: {tool}\n"
@@ -116,20 +117,21 @@ def write_run_dossier(
         "## Summary\n"
         f"- Status: {status.upper()}\n"
         f"- Summary: {summary}\n\n"
-        "## Test Matrix\n"
-        "| Check | Result | Notes |\n"
+        "## Check Matrix\n"
+        "| Tool | Result | Notes |\n"
         "|---|---|---|\n"
         f"| {tool} | {status.upper()} | {summary} |\n\n"
         "## Detailed Results\n"
         f"- Issue count: {len(issues)}\n"
         f"- Accepted issue count: {accepted_issue_count}\n"
+        f"- Deferred issue count: {deferred_issue_count}\n"
         f"- Diagnostics source: {diagnostics_path or '[not recorded]'}\n\n"
         "## Bugs / Blockers Found\n"
         f"{issue_lines}\n\n"
         "## Accepted / Deferred Issues\n"
         + (
-            f"- {accepted_issue_count} accepted/deferred issue(s) recorded in known-issues.json\n"
-            if accepted_issue_count
+            f"- {accepted_issue_count} accepted and {deferred_issue_count} deferred issue(s) recorded in known-issues.json\n"
+            if accepted_issue_count or deferred_issue_count
             else "- (None)\n"
         )
     )
@@ -231,23 +233,32 @@ def cmd_summarize(args: argparse.Namespace) -> int:
     )
     diagnostics_payload: dict[str, Any] = {}
     if diagnostics_path.exists():
-        diagnostics_payload = json.loads(
-            diagnostics_path.read_text(encoding="utf-8", errors="replace")
-        )
+        try:
+            diagnostics_payload = json.loads(
+                diagnostics_path.read_text(encoding="utf-8", errors="replace")
+            )
+        except json.JSONDecodeError:
+            diagnostics_payload = {}
 
     known_issues = []
     if args.known_issues:
         known_path = Path(args.known_issues)
         if known_path.exists():
-            known_payload = json.loads(
-                known_path.read_text(encoding="utf-8", errors="replace")
-            )
-            known_issues = known_payload.get("issues", [])
+            try:
+                known_payload = json.loads(
+                    known_path.read_text(encoding="utf-8", errors="replace")
+                )
+                known_issues = known_payload.get("issues", [])
+            except json.JSONDecodeError:
+                known_issues = []
 
     issues = diagnostics_payload.get("issues", [])
     status = "passed" if args.exit_code == 0 else "failed"
     accepted_issue_count = sum(
         1 for issue in known_issues if issue.get("status") == "accepted"
+    )
+    deferred_issue_count = sum(
+        1 for issue in known_issues if issue.get("status") == "deferred"
     )
 
     payload = {
@@ -277,6 +288,7 @@ def cmd_summarize(args: argparse.Namespace) -> int:
             "diagnostics_path": payload["diagnostics_path"],
         },
         accepted_issue_count=accepted_issue_count,
+        deferred_issue_count=deferred_issue_count,
         notes=args.notes,
     )
     payload.update(dossier)

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -178,6 +178,138 @@ EVIDENCE_REQUIRED = {
 }
 
 
+def _read_text_if_exists(path: Path) -> str:
+    """Return UTF-8 text content for a file when present."""
+    if not path.exists() or not path.is_file():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _extract_recent_markdown_section(content: str, max_lines: int = 12) -> str:
+    """Return the most recent non-empty lines from markdown content."""
+    if not content:
+        return ""
+    lines = [line.rstrip() for line in content.splitlines() if line.strip()]
+    if not lines:
+        return ""
+    return "\n".join(lines[-max_lines:])
+
+
+def _latest_numbered_artifact(plan_dir: Path, prefix: str) -> Optional[Path]:
+    """Return latest numbered artifact like review-003.md."""
+    matches = sorted(plan_dir.glob(f"{prefix}-*.md"))
+    numbered = []
+    for path in matches:
+        stem = path.stem
+        suffix = stem.removeprefix(f"{prefix}-")
+        if suffix.isdigit():
+            numbered.append((int(suffix), path))
+    if not numbered:
+        return None
+    return max(numbered, key=lambda item: item[0])[1]
+
+
+def get_resume_briefing(branch: str) -> Dict:
+    """Collect human-readable artifact context for resume and handoff flows."""
+    plan_dir = Path(f".map/{branch}")
+    session_log = plan_dir / "session-log.md"
+    verification_summary = plan_dir / "verification-summary.md"
+    devlog = plan_dir / "devlog-001.md"
+    latest_review = _latest_numbered_artifact(plan_dir, "review")
+    latest_qa = _latest_numbered_artifact(plan_dir, "qa")
+
+    review_content = _read_text_if_exists(latest_review) if latest_review else ""
+    verification_content = _read_text_if_exists(verification_summary)
+
+    verdict_match = None
+    if verification_content:
+        import re
+
+        verdict_match = re.search(r"- Verdict:\s*(.+)", verification_content)
+
+    fix_lines = []
+    for line in review_content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            fix_lines.append(stripped)
+    fix_lines = fix_lines[:5]
+
+    return {
+        "branch": branch,
+        "session_log_path": str(session_log) if session_log.exists() else None,
+        "verification_summary_path": (
+            str(verification_summary) if verification_summary.exists() else None
+        ),
+        "latest_review_path": str(latest_review) if latest_review else None,
+        "latest_qa_path": str(latest_qa) if latest_qa else None,
+        "devlog_path": str(devlog) if devlog.exists() else None,
+        "latest_verification_verdict": (
+            verdict_match.group(1).strip() if verdict_match else None
+        ),
+        "recent_session_log": _extract_recent_markdown_section(
+            _read_text_if_exists(session_log)
+        ),
+        "latest_review_summary": _extract_recent_markdown_section(review_content),
+        "latest_verification_summary": _extract_recent_markdown_section(
+            verification_content
+        ),
+        "suggested_fixes": fix_lines,
+    }
+
+
+def build_resume_briefing(branch: str) -> Dict:
+    """Build a concise next-action briefing from plan progress and artifacts."""
+    plan_progress = get_plan_progress(branch)
+    briefing = get_resume_briefing(branch)
+
+    suggested_next = None
+    completed_count = 0
+    pending_count = 0
+    current_subtask = None
+    if plan_progress.get("status") == "success":
+        suggested_next = plan_progress.get("suggested_next")
+        completed_count = plan_progress.get("completed_count", 0)
+        pending_count = plan_progress.get("pending_count", 0)
+
+    state_file = Path(f".map/{branch}/step_state.json")
+    if state_file.exists():
+        state = StepState.load(state_file)
+        current_subtask = state.current_subtask_id
+        current_phase = state.current_step_phase
+    else:
+        current_phase = None
+
+    next_action = []
+    if briefing.get("latest_verification_verdict") == "NEEDS WORK":
+        next_action.append(
+            "Address issues from the latest verification before continuing"
+        )
+    if briefing.get("suggested_fixes"):
+        next_action.append("Review requested fixes from latest review artifact")
+    if current_subtask and current_phase:
+        next_action.append(f"Resume {current_subtask} at phase {current_phase}")
+    elif suggested_next:
+        next_action.append(f"Start next pending subtask {suggested_next}")
+    elif pending_count == 0 and completed_count > 0:
+        next_action.append(
+            "Workflow appears complete; review PR and verification artifacts"
+        )
+
+    return {
+        "branch": branch,
+        "current_subtask": current_subtask,
+        "current_phase": current_phase,
+        "completed_count": completed_count,
+        "pending_count": pending_count,
+        "suggested_next": suggested_next,
+        "resume_briefing": briefing,
+        "next_action": next_action,
+    }
+
+
 @dataclass
 class StepState:
     """Workflow step state tracking."""
@@ -745,13 +877,9 @@ def set_tdd_mode(value: str, branch: str) -> Dict:
                 s for s in step_order[pos:] if s not in done_and_skipped
             ]
         else:
-            state.pending_steps = [
-                s for s in step_order if s not in done_and_skipped
-            ]
+            state.pending_steps = [s for s in step_order if s not in done_and_skipped]
     else:
-        state.pending_steps = [
-            s for s in step_order if s not in done_and_skipped
-        ]
+        state.pending_steps = [s for s in step_order if s not in done_and_skipped]
 
     state.save(state_file)
     return {"status": "success", "tdd_mode": state.tdd_mode}
@@ -782,12 +910,17 @@ def set_waves(branch: str, blueprint_path: Optional[str] = None) -> Dict:
 
         dg_candidates = [
             Path("src/mapify_cli/dependency_graph.py"),
-            Path(__file__).resolve().parents[3] / "src" / "mapify_cli" / "dependency_graph.py",
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "mapify_cli"
+            / "dependency_graph.py",
         ]
         loaded = False
         for candidate in dg_candidates:
             if candidate.exists():
-                spec = importlib.util.spec_from_file_location("dependency_graph", candidate)
+                spec = importlib.util.spec_from_file_location(
+                    "dependency_graph", candidate
+                )
                 if spec and spec.loader:
                     mod = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(mod)
@@ -903,11 +1036,13 @@ def get_wave_step(branch: str) -> Dict:
     for st_id in wave:
         phase = state.subtask_phases.get(st_id, default_phase)
         phase_name = STEP_PHASES.get(phase, "ACTOR")
-        subtask_infos.append({
-            "subtask_id": st_id,
-            "phase": phase_name,
-            "step_id": phase,
-        })
+        subtask_infos.append(
+            {
+                "subtask_id": st_id,
+                "phase": phase_name,
+                "step_id": phase,
+            }
+        )
 
     return {
         "mode": mode,
@@ -955,8 +1090,12 @@ def validate_wave_step(subtask_id: str, step_id: str, branch: str) -> Dict:
             }
 
     # Determine next phase for this subtask
-    subtask_step_order = [s for s in _get_step_order(state.tdd_mode) if s.startswith("2.")]
-    current_idx = subtask_step_order.index(step_id) if step_id in subtask_step_order else -1
+    subtask_step_order = [
+        s for s in _get_step_order(state.tdd_mode) if s.startswith("2.")
+    ]
+    current_idx = (
+        subtask_step_order.index(step_id) if step_id in subtask_step_order else -1
+    )
 
     if current_idx >= 0 and current_idx + 1 < len(subtask_step_order):
         next_phase = subtask_step_order[current_idx + 1]
@@ -1192,7 +1331,9 @@ def resume_from_plan(branch: str) -> Dict:
         subtask_index=0,
         subtask_sequence=subtask_ids,
         current_step_id=execution_start[0] if execution_start else "1.6",
-        current_step_phase=STEP_PHASES.get(execution_start[0], "INIT_STATE") if execution_start else "INIT_STATE",
+        current_step_phase=STEP_PHASES.get(execution_start[0], "INIT_STATE")
+        if execution_start
+        else "INIT_STATE",
         completed_steps=skipped_phases,
         pending_steps=execution_start,
         plan_approved=True,
@@ -1204,6 +1345,8 @@ def resume_from_plan(branch: str) -> Dict:
     evidence_dir = plan_dir / "evidence"
     evidence_dir.mkdir(parents=True, exist_ok=True)
 
+    briefing = get_resume_briefing(branch)
+
     return {
         "status": "success",
         "message": "Resumed from /map-plan. Skipped DECOMPOSE, INIT_PLAN, REVIEW_PLAN, CHOOSE_MODE. Mode: batch.",
@@ -1211,6 +1354,7 @@ def resume_from_plan(branch: str) -> Dict:
         "current_subtask_id": subtask_ids[0],
         "aag_contracts_found": len(aag_contracts),
         "next_phase": "INIT_STATE",
+        "resume_briefing": briefing,
     }
 
 
@@ -1255,6 +1399,8 @@ def get_plan_progress(branch: str) -> Dict:
     # Determine suggested next subtask (first pending in plan order)
     suggested_next = pending[0]["id"] if pending else None
 
+    briefing = get_resume_briefing(branch)
+
     return {
         "status": "success",
         "total": len(subtasks),
@@ -1264,6 +1410,7 @@ def get_plan_progress(branch: str) -> Dict:
         "completed": [s["id"] for s in completed],
         "pending": [s["id"] for s in pending],
         "suggested_next": suggested_next,
+        "resume_briefing": briefing,
     }
 
 
@@ -1335,6 +1482,8 @@ def resume_single_subtask(subtask_id: str, branch: str, tdd_mode: bool = False) 
     evidence_dir = plan_dir / "evidence"
     evidence_dir.mkdir(parents=True, exist_ok=True)
 
+    briefing = get_resume_briefing(branch)
+
     return {
         "status": "success",
         "message": (
@@ -1346,6 +1495,7 @@ def resume_single_subtask(subtask_id: str, branch: str, tdd_mode: bool = False) 
         "tdd_mode": tdd_mode,
         "all_subtasks_in_plan": all_subtask_ids,
         "next_phase": "XML_PACKET",
+        "resume_briefing": briefing,
     }
 
 
@@ -1483,7 +1633,9 @@ def main():
             print(json.dumps(result, indent=2))
 
         elif args.command == "set_waves":
-            blueprint_path = args.blueprint or args.task_or_step  # --blueprint or positional
+            blueprint_path = (
+                args.blueprint or args.task_or_step
+            )  # --blueprint or positional
             result = set_waves(branch, blueprint_path)
             print(json.dumps(result, indent=2))
 
@@ -1516,7 +1668,9 @@ def main():
             if not args.task_or_step:
                 print(
                     json.dumps(
-                        {"error": "subtask_id required. Usage: resume_single_subtask ST-001 [--tdd]"}
+                        {
+                            "error": "subtask_id required. Usage: resume_single_subtask ST-001 [--tdd]"
+                        }
                     ),
                     file=sys.stderr,
                 )

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -218,7 +218,7 @@ def get_resume_briefing(branch: str) -> Dict:
     session_log = plan_dir / "session-log.md"
     verification_summary = plan_dir / "verification-summary.md"
     devlog = plan_dir / "devlog-001.md"
-    latest_review = _latest_numbered_artifact(plan_dir, "review")
+    latest_review = _latest_numbered_artifact(plan_dir, "code-review")
     latest_qa = _latest_numbered_artifact(plan_dir, "qa")
 
     review_content = _read_text_if_exists(latest_review) if latest_review else ""

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -402,8 +402,8 @@ def build_review_handoff(branch: Optional[str] = None) -> Dict:
     payload = {
         "status": "success",
         "branch": branch_name,
-        "plan_review_path": latest_plan_review_name,
-        "code_review_path": latest_code_review_name,
+        "plan_review_path": latest_plan_review_name or None,
+        "code_review_path": latest_code_review_name or None,
         "verification_summary_path": "verification-summary.md"
         if (branch_dir / "verification-summary.md").exists()
         else None,
@@ -414,12 +414,16 @@ def build_review_handoff(branch: Optional[str] = None) -> Dict:
         "active_issues_path": "active-issues.json"
         if (branch_dir / "active-issues.json").exists()
         else None,
-        "plan_review": read(latest_plan_review_name) if latest_plan_review_name else "",
-        "code_review": read(latest_code_review_name) if latest_code_review_name else "",
+        "plan_review": read(latest_plan_review_name)
+        if latest_plan_review_name
+        else None,
+        "code_review": read(latest_code_review_name)
+        if latest_code_review_name
+        else None,
         "verification_summary": read("verification-summary.md"),
         "qa": read("qa-001.md"),
         "pr_draft": read("pr-draft.md"),
-        "active_issues": read("active-issues.json"),
+        "active_issues": read("active-issues.json") or None,
     }
     return payload
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -26,10 +26,444 @@ TESTING:
   python3 -c "from map_step_runner import update_workflow_state; \\
     update_workflow_state('ST-001', 'actor', 'ACTOR_CALLED')"
 """
+
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+
+
+HUMAN_ARTIFACT_DEFAULTS = {
+    "session-log.md": "# Session Log\n\n",
+    "devlog-001.md": "# Devlog 001\n\n",
+    "qa-001.md": "# QA 001\n\n",
+    "pr-draft.md": "# PR Draft\n\n## Summary\n\n## Validation\n\n## Risks / Follow-up\n",
+}
+
+
+KNOWN_ISSUES_DEFAULT = {"issues": []}
+ACTIVE_ISSUES_DEFAULT = {"updated_at": "", "issues": []}
+
+GATE_VERDICTS = {"ready", "needs-revision", "blocked"}
+
+
+def get_branch_dir(branch: Optional[str] = None) -> Path:
+    """Return .map/<branch> directory, auto-detecting branch when omitted."""
+    if branch is None:
+        branch = get_branch_name()
+    return Path(f".map/{branch}")
+
+
+def ensure_human_artifacts(branch: Optional[str] = None) -> Dict:
+    """Ensure core human-readable workflow artifacts exist for the branch."""
+    branch_dir = get_branch_dir(branch)
+    branch_dir.mkdir(parents=True, exist_ok=True)
+
+    created = []
+    existing = []
+    for file_name, content in HUMAN_ARTIFACT_DEFAULTS.items():
+        path = branch_dir / file_name
+        if path.exists():
+            existing.append(file_name)
+            continue
+        path.write_text(content, encoding="utf-8")
+        created.append(file_name)
+
+    return {
+        "status": "success",
+        "branch_dir": str(branch_dir),
+        "created": created,
+        "existing": existing,
+    }
+
+
+def next_numbered_artifact_path(
+    prefix: str, branch: Optional[str] = None, extension: str = ".md"
+) -> Dict:
+    """Return the next numbered artifact path like review-002.md."""
+    branch_dir = get_branch_dir(branch)
+    branch_dir.mkdir(parents=True, exist_ok=True)
+
+    pattern = re.compile(rf"^{re.escape(prefix)}-(\d{{3}}){re.escape(extension)}$")
+    next_index = 1
+    for path in branch_dir.iterdir():
+        match = pattern.match(path.name)
+        if match:
+            next_index = max(next_index, int(match.group(1)) + 1)
+
+    file_name = f"{prefix}-{next_index:03d}{extension}"
+    return {
+        "status": "success",
+        "path": str(branch_dir / file_name),
+        "file_name": file_name,
+        "index": next_index,
+    }
+
+
+def append_session_log(
+    phase: str,
+    outcome: str,
+    subtask_id: str = "",
+    details: str = "",
+    artifact_refs: Optional[List[str]] = None,
+    branch: Optional[str] = None,
+) -> Dict:
+    """Append a concise entry to session-log.md."""
+    ensure_human_artifacts(branch)
+    branch_dir = get_branch_dir(branch)
+    log_file = branch_dir / "session-log.md"
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    refs = ", ".join(artifact_refs or [])
+
+    lines = [
+        f"## {timestamp} — {phase}",
+        f"- Outcome: {outcome}",
+    ]
+    if subtask_id:
+        lines.append(f"- Subtask: {subtask_id}")
+    if details:
+        lines.append(f"- Details: {details}")
+    if refs:
+        lines.append(f"- Artifacts: {refs}")
+    lines.append("")
+
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+
+    return {"status": "success", "path": str(log_file)}
+
+
+def write_verification_summary(
+    verdict: str,
+    task_title: str = "",
+    checks_run: str = "",
+    findings: str = "",
+    next_action: str = "",
+    branch: Optional[str] = None,
+) -> Dict:
+    """Write a compact human-readable verification summary."""
+    branch_name = branch or get_branch_name()
+    branch_dir = get_branch_dir(branch_name)
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    summary_file = branch_dir / "verification-summary.md"
+
+    content = (
+        "# Verification Summary\n\n"
+        f"- Branch: {branch_name}\n"
+        f"- Task: {task_title or '[not provided]'}\n"
+        f"- Verdict: {verdict}\n\n"
+        "## Checks Run\n"
+        f"{checks_run or '- [not recorded]'}\n\n"
+        "## Findings\n"
+        f"{findings or '- [not recorded]'}\n\n"
+        "## Next Action\n"
+        f"{next_action or '- [not recorded]'}\n"
+    )
+    summary_file.write_text(content, encoding="utf-8")
+    return {"status": "success", "path": str(summary_file)}
+
+
+def write_pr_draft(
+    summary: str = "",
+    validation: str = "",
+    risks_follow_up: str = "",
+    branch: Optional[str] = None,
+) -> Dict:
+    """Write a compact PR draft artifact for the current branch."""
+    branch_dir = get_branch_dir(branch)
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    pr_file = branch_dir / "pr-draft.md"
+
+    content = (
+        "# PR Draft\n\n"
+        "## Summary\n"
+        f"{summary or '- [not recorded]'}\n\n"
+        "## Validation\n"
+        f"{validation or '- [not recorded]'}\n\n"
+        "## Risks / Follow-up\n"
+        f"{risks_follow_up or '- [not recorded]'}\n"
+    )
+    pr_file.write_text(content, encoding="utf-8")
+    return {"status": "success", "path": str(pr_file)}
+
+
+def write_plan_review(
+    summary: str = "",
+    high: str = "",
+    medium: str = "",
+    low: str = "",
+    resolved_since_previous: str = "",
+    open_concerns: str = "",
+    recommendation: str = "needs-revision",
+    branch: Optional[str] = None,
+) -> Dict:
+    """Write the next staged planning review artifact."""
+    recommendation = recommendation.strip().lower()
+    if recommendation not in GATE_VERDICTS:
+        return {
+            "status": "error",
+            "message": f"Invalid recommendation: {recommendation}",
+        }
+
+    artifact = next_numbered_artifact_path("plan-review", branch)
+    review_file = Path(artifact["path"])
+    review_file.parent.mkdir(parents=True, exist_ok=True)
+    review_number = artifact["index"]
+
+    content = (
+        f"# Plan Review {review_number:03d}\n\n"
+        "## Summary\n"
+        f"{summary or '- [not recorded]'}\n\n"
+        "## High\n"
+        f"{high or '(None)'}\n\n"
+        "## Medium\n"
+        f"{medium or '(None)'}\n\n"
+        "## Low\n"
+        f"{low or '(None)'}\n\n"
+        "## Resolved Since Previous Review\n"
+        f"{resolved_since_previous or '(None)'}\n\n"
+        "## Open Concerns\n"
+        f"{open_concerns or '(None)'}\n\n"
+        "## Recommendation\n"
+        f"- {recommendation}\n"
+    )
+    review_file.write_text(content, encoding="utf-8")
+    return {
+        "status": "success",
+        "path": str(review_file),
+        "file_name": review_file.name,
+        "index": review_number,
+    }
+
+
+def write_stage_gate(
+    stage: str,
+    verdict: str,
+    source_artifact: str = "",
+    notes: str = "",
+    branch: Optional[str] = None,
+) -> Dict:
+    """Write a machine-readable gate artifact for a workflow stage."""
+    verdict = verdict.strip().lower()
+    if verdict not in GATE_VERDICTS:
+        return {"status": "error", "message": f"Invalid verdict: {verdict}"}
+
+    normalized_stage = stage.strip().lower().replace("_", "-")
+    gate_file = get_branch_dir(branch) / f"{normalized_stage}-gate.json"
+    gate_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "stage": normalized_stage,
+        "verdict": verdict,
+        "source_artifact": source_artifact or None,
+        "updated_at": datetime.now().isoformat(),
+        "notes": notes or "",
+    }
+    gate_file.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    return {"status": "success", "path": str(gate_file), "verdict": verdict}
+
+
+def ensure_active_issues_file(branch: Optional[str] = None) -> Dict:
+    """Ensure active-issues.json exists for current unresolved issue set."""
+    branch_dir = get_branch_dir(branch)
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    issues_file = branch_dir / "active-issues.json"
+    if not issues_file.exists():
+        payload = {**ACTIVE_ISSUES_DEFAULT, "updated_at": datetime.now().isoformat()}
+        issues_file.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+        )
+        return {"status": "success", "path": str(issues_file), "created": True}
+    return {"status": "success", "path": str(issues_file), "created": False}
+
+
+def replace_active_issues(
+    stage: str,
+    source_artifact: str,
+    issues_text: str = "",
+    branch: Optional[str] = None,
+) -> Dict:
+    """Replace active unresolved issue set from newline-delimited bullets/text."""
+    ensure_active_issues_file(branch)
+    issues_file = get_branch_dir(branch) / "active-issues.json"
+
+    issue_lines = []
+    for raw in issues_text.splitlines():
+        line = raw.strip()
+        if not line or line in {"(None)", "- (None)"}:
+            continue
+        if line.startswith("- "):
+            line = line[2:].strip()
+        issue_lines.append(line)
+
+    issues = [
+        {
+            "id": f"{stage[:3].upper()}-{index:03d}",
+            "stage": stage,
+            "source_artifact": source_artifact,
+            "status": "open",
+            "summary": line,
+        }
+        for index, line in enumerate(issue_lines, start=1)
+    ]
+    payload = {
+        "updated_at": datetime.now().isoformat(),
+        "issues": issues,
+    }
+    issues_file.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    return {"status": "success", "path": str(issues_file), "count": len(issues)}
+
+
+def build_handoff_bundle(branch: Optional[str] = None) -> Dict:
+    """Build a compact handoff bundle from branch-scoped human artifacts."""
+    branch_name = branch or get_branch_name()
+    branch_dir = get_branch_dir(branch_name)
+    ensure_human_artifacts(branch_name)
+
+    def read(name: str) -> str:
+        path = branch_dir / name
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+
+    session_log = read("session-log.md")
+    verification = read("verification-summary.md")
+    qa = read("qa-001.md")
+    active_issues = read("active-issues.json")
+    verification_gate = read("verification-gate.json")
+    review_path = next_numbered_artifact_path("code-review", branch_name)
+    latest_review_index = max(0, review_path["index"] - 1)
+    latest_review_name = (
+        f"code-review-{latest_review_index:03d}.md" if latest_review_index > 0 else ""
+    )
+    latest_review = read(latest_review_name) if latest_review_name else ""
+
+    summary = []
+    if verification:
+        summary.append("- Verification summary available")
+    if verification_gate:
+        summary.append("- Verification gate recorded")
+    if latest_review:
+        summary.append(f"- Latest review: {latest_review_name}")
+    if session_log:
+        summary.append("- Session log captured")
+    if active_issues:
+        summary.append("- Active unresolved issues tracked")
+
+    validation = []
+    if verification:
+        validation.append(verification.strip())
+    if qa:
+        validation.append(qa.strip())
+    if verification_gate:
+        validation.append(verification_gate.strip())
+
+    risks = []
+    if latest_review:
+        risks.append(latest_review.strip())
+    if active_issues:
+        risks.append(active_issues.strip())
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "summary": "\n".join(summary) or "- [not recorded]",
+        "validation": "\n\n".join(validation) or "- [not recorded]",
+        "risks_follow_up": "\n\n".join(risks) or "- [not recorded]",
+    }
+
+
+def build_review_handoff(branch: Optional[str] = None) -> Dict:
+    """Build final review context from planning, execution, and verification artifacts."""
+    branch_name = branch or get_branch_name()
+    branch_dir = get_branch_dir(branch_name)
+
+    def read(name: str) -> str:
+        path = branch_dir / name
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+
+    plan_review_next = next_numbered_artifact_path("plan-review", branch_name)
+    latest_plan_review_index = max(0, plan_review_next["index"] - 1)
+    latest_plan_review_name = (
+        f"plan-review-{latest_plan_review_index:03d}.md"
+        if latest_plan_review_index > 0
+        else ""
+    )
+    code_review_next = next_numbered_artifact_path("code-review", branch_name)
+    latest_code_review_index = max(0, code_review_next["index"] - 1)
+    latest_code_review_name = (
+        f"code-review-{latest_code_review_index:03d}.md"
+        if latest_code_review_index > 0
+        else ""
+    )
+
+    payload = {
+        "status": "success",
+        "branch": branch_name,
+        "plan_review_path": latest_plan_review_name,
+        "code_review_path": latest_code_review_name,
+        "verification_summary_path": "verification-summary.md"
+        if (branch_dir / "verification-summary.md").exists()
+        else None,
+        "qa_path": "qa-001.md" if (branch_dir / "qa-001.md").exists() else None,
+        "pr_draft_path": "pr-draft.md"
+        if (branch_dir / "pr-draft.md").exists()
+        else None,
+        "active_issues_path": "active-issues.json"
+        if (branch_dir / "active-issues.json").exists()
+        else None,
+        "plan_review": read(latest_plan_review_name) if latest_plan_review_name else "",
+        "code_review": read(latest_code_review_name) if latest_code_review_name else "",
+        "verification_summary": read("verification-summary.md"),
+        "qa": read("qa-001.md"),
+        "pr_draft": read("pr-draft.md"),
+        "active_issues": read("active-issues.json"),
+    }
+    return payload
+
+
+def ensure_known_issues_file(branch: Optional[str] = None) -> Dict:
+    """Ensure known-issues.json exists for accepted blockers / known limitations."""
+    branch_dir = get_branch_dir(branch)
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    issues_file = branch_dir / "known-issues.json"
+    if not issues_file.exists():
+        issues_file.write_text(
+            json.dumps(KNOWN_ISSUES_DEFAULT, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+        return {"status": "success", "path": str(issues_file), "created": True}
+    return {"status": "success", "path": str(issues_file), "created": False}
+
+
+def add_known_issue(
+    title: str,
+    status: str = "accepted",
+    notes: str = "",
+    branch: Optional[str] = None,
+) -> Dict:
+    """Append a known issue / accepted blocker entry."""
+    ensure_known_issues_file(branch)
+    issues_file = get_branch_dir(branch) / "known-issues.json"
+    payload = json.loads(issues_file.read_text(encoding="utf-8"))
+    payload.setdefault("issues", []).append(
+        {
+            "title": title,
+            "status": status,
+            "notes": notes,
+            "recorded_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    )
+    issues_file.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    return {
+        "status": "success",
+        "path": str(issues_file),
+        "count": len(payload["issues"]),
+    }
 
 
 def get_branch_name() -> str:
@@ -450,6 +884,92 @@ if __name__ == "__main__":
     elif func_name == "get_current_phase":
         phase = get_current_phase()
         print(phase or "Phase not found")
+
+    elif func_name == "ensure_human_artifacts":
+        result = ensure_human_artifacts()
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "next_numbered_artifact_path" and len(sys.argv) >= 3:
+        result = next_numbered_artifact_path(sys.argv[2])
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "append_session_log" and len(sys.argv) >= 4:
+        phase = sys.argv[2]
+        outcome = sys.argv[3]
+        subtask_id = sys.argv[4] if len(sys.argv) >= 5 else ""
+        details = sys.argv[5] if len(sys.argv) >= 6 else ""
+        refs = sys.argv[6].split(",") if len(sys.argv) >= 7 and sys.argv[6] else []
+        result = append_session_log(phase, outcome, subtask_id, details, refs)
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "write_verification_summary" and len(sys.argv) >= 3:
+        verdict = sys.argv[2]
+        task_title = sys.argv[3] if len(sys.argv) >= 4 else ""
+        checks_run = sys.argv[4] if len(sys.argv) >= 5 else ""
+        findings = sys.argv[5] if len(sys.argv) >= 6 else ""
+        next_action = sys.argv[6] if len(sys.argv) >= 7 else ""
+        result = write_verification_summary(
+            verdict, task_title, checks_run, findings, next_action
+        )
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "write_pr_draft":
+        summary = sys.argv[2] if len(sys.argv) >= 3 else ""
+        validation = sys.argv[3] if len(sys.argv) >= 4 else ""
+        risks_follow_up = sys.argv[4] if len(sys.argv) >= 5 else ""
+        result = write_pr_draft(summary, validation, risks_follow_up)
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "write_plan_review":
+        summary = sys.argv[2] if len(sys.argv) >= 3 else ""
+        high = sys.argv[3] if len(sys.argv) >= 4 else ""
+        medium = sys.argv[4] if len(sys.argv) >= 5 else ""
+        low = sys.argv[5] if len(sys.argv) >= 6 else ""
+        resolved = sys.argv[6] if len(sys.argv) >= 7 else ""
+        open_concerns = sys.argv[7] if len(sys.argv) >= 8 else ""
+        recommendation = sys.argv[8] if len(sys.argv) >= 9 else "needs-revision"
+        result = write_plan_review(
+            summary, high, medium, low, resolved, open_concerns, recommendation
+        )
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "write_stage_gate" and len(sys.argv) >= 4:
+        stage = sys.argv[2]
+        verdict = sys.argv[3]
+        source_artifact = sys.argv[4] if len(sys.argv) >= 5 else ""
+        notes = sys.argv[5] if len(sys.argv) >= 6 else ""
+        result = write_stage_gate(stage, verdict, source_artifact, notes)
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "build_handoff_bundle":
+        result = build_handoff_bundle()
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "build_review_handoff":
+        result = build_review_handoff()
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "ensure_known_issues_file":
+        result = ensure_known_issues_file()
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "ensure_active_issues_file":
+        result = ensure_active_issues_file()
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "replace_active_issues" and len(sys.argv) >= 4:
+        stage = sys.argv[2]
+        source_artifact = sys.argv[3]
+        issues_text = sys.argv[4] if len(sys.argv) >= 5 else ""
+        result = replace_active_issues(stage, source_artifact, issues_text)
+        print(json.dumps(result, indent=2))
+
+    elif func_name == "add_known_issue" and len(sys.argv) >= 3:
+        title = sys.argv[2]
+        status = sys.argv[3] if len(sys.argv) >= 4 else "accepted"
+        notes = sys.argv[4] if len(sys.argv) >= 5 else ""
+        result = add_known_issue(title, status, notes)
+        print(json.dumps(result, indent=2))
 
     else:
         print(f"Unknown function: {func_name}")

--- a/src/mapify_cli/templates/skills/map-workflows-guide/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-workflows-guide/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # MAP Workflows Guide
 
-This skill helps you choose the optimal MAP workflow for your development tasks. MAP Framework provides **10 workflow commands**: 4 primary workflows (`/map-fast`, `/map-efficient`, `/map-debug`, `/map-debate`) and 6 supporting commands (`/map-review`, `/map-check`, `/map-plan`, `/map-release`, `/map-resume`, `/map-learn`). Each is optimized for different scenarios with varying token costs, learning capabilities, and quality gates. Two additional workflows (`/map-feature`, `/map-refactor`) are planned but not yet implemented.
+This skill helps you choose the optimal MAP workflow for your development tasks. MAP Framework provides **12 workflow commands**: 4 primary workflows (`/map-fast`, `/map-efficient`, `/map-debug`, `/map-debate`) and 8 supporting commands (`/map-review`, `/map-check`, `/map-plan`, `/map-task`, `/map-tdd`, `/map-release`, `/map-resume`, `/map-learn`). Each is optimized for different scenarios with varying token costs, learning capabilities, and quality gates. Two additional workflows (`/map-feature`, `/map-refactor`) are planned but not yet implemented.
 
 ## Quick Decision Tree
 
@@ -216,7 +216,7 @@ Intended for refactoring with dependency-focused impact analysis and breaking ch
 
 ## Understanding MAP Agents
 
-MAP workflows orchestrate **12 specialized agents**, each with specific responsibilities:
+MAP workflows orchestrate **11 specialized agents**, each with specific responsibilities:
 
 ### Execution & Validation Agents
 

--- a/tests/test_command_templates.py
+++ b/tests/test_command_templates.py
@@ -8,6 +8,7 @@ Note: .claude/commands/ is gitignored (generated via mapify init), so tests
 only validate src/mapify_cli/templates/commands/ which is the source of truth.
 """
 
+import json
 import pytest
 from pathlib import Path
 
@@ -34,9 +35,9 @@ class TestCommandTemplates:
     def test_map_efficient_exists_in_templates(self, templates_commands_dir):
         """Test that map-efficient.md exists in templates/commands/."""
         map_efficient = templates_commands_dir / "map-efficient.md"
-        assert (
-            map_efficient.exists()
-        ), f"map-efficient.md not found in {templates_commands_dir}"
+        assert map_efficient.exists(), (
+            f"map-efficient.md not found in {templates_commands_dir}"
+        )
         assert map_efficient.is_file(), "map-efficient.md should be a file"
 
     def test_map_fast_has_frontmatter(self, templates_commands_dir):
@@ -45,9 +46,9 @@ class TestCommandTemplates:
         content = map_fast.read_text()
 
         assert content.startswith("---"), "map-fast.md should start with frontmatter"
-        assert (
-            "description:" in content[:200]
-        ), "Frontmatter should contain description field"
+        assert "description:" in content[:200], (
+            "Frontmatter should contain description field"
+        )
         assert content.split("---")[1].strip(), "Frontmatter should not be empty"
 
     def test_map_efficient_has_frontmatter(self, templates_commands_dir):
@@ -55,12 +56,12 @@ class TestCommandTemplates:
         map_efficient = templates_commands_dir / "map-efficient.md"
         content = map_efficient.read_text()
 
-        assert content.startswith(
-            "---"
-        ), "map-efficient.md should start with frontmatter"
-        assert (
-            "description:" in content[:200]
-        ), "Frontmatter should contain description field"
+        assert content.startswith("---"), (
+            "map-efficient.md should start with frontmatter"
+        )
+        assert "description:" in content[:200], (
+            "Frontmatter should contain description field"
+        )
         assert content.split("---")[1].strip(), "Frontmatter should not be empty"
 
     def test_map_fast_contains_warning(self, templates_commands_dir):
@@ -69,15 +70,15 @@ class TestCommandTemplates:
         content = map_fast.read_text()
 
         # Check for warning markers
-        assert (
-            "⚠️" in content or "WARNING" in content
-        ), "map-fast.md should contain warning indicators"
-        assert (
-            "low-risk" in content.lower() or "low risk" in content.lower()
-        ), "map-fast.md should indicate low-risk use only"
-        assert (
-            "NO learning" in content or "no learning" in content
-        ), "Should mention no learning"
+        assert "⚠️" in content or "WARNING" in content, (
+            "map-fast.md should contain warning indicators"
+        )
+        assert "low-risk" in content.lower() or "low risk" in content.lower(), (
+            "map-fast.md should indicate low-risk use only"
+        )
+        assert "NO learning" in content or "no learning" in content, (
+            "Should mention no learning"
+        )
 
     def test_map_efficient_suggests_map_learn(self, templates_commands_dir):
         """Test that map-efficient.md suggests optional /map-learn for learning."""
@@ -90,7 +91,7 @@ class TestCommandTemplates:
         assert "optional" in content.lower(), "Should mention /map-learn is optional"
 
     def test_all_command_templates_exist(self, templates_commands_dir):
-        """Test that all 10 expected command template files exist."""
+        """Test that all 12 expected command template files exist."""
         expected_commands = [
             "map-check.md",  # Quality gates
             "map-debate.md",  # Multi-variant with Opus arbiter
@@ -102,13 +103,67 @@ class TestCommandTemplates:
             "map-release.md",  # Release workflow
             "map-resume.md",  # Resume interrupted workflow
             "map-review.md",  # Code review
+            "map-task.md",  # Single subtask execution
+            "map-tdd.md",  # Test-first implementation
         ]
 
         for command in expected_commands:
             command_path = templates_commands_dir / command
-            assert (
-                command_path.exists()
-            ), f"Expected command template {command} not found in {templates_commands_dir}"
+            assert command_path.exists(), (
+                f"Expected command template {command} not found in {templates_commands_dir}"
+            )
+
+        actual_commands = sorted(
+            path.name for path in templates_commands_dir.glob("map-*.md")
+        )
+        assert sorted(expected_commands) == actual_commands
+
+    def test_readme_lists_all_shipped_slash_commands(
+        self, project_root, templates_commands_dir
+    ):
+        """README command table should mention every shipped slash command."""
+        readme = (project_root / "README.md").read_text(encoding="utf-8")
+        commands = [path.stem for path in templates_commands_dir.glob("map-*.md")]
+
+        for command in commands:
+            assert f"`/{command}`" in readme, f"README missing /{command}"
+
+    def test_readme_mentions_canonical_flows(self, project_root):
+        """README should document the standard and TDD canonical flows."""
+        readme = (project_root / "README.md").read_text(encoding="utf-8")
+
+        assert (
+            "/map-plan` -> `/map-efficient` -> `/map-check` -> `/map-review" in readme
+        )
+        assert "/map-plan` -> `/map-tdd` -> `/map-check` -> `/map-review" in readme
+
+    def test_usage_mentions_targeted_subtask_tdd_flow(self, project_root):
+        """Usage guide should document the targeted subtask TDD flow."""
+        content = (project_root / "docs" / "USAGE.md").read_text(encoding="utf-8")
+
+        assert "/map-tdd ST-001" in content
+        assert "/map-task ST-001" in content
+
+    def test_cli_reference_json_matches_root_commands(self, project_root):
+        """Machine-readable CLI reference should match root CLI commands."""
+        reference = json.loads(
+            (project_root / "docs" / "CLI_REFERENCE.json").read_text(encoding="utf-8")
+        )
+        root_commands = set(reference["commands"]["root"]["commands"].keys())
+        assert root_commands == {"init", "check", "doctor", "upgrade"}
+
+    def test_cli_reference_markdown_mentions_all_root_commands(self, project_root):
+        """Human-readable CLI reference should stay aligned with root commands."""
+        content = (project_root / "docs" / "CLI_COMMAND_REFERENCE.md").read_text(
+            encoding="utf-8"
+        )
+        for command in [
+            "mapify init",
+            "mapify check",
+            "mapify doctor",
+            "mapify upgrade",
+        ]:
+            assert command in content
 
     def test_map_fast_workflow_structure(self, templates_commands_dir):
         """Test that map-fast.md has correct workflow structure (minimal agents)."""
@@ -122,9 +177,9 @@ class TestCommandTemplates:
 
         # Check that Reflector is mentioned as SKIPPED
         assert "reflector" in content.lower(), "Should mention Reflector (as skipped)"
-        assert (
-            "skipped" in content.lower() or "no learning" in content.lower()
-        ), "Should indicate learning is skipped"
+        assert "skipped" in content.lower() or "no learning" in content.lower(), (
+            "Should indicate learning is skipped"
+        )
 
     def test_map_efficient_workflow_structure(self, templates_commands_dir):
         """Test that map-efficient.md has correct workflow structure (optional learning)."""
@@ -161,9 +216,102 @@ class TestCommandTemplates:
         content = map_efficient.read_text()
 
         # Should describe itself as token-efficient in description
-        assert (
-            "token-efficient" in content.lower() or "efficient" in content.lower()
-        ), "Should describe itself as efficient"
+        assert "token-efficient" in content.lower() or "efficient" in content.lower(), (
+            "Should describe itself as efficient"
+        )
+
+    def test_map_plan_writes_human_artifacts(self, templates_commands_dir):
+        """/map-plan should maintain branch-scoped human-readable artifacts."""
+        content = (templates_commands_dir / "map-plan.md").read_text()
+
+        assert "research.md" in content
+        assert "implementation-plan.md" in content
+        assert "decision-log.md" in content
+        assert "pr-draft.md" in content
+        assert "plan-review-00N.md" in content
+        assert "plan-gate.json" in content
+
+    def test_map_efficient_tracks_review_loop_artifacts(self, templates_commands_dir):
+        """/map-efficient should preserve review/devlog/qa artifacts in branch workspace."""
+        content = (templates_commands_dir / "map-efficient.md").read_text()
+
+        assert "devlog-001.md" in content
+        assert "session-log.md" in content
+        assert "code-review-001.md" in content
+        assert "qa-001.md" in content
+        assert "code-review-XXX.md" in content
+
+    def test_map_tdd_uses_shared_execution_artifacts(self, templates_commands_dir):
+        """/map-tdd should reuse the same branch-scoped artifact model as map-efficient."""
+        content = (templates_commands_dir / "map-tdd.md").read_text()
+
+        assert "code-review-00N.md" in content
+        assert "session-log.md" in content
+        assert "pr-draft.md" in content
+
+    def test_map_task_uses_shared_execution_artifacts(self, templates_commands_dir):
+        """/map-task should keep using shared branch execution artifacts."""
+        content = (templates_commands_dir / "map-task.md").read_text()
+
+        assert "code-review-00N.md" in content
+        assert "session-log.md" in content
+        assert "qa-001.md" in content
+
+    def test_map_check_writes_verification_summary(self, templates_commands_dir):
+        """/map-check should produce a human-readable verification summary artifact."""
+        content = (templates_commands_dir / "map-check.md").read_text()
+
+        assert "verification-summary.md" in content
+        assert "READY FOR REVIEW" in content
+        assert "NEEDS WORK" in content
+
+    def test_map_resume_reads_human_artifact_history(self, templates_commands_dir):
+        """/map-resume should use session and verification artifacts for handoff."""
+        content = (templates_commands_dir / "map-resume.md").read_text()
+
+        assert "session-log.md" in content
+        assert "verification-summary.md" in content
+
+    def test_map_check_rebuilds_pr_draft_from_handoff_bundle(
+        self, templates_commands_dir
+    ):
+        """/map-check should rebuild PR draft from deterministic artifact bundle."""
+        content = (templates_commands_dir / "map-check.md").read_text()
+
+        assert "build_handoff_bundle" in content
+        assert "write_pr_draft" in content
+
+    def test_map_review_refreshes_pr_draft(self, templates_commands_dir):
+        """/map-review should refresh PR handoff after review verdict."""
+        content = (templates_commands_dir / "map-review.md").read_text()
+
+        assert "build_handoff_bundle" in content
+        assert "pr-draft.md" in content
+        assert "code-review-00N.md" in content
+        assert "write_stage_gate" in content
+        assert "build_review_handoff" in content
+        assert "active-issues.json" in content
+
+    def test_map_resume_is_briefing_oriented(self, templates_commands_dir):
+        """/map-resume should surface resume briefing and next action guidance."""
+        content = (templates_commands_dir / "map-resume.md").read_text()
+
+        assert "Resume Briefing" in content
+        assert "Immediate next action" in content
+        assert "Do not improvise a new plan" in content
+
+    def test_map_check_records_run_summaries_and_known_issues(
+        self, templates_commands_dir
+    ):
+        """/map-check should mention run summaries and known issues accounting."""
+        content = (templates_commands_dir / "map-check.md").read_text()
+
+        assert "diagnostics.py summarize" in content
+        assert "known-issues.json" in content
+        assert "add_known_issue" in content
+        assert "runs/<timestamp>/RESULTS.md" in content
+        assert "write_stage_gate" in content
+        assert "replace_active_issues" in content
 
 
 class TestMapReviewStructure:
@@ -220,9 +368,9 @@ class TestMapReviewStructure:
         # Find the section and check the source is mentioned nearby
         idx = review_content.index(section)
         section_block = review_content[idx : idx + 500]
-        assert (
-            source in section_block
-        ), f"{section} should reference {source} as primary source"
+        assert source in section_block, (
+            f"{section} should reference {source} as primary source"
+        )
 
     def test_three_agent_task_calls(self, review_content):
         """Command includes Task calls for all 3 agents."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,83 @@
+"""Tests for diagnostics run summaries."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "mapify_cli"
+    / "templates"
+    / "map"
+    / "scripts"
+)
+
+sys.path.insert(0, str(SCRIPTS_PATH))
+
+import diagnostics  # noqa: E402
+
+
+@pytest.fixture
+def branch_workspace(tmp_path, monkeypatch):
+    branch = "test-branch"
+    workspace = tmp_path / ".map" / branch
+    workspace.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(diagnostics, "get_branch_name", lambda: branch)
+    return workspace
+
+
+def test_cmd_summarize_writes_run_summary(branch_workspace):
+    diagnostics_file = branch_workspace / "diagnostics.json"
+    diagnostics_file.write_text(
+        json.dumps({"issues": [{"path": "app.py", "line": 10, "message": "boom"}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    known_issues_file = branch_workspace / "known-issues.json"
+    known_issues_file.write_text(
+        json.dumps({"issues": [{"title": "Flaky test", "status": "accepted"}]}) + "\n",
+        encoding="utf-8",
+    )
+
+    args = type(
+        "Args",
+        (),
+        {
+            "branch": "",
+            "out": "",
+            "diagnostics": str(diagnostics_file),
+            "known_issues": str(known_issues_file),
+            "tool": "tests",
+            "command": "pytest",
+            "exit_code": 1,
+            "summary": "Pytest failed",
+            "notes": "Observed flaky timing in integration setup",
+        },
+    )()
+
+    result = diagnostics.cmd_summarize(args)
+    assert result == 0
+
+    payload = json.loads(
+        (branch_workspace / "run-summary.json").read_text(encoding="utf-8")
+    )
+    assert payload["tool"] == "tests"
+    assert payload["status"] == "failed"
+    assert payload["issue_count"] == 1
+    assert payload["accepted_issue_count"] == 1
+    assert payload["run_dir"].endswith(
+        ".map/test-branch/runs/" + Path(payload["run_dir"]).name
+    )
+    results_path = Path(payload["results_path"])
+    assert results_path.exists()
+    assert results_path.name == "RESULTS.md"
+    results = results_path.read_text(encoding="utf-8")
+    assert "Testing Results" in results
+    assert "Pytest failed" in results
+    notes_path = Path(payload["notes_path"])
+    assert notes_path.exists()
+    assert "Observed flaky timing" in notes_path.read_text(encoding="utf-8")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -39,7 +39,15 @@ def test_cmd_summarize_writes_run_summary(branch_workspace):
     )
     known_issues_file = branch_workspace / "known-issues.json"
     known_issues_file.write_text(
-        json.dumps({"issues": [{"title": "Flaky test", "status": "accepted"}]}) + "\n",
+        json.dumps(
+            {
+                "issues": [
+                    {"title": "Flaky test", "status": "accepted"},
+                    {"title": "Manual repro pending", "status": "deferred"},
+                ]
+            }
+        )
+        + "\n",
         encoding="utf-8",
     )
 
@@ -76,8 +84,41 @@ def test_cmd_summarize_writes_run_summary(branch_workspace):
     assert results_path.exists()
     assert results_path.name == "RESULTS.md"
     results = results_path.read_text(encoding="utf-8")
-    assert "Testing Results" in results
+    assert "Run Results" in results
+    assert "Deferred issue count: 1" in results
     assert "Pytest failed" in results
     notes_path = Path(payload["notes_path"])
     assert notes_path.exists()
     assert "Observed flaky timing" in notes_path.read_text(encoding="utf-8")
+
+
+def test_cmd_summarize_handles_invalid_json_gracefully(branch_workspace):
+    diagnostics_file = branch_workspace / "diagnostics.json"
+    diagnostics_file.write_text("{invalid json\n", encoding="utf-8")
+    known_issues_file = branch_workspace / "known-issues.json"
+    known_issues_file.write_text("{invalid json\n", encoding="utf-8")
+
+    args = type(
+        "Args",
+        (),
+        {
+            "branch": "",
+            "out": "",
+            "diagnostics": str(diagnostics_file),
+            "known_issues": str(known_issues_file),
+            "tool": "lint",
+            "command": "ruff check .",
+            "exit_code": 0,
+            "summary": "Lint passed",
+            "notes": "",
+        },
+    )()
+
+    result = diagnostics.cmd_summarize(args)
+    assert result == 0
+
+    payload = json.loads(
+        (branch_workspace / "run-summary.json").read_text(encoding="utf-8")
+    )
+    assert payload["status"] == "passed"
+    assert payload["issue_count"] == 0

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -193,9 +193,7 @@ class TestGetWaveStep:
         assert result["is_complete"] is True
         assert result["mode"] == "sequential"
 
-    def test_tdd_mode_default_phase_is_test_writer(
-        self, branch_dir, sample_blueprint
-    ):
+    def test_tdd_mode_default_phase_is_test_writer(self, branch_dir, sample_blueprint):
         """In TDD mode, wave subtasks default to TEST_WRITER (2.25) not ACTOR."""
         map_orchestrator.set_waves(branch_dir, sample_blueprint)
         state_file = Path(f".map/{branch_dir}/step_state.json")
@@ -393,8 +391,22 @@ class TestTDDMode:
         """Enabling TDD mode doesn't re-add already completed steps."""
         state = map_orchestrator.StepState()
         state.completed_steps = ["1.0", "1.5"]
-        state.pending_steps = ["1.55", "1.56", "1.6", "2.0", "2.1", "2.2", "2.3",
-                               "2.4", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11"]
+        state.pending_steps = [
+            "1.55",
+            "1.56",
+            "1.6",
+            "2.0",
+            "2.1",
+            "2.2",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         map_orchestrator.set_tdd_mode("true", branch_dir)
@@ -423,8 +435,18 @@ class TestTDDMode:
         state.current_subtask_id = "ST-001"
         state.current_step_id = "2.2"
         state.current_step_phase = "AAG_CONTRACT"
-        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
-                               "2.8", "2.9", "2.10", "2.11"]
+        state.pending_steps = [
+            "2.25",
+            "2.26",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         result = map_orchestrator.get_next_step(branch_dir)
@@ -439,8 +461,18 @@ class TestTDDMode:
         state.current_subtask_id = "ST-001"
         state.current_step_id = "2.2"
         state.current_step_phase = "AAG_CONTRACT"
-        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
-                               "2.8", "2.9", "2.10", "2.11"]
+        state.pending_steps = [
+            "2.25",
+            "2.26",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         result = map_orchestrator.get_next_step(branch_dir)
@@ -520,7 +552,9 @@ class TestTDDMode:
 
     def test_tdd_step_order_has_more_steps(self):
         """TDD_STEP_ORDER has exactly 2 more steps than STEP_ORDER."""
-        assert len(map_orchestrator.TDD_STEP_ORDER) == len(map_orchestrator.STEP_ORDER) + 2
+        assert (
+            len(map_orchestrator.TDD_STEP_ORDER) == len(map_orchestrator.STEP_ORDER) + 2
+        )
 
     def test_set_tdd_mode_accepts_various_falsy_values(self, branch_dir):
         """set_tdd_mode accepts 'no', 'n', '0', 'false' as falsy."""
@@ -536,10 +570,17 @@ class TestTDDMode:
         state = map_orchestrator.StepState()
         state.subtask_sequence = ["ST-001"]
         state.current_subtask_id = "ST-001"
-        state.completed_steps = ["1.0", "1.5", "1.55", "1.56", "1.6",
-                                 "2.0", "2.1", "2.2"]
-        state.pending_steps = ["2.3", "2.4", "2.6", "2.7", "2.8",
-                               "2.9", "2.10", "2.11"]
+        state.completed_steps = [
+            "1.0",
+            "1.5",
+            "1.55",
+            "1.56",
+            "1.6",
+            "2.0",
+            "2.1",
+            "2.2",
+        ]
+        state.pending_steps = ["2.3", "2.4", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11"]
         state.current_step_id = "2.2"
         state.current_step_phase = "RESEARCH"
         state.save(Path(f".map/{branch_dir}/step_state.json"))
@@ -555,8 +596,18 @@ class TestTDDMode:
         state.tdd_mode = True
         state.current_step_id = "2.25"
         state.current_step_phase = "TEST_WRITER"
-        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
-                               "2.8", "2.9", "2.10", "2.11"]
+        state.pending_steps = [
+            "2.25",
+            "2.26",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         result = map_orchestrator.skip_step("2.25", branch_dir)
@@ -574,8 +625,18 @@ class TestTDDMode:
         state.tdd_mode = False
         state.subtask_sequence = ["ST-001"]
         state.current_subtask_id = "ST-001"
-        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
-                               "2.8", "2.9", "2.10", "2.11"]
+        state.pending_steps = [
+            "2.25",
+            "2.26",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         map_orchestrator.get_next_step(branch_dir)
@@ -594,10 +655,28 @@ class TestTDDMode:
         state.tdd_mode = True
         state.subtask_sequence = ["ST-001"]
         state.current_subtask_id = "ST-001"
-        state.completed_steps = ["1.0", "1.5", "1.55", "1.56", "1.6",
-                                 "2.0", "2.1", "2.2"]
-        state.pending_steps = ["2.25", "2.26", "2.3", "2.4", "2.6", "2.7",
-                               "2.8", "2.9", "2.10", "2.11"]
+        state.completed_steps = [
+            "1.0",
+            "1.5",
+            "1.55",
+            "1.56",
+            "1.6",
+            "2.0",
+            "2.1",
+            "2.2",
+        ]
+        state.pending_steps = [
+            "2.25",
+            "2.26",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         # Disable TDD
@@ -622,8 +701,19 @@ class TestTDDMode:
         state.subtask_index = 1
         state.current_subtask_id = "ST-002"
         state.completed_steps = []  # Reset after subtask transition
-        state.pending_steps = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.6",
-                               "2.7", "2.8", "2.9", "2.10", "2.11"]
+        state.pending_steps = [
+            "2.0",
+            "2.1",
+            "2.2",
+            "2.3",
+            "2.4",
+            "2.6",
+            "2.7",
+            "2.8",
+            "2.9",
+            "2.10",
+            "2.11",
+        ]
         state.save(Path(f".map/{branch_dir}/step_state.json"))
 
         map_orchestrator.set_tdd_mode("true", branch_dir)
@@ -647,7 +737,9 @@ class TestTDDMode:
         loaded = map_orchestrator.StepState.load(state_file)
         assert loaded.skipped_steps == ["2.25", "2.26"]
 
-    def test_validate_wave_step_missing_evidence_dir(self, branch_dir, sample_blueprint):
+    def test_validate_wave_step_missing_evidence_dir(
+        self, branch_dir, sample_blueprint
+    ):
         """validate_wave_step returns error when evidence directory is missing."""
         result = map_orchestrator.set_waves(branch_dir, sample_blueprint)
         assert result["status"] == "success"
@@ -658,6 +750,7 @@ class TestTDDMode:
         evidence_dir = Path(f".map/{branch_dir}/evidence")
         if evidence_dir.exists():
             import shutil
+
             shutil.rmtree(evidence_dir)
         state.save(state_file)
 
@@ -701,7 +794,9 @@ class TestResumeSingleSubtask:
     def test_resume_single_subtask_with_tdd(self, branch_dir, tmp_path):
         """TDD mode adds TEST_WRITER and TEST_FAIL_GATE to pending steps."""
         self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002"])
-        result = map_orchestrator.resume_single_subtask("ST-001", branch_dir, tdd_mode=True)
+        result = map_orchestrator.resume_single_subtask(
+            "ST-001", branch_dir, tdd_mode=True
+        )
         assert result["status"] == "success"
         assert result["tdd_mode"] is True
 
@@ -729,6 +824,7 @@ class TestResumeSingleSubtask:
         """Evidence directory is created automatically."""
         # Remove the evidence dir created by fixture
         import shutil
+
         evidence_dir = tmp_path / ".map" / branch_dir / "evidence"
         if evidence_dir.exists():
             shutil.rmtree(evidence_dir)
@@ -751,6 +847,32 @@ class TestResumeSingleSubtask:
         assert result["phase"] == "XML_PACKET"
         assert result["current_subtask"] == "ST-002"
 
+    def test_resume_single_subtask_includes_human_artifact_briefing(
+        self, branch_dir, tmp_path
+    ):
+        """Resume returns session/review/verification context for handoff."""
+        plan_dir = self._create_plan(tmp_path, branch_dir, ["ST-001", "ST-002"])
+        (plan_dir / "session-log.md").write_text(
+            "# Session Log\n\n## 2026-03-19 — MONITOR\n- Outcome: revise\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "review-002.md").write_text(
+            "# Review 002\n\n- fix auth edge case\n- rerun pytest\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "verification-summary.md").write_text(
+            "# Verification Summary\n\n- Verdict: NEEDS WORK\n",
+            encoding="utf-8",
+        )
+
+        result = map_orchestrator.resume_single_subtask("ST-001", branch_dir)
+
+        briefing = result["resume_briefing"]
+        assert briefing["latest_review_path"].endswith("review-002.md")
+        assert briefing["latest_verification_verdict"] == "NEEDS WORK"
+        assert "MONITOR" in briefing["recent_session_log"]
+        assert "fix auth edge case" in "\n".join(briefing["suggested_fixes"])
+
 
 class TestGetPlanProgress:
     """Tests for get_plan_progress — plan status overview."""
@@ -767,7 +889,8 @@ class TestGetPlanProgress:
     def test_all_pending(self, branch_dir, tmp_path):
         """All subtasks pending — suggested_next is first one."""
         self._create_plan_with_statuses(
-            tmp_path, branch_dir,
+            tmp_path,
+            branch_dir,
             [("ST-001", "pending"), ("ST-002", "pending"), ("ST-003", "pending")],
         )
         result = map_orchestrator.get_plan_progress(branch_dir)
@@ -780,7 +903,8 @@ class TestGetPlanProgress:
     def test_some_complete(self, branch_dir, tmp_path):
         """Mix of complete and pending — suggested_next skips completed."""
         self._create_plan_with_statuses(
-            tmp_path, branch_dir,
+            tmp_path,
+            branch_dir,
             [("ST-001", "complete"), ("ST-002", "complete"), ("ST-003", "pending")],
         )
         result = map_orchestrator.get_plan_progress(branch_dir)
@@ -793,7 +917,8 @@ class TestGetPlanProgress:
     def test_all_complete(self, branch_dir, tmp_path):
         """All subtasks complete — suggested_next is None."""
         self._create_plan_with_statuses(
-            tmp_path, branch_dir,
+            tmp_path,
+            branch_dir,
             [("ST-001", "complete"), ("ST-002", "complete")],
         )
         result = map_orchestrator.get_plan_progress(branch_dir)
@@ -810,13 +935,109 @@ class TestGetPlanProgress:
     def test_in_progress_counts_as_pending(self, branch_dir, tmp_path):
         """in_progress subtask counts as pending (not complete)."""
         self._create_plan_with_statuses(
-            tmp_path, branch_dir,
+            tmp_path,
+            branch_dir,
             [("ST-001", "complete"), ("ST-002", "in_progress"), ("ST-003", "pending")],
         )
         result = map_orchestrator.get_plan_progress(branch_dir)
         assert result["completed_count"] == 1
         assert result["pending_count"] == 2
         assert result["suggested_next"] == "ST-002"
+
+    def test_plan_progress_includes_resume_briefing(self, branch_dir, tmp_path):
+        """Plan progress surfaces latest human-readable branch artifacts."""
+        self._create_plan_with_statuses(
+            tmp_path, branch_dir, [("ST-001", "complete"), ("ST-002", "pending")]
+        )
+        plan_dir = tmp_path / ".map" / branch_dir
+        (plan_dir / "session-log.md").write_text(
+            "# Session Log\n\n## 2026-03-19 — ACTOR\n- Outcome: implemented\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "review-001.md").write_text(
+            "# Review 001\n\n- update tests\n",
+            encoding="utf-8",
+        )
+
+        result = map_orchestrator.get_plan_progress(branch_dir)
+
+        briefing = result["resume_briefing"]
+        assert briefing["latest_review_path"].endswith("review-001.md")
+        assert "ACTOR" in briefing["recent_session_log"]
+        assert "update tests" in "\n".join(briefing["suggested_fixes"])
+
+
+class TestResumeFromPlan:
+    """Tests for resume_from_plan artifact-aware context."""
+
+    def test_resume_from_plan_includes_resume_briefing(self, branch_dir, tmp_path):
+        plan_dir = tmp_path / ".map" / branch_dir
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        (plan_dir / f"task_plan_{branch_dir}.md").write_text(
+            "# Task Plan\n\n### ST-001\n- **Status:** pending\n\n### ST-002\n- **Status:** pending\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "workflow_state.json").write_text(
+            json.dumps({"aag_contracts": {"ST-001": "Keep auth isolated"}}),
+            encoding="utf-8",
+        )
+        (plan_dir / "session-log.md").write_text(
+            "# Session Log\n\n## 2026-03-19 — INIT\n- Outcome: ready\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "verification-summary.md").write_text(
+            "# Verification Summary\n\n- Verdict: READY FOR REVIEW\n",
+            encoding="utf-8",
+        )
+
+        result = map_orchestrator.resume_from_plan(branch_dir)
+
+        assert result["status"] == "success"
+        briefing = result["resume_briefing"]
+        assert briefing["latest_verification_verdict"] == "READY FOR REVIEW"
+        assert "INIT" in briefing["recent_session_log"]
+
+
+class TestBuildResumeBriefing:
+    """Tests for next-action resume briefing synthesis."""
+
+    def test_build_resume_briefing_prefers_fixing_failed_verification(
+        self, branch_dir, tmp_path
+    ):
+        plan_dir = tmp_path / ".map" / branch_dir
+        plan_dir.mkdir(parents=True, exist_ok=True)
+        (plan_dir / f"task_plan_{branch_dir}.md").write_text(
+            "# Task Plan\n\n### ST-001: Auth\n- **Status:** in_progress\n\n### ST-002: UI\n- **Status:** pending\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "step_state.json").write_text(
+            json.dumps(
+                {
+                    "current_subtask_id": "ST-001",
+                    "current_step_phase": "MONITOR",
+                    "subtask_sequence": ["ST-001", "ST-002"],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (plan_dir / "verification-summary.md").write_text(
+            "# Verification Summary\n\n- Verdict: NEEDS WORK\n",
+            encoding="utf-8",
+        )
+        (plan_dir / "review-001.md").write_text(
+            "# Review 001\n\n- fix auth edge case\n",
+            encoding="utf-8",
+        )
+
+        result = map_orchestrator.build_resume_briefing(branch_dir)
+
+        assert result["current_subtask"] == "ST-001"
+        assert result["current_phase"] == "MONITOR"
+        assert result["suggested_next"] == "ST-001"
+        assert result["next_action"][0].startswith(
+            "Address issues from the latest verification"
+        )
+        assert "Review requested fixes" in result["next_action"][1]
 
 
 if __name__ == "__main__":

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -856,8 +856,8 @@ class TestResumeSingleSubtask:
             "# Session Log\n\n## 2026-03-19 — MONITOR\n- Outcome: revise\n",
             encoding="utf-8",
         )
-        (plan_dir / "review-002.md").write_text(
-            "# Review 002\n\n- fix auth edge case\n- rerun pytest\n",
+        (plan_dir / "code-review-002.md").write_text(
+            "# Code Review 002\n\n- fix auth edge case\n- rerun pytest\n",
             encoding="utf-8",
         )
         (plan_dir / "verification-summary.md").write_text(
@@ -868,7 +868,7 @@ class TestResumeSingleSubtask:
         result = map_orchestrator.resume_single_subtask("ST-001", branch_dir)
 
         briefing = result["resume_briefing"]
-        assert briefing["latest_review_path"].endswith("review-002.md")
+        assert briefing["latest_review_path"].endswith("code-review-002.md")
         assert briefing["latest_verification_verdict"] == "NEEDS WORK"
         assert "MONITOR" in briefing["recent_session_log"]
         assert "fix auth edge case" in "\n".join(briefing["suggested_fixes"])
@@ -954,15 +954,15 @@ class TestGetPlanProgress:
             "# Session Log\n\n## 2026-03-19 — ACTOR\n- Outcome: implemented\n",
             encoding="utf-8",
         )
-        (plan_dir / "review-001.md").write_text(
-            "# Review 001\n\n- update tests\n",
+        (plan_dir / "code-review-001.md").write_text(
+            "# Code Review 001\n\n- update tests\n",
             encoding="utf-8",
         )
 
         result = map_orchestrator.get_plan_progress(branch_dir)
 
         briefing = result["resume_briefing"]
-        assert briefing["latest_review_path"].endswith("review-001.md")
+        assert briefing["latest_review_path"].endswith("code-review-001.md")
         assert "ACTOR" in briefing["recent_session_log"]
         assert "update tests" in "\n".join(briefing["suggested_fixes"])
 
@@ -1024,8 +1024,8 @@ class TestBuildResumeBriefing:
             "# Verification Summary\n\n- Verdict: NEEDS WORK\n",
             encoding="utf-8",
         )
-        (plan_dir / "review-001.md").write_text(
-            "# Review 001\n\n- fix auth edge case\n",
+        (plan_dir / "code-review-001.md").write_text(
+            "# Code Review 001\n\n- fix auth edge case\n",
             encoding="utf-8",
         )
 
@@ -1037,7 +1037,9 @@ class TestBuildResumeBriefing:
         assert result["next_action"][0].startswith(
             "Address issues from the latest verification"
         )
-        assert "Review requested fixes" in result["next_action"][1]
+        assert any(
+            "Review requested fixes" in action for action in result["next_action"]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -1,0 +1,209 @@
+"""Tests for map_step_runner human-readable artifact helpers."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "mapify_cli"
+    / "templates"
+    / "map"
+    / "scripts"
+)
+
+sys.path.insert(0, str(SCRIPTS_PATH))
+
+import map_step_runner  # noqa: E402
+
+
+@pytest.fixture
+def branch_workspace(tmp_path, monkeypatch):
+    branch = "test-branch"
+    workspace = tmp_path / ".map" / branch
+    workspace.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(map_step_runner, "get_branch_name", lambda: branch)
+    return workspace
+
+
+def test_ensure_human_artifacts_creates_defaults(branch_workspace):
+    result = map_step_runner.ensure_human_artifacts()
+
+    assert result["status"] == "success"
+    assert (branch_workspace / "session-log.md").exists()
+    assert (branch_workspace / "devlog-001.md").exists()
+    assert (branch_workspace / "qa-001.md").exists()
+    assert (branch_workspace / "pr-draft.md").exists()
+
+
+def test_next_numbered_artifact_path_increments(branch_workspace):
+    (branch_workspace / "code-review-001.md").write_text("one", encoding="utf-8")
+    (branch_workspace / "code-review-002.md").write_text("two", encoding="utf-8")
+
+    result = map_step_runner.next_numbered_artifact_path("code-review")
+
+    assert result["status"] == "success"
+    assert result["file_name"] == "code-review-003.md"
+
+
+def test_append_session_log_records_entry(branch_workspace):
+    map_step_runner.append_session_log(
+        "ACTOR",
+        "implemented",
+        "ST-001",
+        "updated models",
+        ["devlog-001.md", "code-review-001.md"],
+    )
+
+    content = (branch_workspace / "session-log.md").read_text(encoding="utf-8")
+    assert "ACTOR" in content
+    assert "ST-001" in content
+    assert "devlog-001.md, code-review-001.md" in content
+
+
+def test_write_verification_summary_creates_report(branch_workspace):
+    result = map_step_runner.write_verification_summary(
+        "READY FOR REVIEW",
+        "Implement auth",
+        "- pytest\n- ruff",
+        "- no blocking issues",
+        "- open PR",
+    )
+
+    assert result["status"] == "success"
+    content = (branch_workspace / "verification-summary.md").read_text(encoding="utf-8")
+    assert "READY FOR REVIEW" in content
+    assert "Implement auth" in content
+    assert "open PR" in content
+
+
+def test_write_pr_draft_creates_report(branch_workspace):
+    result = map_step_runner.write_pr_draft(
+        "- Added auth flow",
+        "- pytest\n- ruff",
+        "- follow up on metrics",
+    )
+
+    assert result["status"] == "success"
+    content = (branch_workspace / "pr-draft.md").read_text(encoding="utf-8")
+    assert "Added auth flow" in content
+    assert "pytest" in content
+    assert "follow up on metrics" in content
+
+
+def test_build_handoff_bundle_reads_artifacts(branch_workspace):
+    (branch_workspace / "session-log.md").write_text(
+        "# Session Log\n\n## 2026-03-19 — ACTOR\n- Outcome: implemented\n",
+        encoding="utf-8",
+    )
+    (branch_workspace / "verification-summary.md").write_text(
+        "# Verification Summary\n\n- Verdict: READY FOR REVIEW\n",
+        encoding="utf-8",
+    )
+    (branch_workspace / "qa-001.md").write_text(
+        "# QA 001\n\n- Commands Run: pytest\n",
+        encoding="utf-8",
+    )
+    (branch_workspace / "code-review-001.md").write_text(
+        "# Code Review 001\n\n- follow up on edge case\n",
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_handoff_bundle()
+
+    assert result["status"] == "success"
+    assert "Verification summary available" in result["summary"]
+    assert "READY FOR REVIEW" in result["validation"]
+    assert "follow up on edge case" in result["risks_follow_up"]
+
+
+def test_write_plan_review_creates_numbered_artifact(branch_workspace):
+    result = map_step_runner.write_plan_review(
+        "Planning looks solid overall",
+        "(None)",
+        "- PR-001 Clarify retry policy",
+        "(None)",
+        "(None)",
+        "- PR-001 Clarify retry policy",
+        "needs-revision",
+    )
+
+    assert result["status"] == "success"
+    content = (branch_workspace / "plan-review-001.md").read_text(encoding="utf-8")
+    assert "Plan Review 001" in content
+    assert "PR-001 Clarify retry policy" in content
+    assert "needs-revision" in content
+
+
+def test_write_stage_gate_creates_plan_gate(branch_workspace):
+    result = map_step_runner.write_stage_gate(
+        "plan", "ready", "plan-review-001.md", "Planning approved"
+    )
+
+    assert result["status"] == "success"
+    content = (branch_workspace / "plan-gate.json").read_text(encoding="utf-8")
+    assert '"verdict": "ready"' in content
+    assert '"source_artifact": "plan-review-001.md"' in content
+
+
+def test_active_issues_file_replace(branch_workspace):
+    ensure = map_step_runner.ensure_active_issues_file()
+    assert ensure["status"] == "success"
+
+    result = map_step_runner.replace_active_issues(
+        "verification",
+        "verification-summary.md",
+        "- fix flaky auth test\n- clarify migration rollback",
+    )
+    assert result["status"] == "success"
+
+    content = (branch_workspace / "active-issues.json").read_text(encoding="utf-8")
+    assert '"stage": "verification"' in content
+    assert "fix flaky auth test" in content
+    assert "clarify migration rollback" in content
+
+
+def test_build_review_handoff_collects_branch_artifacts(branch_workspace):
+    (branch_workspace / "plan-review-001.md").write_text(
+        "# Plan Review 001\n\n- PR-001 tighten scope\n", encoding="utf-8"
+    )
+    (branch_workspace / "code-review-001.md").write_text(
+        "# Code Review 001\n\n- CR-001 add null guard\n", encoding="utf-8"
+    )
+    (branch_workspace / "verification-summary.md").write_text(
+        "# Verification Summary\n\n- Verdict: READY FOR REVIEW\n",
+        encoding="utf-8",
+    )
+    (branch_workspace / "qa-001.md").write_text("# QA 001\n", encoding="utf-8")
+    (branch_workspace / "pr-draft.md").write_text(
+        "# PR Draft\n\n## Summary\n", encoding="utf-8"
+    )
+    (branch_workspace / "active-issues.json").write_text(
+        '{"updated_at":"2026-03-19T00:00:00","issues":[{"id":"VER-001"}]}\n',
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_review_handoff()
+
+    assert result["status"] == "success"
+    assert result["plan_review_path"] == "plan-review-001.md"
+    assert result["code_review_path"] == "code-review-001.md"
+    assert result["verification_summary_path"] == "verification-summary.md"
+    assert result["active_issues_path"] == "active-issues.json"
+
+
+def test_known_issues_file_and_add_issue(branch_workspace):
+    result = map_step_runner.ensure_known_issues_file()
+    assert result["status"] == "success"
+
+    add_result = map_step_runner.add_known_issue(
+        "Flaky integration test", "accepted", "Track in follow-up"
+    )
+    assert add_result["status"] == "success"
+
+    content = (branch_workspace / "known-issues.json").read_text(encoding="utf-8")
+    assert "Flaky integration test" in content
+    assert "accepted" in content

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -17,6 +17,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from mapify_cli import (
     app,
     build_standard_mcp_servers,
+    count_agent_templates,
+    count_command_templates,
     create_agent_files,
     create_command_files,
     create_commands_dir,
@@ -493,7 +495,11 @@ class TestCheckCommand:
             "Check Available Tools" in result.stdout or "MAP Framework" in result.stdout
         )
         assert "initialized" in result.stdout
-        assert "11 agents, 12 commands" in result.stdout
+        expected_agents = count_agent_templates()
+        expected_commands = count_command_templates()
+        assert (
+            f"{expected_agents} agents, {expected_commands} commands" in result.stdout
+        )
 
     @mock.patch("mapify_cli.check_tool")
     def test_check_with_mcp_servers(self, mock_check_tool, tmp_path):
@@ -525,8 +531,10 @@ class TestDoctorCommand:
         assert result.exit_code == 0
         assert "MAP Doctor" in result.stdout
         assert ".map/main/" in result.stdout
-        assert "11/11" in result.stdout
-        assert "12/12" in result.stdout
+        expected_agents = count_agent_templates()
+        expected_commands = count_command_templates()
+        assert f"{expected_agents}/{expected_agents}" in result.stdout
+        assert f"{expected_commands}/{expected_commands}" in result.stdout
 
     @mock.patch("mapify_cli.check_tool")
     def test_doctor_reports_missing_structure(self, mock_check_tool, tmp_path):

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -394,7 +394,7 @@ class TestInitCommand:
         assert (tmp_path / ".claude" / "agents").exists()
         assert (tmp_path / ".claude" / "mcp_config.json").exists()
 
-        # Verify all 4 MCP servers are configured
+        # Verify default MCP servers are configured
         mcp_config = json.loads((tmp_path / ".claude" / "mcp_config.json").read_text())
         expected_servers = [
             "sequential-thinking",
@@ -407,9 +407,9 @@ class TestInitCommand:
                 f"MCP server '{server}' not found in config"
             )
 
-        # Verify exactly 4 servers (no extras)
-        assert len(mcp_config["mcp_servers"]) == 4, (
-            f"Expected 4 servers, found {len(mcp_config['mcp_servers'])}"
+        # Verify exactly the expected default set (no extras)
+        assert sorted(mcp_config["mcp_servers"]) == sorted(expected_servers), (
+            f"Expected default MCP servers {expected_servers}, found {mcp_config['mcp_servers']}"
         )
 
     def test_init_force_no_prompts(self, tmp_path):

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -401,14 +401,14 @@ class TestInitCommand:
 
         assert "mcp_servers" in mcp_config, "mcp_config missing 'mcp_servers' key"
         for server in expected_servers:
-            assert (
-                server in mcp_config["mcp_servers"]
-            ), f"MCP server '{server}' not found in config"
+            assert server in mcp_config["mcp_servers"], (
+                f"MCP server '{server}' not found in config"
+            )
 
         # Verify exactly 4 servers (no extras)
-        assert (
-            len(mcp_config["mcp_servers"]) == 4
-        ), f"Expected 4 servers, found {len(mcp_config['mcp_servers'])}"
+        assert len(mcp_config["mcp_servers"]) == 4, (
+            f"Expected 4 servers, found {len(mcp_config['mcp_servers'])}"
+        )
 
     def test_init_force_no_prompts(self, tmp_path):
         """Test that init --force completes without interactive confirmation prompts.
@@ -456,9 +456,9 @@ class TestInitCommand:
         # This confirms --force actually re-initialized the files
         assert actor_file.exists()
         restored_content = actor_file.read_text()
-        assert (
-            restored_content != "# Modified by user"
-        ), "--force did not restore template files"
+        assert restored_content != "# Modified by user", (
+            "--force did not restore template files"
+        )
         # Should contain some template markers (not exact match due to potential updates)
         assert len(restored_content) > 100, "Restored actor.md seems too short"
 
@@ -483,12 +483,17 @@ class TestCheckCommand:
         os.chdir(tmp_path)
         mock_check_tool.return_value = True
 
+        init_result = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
+        assert init_result.exit_code == 0
+
         result = runner.invoke(app, ["check"])
 
         assert result.exit_code == 0
         assert (
             "Check Available Tools" in result.stdout or "MAP Framework" in result.stdout
         )
+        assert "initialized" in result.stdout
+        assert "11 agents, 12 commands" in result.stdout
 
     @mock.patch("mapify_cli.check_tool")
     def test_check_with_mcp_servers(self, mock_check_tool, tmp_path):
@@ -499,7 +504,41 @@ class TestCheckCommand:
         result = runner.invoke(app, ["check"])
 
         assert result.exit_code == 0
-        assert "Check Available Tools" in result.stdout or "MAP" in result.stdout
+        assert "sequential-thinking" in result.stdout
+        assert "deepwiki" in result.stdout
+
+
+class TestDoctorCommand:
+    """Test the doctor command."""
+
+    @mock.patch("mapify_cli.check_tool")
+    def test_doctor_initialized_project(self, mock_check_tool, tmp_path):
+        """Doctor should report healthy project structure after init."""
+        os.chdir(tmp_path)
+        mock_check_tool.return_value = True
+
+        init_result = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
+        assert init_result.exit_code == 0
+
+        result = runner.invoke(app, ["doctor"])
+
+        assert result.exit_code == 0
+        assert "MAP Doctor" in result.stdout
+        assert ".map/main/" in result.stdout
+        assert "11/11" in result.stdout
+        assert "12/12" in result.stdout
+
+    @mock.patch("mapify_cli.check_tool")
+    def test_doctor_reports_missing_structure(self, mock_check_tool, tmp_path):
+        """Doctor should surface missing paths in non-initialized directories."""
+        os.chdir(tmp_path)
+        mock_check_tool.return_value = True
+
+        result = runner.invoke(app, ["doctor"])
+
+        assert result.exit_code == 0
+        assert "Missing core paths" in result.stdout
+        assert ".map/scripts" in result.stdout
 
 
 class TestUpgradeCommand:
@@ -507,38 +546,43 @@ class TestUpgradeCommand:
 
     @mock.patch("mapify_cli.get_latest_release")
     def test_upgrade_available(self, mock_get_latest, tmp_path):
-        """Test upgrade when newer version is available."""
+        """Test upgrade refreshes files and reports newer release."""
         os.chdir(tmp_path)
+        init_result = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
+        assert init_result.exit_code == 0
+
+        actor_file = tmp_path / ".claude" / "agents" / "actor.md"
+        original_content = actor_file.read_text()
+        actor_file.write_text("stale content\n")
+
         mock_get_latest.return_value = {
-            "tag_name": "v2.0.0",
-            "html_url": "https://github.com/azalio/map-framework/releases/tag/v2.0.0",
+            "tag_name": "v9.9.9",
+            "html_url": "https://github.com/azalio/map-framework/releases/tag/v9.9.9",
         }
 
         result = runner.invoke(app, ["upgrade"])
 
         assert result.exit_code == 0
-        # For now, upgrade shows "coming soon" message
-        assert (
-            "Upgrade feature coming soon" in result.stdout
-            or "New version available" in result.stdout
-        )
+        assert "New version available" in result.stdout
+        assert "Upgrade complete" in result.stdout
+        assert actor_file.read_text() == original_content
 
     @mock.patch("mapify_cli.get_latest_release")
     def test_upgrade_not_available(self, mock_get_latest, tmp_path):
         """Test upgrade when already on latest version."""
         os.chdir(tmp_path)
+        init_result = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
+        assert init_result.exit_code == 0
         mock_get_latest.return_value = {
-            "tag_name": "v1.0.0",
-            "html_url": "https://github.com/azalio/map-framework/releases/tag/v1.0.0",
+            "tag_name": "v3.5.0",
+            "html_url": "https://github.com/azalio/map-framework/releases/tag/v3.5.0",
         }
 
         result = runner.invoke(app, ["upgrade"])
 
         assert result.exit_code == 0
-        assert (
-            "Upgrade feature coming soon" in result.stdout
-            or "already on the latest version" in result.stdout
-        )
+        assert "latest installed version" in result.stdout
+        assert "Upgrade complete" in result.stdout
 
     def test_upgrade_not_initialized(self, tmp_path):
         """Test upgrade in non-initialized directory."""
@@ -546,10 +590,7 @@ class TestUpgradeCommand:
         result = runner.invoke(app, ["upgrade"])
 
         assert result.exit_code == 0
-        assert (
-            "Upgrade feature coming soon" in result.stdout
-            or "MAP Framework not initialized" in result.stdout
-        )
+        assert "MAP Framework not initialized" in result.stdout
 
 
 class TestAgentCreation:
@@ -631,9 +672,9 @@ class TestAgentCreation:
                 name in agent_file
                 for name in ["task-decomposer", "actor", "monitor", "predictor"]
             ):
-                assert (
-                    "mcp" in content.lower() or "tool" in content.lower()
-                ), f"Agent {agent_file} missing MCP integration section"
+                assert "mcp" in content.lower() or "tool" in content.lower(), (
+                    f"Agent {agent_file} missing MCP integration section"
+                )
 
 
 class TestCommandCreation:
@@ -712,9 +753,9 @@ class TestMcpJsonConfig:
 
         # http servers should have 'type' and 'url' keys
         for server_name in ["deepwiki"]:
-            assert (
-                servers[server_name].get("type") == "http"
-            ), f"{server_name} should be http"
+            assert servers[server_name].get("type") == "http", (
+                f"{server_name} should be http"
+            )
             assert "url" in servers[server_name], f"{server_name} missing url"
 
     def test_read_project_mcp_json_missing_file(self, tmp_path):
@@ -891,9 +932,9 @@ class TestMcpJsonConfig:
 
         # Allow exit code 0 or initialization messages
         mcp_file = tmp_path / ".mcp.json"
-        assert (
-            mcp_file.exists()
-        ), f"Expected .mcp.json to be created. Output: {result.output}"
+        assert mcp_file.exists(), (
+            f"Expected .mcp.json to be created. Output: {result.output}"
+        )
 
         config = json.loads(mcp_file.read_text())
         assert "mcpServers" in config
@@ -997,19 +1038,16 @@ class TestCreateMapTools:
     def test_create_map_tools_map_exists_but_no_static_analysis(
         self, mock_get_templates, tmp_path
     ):
-        """Test when templates_dir/map exists but static-analysis subdirectory doesn't."""
-        # Create templates/map without static-analysis
+        """Test when templates_dir/map exists but has no shipped content."""
         mock_templates = tmp_path / "templates"
         mock_templates.mkdir()
         (mock_templates / "map").mkdir()
-        # Don't create static-analysis subdirectory
         mock_get_templates.return_value = mock_templates
 
         count = create_map_tools(tmp_path)
 
-        # Should return 0 when static-analysis doesn't exist
+        # Should return 0 when map template is empty
         assert count == 0
-        # .map directory should still be created
         assert (tmp_path / ".map").exists()
 
     def test_create_map_tools_preserves_other_map_contents(self, tmp_path):


### PR DESCRIPTION
## Summary
- harden canonical MAP workflow artifacts across planning, execution, verification, and review stages inside `.map/<branch>/`
- add deterministic helpers for planning reviews, stage gates, active issues, run dossiers, and review handoff consumption
- align command/docs/test coverage for standard and TDD MAP flows, including `code-review-00N.md` naming and verification handoff artifacts

## Testing
- pytest