### PR TITLE
fix: remove redundant map-plan artifacts

### DIFF
--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -12,7 +12,6 @@
 - Calls task-decomposer agent to break down the user's request into subtasks
 - Creates `.map/<branch>/task_plan_<branch>.md` with subtask list
 - Initializes `.map/<branch>/step_state.json` with subtask sequence
-- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
 - **STOPS** after planning (forces context flush)
 
 **What this command CANNOT do:**
@@ -34,9 +33,6 @@ echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "state:       $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
-echo "impl_plan:   $(test -f .map/${BRANCH}/implementation-plan.md && echo EXISTS || echo MISSING)"
-echo "decisions:   $(test -f .map/${BRANCH}/decision-log.md && echo EXISTS || echo MISSING)"
-echo "pr_draft:    $(test -f .map/${BRANCH}/pr-draft.md && echo EXISTS || echo MISSING)"
 ```
 
 **Resume rules:**
@@ -270,57 +266,6 @@ If interview was skipped (task is well-defined), still write `spec_<branch>.md` 
 - **Out of Scope**: explicitly state what is NOT being changed
 
 This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
-
-### Step 2c: Write Human-Readable Planning Artifacts
-
-After the spec is finalized, maintain these branch-scoped artifacts in `.map/<branch>/`:
-
-- `implementation-plan.md` — concise goals, non-goals, milestones, validation plan
-- `decision-log.md` — high-signal decisions and rationale from interview/spec review
-- `pr-draft.md` — placeholder PR summary that execution will update later
-
-Use the **Write** tool to create or overwrite them with distilled content from the spec and decomposition. Keep them short and useful for a human resuming work.
-
-Recommended structure:
-
-```markdown
-# Implementation Plan
-
-## Goal
-[1 sentence]
-
-## Non-Goals
-- ...
-
-## Planned Steps
-1. ST-001 — ...
-2. ST-002 — ...
-
-## Validation Plan
-- [command or check]
-```
-
-```markdown
-# Decision Log
-
-## Decision 001
-- Decision: ...
-- Rationale: ...
-- Impacted files: ...
-```
-
-```markdown
-# PR Draft
-
-## Summary
-- Planning completed for [goal]
-
-## Planned Validation
-- ...
-
-## Risks
-- ...
-```
 
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
@@ -566,8 +511,6 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ step_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
-✅ Human-readable artifacts updated: implementation-plan.md, decision-log.md, pr-draft.md
-✅ Planning review recorded: plan-review-00N.md + plan-gate.json
 ✅ Context distilled (plan files ≤4000 tokens per subtask)
 
 Next Steps:
@@ -590,13 +533,9 @@ Next Steps:
 DISTILLATION CHECKLIST:
   [x] task_plan_<branch>.md — has AAG contracts for every subtask
   [x] step_state.json   — has aag_contracts map + subtask_sequence
+  [x] blueprint.json     — raw decomposer output for wave computation
   [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
-  [x] implementation-plan.md — concise execution roadmap for humans
-  [x] decision-log.md       — key tradeoffs captured before implementation
-  [x] pr-draft.md           — initial summary + validation + risk notes
-  [x] plan-review-00N.md    — staged planning review with carry-forward concerns
-  [x] plan-gate.json        — machine-readable planning verdict (`ready|needs-revision|blocked`)
 
 TARGET: Executor reads ≤4000 tokens of distilled state to start any subtask.
 If plan files exceed this, condense — remove redundant descriptions, keep AAG contracts + criteria.

--- a/.claude/hooks/workflow-context-injector.py
+++ b/.claude/hooks/workflow-context-injector.py
@@ -144,8 +144,6 @@ def should_inject_for_bash(command: str) -> bool:
 
 def required_action_for_step(step_id: str, step_phase: str, state: dict) -> str | None:
     """Return a short required-next-action hint for common steps."""
-    mode = (state.get("execution_mode") or "").strip()
-
     if step_id == "1.55":
         return "Approve plan (set_plan_approved true)"
     if step_id == "1.56":

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Canonical MAP flows:
 - Full TDD: `/map-plan` -> `/map-tdd` -> `/map-check` -> `/map-review`
 - Targeted subtask TDD: `/map-plan` -> `/map-tdd ST-001` -> `/map-task ST-001` -> ... -> `/map-check` -> `/map-review`
 
-These workflows maintain branch-scoped artifacts like `implementation-plan.md`, `code-review-001.md`, `qa-001.md`, `verification-summary.md`, `pr-draft.md`, and run dossiers under `.map/<branch>/`.
+These workflows maintain branch-scoped artifacts like `code-review-001.md`, `qa-001.md`, `verification-summary.md`, `pr-draft.md`, and run dossiers under `.map/<branch>/`.
 
 ## How It Works
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -576,8 +576,6 @@ def get_project_health(project_path: Path) -> Dict[str, Any]:
     mcp_json_path = project_path / ".mcp.json"
     internal_mcp_path = project_path / ".claude" / "mcp_config.json"
     branch_artifact_files = [
-        "implementation-plan.md",
-        "decision-log.md",
         "qa-001.md",
         "verification-summary.md",
         "pr-draft.md",
@@ -668,11 +666,9 @@ def get_branch_workspace_dir(project_path: Path, branch: Optional[str] = None) -
     return project_path / ".map" / branch_name
 
 
-def get_branch_artifact_templates(branch: str) -> Dict[str, str]:
-    """Return cook-inspired artifact templates aligned to MAP branch workspaces."""
+def get_branch_artifact_templates(branch: str = "") -> Dict[str, str]:
+    """Return artifact templates aligned to MAP branch workspaces."""
     return {
-        "implementation-plan.md": f"# Implementation Plan\n\n## Branch\n`{branch}`\n\n## Summary\n\n## Goals\n\n## Non-Goals\n\n## Steps\n1.\n2.\n3.\n\n## Validation Plan\n\n## Risks\n",
-        "decision-log.md": "# Decision Log\n\n## Decision\n\n## Options Considered\n\n## Chosen Approach\n\n## Consequences\n",
         "code-review-001.md": "# Code Review 001\n\n## Scope\n\n## Findings\n\n### High\n\n### Medium\n\n### Low\n\n## Verdict\n- [ ] Ready\n- [ ] Needs revision\n",
         "qa-001.md": "# QA 001\n\n## Commands Run\n\n## Expected Result\n\n## Actual Result\n\n## Follow-ups\n",
         "pr-draft.md": "# PR Draft\n\n## Summary\n\n## Validation\n\n## Risks / Rollback\n",

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -666,7 +666,7 @@ def get_branch_workspace_dir(project_path: Path, branch: Optional[str] = None) -
     return project_path / ".map" / branch_name
 
 
-def get_branch_artifact_templates(branch: str = "") -> Dict[str, str]:
+def get_branch_artifact_templates() -> Dict[str, str]:
     """Return artifact templates aligned to MAP branch workspaces."""
     return {
         "code-review-001.md": "# Code Review 001\n\n## Scope\n\n## Findings\n\n### High\n\n### Medium\n\n### Low\n\n## Verdict\n- [ ] Ready\n- [ ] Needs revision\n",
@@ -683,7 +683,7 @@ def initialize_branch_workspace(
     workspace_dir = get_branch_workspace_dir(project_path, branch_name)
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
-    for file_name, content in get_branch_artifact_templates(branch_name).items():
+    for file_name, content in get_branch_artifact_templates().items():
         destination = workspace_dir / file_name
         if not destination.exists():
             destination.write_text(content, encoding="utf-8")
@@ -697,7 +697,7 @@ def get_branch_workspace_status(
     """Collect status information for branch-scoped planning artifacts."""
     branch_name = sanitize_identifier(branch or get_current_branch_name())
     workspace_dir = get_branch_workspace_dir(project_path, branch_name)
-    expected_files = list(get_branch_artifact_templates(branch_name).keys())
+    expected_files = list(get_branch_artifact_templates().keys())
     existing_files = (
         sorted(path.name for path in workspace_dir.iterdir())
         if workspace_dir.exists()

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -12,7 +12,6 @@
 - Calls task-decomposer agent to break down the user's request into subtasks
 - Creates `.map/<branch>/task_plan_<branch>.md` with subtask list
 - Initializes `.map/<branch>/step_state.json` with subtask sequence
-- Maintains branch-scoped human-readable artifacts in `.map/<branch>/` (`implementation-plan.md`, `decision-log.md`, `pr-draft.md`)
 - **STOPS** after planning (forces context flush)
 
 **What this command CANNOT do:**
@@ -34,9 +33,6 @@ echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS
 echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
 echo "state:       $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
-echo "impl_plan:   $(test -f .map/${BRANCH}/implementation-plan.md && echo EXISTS || echo MISSING)"
-echo "decisions:   $(test -f .map/${BRANCH}/decision-log.md && echo EXISTS || echo MISSING)"
-echo "pr_draft:    $(test -f .map/${BRANCH}/pr-draft.md && echo EXISTS || echo MISSING)"
 ```
 
 **Resume rules:**
@@ -270,57 +266,6 @@ If interview was skipped (task is well-defined), still write `spec_<branch>.md` 
 - **Out of Scope**: explicitly state what is NOT being changed
 
 This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
-
-### Step 2c: Write Human-Readable Planning Artifacts
-
-After the spec is finalized, maintain these branch-scoped artifacts in `.map/<branch>/`:
-
-- `implementation-plan.md` — concise goals, non-goals, milestones, validation plan
-- `decision-log.md` — high-signal decisions and rationale from interview/spec review
-- `pr-draft.md` — placeholder PR summary that execution will update later
-
-Use the **Write** tool to create or overwrite them with distilled content from the spec and decomposition. Keep them short and useful for a human resuming work.
-
-Recommended structure:
-
-```markdown
-# Implementation Plan
-
-## Goal
-[1 sentence]
-
-## Non-Goals
-- ...
-
-## Planned Steps
-1. ST-001 — ...
-2. ST-002 — ...
-
-## Validation Plan
-- [command or check]
-```
-
-```markdown
-# Decision Log
-
-## Decision 001
-- Decision: ...
-- Rationale: ...
-- Impacted files: ...
-```
-
-```markdown
-# PR Draft
-
-## Summary
-- Planning completed for [goal]
-
-## Planned Validation
-- ...
-
-## Risks
-- ...
-```
 
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
@@ -566,8 +511,6 @@ WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ step_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
-✅ Human-readable artifacts updated: implementation-plan.md, decision-log.md, pr-draft.md
-✅ Planning review recorded: plan-review-00N.md + plan-gate.json
 ✅ Context distilled (plan files ≤4000 tokens per subtask)
 
 Next Steps:
@@ -590,13 +533,9 @@ Next Steps:
 DISTILLATION CHECKLIST:
   [x] task_plan_<branch>.md — has AAG contracts for every subtask
   [x] step_state.json   — has aag_contracts map + subtask_sequence
+  [x] blueprint.json     — raw decomposer output for wave computation
   [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
-  [x] implementation-plan.md — concise execution roadmap for humans
-  [x] decision-log.md       — key tradeoffs captured before implementation
-  [x] pr-draft.md           — initial summary + validation + risk notes
-  [x] plan-review-00N.md    — staged planning review with carry-forward concerns
-  [x] plan-gate.json        — machine-readable planning verdict (`ready|needs-revision|blocked`)
 
 TARGET: Executor reads ≤4000 tokens of distilled state to start any subtask.
 If plan files exceed this, condense — remove redundant descriptions, keep AAG contracts + criteria.

--- a/src/mapify_cli/templates/hooks/workflow-context-injector.py
+++ b/src/mapify_cli/templates/hooks/workflow-context-injector.py
@@ -144,8 +144,6 @@ def should_inject_for_bash(command: str) -> bool:
 
 def required_action_for_step(step_id: str, step_phase: str, state: dict) -> str | None:
     """Return a short required-next-action hint for common steps."""
-    mode = (state.get("execution_mode") or "").strip()
-
     if step_id == "1.55":
         return "Approve plan (set_plan_approved true)"
     if step_id == "1.56":

--- a/tests/test_command_templates.py
+++ b/tests/test_command_templates.py
@@ -220,15 +220,14 @@ class TestCommandTemplates:
             "Should describe itself as efficient"
         )
 
-    def test_map_plan_writes_human_artifacts(self, templates_commands_dir):
-        """/map-plan should maintain branch-scoped human-readable artifacts."""
+    def test_map_plan_writes_core_artifacts(self, templates_commands_dir):
+        """/map-plan should create core planning artifacts."""
         content = (templates_commands_dir / "map-plan.md").read_text()
 
-        assert "implementation-plan.md" in content
-        assert "decision-log.md" in content
-        assert "pr-draft.md" in content
-        assert "plan-review-00N.md" in content
-        assert "plan-gate.json" in content
+        assert "task_plan_" in content
+        assert "step_state.json" in content
+        assert "blueprint.json" in content
+        assert "spec_" in content
 
     def test_map_efficient_tracks_review_loop_artifacts(self, templates_commands_dir):
         """/map-efficient should preserve review/devlog/qa artifacts in branch workspace."""

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -25,6 +25,7 @@ from mapify_cli import (
     create_map_tools,
     create_or_merge_project_mcp_json,
     create_ssl_context,
+    get_branch_artifact_templates,
     get_latest_release,
     get_templates_dir,
     init_git_repo,
@@ -1075,3 +1076,16 @@ class TestCreateMapTools:
 
         # New scripts should also exist
         assert (map_dir / "static-analysis" / "analyze.sh").exists()
+
+
+class TestBranchArtifactTemplates:
+    """Tests for get_branch_artifact_templates()."""
+
+    def test_returns_expected_keys(self):
+        """Artifact template keys must match the expected set exactly."""
+        templates = get_branch_artifact_templates()
+        assert set(templates.keys()) == {
+            "code-review-001.md",
+            "qa-001.md",
+            "pr-draft.md",
+        }


### PR DESCRIPTION
## Summary

- Remove `implementation-plan.md`, `decision-log.md` creation from `/map-plan` — zero downstream consumers, content duplicated in `spec_<branch>.md` and `task_plan_<branch>.md`
- Remove `pr-draft.md` placeholder at plan time — downstream commands (map-efficient, map-check, map-review) create it themselves via `write_pr_draft()`
- Remove phantom `plan-review-00N.md` and `plan-gate.json` from checkpoint output — no creation step existed in map-plan
- Fix unused `mode` variable in `workflow-context-injector.py` (ruff F841)
- Remove vestigial `branch` parameter from `get_branch_artifact_templates()`
- Add `blueprint.json` to distillation checklist (was missing)

**Result:** `/map-plan` now creates 5 focused files instead of 10, reducing token waste and file bloat.

## Test plan

- [x] `ruff check` — clean
- [x] `pytest` — 745 passed
- [x] `test_template_sync` — templates in sync
- [x] `test_map_plan_writes_core_artifacts` — updated assertions
- [x] `TestBranchArtifactTemplates` — new test for exact artifact key set