### PR TITLE
feat: guard pattern, stuck recovery, scenario dimensions, constraints, noise handling

### DIFF
--- a/.claude/agents/actor.md
+++ b/.claude/agents/actor.md
@@ -145,6 +145,21 @@ When multiple sources provide conflicting guidance, follow this priority (highes
 
 ---
 
+# GIT HISTORY CONTEXT (Conditional)
+
+When `{{git_history}}` is present (non-empty), read it before implementing.
+
+**Format:** Condensed `git log --oneline -10` + `git diff HEAD~1 --stat` for affected files.
+
+**Trigger contexts** (injected by orchestrator):
+- **debug**: When investigating a bug (monitor retry > 0)
+- **retry**: When re-invoked after monitor rejection (monitor_retry >= 2) — learn from prior failed approaches
+- **resume**: When workflow resumes after context compaction or session gap
+
+**When `{{git_history}}` is absent or empty:** Skip silently. Do NOT run git commands yourself.
+
+---
+
 # RESEARCH PHASE (Context Isolation)
 
 BEFORE implementation, if task requires understanding existing code.

--- a/.claude/agents/final-verifier.md
+++ b/.claude/agents/final-verifier.md
@@ -57,6 +57,15 @@ Read `.map/<branch>/task_plan_<branch>.md` to extract:
 - Review integration points between subtasks
 - Verify ALL validation_criteria are met
 
+#### Noise Handling Protocol (Flaky Test Re-runs)
+When tests fail on first run, apply the confirmation policy:
+1. Re-run the failed test suite up to **2 more times** (3 total runs)
+2. Use **2/3 majority rule**: if 2 out of 3 runs pass, mark tests as `passed`
+3. If majority fails: mark tests as `failed`
+4. If results are inconsistent (some pass, some fail across runs): set `flaky_detected: true`
+5. Linter checks: always **1/1** (deterministic, no re-run needed)
+6. Record `test_run_count` (how many times the test suite was executed)
+
 ### Step 3: Adversarial Checks
 - Are there edge cases not covered by tests?
 - Do subtask outputs integrate correctly?
@@ -86,6 +95,8 @@ Score confidence (0.0-1.0):
     "tests_run": ["test_name"],
     "tests_passed": 10,
     "tests_failed": 0,
+    "test_run_count": 1,
+    "flaky_detected": false,
     "ground_truth_check": "passed|failed|skipped",
     "integration_check": "passed|failed"
   },
@@ -143,8 +154,12 @@ If verification passes, update the `Status` column in the Acceptance Criteria ta
 
 ## Decision Rules
 
+### Flaky Confidence Adjustment
+Before applying threshold checks: if `flaky_detected == true`, subtract 0.1 from confidence score.
+This applies before the 0.7 threshold check below.
+
 ### PASS (confidence >= 0.7)
-- All tests pass
+- All tests pass (or 2/3 majority pass with flaky_detected noted)
 - All acceptance criteria met
 - No blocking issues found
 - Recommend: `COMPLETE`

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -158,7 +158,13 @@ Return **ONLY** valid JSON in this exact structure:
         "test_strategy": {
           "unit": "Specific unit tests (function/method level)",
           "integration": "Integration tests (component interactions) or 'N/A'",
-          "e2e": "E2E tests (full user flows) or 'N/A'"
+          "e2e": "E2E tests (full user flows) or 'N/A'",
+          "scenario_dimensions": {
+            "happy_path": "Primary success scenario test(s)",
+            "error": "Error/failure handling test(s)",
+            "edge_case": "Boundary conditions and unusual inputs test(s)",
+            "security": "Security-relevant test(s) or 'N/A'"
+          }
         },
         "affected_files": [
           "path/to/file1.py",
@@ -261,7 +267,8 @@ Return **ONLY** valid JSON in this exact structure:
   - RECOMMENDED when: complexity_score >= 5 OR security_critical OR dependencies.length >= 2
   - OMIT when: standard pattern with obvious implementation
   - Example: "Use existing RateLimiter middleware, configure for /api/* routes"
-**subtasks[].test_strategy**: Required object with unit/integration/e2e keys. Use "N/A" for levels not applicable.
+**subtasks[].test_strategy**: Required object with unit/integration/e2e keys plus `scenario_dimensions`. Use "N/A" for levels not applicable.
+  - **scenario_dimensions** (required): Object with four keys — `happy_path`, `error`, `edge_case`, `security`. Each describes at least one planned test covering that dimension. Use "N/A" for dimensions not relevant to the subtask. Testing-heavy subtasks must cover at minimum 4 dimensions.
   - MUST map `validation_criteria` → tests:
     - For each `VCn:` criterion, include at least one planned test name that covers it.
     - Recommended naming: include `vc<n>` in the test name (e.g., `test_vc1_*`, `TestVC1*`) for deterministic grep-ability.
@@ -751,7 +758,13 @@ For detailed examples and anti-patterns, see: `.claude/references/decomposition-
         "test_strategy": {
           "unit": "Test field accepts timestamps, test default is null",
           "integration": "Test migration applies cleanly",
-          "e2e": "N/A"
+          "e2e": "N/A",
+          "scenario_dimensions": {
+            "happy_path": "Test archived_at stores valid timestamp",
+            "error": "Test migration rollback on failure",
+            "edge_case": "Test field with existing null values in table",
+            "security": "N/A"
+          }
         },
         "affected_files": [
           "models/project.py",

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -659,35 +659,40 @@ python3 .map/scripts/map_step_runner.py update_plan_status "ST-XXX" "in_progress
 ### Phase: TESTS_GATE (2.8)
 
 ```bash
-# Run tests if available (do NOT install dependencies). Capture exit code for guard pattern.
+# Run tests if available (do NOT install dependencies). Capture exit code + output for guard pattern.
 TESTS_EXIT=0
+TEST_OUTPUT=""
 if [ -f "pytest.ini" ] || [ -f "setup.py" ]; then
-  pytest; TESTS_EXIT=$?
+  TEST_OUTPUT=$(pytest 2>&1); TESTS_EXIT=$?
 elif [ -f "package.json" ]; then
-  npm test; TESTS_EXIT=$?
+  TEST_OUTPUT=$(npm test 2>&1); TESTS_EXIT=$?
 elif [ -f "go.mod" ]; then
-  go test ./...; TESTS_EXIT=$?
+  TEST_OUTPUT=$(go test ./... 2>&1); TESTS_EXIT=$?
 elif [ -f "Cargo.toml" ]; then
-  cargo test; TESTS_EXIT=$?
+  TEST_OUTPUT=$(cargo test 2>&1); TESTS_EXIT=$?
 else
   echo "No tests found, skipping gate"
 fi
+# Print output so it's visible in the conversation
+echo "$TEST_OUTPUT"
 ```
 
 ### Phase: LINTER_GATE (2.9)
 
 ```bash
-# Run linter if available. Capture exit code for guard pattern.
+# Run linter if available. Capture exit code + output for guard pattern.
 LINT_EXIT=0
+LINT_OUTPUT=""
 if command -v ruff &> /dev/null; then
-  ruff check .; LINT_EXIT=$?
+  LINT_OUTPUT=$(ruff check . 2>&1); LINT_EXIT=$?
 elif command -v eslint &> /dev/null; then
-  eslint .; LINT_EXIT=$?
+  LINT_OUTPUT=$(eslint . 2>&1); LINT_EXIT=$?
 elif command -v golangci-lint &> /dev/null; then
-  golangci-lint run; LINT_EXIT=$?
+  LINT_OUTPUT=$(golangci-lint run 2>&1); LINT_EXIT=$?
 else
   echo "No linter found, skipping gate"
 fi
+echo "$LINT_OUTPUT"
 ```
 
 ### Phase: GUARD_DECISION (2.95)

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -266,7 +266,8 @@ Then use the **Write** tool to create `.map/<branch>/workflow_state.json`:
   "current_state": "INITIALIZED",
   "completed_steps": {},
   "pending_steps": {},
-  "subtask_sequence": []
+  "subtask_sequence": [],
+  "constraints": null
 }
 ```
 
@@ -533,9 +534,51 @@ if monitor_output["valid"] == false:
     if retry_count < 5:
         # Go back to Phase: ACTOR with Monitor feedback
         # Actor will fix issues and re-apply code
+
+        # === STUCK RECOVERY (at retry 3) ===
+        # At retry 3, intercept with intermediate recovery before retries 4-5.
+        # This gives Actor better context to break out of a stuck loop.
+        if retry_count == 3:
+            # Step 1: Check if research-agent already ran for this subtask
+            findings_file = f".map/{branch}/findings_{branch}.md"
+            if findings_file exists and has content for this subtask:
+                # Reuse existing findings (Edge Case 12: skip re-invocation)
+                recovery_context = read(findings_file)
+            else:
+                # Invoke research-agent for alternative approaches
+                Task(
+                    subagent_type="research-agent",
+                    description="Stuck recovery: find alternative approach",
+                    prompt=f"""Subtask {subtask_id} failed 3 monitor retries.
+Monitor feedback: {latest_monitor_feedback}
+Find an ALTERNATIVE approach. Current approach is not working.
+Focus on: different patterns, simpler implementations, existing utilities."""
+                )
+                recovery_context = research_agent_output
+
+            # Step 2: Invoke predictor (skip for low-risk subtasks — Edge Case 7)
+            if subtask.risk_level != "low":
+                Task(
+                    subagent_type="predictor",
+                    description="Stuck recovery: analyze why approach fails",
+                    prompt=f"""Subtask {subtask_id} failed 3 retries.
+Research findings: {recovery_context}
+Analyze: why is the current approach failing? What dependencies are missed?"""
+                )
+                recovery_context += predictor_output
+
+            # Step 3: Pass recovery context to Actor for retries 4-5
+            # Actor receives: original task + monitor feedback + recovery context
+            # This gives Actor a fresh perspective from research-agent/predictor
+
+            # If both research-agent and predictor found nothing useful:
+            if recovery_context is empty or unhelpful:
+                AskUserQuestion(questions=[{"question": "Stuck recovery: research-agent and predictor found no alternative. How to proceed?", "header": "Stuck", "options": [{"label": "Continue", "description": "Try 2 more retries with current approach"}, {"label": "Skip", "description": "Skip subtask, move to next"}, {"label": "Abort", "description": "Stop workflow"}], "multiSelect": false}])
+        # === END STUCK RECOVERY ===
+
     else:
-        # Escalate to user (retry limit reached)
-        AskUserQuestion(questions=[{"question": "Monitor retry limit reached. How to proceed?", "header": "Retry limit", "options": [{"label": "Continue", "description": "Reset retry counter and try again"}, {"label": "Skip", "description": "Skip this subtask and move to next"}, {"label": "Abort", "description": "Stop workflow"}], "multiSelect": false}])
+        # Escalate to user (retry limit reached after 5 attempts)
+        AskUserQuestion(questions=[{"question": "Monitor retry limit reached (5 attempts). How to proceed?", "header": "Retry limit", "options": [{"label": "Continue", "description": "Reset retry counter and try again"}, {"label": "Skip", "description": "Skip this subtask and move to next"}, {"label": "Abort", "description": "Stop workflow"}], "multiSelect": false}])
 ```
 
 ### Phase: PREDICTOR (2.6)
@@ -616,15 +659,16 @@ python3 .map/scripts/map_step_runner.py update_plan_status "ST-XXX" "in_progress
 ### Phase: TESTS_GATE (2.8)
 
 ```bash
-# Run tests if available (do NOT install dependencies)
+# Run tests if available (do NOT install dependencies). Capture exit code for guard pattern.
+TESTS_EXIT=0
 if [ -f "pytest.ini" ] || [ -f "setup.py" ]; then
-  pytest
+  pytest; TESTS_EXIT=$?
 elif [ -f "package.json" ]; then
-  npm test
+  npm test; TESTS_EXIT=$?
 elif [ -f "go.mod" ]; then
-  go test ./...
+  go test ./...; TESTS_EXIT=$?
 elif [ -f "Cargo.toml" ]; then
-  cargo test
+  cargo test; TESTS_EXIT=$?
 else
   echo "No tests found, skipping gate"
 fi
@@ -633,17 +677,48 @@ fi
 ### Phase: LINTER_GATE (2.9)
 
 ```bash
-# Run linter if available
+# Run linter if available. Capture exit code for guard pattern.
+LINT_EXIT=0
 if command -v ruff &> /dev/null; then
-  ruff check .
+  ruff check .; LINT_EXIT=$?
 elif command -v eslint &> /dev/null; then
-  eslint .
+  eslint .; LINT_EXIT=$?
 elif command -v golangci-lint &> /dev/null; then
-  golangci-lint run
+  golangci-lint run; LINT_EXIT=$?
 else
   echo "No linter found, skipping gate"
 fi
 ```
+
+### Phase: GUARD_DECISION (2.95)
+
+**Guard Pattern Decision Table** — applies after TESTS_GATE and LINTER_GATE.
+
+Guard rework counter (`guard_rework`) is **independent** of monitor retry counter.
+
+```
+IF monitor_output["valid"] == true:
+  IF TESTS_EXIT == 0 AND LINT_EXIT == 0:
+    → KEEP: Proceed to VERIFY_ADHERENCE (all green)
+
+  ELSE (monitor pass + guard fail = regression detected):
+    guard_rework += 1
+    IF guard_rework <= 2:
+      → RETRY Actor with guard failure context:
+        - Pass: test/lint stderr output
+        - Pass: "Monitor approved your changes but tests/linter failed (regression)"
+        - Pass: "Fix the regression without breaking the new behavior"
+        - After Actor retry → re-run Monitor → re-run TESTS_GATE + LINTER_GATE
+    ELSE (guard_rework > 2):
+      → ESCALATE to user:
+        AskUserQuestion("Guard failure after 2 rework attempts. Tests/linter still failing.")
+        Options: ["Skip this subtask", "Abort workflow"]
+
+ELSE (monitor_output["valid"] == false):
+  → Standard monitor retry logic (existing behavior, max 5 retries)
+```
+
+**Key invariant:** Guard rework never modifies test files — Actor must adapt implementation to pass existing tests.
 
 ### Phase: VERIFY_ADHERENCE (2.10)
 

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -12,7 +12,7 @@
 - Calls task-decomposer agent to break down the user's request into subtasks
 - Creates `.map/<branch>/task_plan_<branch>.md` with subtask list
 - Initializes `.map/<branch>/workflow_state.json` with subtask sequence
-- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`research.md`, `implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
+- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
 - **STOPS** after planning (forces context flush)
 
 **What this command CANNOT do:**
@@ -34,7 +34,6 @@ echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "state:       $(test -f .map/${BRANCH}/workflow_state.json && echo EXISTS || echo MISSING)"
-echo "research:    $(test -f .map/${BRANCH}/research.md && echo EXISTS || echo MISSING)"
 echo "impl_plan:   $(test -f .map/${BRANCH}/implementation-plan.md && echo EXISTS || echo MISSING)"
 echo "decisions:   $(test -f .map/${BRANCH}/decision-log.md && echo EXISTS || echo MISSING)"
 echo "pr_draft:    $(test -f .map/${BRANCH}/pr-draft.md && echo EXISTS || echo MISSING)"
@@ -100,7 +99,7 @@ User request:
 )
 ```
 
-**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to both `.map/<branch>/findings_<branch>.md` and `.map/<branch>/research.md` so they persist across sessions. `findings_<branch>.md` stays optimized for executor distillation; `research.md` is the human-readable planning note.
+**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to `.map/<branch>/findings_<branch>.md` so they persist across sessions.
 
 **Discovery output format** (in findings file):
 ```markdown
@@ -567,7 +566,7 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ workflow_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
-✅ Human-readable artifacts updated: research.md, implementation-plan.md, decision-log.md, pr-draft.md
+✅ Human-readable artifacts updated: implementation-plan.md, decision-log.md, pr-draft.md
 ✅ Planning review recorded: plan-review-00N.md + plan-gate.json
 ✅ Context distilled (plan files ≤4000 tokens per subtask)
 
@@ -593,7 +592,6 @@ DISTILLATION CHECKLIST:
   [x] workflow_state.json   — has aag_contracts map + subtask_sequence
   [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
-  [x] research.md           — human-readable discovery and context for resume/handoff
   [x] implementation-plan.md — concise execution roadmap for humans
   [x] decision-log.md       — key tradeoffs captured before implementation
   [x] pr-draft.md           — initial summary + validation + risk notes

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -208,6 +208,18 @@ These are hard constraints — violating any invariant is a blocker.
 - [e.g., "Database migrations must be backward-compatible (no column drops)"]
 - [e.g., "Response time for any endpoint must stay under 500ms p95"]
 
+## Constraints
+
+Workflow execution limits. When no constraints specified, all default to null (unlimited) and the enforcement hook skips checks.
+
+```yaml
+constraints:
+  max_files: null        # Maximum files Actor can modify per workflow (int or null)
+  max_subtasks: null     # Maximum subtasks in decomposition (int or null)
+  time_budget: null      # Maximum minutes for entire workflow (int or null)
+  scope_glob: null       # File glob restricting Actor's edit scope (string or null)
+```
+
 ## Edge Cases
 
 Enumerate boundary conditions and unusual inputs that implementation must handle.
@@ -486,6 +498,25 @@ Then use the **Write** tool to create `.map/<branch>/task_plan_<branch>.md` with
 
 **AAG Contract is REQUIRED** for every subtask. Copy directly from task-decomposer output's `aag_contract` field. This is the primary handoff to the Actor agent — without it, the Actor reasons instead of compiles.
 
+### Step 6.5: Validate Constraints (Before State Initialization)
+
+If the spec includes a `## Constraints` section with non-null values, validate before writing workflow_state.json:
+
+**scope_glob validation** (REQUIRED if scope_glob is non-null):
+- Reject if contains `..` (path traversal)
+- Reject if starts with `/` (absolute path)
+- Reject if contains `{` (brace expansion — Python version-dependent behavior)
+- On validation failure: print error and STOP — do not create workflow_state.json
+
+```bash
+# Example validation (run in Bash)
+SCOPE_GLOB="src/auth/**"  # from spec constraints
+if echo "$SCOPE_GLOB" | grep -qE '(\.\.)|^/|\{'; then
+  echo "ERROR: Invalid scope_glob '$SCOPE_GLOB'. Must be relative, no '..' or brace expansion."
+  exit 1
+fi
+```
+
 ### Step 7: Initialize Workflow State (Do This Last)
 
 Create `.map/<branch>/workflow_state.json` with the decomposition results. Wrap in `MAP_State_v1_0` tag for executor parsing.
@@ -507,6 +538,12 @@ Use the **Write** tool to create `.map/<branch>/workflow_state.json` with this s
   "aag_contracts": {
     "ST-001": "Actor -> Action(params) -> Goal",
     "ST-002": "Actor -> Action(params) -> Goal"
+  },
+  "constraints": {
+    "max_files": null,
+    "max_subtasks": null,
+    "time_budget": null,
+    "scope_glob": null
   }
 }
 ```
@@ -514,6 +551,7 @@ Use the **Write** tool to create `.map/<branch>/workflow_state.json` with this s
 **IMPORTANT:**
 - Replace `subtask_sequence` with actual IDs from the decomposition
 - Populate `aag_contracts` map with each subtask's AAG contract from the decomposer output — executors read this to set context for each subtask
+- Populate `constraints` from the spec's Constraints section. null = unlimited (hook skips enforcement)
 
 ### Step 8: Output Checkpoint
 

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -130,7 +130,7 @@ STRICT RULES:
 8. Cover scenario dimensions from test_strategy: write tests for at minimum
    happy_path, error, edge_case, and security dimensions (use "N/A" if not applicable).
    Each dimension should have at least one dedicated test or test case.
-8. Test files MUST be lint-clean. Use proper imports at the top of the file
+9. Test files MUST be lint-clean. Use proper imports at the top of the file
    (not inside type annotations). Run the project linter (ruff/eslint/golangci-lint)
    on test files before finishing. Fix any lint errors in your test files.
 

--- a/.claude/commands/map-tdd.md
+++ b/.claude/commands/map-tdd.md
@@ -127,6 +127,9 @@ STRICT RULES:
 5. Use standard test patterns for the project's language/framework.
 6. Each validation_criteria item (VCn:) must have at least one corresponding test.
 7. Include edge cases from the spec's Edge Cases section if available.
+8. Cover scenario dimensions from test_strategy: write tests for at minimum
+   happy_path, error, edge_case, and security dimensions (use "N/A" if not applicable).
+   Each dimension should have at least one dedicated test or test case.
 8. Test files MUST be lint-clean. Use proper imports at the top of the file
    (not inside type annotations). Run the project linter (ruff/eslint/golangci-lint)
    on test files before finishing. Fix any lint errors in your test files.

--- a/.claude/hooks/ralph-iteration-logger.py
+++ b/.claude/hooks/ralph-iteration-logger.py
@@ -317,36 +317,43 @@ def main() -> None:
 def derive_summary(log_file: Path) -> None:
     """Derive iteration_summary.json from iteration_log.jsonl.
 
-    Aggregates per-file stats, truncates to last 50 entries when > 100,
-    and writes a summary JSON to the same branch directory.
+    Reads only the last 100 lines (via deque) to keep O(1) memory and fast I/O.
+    Aggregates per-file stats, skips entries without a file path.
     """
     if not log_file.exists():
         return
 
-    lines = log_file.read_text(encoding="utf-8").strip().split("\n")
-    entries = []
-    for line in lines:
-        if line.strip():
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
+    from collections import deque
 
-    total_entries_seen = len(entries)
-    if total_entries_seen == 0:
+    # Stream only last 100 lines — O(N) read but O(1) memory
+    total_lines = 0
+    last_lines: deque[str] = deque(maxlen=100)
+    with open(log_file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                total_lines += 1
+                last_lines.append(stripped)
+
+    entries = []
+    for line in last_lines:
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    if not entries:
         return
 
-    # Truncate to last 50 if > 100 entries
-    dropped_count = 0
-    if total_entries_seen > 100:
-        dropped_count = total_entries_seen - 50
-        entries = entries[-50:]
+    dropped_count = max(0, total_lines - len(entries))
 
-    # Aggregate per-file stats
+    # Aggregate per-file stats — skip entries without a concrete file path
     file_data: dict[str, list[float]] = {}
     file_thrashing: Counter[str] = Counter()
     for entry in entries:
-        f = entry.get("file", "unknown")
+        f = (entry.get("file") or "").strip()
+        if not f:
+            continue
         eff = entry.get("effectiveness", 0.0)
         file_data.setdefault(f, []).append(eff)
         file_thrashing[f] += 1
@@ -363,23 +370,23 @@ def derive_summary(log_file: Path) -> None:
             "thrashing_count": is_thrashing,
         })
 
-    all_effs = [e.get("effectiveness", 0.0) for e in entries]
+    all_effs = [e.get("effectiveness", 0.0) for e in entries if (e.get("file") or "").strip()]
     summary: dict[str, object] = {
         "generated_at": datetime.now().isoformat(),
         "entry_count": len(entries),
-        "total_entries_seen": total_entries_seen,
+        "total_entries_seen": total_lines,
         "dropped_count": dropped_count,
         "file_stats": file_stats,
         "aggregate": {
-            "total_iterations": total_entries_seen,
+            "total_iterations": total_lines,
             "avg_effectiveness": round(sum(all_effs) / len(all_effs), 3) if all_effs else 0.0,
             "total_thrashing_alerts": thrashing_alert_count,
         },
     }
 
     summary_file = log_file.parent / "iteration_summary.json"
-    with open(summary_file, "w", encoding="utf-8") as f:
-        json.dump(summary, f, indent=2, ensure_ascii=True)
+    with open(summary_file, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2, ensure_ascii=True)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/ralph-iteration-logger.py
+++ b/.claude/hooks/ralph-iteration-logger.py
@@ -304,8 +304,82 @@ def main() -> None:
                 file=sys.stderr,
             )
 
+    # Derive iteration summary (best-effort, never blocks)
+    try:
+        derive_summary(log_file)
+    except Exception:
+        pass
+
     print("{}")
     sys.exit(0)
+
+
+def derive_summary(log_file: Path) -> None:
+    """Derive iteration_summary.json from iteration_log.jsonl.
+
+    Aggregates per-file stats, truncates to last 50 entries when > 100,
+    and writes a summary JSON to the same branch directory.
+    """
+    if not log_file.exists():
+        return
+
+    lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+    entries = []
+    for line in lines:
+        if line.strip():
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    total_entries_seen = len(entries)
+    if total_entries_seen == 0:
+        return
+
+    # Truncate to last 50 if > 100 entries
+    dropped_count = 0
+    if total_entries_seen > 100:
+        dropped_count = total_entries_seen - 50
+        entries = entries[-50:]
+
+    # Aggregate per-file stats
+    file_data: dict[str, list[float]] = {}
+    file_thrashing: Counter[str] = Counter()
+    for entry in entries:
+        f = entry.get("file", "unknown")
+        eff = entry.get("effectiveness", 0.0)
+        file_data.setdefault(f, []).append(eff)
+        file_thrashing[f] += 1
+
+    file_stats: list[dict[str, object]] = []
+    thrashing_alert_count = 0
+    for f, effs in sorted(file_data.items(), key=lambda x: -len(x[1])):
+        is_thrashing = 1 if file_thrashing[f] >= THRASHING_WINDOW else 0
+        thrashing_alert_count += is_thrashing
+        file_stats.append({
+            "file": f,
+            "iterations": len(effs),
+            "avg_effectiveness": round(sum(effs) / len(effs), 3) if effs else 0.0,
+            "thrashing_count": is_thrashing,
+        })
+
+    all_effs = [e.get("effectiveness", 0.0) for e in entries]
+    summary: dict[str, object] = {
+        "generated_at": datetime.now().isoformat(),
+        "entry_count": len(entries),
+        "total_entries_seen": total_entries_seen,
+        "dropped_count": dropped_count,
+        "file_stats": file_stats,
+        "aggregate": {
+            "total_iterations": total_entries_seen,
+            "avg_effectiveness": round(sum(all_effs) / len(all_effs), 3) if all_effs else 0.0,
+            "total_thrashing_alerts": thrashing_alert_count,
+        },
+    }
+
+    summary_file = log_file.parent / "iteration_summary.json"
+    with open(summary_file, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=True)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -169,11 +169,16 @@ def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
     # scope_glob
     scope_glob = constraints.get("scope_glob")
     if scope_glob and target_paths:
+        repo_root = Path.cwd().resolve()
         for tp in target_paths:
+            resolved = Path(tp).resolve()
             try:
-                rel = str(Path(tp).resolve().relative_to(Path.cwd().resolve()))
+                rel = str(resolved.relative_to(repo_root))
             except ValueError:
-                rel = tp
+                return (
+                    f"Constraint: scope_glob='{scope_glob}'\n"
+                    f"File '{resolved}' resolves outside repository root."
+                )
             if not fnmatch(rel, scope_glob):
                 return (
                     f"Constraint: scope_glob='{scope_glob}'\n"

--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -2,63 +2,38 @@
 """
 Claude Code PreToolUse Hook: Workflow Enforcement Gate
 
-Enforces MAP Framework workflow adherence by blocking Edit/Write/MultiEdit
-operations until required workflow steps (Actor + Monitor) are completed.
+Blocks Edit/Write/MultiEdit outside of Actor-related phases.
+Uses step_state.json (orchestrator canonical state) as single source of truth.
 
-USAGE:
-  This hook runs automatically before Edit/Write/MultiEdit tool calls.
-  No manual invocation needed - Claude Code handles hook execution.
+ENFORCEMENT:
+  - Edit allowed during phases: ACTOR, APPLY, TEST_WRITER
+  - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
+  - Fail-open: no step_state.json or no workflow_state.json → allow
+  - Always allows: .map/ artifacts, ~/.claude/ memory, non-editing tools
 
-ENFORCEMENT RULES:
-  - Allows Edit/Write/MultiEdit when workflow_state.json is missing (fail-open)
-  - Blocks if current subtask hasn't completed required steps: ['actor', 'monitor']
-  - Allows tools if all required steps are completed
-  - Always allows edits under .map/ (workflow artifacts/state) to prevent deadlocks
-  - Always allows edits under ~/.claude/ (auto-memory, project settings)
-  - Allows Read, Bash, and other non-editing tools always
+CONSTRAINTS (from workflow_state.json):
+  - scope_glob: restrict edits to matching file patterns
+  - time_budget: block after N minutes elapsed
 
-WORKFLOW STATE FILE:
-  Location: .map/<branch>/workflow_state.json
-  Required fields:
-    - current_subtask: Current subtask ID (e.g., "ST-001")
-    - completed_steps: Dict mapping subtask_id -> list of completed steps
-    - pending_steps: Dict mapping subtask_id -> list of pending steps
-
-HOOK BEHAVIOR:
-  - Exit code 0: Allow tool execution
-  - Exit code 0 + permissionDecision=deny: Block tool execution with reason (preferred)
-
-TESTING:
-  echo '{"tool_name": "Edit", "tool_input": {"file_path": "test.py"}}' | python3 workflow-gate.py
-  # Expected (no workflow state): Exit 0, stdout: {}
-  # Expected (workflow active, missing steps): Exit 0, stdout: {"hookSpecificOutput":{"permissionDecision":"deny",...}}
-
-PERFORMANCE:
-  Target: <100ms per invocation
-  Design: Minimal I/O, fast JSON parsing, pre-compiled checks
-
-DESIGN RATIONALE:
-  Based on LLM Council recommendation: "Reify State - Don't tell the model
-  'remember to call Monitor.' Make the environment hostile to action until
-  the Monitor is called." This hook implements that principle through
-  filesystem-based enforcement.
+Exit code 0 always (fail-open on errors).
 """
 import json
 import os
 import re
 import sys
+from datetime import datetime, timezone
+from fnmatch import fnmatch
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
-# Tools that require workflow enforcement
 EDITING_TOOLS = {"Edit", "Write", "MultiEdit"}
 
-# Required steps before allowing edits
-REQUIRED_STEPS = ["actor", "monitor"]
+# Phases where Edit/Write is expected (Actor applies code)
+EDITING_PHASES = {"ACTOR", "APPLY", "TEST_WRITER"}
 
 
-def extract_target_file_paths(tool_call: Dict) -> list[str]:
-    """Best-effort extraction of file paths from Claude Code tool payloads."""
+def extract_target_file_paths(tool_call: dict) -> list[str]:
+    """Extract file paths from tool call payload."""
     tool_input = tool_call.get("tool_input") or {}
     if not isinstance(tool_input, dict):
         return []
@@ -72,23 +47,16 @@ def extract_target_file_paths(tool_call: Dict) -> list[str]:
     edits = tool_input.get("edits")
     if isinstance(edits, list):
         for edit in edits:
-            if not isinstance(edit, dict):
-                continue
-            fp = edit.get("file_path")
-            if isinstance(fp, str) and fp.strip():
-                paths.append(fp)
+            if isinstance(edit, dict):
+                fp = edit.get("file_path")
+                if isinstance(fp, str) and fp.strip():
+                    paths.append(fp)
 
     return paths
 
 
 def is_exempt_path(file_path: str) -> bool:
-    """
-    Return True if file_path is exempt from workflow enforcement.
-
-    Exempt paths:
-    - .map/ artifacts (workflow state, plans, findings) -- prevents deadlocks
-    - ~/.claude/ (auto-memory, project settings) -- Claude's own persistence
-    """
+    """Return True if path is exempt from enforcement (.map/, ~/.claude/memory/)."""
     if not isinstance(file_path, str) or not file_path.strip():
         return False
 
@@ -99,20 +67,18 @@ def is_exempt_path(file_path: str) -> bool:
         else (Path.cwd().resolve() / candidate).resolve(strict=False)
     )
 
-    # Allow Claude auto-memory writes (~/.claude/projects/*/memory/)
+    # Allow ~/.claude/projects/*/memory/
     claude_memory_dir = Path.home() / ".claude" / "projects"
     try:
         rel = resolved.relative_to(claude_memory_dir.resolve())
-        # Only allow paths that include a "memory" component
         if "memory" in rel.parts:
             return True
     except ValueError:
         pass
 
-    # Allow .map/ artifacts
-    repo_root = Path.cwd().resolve()
+    # Allow .map/
     try:
-        rel = resolved.relative_to(repo_root)
+        rel = resolved.relative_to(Path.cwd().resolve())
     except ValueError:
         return False
 
@@ -120,7 +86,7 @@ def is_exempt_path(file_path: str) -> bool:
 
 
 def sanitize_branch_name(branch: str) -> str:
-    """Sanitize branch name for safe filesystem paths."""
+    """Sanitize branch name for filesystem paths."""
     sanitized = branch.replace("/", "-")
     sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "-", sanitized)
     sanitized = re.sub(r"-+", "-", sanitized).strip("-")
@@ -130,7 +96,7 @@ def sanitize_branch_name(branch: str) -> str:
 
 
 def get_branch_name() -> str:
-    """Get current git branch name (sanitized for filesystem)."""
+    """Get current git branch name (sanitized)."""
     try:
         import subprocess
 
@@ -147,134 +113,147 @@ def get_branch_name() -> str:
     return "default"
 
 
-def load_workflow_state(branch: str) -> Optional[Dict]:
-    """Load workflow state from .map/<branch>/workflow_state.json"""
-    state_file = Path(f".map/{branch}/workflow_state.json")
+def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
+    """Check step_state.json: is current phase one where Edit is allowed?
 
+    Returns (allowed, error_message).
+    """
+    step_file = Path(f".map/{branch}/step_state.json")
+    if not step_file.exists():
+        return True, None  # No step state → fail-open
+
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return True, None  # Corrupt/unreadable → fail-open
+
+    # Parallel wave mode: check subtask_phases dict
+    subtask_phases = state.get("subtask_phases", {})
+    if subtask_phases:
+        for phase in subtask_phases.values():
+            if phase in EDITING_PHASES:
+                return True, None
+
+    # Sequential mode: check current_step_phase
+    current_phase = state.get("current_step_phase", "")
+    if current_phase in EDITING_PHASES:
+        return True, None
+
+    # Not in an editing phase → block
+    subtask = state.get("current_subtask_id", "?")
+    return False, (
+        f"Workflow gate: Edit blocked during phase '{current_phase}' "
+        f"(subtask {subtask}).\n"
+        f"Edit is only allowed during: {', '.join(sorted(EDITING_PHASES))}.\n"
+        "Call the Actor agent first — it will apply code changes."
+    )
+
+
+def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
+    """Check constraints from workflow_state.json. Returns error or None."""
+    state_file = Path(f".map/{branch}/workflow_state.json")
     if not state_file.exists():
         return None
 
     try:
         with open(state_file, "r", encoding="utf-8") as f:
-            return json.load(f)
+            state = json.load(f)
     except (json.JSONDecodeError, OSError):
         return None
 
+    constraints = state.get("constraints")
+    if not constraints:
+        return None
 
-def check_workflow_compliance(state: Dict) -> tuple[bool, Optional[str]]:
-    """
-    Check if current subtask(s) have completed required workflow steps.
+    # scope_glob
+    scope_glob = constraints.get("scope_glob")
+    if scope_glob and target_paths:
+        for tp in target_paths:
+            try:
+                rel = str(Path(tp).resolve().relative_to(Path.cwd().resolve()))
+            except ValueError:
+                rel = tp
+            if not fnmatch(rel, scope_glob):
+                return (
+                    f"Constraint: scope_glob='{scope_glob}'\n"
+                    f"File '{rel}' is outside allowed scope."
+                )
 
-    Supports both single-subtask mode (current_subtask) and parallel wave mode
-    (active_subtasks list). In parallel mode, allows edits if ANY active
-    subtask has completed the required steps.
+    # time_budget
+    time_budget = constraints.get("time_budget")
+    if time_budget is not None:
+        started_at = state.get("started_at")
+        if started_at:
+            try:
+                start = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() / 60
+                if elapsed > time_budget:
+                    return (
+                        f"Constraint: time_budget={time_budget} min, "
+                        f"elapsed={elapsed:.0f} min."
+                    )
+            except (ValueError, TypeError):
+                pass
 
-    Returns:
-        (is_compliant, error_message)
-    """
-    # Try active_subtasks first (parallel wave mode)
-    active = state.get("active_subtasks", [])
-    if not active:
-        # Backward compat: single current_subtask
-        current = state.get("current_subtask")
-        if current:
-            active = [current]
+    return None
 
-    if not active:
-        current_state = state.get("current_state") or "UNKNOWN"
-        return False, (
-            "⛔ Workflow Enforcement: No current_subtask defined in workflow_state.json\n\n"
-            f"current_state: {current_state}\n\n"
-            "Edits to non-.map files are blocked until current_subtask is set and "
-            "the required steps are completed.\n\n"
-            "To fix:\n"
-            "  - Update .map/<branch>/workflow_state.json to set current_subtask\n"
-            "  - Or re-run /map-resume or /map-plan to regenerate state\n"
-            "  - Or delete .map/<branch>/workflow_state.json to disable enforcement"
+
+def deny(reason: str) -> None:
+    """Print deny response and exit."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
         )
-
-    # Allow if ANY active subtask has completed required steps
-    for subtask_id in active:
-        completed = state.get("completed_steps", {}).get(subtask_id, [])
-        if all(step in completed for step in REQUIRED_STEPS):
-            return True, None
-
-    # Block with appropriate message
-    missing_details = []
-    for subtask_id in active:
-        completed = state.get("completed_steps", {}).get(subtask_id, [])
-        missing = [step for step in REQUIRED_STEPS if step not in completed]
-        if missing:
-            missing_details.append(f"{subtask_id}: missing {', '.join(missing)}")
-
-    return False, (
-        f"⛔ Workflow Enforcement: Cannot edit code for active subtasks\n\n"
-        f"Active subtasks: {', '.join(active)}\n"
-        f"Missing steps:\n" + "\n".join(f"  - {d}" for d in missing_details) + "\n\n"
-        "Required workflow:\n"
-        "  1. Call Task(subagent_type='actor') to generate implementation\n"
-        "  2. Call Task(subagent_type='monitor') to validate\n"
-        "  3. Only then can you apply changes with Edit/Write\n\n"
-        "To fix: Complete missing steps before editing code.\n"
-        "Or update workflow_state.json if steps were completed."
     )
+    sys.exit(0)
 
 
-def main():
-    """Main hook entry point."""
+def allow() -> None:
+    """Print allow response and exit."""
+    print("{}")
+    sys.exit(0)
+
+
+def main() -> None:
     try:
-        # Read tool call from stdin
         tool_call = json.load(sys.stdin)
         tool_name = tool_call.get("tool_name", "")
 
-        # Allow non-editing tools
+        # Non-editing tools → always allow
         if tool_name not in EDITING_TOOLS:
-            print("{}")
-            sys.exit(0)
+            allow()
 
-        # Always allow edits to MAP workflow artifacts under .map/
+        # Exempt paths (.map/, ~/.claude/memory/) → always allow
         target_paths = extract_target_file_paths(tool_call)
         if target_paths and all(is_exempt_path(p) for p in target_paths):
-            print("{}")
-            sys.exit(0)
+            allow()
 
-        # Get current branch
         branch = get_branch_name()
 
-        # Load workflow state
-        state = load_workflow_state(branch)
+        # Phase check (step_state.json)
+        allowed, error = is_editing_phase(branch)
+        if not allowed:
+            deny(error or "Edit blocked: not in an editing phase.")
 
-        if state is None:
-            # No workflow state = not in MAP workflow mode, allow
-            # (This prevents breaking non-MAP work)
-            print("{}")
-            sys.exit(0)
+        # Constraint check (workflow_state.json)
+        constraint_error = check_constraints(branch, target_paths)
+        if constraint_error:
+            deny(constraint_error)
 
-        # Check workflow compliance
-        is_compliant, error_message = check_workflow_compliance(state)
-
-        if is_compliant:
-            print("{}")
-            sys.exit(0)
-        else:
-            print(
-                json.dumps(
-                    {
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "deny",
-                            "permissionDecisionReason": error_message,
-                        }
-                    }
-                )
-            )
-            sys.exit(0)
+        allow()
 
     except Exception as e:
-        # On hook failure, approve (fail-open to avoid blocking work)
-        print("{}")
+        # Fail-open on any error
         if os.environ.get("DEBUG_WORKFLOW_GATE"):
             print(f"[workflow-gate] ERROR: {e}", file=sys.stderr)
+        print("{}")
         sys.exit(0)
 
 

--- a/.claude/references/escalation-matrix.md
+++ b/.claude/references/escalation-matrix.md
@@ -22,6 +22,30 @@ Reference guide for orchestrator agents on when to escalate failures vs. retry.
 | Confidence oscillating > 0.3 | Model uncertain |
 | Same error message 2+ times | Not making progress |
 
+## Stuck Recovery (Intermediate — at retry 3)
+
+Before exhausting retries, invoke intermediate recovery at monitor retry 3:
+
+| Step | Action | Skip Condition |
+|------|--------|----------------|
+| 1. research-agent | Find alternative approach for stuck subtask | Reuse existing findings if already ran for this subtask |
+| 2. predictor | Analyze why current approach fails, suggest alternatives | Skip for `risk_level == "low"` subtasks |
+| 3. Resume retries | Pass recovery context to Actor for retries 4-5 | — |
+| 4. User escalation | If research-agent + predictor found nothing useful | Only if recovery context is empty |
+
+This path is orchestrator-level logic in `map-efficient.md`, not a Ralph Loop state transition.
+
+## Guard Pattern Escalation (after 2 rework attempts)
+
+When Monitor passes but TESTS_GATE/LINTER_GATE fails (regression detected):
+
+| Rework Attempt | Action |
+|----------------|--------|
+| 1-2 | Retry Actor with guard failure context (test/lint stderr) |
+| 3+ | Escalate to user: "Guard failure after 2 rework attempts. Skip/Abort?" |
+
+Guard rework counter is independent of monitor retry counter.
+
 ## Continue Retrying
 
 | Condition | Max Retries |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,11 +17,9 @@
     "allow": [
       "Edit(.claude/agents/*)",
       "Edit(.claude/commands/*)",
-      "Edit(.claude/hooks/*)",
       "Edit(.claude/references/*)",
       "Write(.claude/agents/*)",
       "Write(.claude/commands/*)",
-      "Write(.claude/hooks/*)",
       "Write(.claude/references/*)",
       "Bash(mapify *)",
       "Bash(pytest *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,14 @@
       "Bash(git reset --hard)"
     ],
     "allow": [
+      "Edit(.claude/agents/*)",
+      "Edit(.claude/commands/*)",
+      "Edit(.claude/hooks/*)",
+      "Edit(.claude/references/*)",
+      "Write(.claude/agents/*)",
+      "Write(.claude/commands/*)",
+      "Write(.claude/hooks/*)",
+      "Write(.claude/references/*)",
       "Bash(mapify *)",
       "Bash(pytest *)",
       "Bash(make lint)",

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Canonical MAP flows:
 - Full TDD: `/map-plan` -> `/map-tdd` -> `/map-check` -> `/map-review`
 - Targeted subtask TDD: `/map-plan` -> `/map-tdd ST-001` -> `/map-task ST-001` -> ... -> `/map-check` -> `/map-review`
 
-These workflows maintain branch-scoped artifacts like `research.md`, `implementation-plan.md`, `code-review-001.md`, `qa-001.md`, `verification-summary.md`, `pr-draft.md`, and run dossiers under `.map/<branch>/`.
+These workflows maintain branch-scoped artifacts like `implementation-plan.md`, `code-review-001.md`, `qa-001.md`, `verification-summary.md`, `pr-draft.md`, and run dossiers under `.map/<branch>/`.
 
 ## How It Works
 

--- a/docs/research/pipeline-simplification.md
+++ b/docs/research/pipeline-simplification.md
@@ -1,0 +1,323 @@
+# Pipeline Simplification Design Doc
+
+**Date:** 2026-03-22
+**Branch:** autoresearch
+**Status:** Approved direction, pending execution plan
+
+---
+
+## Problem
+
+Current map-efficient pipeline has 11 phases per subtask. In practice ~6-7 are no-op for typical tasks. Feedback from real workflow run (7 subtasks, greenfield):
+
+- ~70 validate_step calls, mostly rubber-stamp
+- 21 evidence files nobody reads
+- XML_PACKET reformats data Actor already has in prompt
+- VERIFY_ADHERENCE self-audit never actually executed
+- Hooks print noise on every tool call
+- Dual state files (workflow_state.json + step_state.json) cause confusion
+
+~80% of value came from /map-plan. The rest was ceremony.
+
+## New Pipeline
+
+### Per subtask (2-3 phases):
+
+```
+[RESEARCH] → ACTOR → MONITOR
+   ^only if: 3+ existing files OR risk=high
+```
+
+### Per wave (after all subtasks in wave pass Monitor):
+
+```
+TESTS + LINTER (one run)
+```
+
+### After all waves:
+
+```
+[FINAL-VERIFIER] → done
+   ^optional: skip if all subtasks low-risk AND < 5 subtasks
+```
+
+### Retry loop
+
+ACTOR → MONITOR, max 5 retries per subtask. Stuck recovery at retry 3 (research-agent → predictor).
+
+### Per-wave guard failure isolation (P1 resolution)
+
+When per-wave TESTS/LINTER gate fails after a parallel wave, the orchestrator cannot know which subtask caused the regression. Isolation strategy:
+
+1. **Isolate:** Use `subtask_files_changed` from step_state.json to identify which files belong to which subtask. Run the failing test/linter against each subtask's file set individually to narrow the culprit.
+2. **Identify:** The subtask(s) whose files trigger the failure are the culprits.
+3. **Interaction fallback:** If no single subtask's files reproduce the failure (interaction bug between subtasks), rerun the wave sequentially — Actor+Monitor each subtask one at a time with full test suite after each. The subtask whose addition causes the gate to fail is the culprit (or both are, if failure requires their combination — in that case reopen both).
+4. **Retry:** Send identified culprit subtask(s) back to Actor with guard failure context (test/lint output + which other subtask(s) interact). Max 2 rework attempts per identified subtask.
+5. **Re-gate:** After rework, re-run the full wave gate (all subtasks together).
+6. **Escalate:** If 2 rework attempts fail, escalate to user: "Guard failure in wave N after 2 rework attempts. Subtask(s): ST-XXX. Skip/Abort?"
+
+For sequential waves (single subtask), the culprit is trivially the only subtask — no isolation needed.
+
+### State lifecycle (P1 resolution)
+
+State does NOT auto-advance on Monitor pass. Instead:
+
+```
+Per-subtask states:
+  ACTOR_PENDING → ACTOR_DONE → MONITOR_PASSED | MONITOR_FAILED
+
+Per-wave states:
+  WAVE_MONITORS_DONE → WAVE_GATES_PENDING → WAVE_GATES_PASSED | WAVE_GATES_FAILED
+  (WAVE_GATES_FAILED → isolation → rework → re-gate)
+
+Post-all-waves:
+  FINAL_VERIFY_PENDING → COMPLETE | FAILED
+```
+
+State advances:
+- After Monitor pass → subtask marked MONITOR_PASSED (not "done")
+- After ALL subtasks in wave reach MONITOR_PASSED → wave state becomes WAVE_GATES_PENDING
+- After TESTS+LINTER pass → WAVE_GATES_PASSED, wave advances
+- After FINAL-VERIFIER (if required) → COMPLETE
+
+This ensures resume always lands at the correct execution point. The single `step_state.json` file tracks both per-subtask and per-wave states.
+
+### Predictor: single authoritative rule (P2 resolution)
+
+Predictor runs in exactly ONE context: **stuck recovery at retry 3**.
+
+It is NOT a regular phase in the pipeline. The per-subtask pipeline is always:
+```
+[RESEARCH] → ACTOR → MONITOR
+```
+
+Predictor is invoked only when:
+1. Actor → Monitor retry count reaches 3
+2. Research-agent is called first for alternative approaches
+3. Predictor analyzes why current approach fails (skip for risk_level=low)
+4. Recovery context passed to Actor for retries 4-5
+
+The phase-count table reflects this: "high-risk, security" row is 3 phases (RESEARCH → ACTOR → MONITOR), same as medium-risk with 3+ files. Predictor does not add a phase — it's an inline recovery step within the retry loop.
+
+## What's Removed
+
+| Removed | Reason |
+|---------|--------|
+| XML_PACKET (2.0) | Actor gets same info in prompt via AAG contract |
+| CONTEXT_SEARCH (2.1) | Never used; /map-plan discovery sufficient |
+| Evidence files (actor/monitor/predictor JSON) | Write-only, nobody reads; validate_step existence check removed |
+| Evidence directory | Consequence of above |
+| VERIFY_ADHERENCE (2.10) | Self-audit checklist never actually executed |
+| APPROVAL (2.11) | Already auto-skipped in batch mode |
+| UPDATE_STATE (2.7) | Replaced by state lifecycle (per-subtask + per-wave states) |
+| workflow_state.json | Merged into step_state.json (single source of truth) |
+| session-log.md | Boilerplate, not read |
+| devlog-XXX.md | Boilerplate, not read |
+| Per-subtask TESTS/LINTER gates | Moved to per-wave (one run after all Monitor passes in wave) |
+| PREDICTOR as regular phase | Moved to stuck recovery only (retry 3) |
+
+## What's Kept
+
+| Kept | Why |
+|------|-----|
+| /map-plan (decomposition + DA) | ~80% of value |
+| Wave computation + parallel execution | Real time savings |
+| AAG contracts | Clear spec for Actor |
+| RESEARCH (conditional) | Useful for complex existing-code tasks |
+| ACTOR agent | Core implementation |
+| MONITOR agent | Catches real bugs (1/7 in test run) |
+| Predictor (stuck recovery only) | Intermediate recovery at retry 3 |
+| Guard pattern (per-wave) | Regression prevention with isolation strategy |
+| Stuck recovery (retry 3) | research-agent → predictor → retry 4-5 |
+| FINAL-VERIFIER (conditional) | Full goal verification, useful for complex tasks |
+| code-review-XXX.md | Monitor results, readable history |
+| step_state.json | Single canonical state file |
+
+## What's Changed
+
+### RESEARCH gating
+
+**Was:** Call if refactoring OR touching 3+ files
+**Now:** Call only if 3+ existing files OR risk=high. Medium-risk with 1-2 existing files → Actor handles it, Monitor catches if not.
+
+### Per-wave GATES
+
+- Tests + linter run once after ALL Monitor passes in wave
+- NOT between Actor→Monitor retry iterations
+- Guard failure → isolation (identify culprit subtask) → rework (max 2) → re-gate → escalate
+
+### FINAL-VERIFIER
+
+- Optional: skip if all subtasks low-risk AND < 5 subtasks total
+- Always run for: high-risk subtasks, security_critical, 5+ subtasks
+
+### Hooks
+
+- **workflow-context-injector.py**: print only on phase/subtask change, not every tool call. Track last-printed state; skip if unchanged.
+- **workflow-gate.py**: reads step_state.json only (already done). Constraints field moves from workflow_state.json to step_state.json.
+
+### State management
+
+- Single file: step_state.json
+- workflow_state.json: removed entirely
+- Per-subtask state: ACTOR_PENDING → ACTOR_DONE → MONITOR_PASSED
+- Per-wave state: WAVE_GATES_PENDING → WAVE_GATES_PASSED
+- Constraints: moved to step_state.json
+
+## Phase Count Comparison
+
+| Scenario | Old (11 phases) | New (2-3 phases) | Reduction |
+|----------|-----------------|-------------------|-----------|
+| Low-risk, new files | 11 (6-7 no-op) | 2 (ACTOR → MONITOR) | 82% |
+| Medium-risk, 1-2 files | 11 (4-5 no-op) | 2 (ACTOR → MONITOR) | 82% |
+| Medium-risk, 3+ files | 11 (3-4 no-op) | 3 (RESEARCH → ACTOR → MONITOR) | 73% |
+| High-risk, security | 11 (1-2 no-op) | 3 (RESEARCH → ACTOR → MONITOR) | 73% |
+
+Per-wave GATES and optional FINAL-VERIFIER add 1-2 phases total (not per subtask).
+Predictor is inline within stuck recovery, not a separate phase.
+
+## step_state.json Schema (new)
+
+```json
+{
+  "workflow": "map-efficient",
+  "started_at": "ISO-8601",
+  "subtask_sequence": ["ST-001", "ST-002", "ST-003"],
+  "aag_contracts": {"ST-001": "...", "ST-002": "..."},
+
+  "execution_waves": [["ST-001", "ST-002"], ["ST-003"]],
+  "current_wave_index": 0,
+
+  "active_phase": "ACTOR",
+  "active_subtask_id": "ST-002",
+
+  "subtask_states": {
+    "ST-001": "MONITOR_PASSED",
+    "ST-002": "ACTOR_DONE",
+    "ST-003": "ACTOR_PENDING"
+  },
+  "subtask_retry_counts": {"ST-001": 0, "ST-002": 1},
+  "guard_rework_counts": {},
+
+  "subtask_files_changed": {
+    "ST-001": ["src/models/user.py", "src/models/__init__.py"],
+    "ST-002": ["src/services/auth.py"]
+  },
+
+  "wave_states": {
+    "0": "WAVE_GATES_PENDING",
+    "1": "PENDING"
+  },
+
+  "constraints": {
+    "scope_glob": null,
+    "time_budget": null
+  },
+
+  "workflow_status": "IN_PROGRESS",
+
+  "tdd_mode": false,
+  "plan_approved": true
+}
+```
+
+### Field contracts for hooks
+
+| Field | Written by | Read by | Purpose |
+|-------|-----------|---------|---------|
+| `active_phase` | Orchestrator (before each agent call) | workflow-gate.py, workflow-context-injector.py | Gating: Edit allowed only during ACTOR, APPLY, TEST_WRITER. Reminder: show current phase. |
+| `active_subtask_id` | Orchestrator | workflow-context-injector.py | Reminder: show which subtask is active |
+| `subtask_states` | Orchestrator (after Monitor/gates) | Resume logic, orchestrator | Track per-subtask progress for resume |
+| `wave_states` | Orchestrator (after gates) | Resume logic, orchestrator | Track per-wave gate status for resume |
+| `subtask_files_changed` | Orchestrator (after Actor returns) | Guard isolation strategy | Map subtask → files for per-subtask revert during wave gate failure |
+| `workflow_status` | Orchestrator (at lifecycle boundaries) | Resume, /map-check, CI/CD | Overall workflow outcome |
+
+Valid `active_phase` values: `RESEARCH`, `ACTOR`, `APPLY`, `TEST_WRITER`, `MONITOR`, `GATES`, `GATE_ISOLATION`, `FINAL_VERIFY`, `COMPLETE`
+Valid subtask states: `ACTOR_PENDING`, `RESEARCH_DONE`, `ACTOR_DONE`, `MONITOR_PASSED`, `MONITOR_FAILED`, `SKIPPED`
+Valid wave states: `PENDING`, `WAVE_GATES_PENDING`, `WAVE_GATES_PASSED`, `WAVE_GATES_FAILED`, `REWORK_IN_PROGRESS`
+Valid `workflow_status` values: `INITIALIZED`, `IN_PROGRESS`, `FINAL_VERIFY_PENDING`, `COMPLETE`, `FAILED`, `ABORTED`
+
+### Hook contract mapping (old → new)
+
+| Hook | Old field | New field | Notes |
+|------|-----------|-----------|-------|
+| workflow-gate.py | `current_step_phase` in EDITING_PHASES | `active_phase` in {ACTOR, APPLY, TEST_WRITER} | Same logic, renamed field |
+| workflow-gate.py | `subtask_phases` dict (parallel) | `active_phase` (single value, covers wave) | During parallel wave Actor phase, active_phase=ACTOR for entire wave |
+| workflow-gate.py | constraints from workflow_state.json | `constraints` in step_state.json | Same structure, moved |
+| context-injector | `current_step_phase` + `current_subtask_id` | `active_phase` + `active_subtask_id` | Same contract, renamed |
+
+## Full Migration Surface (P2 resolution)
+
+All files referencing workflow_state.json, evidence/, session-log, devlog, or removed phases.
+
+### Commands (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `.claude/commands/map-efficient.md` | workflow_state.json, evidence, all 11 phases, session-log, devlog | **Rewrite** |
+| `.claude/commands/map-plan.md` | workflow_state.json (init) | Update to write step_state.json |
+| `.claude/commands/map-tdd.md` | evidence (test_writer), XML_PACKET | Remove evidence, remove XML_PACKET |
+| `.claude/commands/map-task.md` | workflow_state.json | Update to step_state.json |
+| `.claude/commands/map-resume.md` | workflow_state.json, evidence | Update to step_state.json |
+| `.claude/commands/map-check.md` | workflow_state.json | Update to step_state.json |
+| `.claude/commands/map-debate.md` | evidence | Remove evidence refs |
+
+### Hooks (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `.claude/hooks/workflow-gate.py` | step_state.json (already migrated) | Remove workflow_state.json fallback if any |
+| `.claude/hooks/workflow-context-injector.py` | step_state.json, phase names | Update phase names, add dedup |
+| `.claude/hooks/ralph-context-pruner.py` | evidence/ | Remove evidence refs |
+| `.claude/hooks/post-compact-context.py` | workflow_state.json | Update to step_state.json |
+
+### Agents (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `.claude/agents/actor.md` | evidence file writing | Remove evidence instructions |
+| `.claude/agents/monitor.md` | evidence file writing | Remove evidence instructions |
+| `.claude/agents/predictor.md` | evidence file writing | Remove evidence instructions |
+
+### Python scripts (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `src/mapify_cli/templates/map/scripts/map_orchestrator.py` | STEP_PHASES, evidence checks, all phase constants | **Major rewrite** |
+| `src/mapify_cli/templates/map/scripts/map_step_runner.py` | workflow_state.json, session-log, devlog | Remove/update |
+| `src/mapify_cli/__init__.py` | session-log, devlog in artifact list | Remove |
+
+### References/schemas (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `.claude/references/workflow-state-schema.md` | workflow_state.json schema | Remove or redirect to step_state.json |
+| `.claude/references/step-state-schema.md` | step_state.json schema | Update with new schema |
+
+### Documentation (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `docs/ARCHITECTURE.md` | workflow_state.json, evidence, phase descriptions | Update |
+| `docs/WORKFLOW_FLOW.md` | Phase flow diagrams | Update |
+
+### Skills (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `.claude/skills/map-planning/SKILL.md` | workflow_state.json | Update to step_state.json |
+
+### Tests (must update):
+| File | References | Action |
+|------|-----------|--------|
+| `tests/test_map_orchestrator.py` | STEP_PHASES, evidence, phase constants | **Major rewrite** |
+| `tests/test_map_step_runner.py` | workflow_state.json, session-log, devlog | Update |
+| `tests/test_workflow_gate.py` | Already uses step_state.json | May need wave_states tests |
+| `tests/test_command_templates.py` | session-log, devlog assertions | Remove assertions |
+
+### Template sync:
+All `.claude/` changes → `src/mapify_cli/templates/` (doubles the file count above).
+
+**Total: ~25 unique files + ~25 template mirrors = ~50 files to touch.**
+
+## Risk
+
+- map-efficient.md is ~900 lines — major rewrite
+- map_orchestrator.py is ~1700 lines — significant changes to step sequencing
+- Backward compat: old step_state.json files will not work with new pipeline (need migration or clean break)
+- ~50 files to touch across the repo
+- Tests: test_map_orchestrator.py, test_map_step_runner.py, test_command_templates.py need updating
+- Parallel wave guard isolation adds complexity not present in current sequential model

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -576,7 +576,6 @@ def get_project_health(project_path: Path) -> Dict[str, Any]:
     mcp_json_path = project_path / ".mcp.json"
     internal_mcp_path = project_path / ".claude" / "mcp_config.json"
     branch_artifact_files = [
-        "research.md",
         "implementation-plan.md",
         "decision-log.md",
         "session-log.md",
@@ -674,7 +673,6 @@ def get_branch_workspace_dir(project_path: Path, branch: Optional[str] = None) -
 def get_branch_artifact_templates(branch: str) -> Dict[str, str]:
     """Return cook-inspired artifact templates aligned to MAP branch workspaces."""
     return {
-        "research.md": f"# Research\n\n## Branch\n`{branch}`\n\n## Request\n\n## Context\n\n## Constraints\n\n## Related Files\n\n## Prior Art\n\n## Recommendation\n",
         "implementation-plan.md": f"# Implementation Plan\n\n## Branch\n`{branch}`\n\n## Summary\n\n## Goals\n\n## Non-Goals\n\n## Steps\n1.\n2.\n3.\n\n## Validation Plan\n\n## Risks\n",
         "decision-log.md": "# Decision Log\n\n## Decision\n\n## Options Considered\n\n## Chosen Approach\n\n## Consequences\n",
         "devlog-001.md": "# Devlog 001\n\n## Changes\n\n## Notes\n\n## Verification\n",

--- a/src/mapify_cli/templates/agents/actor.md
+++ b/src/mapify_cli/templates/agents/actor.md
@@ -145,6 +145,21 @@ When multiple sources provide conflicting guidance, follow this priority (highes
 
 ---
 
+# GIT HISTORY CONTEXT (Conditional)
+
+When `{{git_history}}` is present (non-empty), read it before implementing.
+
+**Format:** Condensed `git log --oneline -10` + `git diff HEAD~1 --stat` for affected files.
+
+**Trigger contexts** (injected by orchestrator):
+- **debug**: When investigating a bug (monitor retry > 0)
+- **retry**: When re-invoked after monitor rejection (monitor_retry >= 2) — learn from prior failed approaches
+- **resume**: When workflow resumes after context compaction or session gap
+
+**When `{{git_history}}` is absent or empty:** Skip silently. Do NOT run git commands yourself.
+
+---
+
 # RESEARCH PHASE (Context Isolation)
 
 BEFORE implementation, if task requires understanding existing code.

--- a/src/mapify_cli/templates/agents/final-verifier.md
+++ b/src/mapify_cli/templates/agents/final-verifier.md
@@ -57,6 +57,15 @@ Read `.map/<branch>/task_plan_<branch>.md` to extract:
 - Review integration points between subtasks
 - Verify ALL validation_criteria are met
 
+#### Noise Handling Protocol (Flaky Test Re-runs)
+When tests fail on first run, apply the confirmation policy:
+1. Re-run the failed test suite up to **2 more times** (3 total runs)
+2. Use **2/3 majority rule**: if 2 out of 3 runs pass, mark tests as `passed`
+3. If majority fails: mark tests as `failed`
+4. If results are inconsistent (some pass, some fail across runs): set `flaky_detected: true`
+5. Linter checks: always **1/1** (deterministic, no re-run needed)
+6. Record `test_run_count` (how many times the test suite was executed)
+
 ### Step 3: Adversarial Checks
 - Are there edge cases not covered by tests?
 - Do subtask outputs integrate correctly?
@@ -86,6 +95,8 @@ Score confidence (0.0-1.0):
     "tests_run": ["test_name"],
     "tests_passed": 10,
     "tests_failed": 0,
+    "test_run_count": 1,
+    "flaky_detected": false,
     "ground_truth_check": "passed|failed|skipped",
     "integration_check": "passed|failed"
   },
@@ -143,8 +154,12 @@ If verification passes, update the `Status` column in the Acceptance Criteria ta
 
 ## Decision Rules
 
+### Flaky Confidence Adjustment
+Before applying threshold checks: if `flaky_detected == true`, subtract 0.1 from confidence score.
+This applies before the 0.7 threshold check below.
+
 ### PASS (confidence >= 0.7)
-- All tests pass
+- All tests pass (or 2/3 majority pass with flaky_detected noted)
 - All acceptance criteria met
 - No blocking issues found
 - Recommend: `COMPLETE`

--- a/src/mapify_cli/templates/agents/task-decomposer.md
+++ b/src/mapify_cli/templates/agents/task-decomposer.md
@@ -158,7 +158,13 @@ Return **ONLY** valid JSON in this exact structure:
         "test_strategy": {
           "unit": "Specific unit tests (function/method level)",
           "integration": "Integration tests (component interactions) or 'N/A'",
-          "e2e": "E2E tests (full user flows) or 'N/A'"
+          "e2e": "E2E tests (full user flows) or 'N/A'",
+          "scenario_dimensions": {
+            "happy_path": "Primary success scenario test(s)",
+            "error": "Error/failure handling test(s)",
+            "edge_case": "Boundary conditions and unusual inputs test(s)",
+            "security": "Security-relevant test(s) or 'N/A'"
+          }
         },
         "affected_files": [
           "path/to/file1.py",
@@ -261,7 +267,8 @@ Return **ONLY** valid JSON in this exact structure:
   - RECOMMENDED when: complexity_score >= 5 OR security_critical OR dependencies.length >= 2
   - OMIT when: standard pattern with obvious implementation
   - Example: "Use existing RateLimiter middleware, configure for /api/* routes"
-**subtasks[].test_strategy**: Required object with unit/integration/e2e keys. Use "N/A" for levels not applicable.
+**subtasks[].test_strategy**: Required object with unit/integration/e2e keys plus `scenario_dimensions`. Use "N/A" for levels not applicable.
+  - **scenario_dimensions** (required): Object with four keys — `happy_path`, `error`, `edge_case`, `security`. Each describes at least one planned test covering that dimension. Use "N/A" for dimensions not relevant to the subtask. Testing-heavy subtasks must cover at minimum 4 dimensions.
   - MUST map `validation_criteria` → tests:
     - For each `VCn:` criterion, include at least one planned test name that covers it.
     - Recommended naming: include `vc<n>` in the test name (e.g., `test_vc1_*`, `TestVC1*`) for deterministic grep-ability.
@@ -751,7 +758,13 @@ For detailed examples and anti-patterns, see: `.claude/references/decomposition-
         "test_strategy": {
           "unit": "Test field accepts timestamps, test default is null",
           "integration": "Test migration applies cleanly",
-          "e2e": "N/A"
+          "e2e": "N/A",
+          "scenario_dimensions": {
+            "happy_path": "Test archived_at stores valid timestamp",
+            "error": "Test migration rollback on failure",
+            "edge_case": "Test field with existing null values in table",
+            "security": "N/A"
+          }
         },
         "affected_files": [
           "models/project.py",

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -659,35 +659,40 @@ python3 .map/scripts/map_step_runner.py update_plan_status "ST-XXX" "in_progress
 ### Phase: TESTS_GATE (2.8)
 
 ```bash
-# Run tests if available (do NOT install dependencies). Capture exit code for guard pattern.
+# Run tests if available (do NOT install dependencies). Capture exit code + output for guard pattern.
 TESTS_EXIT=0
+TEST_OUTPUT=""
 if [ -f "pytest.ini" ] || [ -f "setup.py" ]; then
-  pytest; TESTS_EXIT=$?
+  TEST_OUTPUT=$(pytest 2>&1); TESTS_EXIT=$?
 elif [ -f "package.json" ]; then
-  npm test; TESTS_EXIT=$?
+  TEST_OUTPUT=$(npm test 2>&1); TESTS_EXIT=$?
 elif [ -f "go.mod" ]; then
-  go test ./...; TESTS_EXIT=$?
+  TEST_OUTPUT=$(go test ./... 2>&1); TESTS_EXIT=$?
 elif [ -f "Cargo.toml" ]; then
-  cargo test; TESTS_EXIT=$?
+  TEST_OUTPUT=$(cargo test 2>&1); TESTS_EXIT=$?
 else
   echo "No tests found, skipping gate"
 fi
+# Print output so it's visible in the conversation
+echo "$TEST_OUTPUT"
 ```
 
 ### Phase: LINTER_GATE (2.9)
 
 ```bash
-# Run linter if available. Capture exit code for guard pattern.
+# Run linter if available. Capture exit code + output for guard pattern.
 LINT_EXIT=0
+LINT_OUTPUT=""
 if command -v ruff &> /dev/null; then
-  ruff check .; LINT_EXIT=$?
+  LINT_OUTPUT=$(ruff check . 2>&1); LINT_EXIT=$?
 elif command -v eslint &> /dev/null; then
-  eslint .; LINT_EXIT=$?
+  LINT_OUTPUT=$(eslint . 2>&1); LINT_EXIT=$?
 elif command -v golangci-lint &> /dev/null; then
-  golangci-lint run; LINT_EXIT=$?
+  LINT_OUTPUT=$(golangci-lint run 2>&1); LINT_EXIT=$?
 else
   echo "No linter found, skipping gate"
 fi
+echo "$LINT_OUTPUT"
 ```
 
 ### Phase: GUARD_DECISION (2.95)

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -266,7 +266,8 @@ Then use the **Write** tool to create `.map/<branch>/workflow_state.json`:
   "current_state": "INITIALIZED",
   "completed_steps": {},
   "pending_steps": {},
-  "subtask_sequence": []
+  "subtask_sequence": [],
+  "constraints": null
 }
 ```
 
@@ -533,9 +534,51 @@ if monitor_output["valid"] == false:
     if retry_count < 5:
         # Go back to Phase: ACTOR with Monitor feedback
         # Actor will fix issues and re-apply code
+
+        # === STUCK RECOVERY (at retry 3) ===
+        # At retry 3, intercept with intermediate recovery before retries 4-5.
+        # This gives Actor better context to break out of a stuck loop.
+        if retry_count == 3:
+            # Step 1: Check if research-agent already ran for this subtask
+            findings_file = f".map/{branch}/findings_{branch}.md"
+            if findings_file exists and has content for this subtask:
+                # Reuse existing findings (Edge Case 12: skip re-invocation)
+                recovery_context = read(findings_file)
+            else:
+                # Invoke research-agent for alternative approaches
+                Task(
+                    subagent_type="research-agent",
+                    description="Stuck recovery: find alternative approach",
+                    prompt=f"""Subtask {subtask_id} failed 3 monitor retries.
+Monitor feedback: {latest_monitor_feedback}
+Find an ALTERNATIVE approach. Current approach is not working.
+Focus on: different patterns, simpler implementations, existing utilities."""
+                )
+                recovery_context = research_agent_output
+
+            # Step 2: Invoke predictor (skip for low-risk subtasks — Edge Case 7)
+            if subtask.risk_level != "low":
+                Task(
+                    subagent_type="predictor",
+                    description="Stuck recovery: analyze why approach fails",
+                    prompt=f"""Subtask {subtask_id} failed 3 retries.
+Research findings: {recovery_context}
+Analyze: why is the current approach failing? What dependencies are missed?"""
+                )
+                recovery_context += predictor_output
+
+            # Step 3: Pass recovery context to Actor for retries 4-5
+            # Actor receives: original task + monitor feedback + recovery context
+            # This gives Actor a fresh perspective from research-agent/predictor
+
+            # If both research-agent and predictor found nothing useful:
+            if recovery_context is empty or unhelpful:
+                AskUserQuestion(questions=[{"question": "Stuck recovery: research-agent and predictor found no alternative. How to proceed?", "header": "Stuck", "options": [{"label": "Continue", "description": "Try 2 more retries with current approach"}, {"label": "Skip", "description": "Skip subtask, move to next"}, {"label": "Abort", "description": "Stop workflow"}], "multiSelect": false}])
+        # === END STUCK RECOVERY ===
+
     else:
-        # Escalate to user (retry limit reached)
-        AskUserQuestion(questions=[{"question": "Monitor retry limit reached. How to proceed?", "header": "Retry limit", "options": [{"label": "Continue", "description": "Reset retry counter and try again"}, {"label": "Skip", "description": "Skip this subtask and move to next"}, {"label": "Abort", "description": "Stop workflow"}], "multiSelect": false}])
+        # Escalate to user (retry limit reached after 5 attempts)
+        AskUserQuestion(questions=[{"question": "Monitor retry limit reached (5 attempts). How to proceed?", "header": "Retry limit", "options": [{"label": "Continue", "description": "Reset retry counter and try again"}, {"label": "Skip", "description": "Skip this subtask and move to next"}, {"label": "Abort", "description": "Stop workflow"}], "multiSelect": false}])
 ```
 
 ### Phase: PREDICTOR (2.6)
@@ -616,15 +659,16 @@ python3 .map/scripts/map_step_runner.py update_plan_status "ST-XXX" "in_progress
 ### Phase: TESTS_GATE (2.8)
 
 ```bash
-# Run tests if available (do NOT install dependencies)
+# Run tests if available (do NOT install dependencies). Capture exit code for guard pattern.
+TESTS_EXIT=0
 if [ -f "pytest.ini" ] || [ -f "setup.py" ]; then
-  pytest
+  pytest; TESTS_EXIT=$?
 elif [ -f "package.json" ]; then
-  npm test
+  npm test; TESTS_EXIT=$?
 elif [ -f "go.mod" ]; then
-  go test ./...
+  go test ./...; TESTS_EXIT=$?
 elif [ -f "Cargo.toml" ]; then
-  cargo test
+  cargo test; TESTS_EXIT=$?
 else
   echo "No tests found, skipping gate"
 fi
@@ -633,17 +677,48 @@ fi
 ### Phase: LINTER_GATE (2.9)
 
 ```bash
-# Run linter if available
+# Run linter if available. Capture exit code for guard pattern.
+LINT_EXIT=0
 if command -v ruff &> /dev/null; then
-  ruff check .
+  ruff check .; LINT_EXIT=$?
 elif command -v eslint &> /dev/null; then
-  eslint .
+  eslint .; LINT_EXIT=$?
 elif command -v golangci-lint &> /dev/null; then
-  golangci-lint run
+  golangci-lint run; LINT_EXIT=$?
 else
   echo "No linter found, skipping gate"
 fi
 ```
+
+### Phase: GUARD_DECISION (2.95)
+
+**Guard Pattern Decision Table** — applies after TESTS_GATE and LINTER_GATE.
+
+Guard rework counter (`guard_rework`) is **independent** of monitor retry counter.
+
+```
+IF monitor_output["valid"] == true:
+  IF TESTS_EXIT == 0 AND LINT_EXIT == 0:
+    → KEEP: Proceed to VERIFY_ADHERENCE (all green)
+
+  ELSE (monitor pass + guard fail = regression detected):
+    guard_rework += 1
+    IF guard_rework <= 2:
+      → RETRY Actor with guard failure context:
+        - Pass: test/lint stderr output
+        - Pass: "Monitor approved your changes but tests/linter failed (regression)"
+        - Pass: "Fix the regression without breaking the new behavior"
+        - After Actor retry → re-run Monitor → re-run TESTS_GATE + LINTER_GATE
+    ELSE (guard_rework > 2):
+      → ESCALATE to user:
+        AskUserQuestion("Guard failure after 2 rework attempts. Tests/linter still failing.")
+        Options: ["Skip this subtask", "Abort workflow"]
+
+ELSE (monitor_output["valid"] == false):
+  → Standard monitor retry logic (existing behavior, max 5 retries)
+```
+
+**Key invariant:** Guard rework never modifies test files — Actor must adapt implementation to pass existing tests.
 
 ### Phase: VERIFY_ADHERENCE (2.10)
 

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -12,7 +12,7 @@
 - Calls task-decomposer agent to break down the user's request into subtasks
 - Creates `.map/<branch>/task_plan_<branch>.md` with subtask list
 - Initializes `.map/<branch>/workflow_state.json` with subtask sequence
-- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`research.md`, `implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
+- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
 - **STOPS** after planning (forces context flush)
 
 **What this command CANNOT do:**
@@ -34,7 +34,6 @@ echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "state:       $(test -f .map/${BRANCH}/workflow_state.json && echo EXISTS || echo MISSING)"
-echo "research:    $(test -f .map/${BRANCH}/research.md && echo EXISTS || echo MISSING)"
 echo "impl_plan:   $(test -f .map/${BRANCH}/implementation-plan.md && echo EXISTS || echo MISSING)"
 echo "decisions:   $(test -f .map/${BRANCH}/decision-log.md && echo EXISTS || echo MISSING)"
 echo "pr_draft:    $(test -f .map/${BRANCH}/pr-draft.md && echo EXISTS || echo MISSING)"
@@ -100,7 +99,7 @@ User request:
 )
 ```
 
-**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to both `.map/<branch>/findings_<branch>.md` and `.map/<branch>/research.md` so they persist across sessions. `findings_<branch>.md` stays optimized for executor distillation; `research.md` is the human-readable planning note.
+**Save discovery results:** The research-agent returns findings inline. Use the **Write** tool to save them to `.map/<branch>/findings_<branch>.md` so they persist across sessions.
 
 **Discovery output format** (in findings file):
 ```markdown
@@ -567,7 +566,7 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ workflow_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
-✅ Human-readable artifacts updated: research.md, implementation-plan.md, decision-log.md, pr-draft.md
+✅ Human-readable artifacts updated: implementation-plan.md, decision-log.md, pr-draft.md
 ✅ Planning review recorded: plan-review-00N.md + plan-gate.json
 ✅ Context distilled (plan files ≤4000 tokens per subtask)
 
@@ -593,7 +592,6 @@ DISTILLATION CHECKLIST:
   [x] workflow_state.json   — has aag_contracts map + subtask_sequence
   [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
-  [x] research.md           — human-readable discovery and context for resume/handoff
   [x] implementation-plan.md — concise execution roadmap for humans
   [x] decision-log.md       — key tradeoffs captured before implementation
   [x] pr-draft.md           — initial summary + validation + risk notes

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -208,6 +208,18 @@ These are hard constraints — violating any invariant is a blocker.
 - [e.g., "Database migrations must be backward-compatible (no column drops)"]
 - [e.g., "Response time for any endpoint must stay under 500ms p95"]
 
+## Constraints
+
+Workflow execution limits. When no constraints specified, all default to null (unlimited) and the enforcement hook skips checks.
+
+```yaml
+constraints:
+  max_files: null        # Maximum files Actor can modify per workflow (int or null)
+  max_subtasks: null     # Maximum subtasks in decomposition (int or null)
+  time_budget: null      # Maximum minutes for entire workflow (int or null)
+  scope_glob: null       # File glob restricting Actor's edit scope (string or null)
+```
+
 ## Edge Cases
 
 Enumerate boundary conditions and unusual inputs that implementation must handle.
@@ -486,6 +498,25 @@ Then use the **Write** tool to create `.map/<branch>/task_plan_<branch>.md` with
 
 **AAG Contract is REQUIRED** for every subtask. Copy directly from task-decomposer output's `aag_contract` field. This is the primary handoff to the Actor agent — without it, the Actor reasons instead of compiles.
 
+### Step 6.5: Validate Constraints (Before State Initialization)
+
+If the spec includes a `## Constraints` section with non-null values, validate before writing workflow_state.json:
+
+**scope_glob validation** (REQUIRED if scope_glob is non-null):
+- Reject if contains `..` (path traversal)
+- Reject if starts with `/` (absolute path)
+- Reject if contains `{` (brace expansion — Python version-dependent behavior)
+- On validation failure: print error and STOP — do not create workflow_state.json
+
+```bash
+# Example validation (run in Bash)
+SCOPE_GLOB="src/auth/**"  # from spec constraints
+if echo "$SCOPE_GLOB" | grep -qE '(\.\.)|^/|\{'; then
+  echo "ERROR: Invalid scope_glob '$SCOPE_GLOB'. Must be relative, no '..' or brace expansion."
+  exit 1
+fi
+```
+
 ### Step 7: Initialize Workflow State (Do This Last)
 
 Create `.map/<branch>/workflow_state.json` with the decomposition results. Wrap in `MAP_State_v1_0` tag for executor parsing.
@@ -507,6 +538,12 @@ Use the **Write** tool to create `.map/<branch>/workflow_state.json` with this s
   "aag_contracts": {
     "ST-001": "Actor -> Action(params) -> Goal",
     "ST-002": "Actor -> Action(params) -> Goal"
+  },
+  "constraints": {
+    "max_files": null,
+    "max_subtasks": null,
+    "time_budget": null,
+    "scope_glob": null
   }
 }
 ```
@@ -514,6 +551,7 @@ Use the **Write** tool to create `.map/<branch>/workflow_state.json` with this s
 **IMPORTANT:**
 - Replace `subtask_sequence` with actual IDs from the decomposition
 - Populate `aag_contracts` map with each subtask's AAG contract from the decomposer output — executors read this to set context for each subtask
+- Populate `constraints` from the spec's Constraints section. null = unlimited (hook skips enforcement)
 
 ### Step 8: Output Checkpoint
 

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -130,7 +130,7 @@ STRICT RULES:
 8. Cover scenario dimensions from test_strategy: write tests for at minimum
    happy_path, error, edge_case, and security dimensions (use "N/A" if not applicable).
    Each dimension should have at least one dedicated test or test case.
-8. Test files MUST be lint-clean. Use proper imports at the top of the file
+9. Test files MUST be lint-clean. Use proper imports at the top of the file
    (not inside type annotations). Run the project linter (ruff/eslint/golangci-lint)
    on test files before finishing. Fix any lint errors in your test files.
 

--- a/src/mapify_cli/templates/commands/map-tdd.md
+++ b/src/mapify_cli/templates/commands/map-tdd.md
@@ -127,6 +127,9 @@ STRICT RULES:
 5. Use standard test patterns for the project's language/framework.
 6. Each validation_criteria item (VCn:) must have at least one corresponding test.
 7. Include edge cases from the spec's Edge Cases section if available.
+8. Cover scenario dimensions from test_strategy: write tests for at minimum
+   happy_path, error, edge_case, and security dimensions (use "N/A" if not applicable).
+   Each dimension should have at least one dedicated test or test case.
 8. Test files MUST be lint-clean. Use proper imports at the top of the file
    (not inside type annotations). Run the project linter (ruff/eslint/golangci-lint)
    on test files before finishing. Fix any lint errors in your test files.

--- a/src/mapify_cli/templates/hooks/ralph-iteration-logger.py
+++ b/src/mapify_cli/templates/hooks/ralph-iteration-logger.py
@@ -317,36 +317,43 @@ def main() -> None:
 def derive_summary(log_file: Path) -> None:
     """Derive iteration_summary.json from iteration_log.jsonl.
 
-    Aggregates per-file stats, truncates to last 50 entries when > 100,
-    and writes a summary JSON to the same branch directory.
+    Reads only the last 100 lines (via deque) to keep O(1) memory and fast I/O.
+    Aggregates per-file stats, skips entries without a file path.
     """
     if not log_file.exists():
         return
 
-    lines = log_file.read_text(encoding="utf-8").strip().split("\n")
-    entries = []
-    for line in lines:
-        if line.strip():
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
+    from collections import deque
 
-    total_entries_seen = len(entries)
-    if total_entries_seen == 0:
+    # Stream only last 100 lines — O(N) read but O(1) memory
+    total_lines = 0
+    last_lines: deque[str] = deque(maxlen=100)
+    with open(log_file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                total_lines += 1
+                last_lines.append(stripped)
+
+    entries = []
+    for line in last_lines:
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    if not entries:
         return
 
-    # Truncate to last 50 if > 100 entries
-    dropped_count = 0
-    if total_entries_seen > 100:
-        dropped_count = total_entries_seen - 50
-        entries = entries[-50:]
+    dropped_count = max(0, total_lines - len(entries))
 
-    # Aggregate per-file stats
+    # Aggregate per-file stats — skip entries without a concrete file path
     file_data: dict[str, list[float]] = {}
     file_thrashing: Counter[str] = Counter()
     for entry in entries:
-        f = entry.get("file", "unknown")
+        f = (entry.get("file") or "").strip()
+        if not f:
+            continue
         eff = entry.get("effectiveness", 0.0)
         file_data.setdefault(f, []).append(eff)
         file_thrashing[f] += 1
@@ -363,23 +370,23 @@ def derive_summary(log_file: Path) -> None:
             "thrashing_count": is_thrashing,
         })
 
-    all_effs = [e.get("effectiveness", 0.0) for e in entries]
+    all_effs = [e.get("effectiveness", 0.0) for e in entries if (e.get("file") or "").strip()]
     summary: dict[str, object] = {
         "generated_at": datetime.now().isoformat(),
         "entry_count": len(entries),
-        "total_entries_seen": total_entries_seen,
+        "total_entries_seen": total_lines,
         "dropped_count": dropped_count,
         "file_stats": file_stats,
         "aggregate": {
-            "total_iterations": total_entries_seen,
+            "total_iterations": total_lines,
             "avg_effectiveness": round(sum(all_effs) / len(all_effs), 3) if all_effs else 0.0,
             "total_thrashing_alerts": thrashing_alert_count,
         },
     }
 
     summary_file = log_file.parent / "iteration_summary.json"
-    with open(summary_file, "w", encoding="utf-8") as f:
-        json.dump(summary, f, indent=2, ensure_ascii=True)
+    with open(summary_file, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2, ensure_ascii=True)
 
 
 if __name__ == "__main__":

--- a/src/mapify_cli/templates/hooks/ralph-iteration-logger.py
+++ b/src/mapify_cli/templates/hooks/ralph-iteration-logger.py
@@ -304,8 +304,82 @@ def main() -> None:
                 file=sys.stderr,
             )
 
+    # Derive iteration summary (best-effort, never blocks)
+    try:
+        derive_summary(log_file)
+    except Exception:
+        pass
+
     print("{}")
     sys.exit(0)
+
+
+def derive_summary(log_file: Path) -> None:
+    """Derive iteration_summary.json from iteration_log.jsonl.
+
+    Aggregates per-file stats, truncates to last 50 entries when > 100,
+    and writes a summary JSON to the same branch directory.
+    """
+    if not log_file.exists():
+        return
+
+    lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+    entries = []
+    for line in lines:
+        if line.strip():
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    total_entries_seen = len(entries)
+    if total_entries_seen == 0:
+        return
+
+    # Truncate to last 50 if > 100 entries
+    dropped_count = 0
+    if total_entries_seen > 100:
+        dropped_count = total_entries_seen - 50
+        entries = entries[-50:]
+
+    # Aggregate per-file stats
+    file_data: dict[str, list[float]] = {}
+    file_thrashing: Counter[str] = Counter()
+    for entry in entries:
+        f = entry.get("file", "unknown")
+        eff = entry.get("effectiveness", 0.0)
+        file_data.setdefault(f, []).append(eff)
+        file_thrashing[f] += 1
+
+    file_stats: list[dict[str, object]] = []
+    thrashing_alert_count = 0
+    for f, effs in sorted(file_data.items(), key=lambda x: -len(x[1])):
+        is_thrashing = 1 if file_thrashing[f] >= THRASHING_WINDOW else 0
+        thrashing_alert_count += is_thrashing
+        file_stats.append({
+            "file": f,
+            "iterations": len(effs),
+            "avg_effectiveness": round(sum(effs) / len(effs), 3) if effs else 0.0,
+            "thrashing_count": is_thrashing,
+        })
+
+    all_effs = [e.get("effectiveness", 0.0) for e in entries]
+    summary: dict[str, object] = {
+        "generated_at": datetime.now().isoformat(),
+        "entry_count": len(entries),
+        "total_entries_seen": total_entries_seen,
+        "dropped_count": dropped_count,
+        "file_stats": file_stats,
+        "aggregate": {
+            "total_iterations": total_entries_seen,
+            "avg_effectiveness": round(sum(all_effs) / len(all_effs), 3) if all_effs else 0.0,
+            "total_thrashing_alerts": thrashing_alert_count,
+        },
+    }
+
+    summary_file = log_file.parent / "iteration_summary.json"
+    with open(summary_file, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=True)
 
 
 if __name__ == "__main__":

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -169,11 +169,16 @@ def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
     # scope_glob
     scope_glob = constraints.get("scope_glob")
     if scope_glob and target_paths:
+        repo_root = Path.cwd().resolve()
         for tp in target_paths:
+            resolved = Path(tp).resolve()
             try:
-                rel = str(Path(tp).resolve().relative_to(Path.cwd().resolve()))
+                rel = str(resolved.relative_to(repo_root))
             except ValueError:
-                rel = tp
+                return (
+                    f"Constraint: scope_glob='{scope_glob}'\n"
+                    f"File '{resolved}' resolves outside repository root."
+                )
             if not fnmatch(rel, scope_glob):
                 return (
                     f"Constraint: scope_glob='{scope_glob}'\n"

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -2,63 +2,38 @@
 """
 Claude Code PreToolUse Hook: Workflow Enforcement Gate
 
-Enforces MAP Framework workflow adherence by blocking Edit/Write/MultiEdit
-operations until required workflow steps (Actor + Monitor) are completed.
+Blocks Edit/Write/MultiEdit outside of Actor-related phases.
+Uses step_state.json (orchestrator canonical state) as single source of truth.
 
-USAGE:
-  This hook runs automatically before Edit/Write/MultiEdit tool calls.
-  No manual invocation needed - Claude Code handles hook execution.
+ENFORCEMENT:
+  - Edit allowed during phases: ACTOR, APPLY, TEST_WRITER
+  - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
+  - Fail-open: no step_state.json or no workflow_state.json → allow
+  - Always allows: .map/ artifacts, ~/.claude/ memory, non-editing tools
 
-ENFORCEMENT RULES:
-  - Allows Edit/Write/MultiEdit when workflow_state.json is missing (fail-open)
-  - Blocks if current subtask hasn't completed required steps: ['actor', 'monitor']
-  - Allows tools if all required steps are completed
-  - Always allows edits under .map/ (workflow artifacts/state) to prevent deadlocks
-  - Always allows edits under ~/.claude/ (auto-memory, project settings)
-  - Allows Read, Bash, and other non-editing tools always
+CONSTRAINTS (from workflow_state.json):
+  - scope_glob: restrict edits to matching file patterns
+  - time_budget: block after N minutes elapsed
 
-WORKFLOW STATE FILE:
-  Location: .map/<branch>/workflow_state.json
-  Required fields:
-    - current_subtask: Current subtask ID (e.g., "ST-001")
-    - completed_steps: Dict mapping subtask_id -> list of completed steps
-    - pending_steps: Dict mapping subtask_id -> list of pending steps
-
-HOOK BEHAVIOR:
-  - Exit code 0: Allow tool execution
-  - Exit code 0 + permissionDecision=deny: Block tool execution with reason (preferred)
-
-TESTING:
-  echo '{"tool_name": "Edit", "tool_input": {"file_path": "test.py"}}' | python3 workflow-gate.py
-  # Expected (no workflow state): Exit 0, stdout: {}
-  # Expected (workflow active, missing steps): Exit 0, stdout: {"hookSpecificOutput":{"permissionDecision":"deny",...}}
-
-PERFORMANCE:
-  Target: <100ms per invocation
-  Design: Minimal I/O, fast JSON parsing, pre-compiled checks
-
-DESIGN RATIONALE:
-  Based on LLM Council recommendation: "Reify State - Don't tell the model
-  'remember to call Monitor.' Make the environment hostile to action until
-  the Monitor is called." This hook implements that principle through
-  filesystem-based enforcement.
+Exit code 0 always (fail-open on errors).
 """
 import json
 import os
 import re
 import sys
+from datetime import datetime, timezone
+from fnmatch import fnmatch
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
-# Tools that require workflow enforcement
 EDITING_TOOLS = {"Edit", "Write", "MultiEdit"}
 
-# Required steps before allowing edits
-REQUIRED_STEPS = ["actor", "monitor"]
+# Phases where Edit/Write is expected (Actor applies code)
+EDITING_PHASES = {"ACTOR", "APPLY", "TEST_WRITER"}
 
 
-def extract_target_file_paths(tool_call: Dict) -> list[str]:
-    """Best-effort extraction of file paths from Claude Code tool payloads."""
+def extract_target_file_paths(tool_call: dict) -> list[str]:
+    """Extract file paths from tool call payload."""
     tool_input = tool_call.get("tool_input") or {}
     if not isinstance(tool_input, dict):
         return []
@@ -72,23 +47,16 @@ def extract_target_file_paths(tool_call: Dict) -> list[str]:
     edits = tool_input.get("edits")
     if isinstance(edits, list):
         for edit in edits:
-            if not isinstance(edit, dict):
-                continue
-            fp = edit.get("file_path")
-            if isinstance(fp, str) and fp.strip():
-                paths.append(fp)
+            if isinstance(edit, dict):
+                fp = edit.get("file_path")
+                if isinstance(fp, str) and fp.strip():
+                    paths.append(fp)
 
     return paths
 
 
 def is_exempt_path(file_path: str) -> bool:
-    """
-    Return True if file_path is exempt from workflow enforcement.
-
-    Exempt paths:
-    - .map/ artifacts (workflow state, plans, findings) -- prevents deadlocks
-    - ~/.claude/ (auto-memory, project settings) -- Claude's own persistence
-    """
+    """Return True if path is exempt from enforcement (.map/, ~/.claude/memory/)."""
     if not isinstance(file_path, str) or not file_path.strip():
         return False
 
@@ -99,20 +67,18 @@ def is_exempt_path(file_path: str) -> bool:
         else (Path.cwd().resolve() / candidate).resolve(strict=False)
     )
 
-    # Allow Claude auto-memory writes (~/.claude/projects/*/memory/)
+    # Allow ~/.claude/projects/*/memory/
     claude_memory_dir = Path.home() / ".claude" / "projects"
     try:
         rel = resolved.relative_to(claude_memory_dir.resolve())
-        # Only allow paths that include a "memory" component
         if "memory" in rel.parts:
             return True
     except ValueError:
         pass
 
-    # Allow .map/ artifacts
-    repo_root = Path.cwd().resolve()
+    # Allow .map/
     try:
-        rel = resolved.relative_to(repo_root)
+        rel = resolved.relative_to(Path.cwd().resolve())
     except ValueError:
         return False
 
@@ -120,7 +86,7 @@ def is_exempt_path(file_path: str) -> bool:
 
 
 def sanitize_branch_name(branch: str) -> str:
-    """Sanitize branch name for safe filesystem paths."""
+    """Sanitize branch name for filesystem paths."""
     sanitized = branch.replace("/", "-")
     sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "-", sanitized)
     sanitized = re.sub(r"-+", "-", sanitized).strip("-")
@@ -130,7 +96,7 @@ def sanitize_branch_name(branch: str) -> str:
 
 
 def get_branch_name() -> str:
-    """Get current git branch name (sanitized for filesystem)."""
+    """Get current git branch name (sanitized)."""
     try:
         import subprocess
 
@@ -147,134 +113,147 @@ def get_branch_name() -> str:
     return "default"
 
 
-def load_workflow_state(branch: str) -> Optional[Dict]:
-    """Load workflow state from .map/<branch>/workflow_state.json"""
-    state_file = Path(f".map/{branch}/workflow_state.json")
+def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
+    """Check step_state.json: is current phase one where Edit is allowed?
 
+    Returns (allowed, error_message).
+    """
+    step_file = Path(f".map/{branch}/step_state.json")
+    if not step_file.exists():
+        return True, None  # No step state → fail-open
+
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return True, None  # Corrupt/unreadable → fail-open
+
+    # Parallel wave mode: check subtask_phases dict
+    subtask_phases = state.get("subtask_phases", {})
+    if subtask_phases:
+        for phase in subtask_phases.values():
+            if phase in EDITING_PHASES:
+                return True, None
+
+    # Sequential mode: check current_step_phase
+    current_phase = state.get("current_step_phase", "")
+    if current_phase in EDITING_PHASES:
+        return True, None
+
+    # Not in an editing phase → block
+    subtask = state.get("current_subtask_id", "?")
+    return False, (
+        f"Workflow gate: Edit blocked during phase '{current_phase}' "
+        f"(subtask {subtask}).\n"
+        f"Edit is only allowed during: {', '.join(sorted(EDITING_PHASES))}.\n"
+        "Call the Actor agent first — it will apply code changes."
+    )
+
+
+def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
+    """Check constraints from workflow_state.json. Returns error or None."""
+    state_file = Path(f".map/{branch}/workflow_state.json")
     if not state_file.exists():
         return None
 
     try:
         with open(state_file, "r", encoding="utf-8") as f:
-            return json.load(f)
+            state = json.load(f)
     except (json.JSONDecodeError, OSError):
         return None
 
+    constraints = state.get("constraints")
+    if not constraints:
+        return None
 
-def check_workflow_compliance(state: Dict) -> tuple[bool, Optional[str]]:
-    """
-    Check if current subtask(s) have completed required workflow steps.
+    # scope_glob
+    scope_glob = constraints.get("scope_glob")
+    if scope_glob and target_paths:
+        for tp in target_paths:
+            try:
+                rel = str(Path(tp).resolve().relative_to(Path.cwd().resolve()))
+            except ValueError:
+                rel = tp
+            if not fnmatch(rel, scope_glob):
+                return (
+                    f"Constraint: scope_glob='{scope_glob}'\n"
+                    f"File '{rel}' is outside allowed scope."
+                )
 
-    Supports both single-subtask mode (current_subtask) and parallel wave mode
-    (active_subtasks list). In parallel mode, allows edits if ANY active
-    subtask has completed the required steps.
+    # time_budget
+    time_budget = constraints.get("time_budget")
+    if time_budget is not None:
+        started_at = state.get("started_at")
+        if started_at:
+            try:
+                start = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() / 60
+                if elapsed > time_budget:
+                    return (
+                        f"Constraint: time_budget={time_budget} min, "
+                        f"elapsed={elapsed:.0f} min."
+                    )
+            except (ValueError, TypeError):
+                pass
 
-    Returns:
-        (is_compliant, error_message)
-    """
-    # Try active_subtasks first (parallel wave mode)
-    active = state.get("active_subtasks", [])
-    if not active:
-        # Backward compat: single current_subtask
-        current = state.get("current_subtask")
-        if current:
-            active = [current]
+    return None
 
-    if not active:
-        current_state = state.get("current_state") or "UNKNOWN"
-        return False, (
-            "⛔ Workflow Enforcement: No current_subtask defined in workflow_state.json\n\n"
-            f"current_state: {current_state}\n\n"
-            "Edits to non-.map files are blocked until current_subtask is set and "
-            "the required steps are completed.\n\n"
-            "To fix:\n"
-            "  - Update .map/<branch>/workflow_state.json to set current_subtask\n"
-            "  - Or re-run /map-resume or /map-plan to regenerate state\n"
-            "  - Or delete .map/<branch>/workflow_state.json to disable enforcement"
+
+def deny(reason: str) -> None:
+    """Print deny response and exit."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
         )
-
-    # Allow if ANY active subtask has completed required steps
-    for subtask_id in active:
-        completed = state.get("completed_steps", {}).get(subtask_id, [])
-        if all(step in completed for step in REQUIRED_STEPS):
-            return True, None
-
-    # Block with appropriate message
-    missing_details = []
-    for subtask_id in active:
-        completed = state.get("completed_steps", {}).get(subtask_id, [])
-        missing = [step for step in REQUIRED_STEPS if step not in completed]
-        if missing:
-            missing_details.append(f"{subtask_id}: missing {', '.join(missing)}")
-
-    return False, (
-        f"⛔ Workflow Enforcement: Cannot edit code for active subtasks\n\n"
-        f"Active subtasks: {', '.join(active)}\n"
-        f"Missing steps:\n" + "\n".join(f"  - {d}" for d in missing_details) + "\n\n"
-        "Required workflow:\n"
-        "  1. Call Task(subagent_type='actor') to generate implementation\n"
-        "  2. Call Task(subagent_type='monitor') to validate\n"
-        "  3. Only then can you apply changes with Edit/Write\n\n"
-        "To fix: Complete missing steps before editing code.\n"
-        "Or update workflow_state.json if steps were completed."
     )
+    sys.exit(0)
 
 
-def main():
-    """Main hook entry point."""
+def allow() -> None:
+    """Print allow response and exit."""
+    print("{}")
+    sys.exit(0)
+
+
+def main() -> None:
     try:
-        # Read tool call from stdin
         tool_call = json.load(sys.stdin)
         tool_name = tool_call.get("tool_name", "")
 
-        # Allow non-editing tools
+        # Non-editing tools → always allow
         if tool_name not in EDITING_TOOLS:
-            print("{}")
-            sys.exit(0)
+            allow()
 
-        # Always allow edits to MAP workflow artifacts under .map/
+        # Exempt paths (.map/, ~/.claude/memory/) → always allow
         target_paths = extract_target_file_paths(tool_call)
         if target_paths and all(is_exempt_path(p) for p in target_paths):
-            print("{}")
-            sys.exit(0)
+            allow()
 
-        # Get current branch
         branch = get_branch_name()
 
-        # Load workflow state
-        state = load_workflow_state(branch)
+        # Phase check (step_state.json)
+        allowed, error = is_editing_phase(branch)
+        if not allowed:
+            deny(error or "Edit blocked: not in an editing phase.")
 
-        if state is None:
-            # No workflow state = not in MAP workflow mode, allow
-            # (This prevents breaking non-MAP work)
-            print("{}")
-            sys.exit(0)
+        # Constraint check (workflow_state.json)
+        constraint_error = check_constraints(branch, target_paths)
+        if constraint_error:
+            deny(constraint_error)
 
-        # Check workflow compliance
-        is_compliant, error_message = check_workflow_compliance(state)
-
-        if is_compliant:
-            print("{}")
-            sys.exit(0)
-        else:
-            print(
-                json.dumps(
-                    {
-                        "hookSpecificOutput": {
-                            "hookEventName": "PreToolUse",
-                            "permissionDecision": "deny",
-                            "permissionDecisionReason": error_message,
-                        }
-                    }
-                )
-            )
-            sys.exit(0)
+        allow()
 
     except Exception as e:
-        # On hook failure, approve (fail-open to avoid blocking work)
-        print("{}")
+        # Fail-open on any error
         if os.environ.get("DEBUG_WORKFLOW_GATE"):
             print(f"[workflow-gate] ERROR: {e}", file=sys.stderr)
+        print("{}")
         sys.exit(0)
 
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -42,8 +42,8 @@ HUMAN_ARTIFACT_DEFAULTS = {
 }
 
 
-KNOWN_ISSUES_DEFAULT: dict[str, list[str]] = {"issues": []}
-ACTIVE_ISSUES_DEFAULT: dict[str, str | list[str]] = {"updated_at": "", "issues": []}
+KNOWN_ISSUES_DEFAULT: dict[str, list[dict[str, object]]] = {"issues": []}
+ACTIVE_ISSUES_DEFAULT: dict[str, object] = {"updated_at": "", "issues": []}
 
 GATE_VERDICTS = {"ready", "needs-revision", "blocked"}
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -42,8 +42,8 @@ HUMAN_ARTIFACT_DEFAULTS = {
 }
 
 
-KNOWN_ISSUES_DEFAULT = {"issues": []}
-ACTIVE_ISSUES_DEFAULT = {"updated_at": "", "issues": []}
+KNOWN_ISSUES_DEFAULT: dict[str, list[str]] = {"issues": []}
+ACTIVE_ISSUES_DEFAULT: dict[str, str | list[str]] = {"updated_at": "", "issues": []}
 
 GATE_VERDICTS = {"ready", "needs-revision", "blocked"}
 

--- a/src/mapify_cli/templates/references/escalation-matrix.md
+++ b/src/mapify_cli/templates/references/escalation-matrix.md
@@ -22,6 +22,30 @@ Reference guide for orchestrator agents on when to escalate failures vs. retry.
 | Confidence oscillating > 0.3 | Model uncertain |
 | Same error message 2+ times | Not making progress |
 
+## Stuck Recovery (Intermediate — at retry 3)
+
+Before exhausting retries, invoke intermediate recovery at monitor retry 3:
+
+| Step | Action | Skip Condition |
+|------|--------|----------------|
+| 1. research-agent | Find alternative approach for stuck subtask | Reuse existing findings if already ran for this subtask |
+| 2. predictor | Analyze why current approach fails, suggest alternatives | Skip for `risk_level == "low"` subtasks |
+| 3. Resume retries | Pass recovery context to Actor for retries 4-5 | — |
+| 4. User escalation | If research-agent + predictor found nothing useful | Only if recovery context is empty |
+
+This path is orchestrator-level logic in `map-efficient.md`, not a Ralph Loop state transition.
+
+## Guard Pattern Escalation (after 2 rework attempts)
+
+When Monitor passes but TESTS_GATE/LINTER_GATE fails (regression detected):
+
+| Rework Attempt | Action |
+|----------------|--------|
+| 1-2 | Retry Actor with guard failure context (test/lint stderr) |
+| 3+ | Escalate to user: "Guard failure after 2 rework attempts. Skip/Abort?" |
+
+Guard rework counter is independent of monitor retry counter.
+
 ## Continue Retrying
 
 | Condition | Max Retries |

--- a/src/mapify_cli/templates/settings.json
+++ b/src/mapify_cli/templates/settings.json
@@ -17,11 +17,9 @@
     "allow": [
       "Edit(.claude/agents/*)",
       "Edit(.claude/commands/*)",
-      "Edit(.claude/hooks/*)",
       "Edit(.claude/references/*)",
       "Write(.claude/agents/*)",
       "Write(.claude/commands/*)",
-      "Write(.claude/hooks/*)",
       "Write(.claude/references/*)",
       "Bash(mapify *)",
       "Bash(pytest *)",

--- a/src/mapify_cli/templates/settings.json
+++ b/src/mapify_cli/templates/settings.json
@@ -15,6 +15,14 @@
       "Bash(git reset --hard)"
     ],
     "allow": [
+      "Edit(.claude/agents/*)",
+      "Edit(.claude/commands/*)",
+      "Edit(.claude/hooks/*)",
+      "Edit(.claude/references/*)",
+      "Write(.claude/agents/*)",
+      "Write(.claude/commands/*)",
+      "Write(.claude/hooks/*)",
+      "Write(.claude/references/*)",
       "Bash(mapify *)",
       "Bash(pytest *)",
       "Bash(make lint)",

--- a/tests/test_command_templates.py
+++ b/tests/test_command_templates.py
@@ -224,7 +224,6 @@ class TestCommandTemplates:
         """/map-plan should maintain branch-scoped human-readable artifacts."""
         content = (templates_commands_dir / "map-plan.md").read_text()
 
-        assert "research.md" in content
         assert "implementation-plan.md" in content
         assert "decision-log.md" in content
         assert "pr-draft.md" in content

--- a/tests/test_workflow_gate.py
+++ b/tests/test_workflow_gate.py
@@ -4,7 +4,7 @@ Tests for workflow-gate.py hook.
 Run with: pytest tests/test_workflow_gate.py -v
 
 This hook enforces MAP Framework workflow adherence by blocking Edit/Write/MultiEdit
-until required workflow steps (actor + monitor) are completed.
+outside of Actor-related phases. Uses step_state.json as source of truth.
 """
 
 import json
@@ -14,7 +14,6 @@ from typing import Tuple
 
 import pytest
 
-# Get the repository root directory (where this test file lives is tests/)
 REPO_ROOT = Path(__file__).parent.parent
 
 
@@ -45,86 +44,51 @@ class TestWorkflowGate:
     def run_hook(
         self, input_data: dict, tmp_path: Path, branch: str = "master"
     ) -> Tuple[int, str, str]:
-        """Run workflow-gate.py hook with given input.
-
-        Returns:
-            (exit_code, stdout, stderr)
-        """
-        # Initialize real git repo in tmp_path (only if not already initialized)
+        """Run workflow-gate.py hook with given input."""
         git_dir = tmp_path / ".git"
         if not git_dir.exists():
             subprocess.run(
-                ["git", "init"],
-                cwd=tmp_path,
-                capture_output=True,
-                check=True,
+                ["git", "init"], cwd=tmp_path, capture_output=True, check=True
             )
-
-            # Configure git user for CI environments
             subprocess.run(
                 ["git", "config", "user.email", "test@example.com"],
-                cwd=tmp_path,
-                capture_output=True,
-                check=True,
+                cwd=tmp_path, capture_output=True, check=True,
             )
             subprocess.run(
                 ["git", "config", "user.name", "Test User"],
-                cwd=tmp_path,
-                capture_output=True,
-                check=True,
+                cwd=tmp_path, capture_output=True, check=True,
             )
-
-            # Create initial commit (required for branch to exist)
             (tmp_path / "README.md").write_text("test\n")
             subprocess.run(
                 ["git", "add", "README.md"],
-                cwd=tmp_path,
-                capture_output=True,
-                check=True,
+                cwd=tmp_path, capture_output=True, check=True,
             )
             subprocess.run(
                 ["git", "commit", "-m", "Initial commit"],
-                cwd=tmp_path,
-                capture_output=True,
-                check=True,
+                cwd=tmp_path, capture_output=True, check=True,
             )
 
-        # Get current branch
         current_branch = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=tmp_path,
-            capture_output=True,
-            text=True,
-            check=True,
+            cwd=tmp_path, capture_output=True, text=True, check=True,
         ).stdout.strip()
 
-        # Switch to target branch if different
         if current_branch != branch:
-            # Check if branch exists
             branch_exists = (
                 subprocess.run(
                     ["git", "rev-parse", "--verify", branch],
-                    cwd=tmp_path,
-                    capture_output=True,
-                ).returncode
-                == 0
+                    cwd=tmp_path, capture_output=True,
+                ).returncode == 0
             )
-
             if branch_exists:
-                # Switch to existing branch
                 subprocess.run(
                     ["git", "checkout", branch],
-                    cwd=tmp_path,
-                    capture_output=True,
-                    check=True,
+                    cwd=tmp_path, capture_output=True, check=True,
                 )
             else:
-                # Create and checkout new branch
                 subprocess.run(
                     ["git", "checkout", "-b", branch],
-                    cwd=tmp_path,
-                    capture_output=True,
-                    check=True,
+                    cwd=tmp_path, capture_output=True, check=True,
                 )
 
         result = subprocess.run(
@@ -136,338 +100,204 @@ class TestWorkflowGate:
         )
         return result.returncode, result.stdout, result.stderr
 
+    def _setup_step_state(self, tmp_path: Path, branch: str, phase: str,
+                          subtask_id: str = "ST-001",
+                          subtask_phases: dict | None = None) -> None:
+        """Create step_state.json with given phase."""
+        map_dir = tmp_path / ".map" / branch
+        map_dir.mkdir(parents=True, exist_ok=True)
+        state = {
+            "current_step_phase": phase,
+            "current_subtask_id": subtask_id,
+            "subtask_phases": subtask_phases or {},
+        }
+        (map_dir / "step_state.json").write_text(json.dumps(state))
+
+    # --- Non-editing tools ---
+
     def test_allows_non_editing_tools(self, tmp_path: Path) -> None:
         """Read, Bash, and other non-editing tools should always be allowed."""
         for tool_name in ["Read", "Bash", "Grep", "Glob", "Task"]:
             code, stdout, _ = self.run_hook(
-                {
-                    "tool_name": tool_name,
-                    "tool_input": {"file_path": "/test.py"},
-                },
+                {"tool_name": tool_name, "tool_input": {"file_path": "/test.py"}},
                 tmp_path,
             )
-
             assert code == 0, f"{tool_name} should be allowed"
             self._assert_allowed(stdout)
 
-    def test_allows_edit_when_no_workflow_state(self, tmp_path: Path) -> None:
-        """Edit should be allowed when workflow_state.json doesn't exist (fail-open)."""
+    # --- Fail-open behavior ---
+
+    def test_allows_edit_when_no_state_files(self, tmp_path: Path) -> None:
+        """Edit allowed when neither step_state.json nor workflow_state.json exist."""
         code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
             tmp_path,
         )
-
         assert code == 0
         self._assert_allowed(stdout)
-
-    def test_blocks_edit_without_actor(self, tmp_path: Path) -> None:
-        """Edit should be blocked if 'actor' step not completed."""
-        # Create workflow_state.json with incomplete steps
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {
-                        "ST-001": [
-                            "xml_packet",
-                        ]  # Missing actor and monitor
-                    },
-                    "pending_steps": {
-                        "ST-001": ["actor", "monitor", "tests", "linter"]
-                    },
-                }
-            )
-        )
-
-        code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-        )
-
-        assert code == 0  # Hook signals blocking via JSON decision
-        reason = self._assert_denied(stdout)
-        assert "actor" in reason.lower()
-        assert "monitor" in reason.lower()
-
-    def test_blocks_edit_without_monitor(self, tmp_path: Path) -> None:
-        """Edit should be blocked if 'monitor' step not completed (even if actor done)."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {
-                        "ST-001": [
-                            "xml_packet",
-                            "actor",
-                        ]  # Missing monitor
-                    },
-                    "pending_steps": {"ST-001": ["monitor", "tests", "linter"]},
-                }
-            )
-        )
-
-        code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-        )
-
-        assert code == 0
-        reason = self._assert_denied(stdout)
-        assert "monitor" in reason.lower()
-
-    def test_allows_edit_after_actor_and_monitor(self, tmp_path: Path) -> None:
-        """Edit should be allowed when both actor and monitor are completed."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {"ST-001": ["xml_packet", "actor", "monitor"]},
-                    "pending_steps": {"ST-001": ["tests", "linter"]},
-                }
-            )
-        )
-
-        code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-        )
-
-        assert code == 0
-        self._assert_allowed(stdout)
-
-    def test_blocks_write_without_required_steps(self, tmp_path: Path) -> None:
-        """Write should be blocked like Edit."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {"ST-001": ["xml_packet"]},
-                    "pending_steps": {"ST-001": ["actor", "monitor"]},
-                }
-            )
-        )
-
-        code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Write",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-        )
-
-        assert code == 0
-        self._assert_denied(stdout)
-
-    def test_blocks_multiedit_without_required_steps(self, tmp_path: Path) -> None:
-        """MultiEdit should be blocked like Edit and Write."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {"ST-001": []},
-                    "pending_steps": {"ST-001": ["actor", "monitor"]},
-                }
-            )
-        )
-
-        code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "MultiEdit",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-        )
-
-        assert code == 0
-        self._assert_denied(stdout)
-
-    def test_blocks_when_no_current_subtask(self, tmp_path: Path) -> None:
-        """Should block if current_subtask is null or missing."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": None,  # No active subtask
-                    "completed_steps": {},
-                    "pending_steps": {},
-                }
-            )
-        )
-
-        code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-        )
-
-        assert code == 0
-        reason = self._assert_denied(stdout)
-        assert "current_subtask" in reason.lower()
 
     def test_handles_invalid_json_gracefully(self, tmp_path: Path) -> None:
-        """Should fail-open (allow) on invalid workflow_state.json."""
+        """Should fail-open on invalid step_state.json."""
         map_dir = tmp_path / ".map" / "master"
         map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text("not valid json {")
+        (map_dir / "step_state.json").write_text("not valid json {")
 
         code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
             tmp_path,
         )
-
-        assert code == 0  # Fail-open
+        assert code == 0
         self._assert_allowed(stdout)
 
     def test_handles_malformed_hook_input_gracefully(self, tmp_path: Path) -> None:
-        """Should fail-open (allow) on malformed hook input JSON."""
+        """Should fail-open on malformed hook input JSON."""
         result = subprocess.run(
             ["python3", str(self.HOOK_PATH)],
             input="not valid json",
-            capture_output=True,
-            text=True,
-            cwd=tmp_path,
+            capture_output=True, text=True, cwd=tmp_path,
         )
-
-        assert result.returncode == 0  # Fail-open
+        assert result.returncode == 0
         self._assert_allowed(result.stdout)
 
-    def test_respects_branch_scoping(self, tmp_path: Path) -> None:
-        """Workflow state should be branch-scoped (.map/<branch>/)."""
-        # Create state for different branch
-        map_dir = tmp_path / ".map" / "feature-foo"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {
-                        "ST-001": ["actor", "monitor"]  # Complete on feature-foo
-                    },
-                    "pending_steps": {"ST-001": []},
-                }
-            )
-        )
+    # --- Phase-based enforcement ---
 
-        # Try to edit on master branch (should allow - no state file for master)
+    def test_blocks_edit_during_monitor_phase(self, tmp_path: Path) -> None:
+        """Edit blocked during MONITOR phase."""
+        self._setup_step_state(tmp_path, "master", "MONITOR")
         code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
             tmp_path,
-            branch="master",
         )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "MONITOR" in reason
+        assert "ACTOR" in reason  # Should mention allowed phases
 
+    def test_blocks_edit_during_decompose_phase(self, tmp_path: Path) -> None:
+        """Edit blocked during DECOMPOSE phase."""
+        self._setup_step_state(tmp_path, "master", "DECOMPOSE")
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_blocks_edit_during_predictor_phase(self, tmp_path: Path) -> None:
+        """Edit blocked during PREDICTOR phase."""
+        self._setup_step_state(tmp_path, "master", "PREDICTOR")
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_allows_edit_during_actor_phase(self, tmp_path: Path) -> None:
+        """Edit allowed during ACTOR phase."""
+        self._setup_step_state(tmp_path, "master", "ACTOR")
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
         assert code == 0
         self._assert_allowed(stdout)
 
-    def test_different_subtask_steps_independent(self, tmp_path: Path) -> None:
-        """completed_steps should be tracked per subtask."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-002",  # Working on ST-002
-                    "completed_steps": {
-                        "ST-001": ["actor", "monitor"],  # ST-001 complete
-                        "ST-002": ["xml_packet"],  # ST-002 incomplete
-                    },
-                    "pending_steps": {"ST-001": [], "ST-002": ["actor", "monitor"]},
-                }
-            )
-        )
-
-        # Should block because ST-002 (current) is incomplete
+    def test_allows_edit_during_apply_phase(self, tmp_path: Path) -> None:
+        """Edit allowed during APPLY phase."""
+        self._setup_step_state(tmp_path, "master", "APPLY")
         code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
             tmp_path,
         )
-
         assert code == 0
-        reason = self._assert_denied(stdout)
-        assert "ST-002" in reason or "actor" in reason.lower()
+        self._assert_allowed(stdout)
 
-    def test_error_message_includes_workflow_steps(self, tmp_path: Path) -> None:
-        """Block message should explain required workflow steps."""
-        map_dir = tmp_path / ".map" / "master"
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {"ST-001": []},
-                    "pending_steps": {"ST-001": ["actor", "monitor"]},
-                }
-            )
-        )
-
+    def test_allows_edit_during_test_writer_phase(self, tmp_path: Path) -> None:
+        """Edit allowed during TEST_WRITER phase (TDD mode)."""
+        self._setup_step_state(tmp_path, "master", "TEST_WRITER")
         code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
             tmp_path,
         )
-
         assert code == 0
-        error_msg = self._assert_denied(stdout)
+        self._assert_allowed(stdout)
 
-        # Should mention the workflow steps
-        assert "actor" in error_msg.lower()
-        assert "monitor" in error_msg.lower()
-        assert "Task(subagent_type='actor')" in error_msg
-        assert "Task(subagent_type='monitor')" in error_msg
+    def test_blocks_write_during_non_editing_phase(self, tmp_path: Path) -> None:
+        """Write blocked like Edit during non-editing phases."""
+        self._setup_step_state(tmp_path, "master", "MONITOR")
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Write", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_blocks_multiedit_during_non_editing_phase(self, tmp_path: Path) -> None:
+        """MultiEdit blocked like Edit during non-editing phases."""
+        self._setup_step_state(tmp_path, "master", "MONITOR")
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "MultiEdit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    # --- Parallel wave mode (subtask_phases) ---
+
+    def test_allows_edit_when_any_subtask_in_actor_phase(self, tmp_path: Path) -> None:
+        """In parallel mode, allow if ANY subtask is in an editing phase."""
+        self._setup_step_state(
+            tmp_path, "master", "MONITOR",
+            subtask_phases={"ST-001": "MONITOR", "ST-002": "ACTOR"},
+        )
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
+
+    def test_blocks_edit_when_no_subtask_in_editing_phase(self, tmp_path: Path) -> None:
+        """In parallel mode, block if NO subtask is in an editing phase."""
+        self._setup_step_state(
+            tmp_path, "master", "MONITOR",
+            subtask_phases={"ST-001": "MONITOR", "ST-002": "PREDICTOR"},
+        )
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    # --- Exempt paths ---
+
+    def test_allows_map_dir_edits_always(self, tmp_path: Path) -> None:
+        """Edits under .map/ always allowed (prevents deadlocks)."""
+        self._setup_step_state(tmp_path, "master", "MONITOR")
+        map_file = str(tmp_path / ".map" / "master" / "state.json")
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": map_file}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
+
+    # --- Branch scoping ---
+
+    def test_respects_branch_scoping(self, tmp_path: Path) -> None:
+        """Step state should be branch-scoped."""
+        # Create state for feature-foo only
+        self._setup_step_state(tmp_path, "feature-foo", "ACTOR")
+
+        # On master (no state) → fail-open → allow
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path, branch="master",
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
 
     @pytest.mark.parametrize(
         "branch_name,sanitized",
@@ -482,30 +312,80 @@ class TestWorkflowGate:
         self, tmp_path: Path, branch_name: str, sanitized: str
     ) -> None:
         """Branch names with slashes should be sanitized to dashes."""
-        # Create state for sanitized branch name
-        map_dir = tmp_path / ".map" / sanitized
-        map_dir.mkdir(parents=True)
-        state_file = map_dir / "workflow_state.json"
-        state_file.write_text(
-            json.dumps(
-                {
-                    "workflow": "map-efficient",
-                    "current_subtask": "ST-001",
-                    "completed_steps": {"ST-001": ["actor", "monitor"]},
-                    "pending_steps": {"ST-001": []},
-                }
-            )
-        )
+        self._setup_step_state(tmp_path, sanitized, "ACTOR")
 
-        # Hook should find state using sanitized branch name
         code, stdout, _ = self.run_hook(
-            {
-                "tool_name": "Edit",
-                "tool_input": {"file_path": "/test.py"},
-            },
-            tmp_path,
-            branch=branch_name,
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path, branch=branch_name,
         )
-
         assert code == 0
         self._assert_allowed(stdout)
+
+    # --- Constraint enforcement ---
+
+    def test_scope_glob_blocks_outside_scope(self, tmp_path: Path) -> None:
+        """scope_glob constraint blocks edits outside allowed pattern."""
+        self._setup_step_state(tmp_path, "master", "ACTOR")
+        map_dir = tmp_path / ".map" / "master"
+        (map_dir / "workflow_state.json").write_text(json.dumps({
+            "constraints": {"scope_glob": "src/*"},
+            "started_at": "2026-01-01T00:00:00Z",
+        }))
+
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": str(tmp_path / "tests" / "foo.py")}},
+            tmp_path,
+        )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "scope_glob" in reason
+
+    def test_scope_glob_allows_within_scope(self, tmp_path: Path) -> None:
+        """scope_glob constraint allows edits matching the pattern."""
+        self._setup_step_state(tmp_path, "master", "ACTOR")
+        map_dir = tmp_path / ".map" / "master"
+        (map_dir / "workflow_state.json").write_text(json.dumps({
+            "constraints": {"scope_glob": "src/*"},
+            "started_at": "2026-01-01T00:00:00Z",
+        }))
+        (tmp_path / "src").mkdir(exist_ok=True)
+
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": str(tmp_path / "src" / "foo.py")}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
+
+    def test_no_constraints_allows_all(self, tmp_path: Path) -> None:
+        """When constraints is null, all edits are allowed."""
+        self._setup_step_state(tmp_path, "master", "ACTOR")
+        map_dir = tmp_path / ".map" / "master"
+        (map_dir / "workflow_state.json").write_text(json.dumps({
+            "constraints": None,
+            "started_at": "2026-01-01T00:00:00Z",
+        }))
+
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/anywhere/foo.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
+
+    def test_time_budget_blocks_when_exceeded(self, tmp_path: Path) -> None:
+        """time_budget constraint blocks after elapsed time exceeds budget."""
+        self._setup_step_state(tmp_path, "master", "ACTOR")
+        map_dir = tmp_path / ".map" / "master"
+        (map_dir / "workflow_state.json").write_text(json.dumps({
+            "constraints": {"time_budget": 1},  # 1 minute budget
+            "started_at": "2020-01-01T00:00:00Z",  # Long ago → exceeded
+        }))
+
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/test.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "time_budget" in reason


### PR DESCRIPTION
## Summary

Implements Phase 1 (Cheap Wins) and Phase 2 (Core Execution Quality) from the [autoresearch analysis](docs/research/autoresearch-improvements.md).

### Phase 1: Cheap Wins
- **Scenario dimensions** in task-decomposer + map-tdd: `happy_path`, `error`, `edge_case`, `security`
- **Constraint schema** in map-plan: `max_files`, `max_subtasks`, `time_budget`, `scope_glob` with validation
- **Iteration summary** derivation in ralph-iteration-logger (`iteration_summary.json`)
- **Git-as-memory** conditional context in actor (`{{git_history}}` for debug/retry/resume)

### Phase 2: Core Execution Quality
- **Guard pattern** decision table in map-efficient: monitor pass + guard fail → retry Actor (max 2) → escalate
- **Stuck recovery** at monitor retry 3: research-agent → predictor → retry 4-5
- **Noise handling** in final-verifier: 3x re-run, 2/3 majority, `flaky_detected`, confidence -= 0.1

### Workflow gate rewrite
- Source of truth changed from `workflow_state.json` (completed_steps) to `step_state.json` (phase)
- Fixes chicken-and-egg: Actor agents blocked from Edit because gate required "actor" in completed_steps
- Fixes parallel wave mode: checks `subtask_phases` dict per-subtask instead of disabling gate entirely
- Adds constraint enforcement (scope_glob, time_budget) as hook-level deny
- 379 → 261 lines

## Test plan

- [x] `make check` passes (ruff clean, mypy clean, 676 passed / 1 skipped)
- [x] `make sync-templates` — all `.claude/` ↔ `src/mapify_cli/templates/` in sync
- [x] Workflow gate tests rewritten for phase-based logic (24 tests)
- [x] monitor.md unchanged (2500 lines, within limit)
- [ ] Manual: run `/map-efficient` on a test branch to verify guard pattern + stuck recovery in practice