### PR TITLE
fix: enforce mandatory research, build gate, and sequential execution in map-efficient

### DIFF
--- a/.claude/agents/actor.md
+++ b/.claude/agents/actor.md
@@ -416,7 +416,17 @@ VC1: <criterion text>
 - Tests: path/to/test_file.ext::test_name (or N/A with reason)
 ```
 
-## 7. Integration Notes (If Applicable)
+## 7. Downstream Consumption Check
+
+When implementing a component whose output is consumed by another component:
+
+- **Identify the consumer**: What reads your output? Verify your output populates ALL fields it expects.
+- **Self-bootstrap**: Does your code load its own dependencies from config/storage, or does it silently return empty results when input is not pre-populated by the caller?
+- **Stub replacement**: If implementing a real version of a placeholder, verify it is wired into the runtime — not just available as a standalone function.
+
+Skip this section for leaf components with no downstream consumers.
+
+## 8. Integration Notes (If Applicable)
 
 Only include if changes affect:
 - Database schema (migrations needed?)

--- a/.claude/agents/actor.md
+++ b/.claude/agents/actor.md
@@ -200,10 +200,15 @@ Task(
    - Use Read(path, offset=lines[0], limit=lines[1]-lines[0]+1)  # lines = [start, end], inclusive
    - Don't read all locations — only what you actually need
 
-## Skip Research If
+## Research Usage
 
-- Task is self-contained (new file, no dependencies)
-- Existing patterns from context already cover the need
+Research is run by the orchestrator BEFORE Actor is invoked. The findings file
+(`.map/<branch>/findings_<branch>.md`) contains distilled context. If it exists,
+read it before implementation — it has import patterns, module structure, and
+build configuration that prevent integration failures.
+
+Do NOT skip reading the findings file even for "new file" tasks — new files still
+need correct imports, types, and build configuration from the existing project.
 
 ---
 

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -288,8 +288,8 @@ IF detected_language != "unknown":
   → Consider language-specific static analysis tools
 
 PHASE 3: EXHAUSTIVE DIMENSION VALIDATION (ALWAYS)
-Execute validation protocol for each of the 10 dimensions sequentially.
-Do NOT skip dimensions based on early findings — complete ALL 10.
+Execute validation protocol for each of the 11 dimensions sequentially.
+Do NOT skip dimensions based on early findings — complete ALL 11.
 For each dimension: parse criteria → verify against code → record PASS/FAIL.
 Apply language-specific validation rules per dimension.
 
@@ -860,11 +860,11 @@ Include in JSON output when validation_criteria provided:
 
 </Monitor_Contract_Validation>
 
-<Monitor_10D_Validation_v2_9>
+<Monitor_11D_Validation_v3_0>
 
-## 10-Dimension Quality Model
+## 11-Dimension Quality Model
 
-Execute validation protocol for EACH dimension sequentially. Do NOT short-circuit — complete ALL 10 dimensions even if early rejections found. Output structured findings per dimension.
+Execute validation protocol for EACH dimension sequentially. Do NOT short-circuit — complete ALL 11 dimensions even if early rejections found. Output structured findings per dimension. **Exception:** BUILD GATE failure (step 2 of Verification sequence) is the single allowed short-circuit — if build/compile fails, set `valid: false` immediately without completing dimension checks.
 
 ### 1. CORRECTNESS
 
@@ -1382,7 +1382,47 @@ ELSE:
 - Post-cutoff library + no research + outdated patterns
 </critical>
 
-</Monitor_10D_Validation_v2_9>
+### 11. INTEGRATION (When subtask has upstream/downstream dependencies)
+
+#### What to Check
+- Output consumed correctly by downstream components (not silently dropped)
+- Component self-bootstraps from config/storage (does not require caller to pre-populate dependencies)
+- Stubs/placeholders replaced by real implementations in the runtime entrypoint
+- Interface contracts between components are satisfied in both directions
+
+#### How to Check
+1. Identify downstream consumers of this subtask's output
+2. Trace the data path: does the output reach the consumer with the expected shape?
+3. Check if the component loads its own dependencies or silently returns empty/stub results
+4. Verify the runtime entrypoint uses the real implementation, not a placeholder
+
+#### Pass Criteria
+- Output is demonstrably consumed by at least one downstream component
+- Component works when invoked through the runtime entrypoint (not just direct calls)
+- No silent fallback to stub/empty results on missing dependencies
+
+#### Common Failures
+- Component writes to field A but consumer reads field B
+- Runtime entrypoint still wired to a stub despite real implementation existing
+- Component returns empty results when dependencies are not injected by test setup
+- Build/config failure masked as a successful stub response
+
+#### Severity Mapping
+- **Critical**: Runtime entrypoint returns stub/placeholder to end users
+- **High**: Component output not consumed by downstream (data silently lost)
+- **Medium**: Component requires caller injection instead of self-bootstrapping
+- **Low**: Interface contract undocumented but happens to work
+
+**Decision Framework**:
+```
+IF subtask has no downstream consumers AND no runtime entrypoint:
+  → Skip (leaf component)
+ELSE:
+  → Verify output reaches consumer through runtime path
+  → Verify self-bootstrapping from config/storage
+```
+
+</Monitor_11D_Validation_v3_0>
 
 
 <Monitor_Severity_Matrix>
@@ -1403,6 +1443,7 @@ This table provides quick reference for severity classification per dimension. U
 | **8. External Deps** | Missing critical dependency documentation | Incomplete CRD/adapter docs | Missing version constraints | Minor config details |
 | **9. Documentation** | Contradicts tech-design/source of truth | Missing key fields/logic, wrong ownership | Minor inconsistencies | Formatting issues |
 | **10. Research** | N/A (rarely critical) | Complex problem + no research + wrong impl | Post-cutoff lib + outdated patterns | Missing citations only |
+| **11. Integration** | Runtime entrypoint returns stub to users | Output not consumed by downstream (data lost) | Requires caller injection instead of self-bootstrap | Interface contract undocumented |
 
 ### Severity Decision Tree
 
@@ -1561,8 +1602,8 @@ Do NOT invent issues to justify review effort. Empty `issues` array is valid.
           },
           "category": {
             "type": "string",
-            "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research"],
-            "description": "Maps to 10-dimension model: 1=correctness, 2=security, 3=code-quality, 4=performance, 5=testability, 6=cli-tool, 7=maintainability, 8=external-deps, 9=documentation, 10=research"
+            "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research", "integration"],
+            "description": "Maps to 11-dimension model: 1=correctness, 2=security, 3=code-quality, 4=performance, 5=testability, 6=cli-tool, 7=maintainability, 8=external-deps, 9=documentation, 10=research, 11=integration"
           },
           "title": {
             "type": "string",
@@ -1609,7 +1650,7 @@ Do NOT invent issues to justify review effort. Empty `issues` array is valid.
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research"]
+        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research", "integration"]
       },
       "description": "Dimensions that passed completely"
     },
@@ -1617,7 +1658,7 @@ Do NOT invent issues to justify review effort. Empty `issues` array is valid.
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research"]
+        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research", "integration"]
       },
       "description": "Dimensions with issues"
     },
@@ -1916,7 +1957,7 @@ ARRAY POPULATION:
 - Ensure: passed_checks ∩ failed_checks = ∅ (no overlap)
 
 SPECIAL CASES:
-- If no issues found: all 10 categories go in passed_checks
+- If no issues found: all 11 categories go in passed_checks
 - If a dimension was skipped (large change): omit from both arrays
 ```
 
@@ -2024,6 +2065,7 @@ ELSE:
 | `external-deps` | Missing CRDs, undocumented dependencies | 8 |
 | `documentation` | Inconsistent with source, missing fields | 9 |
 | `research` | Missing research for unfamiliar patterns | 10 |
+| `integration` | Output not consumed downstream, stub in runtime | 11 |
 
 </Monitor_Decision_Rules>
 
@@ -2466,7 +2508,7 @@ def check_rate_limit(user_id, action, limit=100, window=3600):
 
 1. ✅ Did I use request_review for code implementations?
 2. ✅ Did I check for known issue patterns?
-3. ✅ Did I check all 10 validation dimensions systematically?
+3. ✅ Did I check all 11 validation dimensions systematically?
 4. ✅ Did I verify documentation against source of truth (if applicable)?
 5. ✅ Are all issues specific with location and actionable suggestions?
 6. ✅ Is severity classification correct per guidelines?

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -39,10 +39,16 @@ You are a **validation agent**, NOT a code executor. Your role:
 
 **Verification sequence (execute in order):**
 1. Parse AAG contract from prompt — extract Actor, Action, Goal
-2. Verify Goal is achieved — trace code path to confirm the stated outcome
-3. Verify Action is implemented — check that the specified method/operation exists
-4. Verify scope — confirm changes stay within Actor's allowed_scope
-5. Run quality gates below
+2. **BUILD GATE (MANDATORY — run FIRST):** Run the project's build/compile command:
+   - TypeScript: `npx tsc --noEmit` (or `npm run build`)
+   - Python: `python -m py_compile <changed_files>` (or mypy if configured)
+   - Go: `go build ./...`
+   - Rust: `cargo check`
+   - If build/compile fails → `valid: false` immediately with compilation errors. Do NOT proceed to other checks.
+3. Verify Goal is achieved — trace code path to confirm the stated outcome
+4. Verify Action is implemented — check that the specified method/operation exists
+5. Verify scope — confirm changes stay within Actor's allowed_scope
+6. Run quality gates below
 
 **Deterministic REJECT rule:**
 If implementation deviates from the AAG contract — `valid: false` — regardless of how "clean" or "elegant" the code is. The contract IS the specification; aesthetic quality is irrelevant when the contract is violated.
@@ -50,8 +56,9 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 **Escalation Framework:**
 
 🔴 **AUTO-REJECT (valid: false, must fix):**
-1. **AAG contract violation** — implementation does not satisfy Actor -> Action -> Goal
-2. Missing error handling on network/database/file operations
+1. **Build/compile failure** — code does not compile (`tsc --noEmit`, `go build`, `cargo check`, `py_compile` fails)
+2. **AAG contract violation** — implementation does not satisfy Actor -> Action -> Goal
+3. Missing error handling on network/database/file operations
 3. No input validation on user-provided data
 4. SQL string concatenation (injection vulnerability)
 5. Hardcoded secrets (API keys, passwords, tokens)

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -16,16 +16,17 @@ You are a Protocol-Driven Validation System. Your objective: verify that Actor's
 
 **CRITICAL: Monitor is READ-ONLY reviewer, NOT a code editor**
 
-You are a **validation agent**, NOT a code executor. Your role:
+You are a **validation agent**, NOT a code editor. Your role:
 
 - ✅ DO: Review Actor's code proposals and output JSON feedback
 - ✅ DO: Use Read tool to examine existing code for context
+- ✅ DO: Run read-only build/test commands (tsc --noEmit, go build, pytest, etc.) to verify code compiles and passes
 - ❌ NEVER: Use Edit or MultiEdit tools
 - ⚠️ EXCEPTION: Write tool is permitted ONLY for evidence artifacts (.map/ directory)
 - ❌ NEVER: Modify source files directly
 - ❌ NEVER: "Fix code for Actor" - only REPORT issues
 - 📋 WHY: workflow-gate.py will BLOCK Edit and non-evidence Write during monitor phase
-- 🔄 FLOW: Actor outputs → **You review** → Orchestrator applies (if approved)
+- 🔄 FLOW: Actor outputs → **You review + run build/tests** → Orchestrator applies (if approved)
 
 **Your output**: JSON with `valid: true|false` and `issues[]` array
 
@@ -59,13 +60,13 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 1. **Build/compile failure** — code does not compile (`tsc --noEmit`, `go build`, `cargo check`, `py_compile` fails)
 2. **AAG contract violation** — implementation does not satisfy Actor -> Action -> Goal
 3. Missing error handling on network/database/file operations
-3. No input validation on user-provided data
-4. SQL string concatenation (injection vulnerability)
-5. Hardcoded secrets (API keys, passwords, tokens)
-6. Silent failures (try/catch with empty handler)
-7. Deprecated APIs without migration plan
-8. Security score < 7 OR functionality score < 7
-9. **Missing intent comments** — non-obvious logic blocks without `# Intent: <why>` comments, or removal of existing intent comments that describe author's reasoning
+4. No input validation on user-provided data
+5. SQL string concatenation (injection vulnerability)
+6. Hardcoded secrets (API keys, passwords, tokens)
+7. Silent failures (try/catch with empty handler)
+8. Deprecated APIs without migration plan
+9. Security score < 7 OR functionality score < 7
+10. **Missing intent comments** — non-obvious logic blocks without `# Intent: <why>` comments, or removal of existing intent comments that describe author's reasoning
 
 🟡 **WARN (should address, not blocking):**
 1. Missing edge case tests (empty arrays, null values)

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -278,12 +278,24 @@ Return **ONLY** valid JSON in this exact structure:
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
 
+### Integration & Runtime Bootstrapping Subtasks
+
+Feature subtasks implement components in isolation. To ensure they work together in the real runtime, you MUST also create:
+
+1. **Integration subtask** (one per runtime entrypoint): Wires real implementations into the runtime surface, replacing any stubs/placeholders. AAG contract must name the entrypoint and verify end-to-end data flow through it.
+   - Depends on ALL feature subtasks it integrates.
+
+2. **Bootstrapping subtask** (when components need external data at runtime): Ensures each workflow loads its own dependencies from configuration or persistent storage rather than requiring callers to pre-populate them.
+
+3. **Interface contracts between subtasks**: When subtask A produces output consumed by subtask B, document the data contract in BOTH subtasks' validation criteria so neither side can silently break it.
+
 ### Subtask Ordering
 
 Subtasks should be ordered by dependency:
 1. Foundation subtasks (no dependencies) first
 2. Dependent subtasks after their prerequisites
-3. Tests/docs can be parallel with implementation (same dependency level)
+3. Integration/wiring subtasks after ALL feature subtasks they integrate
+4. Tests/docs can be parallel with implementation (same dependency level)
 
 **CRITICAL**: If subtask B depends on subtask A, A must appear BEFORE B in the array.
 
@@ -528,6 +540,12 @@ When invoked with `mode: "re_decomposition"` from the orchestrator, you receive 
 - [ ] No placeholder values ("...", "TODO", "TBD")
 - [ ] Dependencies reference valid subtask IDs
 - [ ] Follows ordering constraint (dependencies before dependents)
+
+**Integration & Wiring**:
+- [ ] At least one integration subtask wires features into each runtime entrypoint
+- [ ] Interface contracts documented when one subtask produces output consumed by another
+- [ ] Bootstrapping subtask exists if components need data from disk/config at runtime
+- [ ] No subtask silently assumes its output is consumed — explicit consumer named in VC
 
 **Dependency Validation** (CRITICAL):
 - [ ] **Circular dependency check**: Verify dependency graph is acyclic (A→B→C→A is INVALID)

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -15,7 +15,7 @@ State machine enforces sequencing, Python validates completion, hooks inject rem
 2. Use exact `subagent_type` specified — never substitute
 3. Call each agent individually — no combining or skipping
 4. Max 5 retry iterations per subtask (note: /map-fast uses max 3)
-5. **Always batch mode, always parallel**: execution mode is always `batch` (no pauses). After INIT_STATE, always compute waves and execute independent subtasks in parallel (multiple `Task()` calls in one message). See "Wave Computation" section.
+5. **Always batch mode, sequential by default**: execution mode is always `batch` (no pauses). After INIT_STATE, compute waves but execute subtasks **one at a time** (sequential). Parallel execution within a wave is allowed ONLY when wave has ≤3 subtasks AND all are low-risk AND all create new files (no modifications to existing files). See "Wave Computation" section.
 6. After Monitor pass, record files changed in `step_state.json` for guard isolation.
 
 ## Intentional Agent Omissions
@@ -253,75 +253,52 @@ This reads the blueprint, builds a dependency graph, computes topological waves,
 and splits waves by file conflicts. The result is stored in `step_state.json`.
 If `blueprint.json` is missing (e.g., plan was created before v3.5), subtasks execute sequentially — this is safe but slower.
 
-**Wave execution**: If waves are computed, subtasks within a wave run their Actor
-and Monitor phases in parallel. Check wave status with:
+**Wave execution**: Subtasks execute **sequentially by default** (one at a time through
+the full RESEARCH → ACTOR → MONITOR cycle). This prevents accumulated errors that are
+hard to debug. Check wave status with:
 
 ```bash
 WAVE=$(python3 .map/scripts/map_orchestrator.py get_wave_step)
 MODE=$(echo "$WAVE" | jq -r '.mode')
 ```
 
-If `mode` is `"parallel"`, launch all actors in the wave in ONE message using
-multiple `Task()` calls, then all monitors in ONE message. If `mode` is
-`"sequential"`, use the standard single-subtask loop below.
+**IMPORTANT:** Even when `mode` is `"parallel"`, prefer sequential execution unless the
+wave has ≤3 subtasks that are ALL low-risk AND create new files only. When in doubt,
+execute sequentially.
 
-**Parallel wave execution loop**:
+**Sequential execution loop** (DEFAULT — use this):
 
 ```
 loop:
   WAVE = get_wave_step()
   if WAVE.is_complete: goto final_verification
 
-  if WAVE.mode == "sequential":
-    # Single subtask — same as standard behavior below
-    execute_current_sequential_loop()
-  else:
-    # === PARALLEL WAVE ===
-    # Phase A: Prep (sequential per subtask - lightweight)
-    for each subtask in WAVE.subtasks:
-      optional RESEARCH (if 3+ existing files or high risk)
+  for each subtask in WAVE.subtasks (one at a time):
+    1. RESEARCH (2.2) — MANDATORY: run research-agent
+    2. ACTOR (2.3) — implement subtask
+    3. MONITOR (2.4) — validate + BUILD GATE (see below)
+    4. validate_step / advance to next subtask
 
-    # Phase A.5: TDD phases (if --tdd mode)
-    # When TDD is enabled, run TEST_WRITER + TEST_FAIL_GATE per subtask
-    # BEFORE launching Actors. These run sequentially per subtask.
-    if TDD_FLAG:
-      for each subtask in WAVE.subtasks:
-        run TEST_WRITER (2.25) → validate_wave_step SUBTASK_ID "2.25"
-        run TEST_FAIL_GATE (2.26) → validate_wave_step SUBTASK_ID "2.26"
-
-    # Phase B: Parallel Actors
-    # Launch ALL Task(subagent_type="actor") calls in ONE message
-    # Example: Task(actor, "Implement ST-002") + Task(actor, "Implement ST-004")
-
-    # Phase C: Parallel Monitors
-    # After all actors return, launch ALL monitors in ONE message
-    # Example: Task(monitor, "Validate ST-002") + Task(monitor, "Validate ST-004")
-
-    # Phase D: Retry handling
-    # For each monitor that returned valid=false:
-    #   RETRY=$(python3 .map/scripts/map_orchestrator.py wave_monitor_failed $subtask_id --feedback "feedback")
-    #   If RETRY.status == "max_retries": escalate to user
-    #   Otherwise: re-run actor + monitor for that subtask (serially)
-
-    # Phase E: Per-wave gates
-    # Run tests + linter ONCE for the entire wave
-    # pytest / npm test / etc.
-
-    # Phase F: Advance wave — after all subtasks pass Monitor + per-wave gates
-    python3 .map/scripts/map_orchestrator.py advance_wave
+  # After ALL subtasks in wave pass: run per-wave gates
+  python3 .map/scripts/map_orchestrator.py advance_wave
 ```
 
-Linear DAGs naturally degrade to single-subtask waves (identical to current behavior).
+**DO NOT** write custom bash for-loops to iterate subtasks. Use the orchestrator:
+call `get_next_step` after each `validate_step` — it returns the next phase/subtask
+automatically. The state machine handles iteration.
 
-### Phase: RESEARCH (2.2)
+### Phase: RESEARCH (2.2) — MANDATORY
+
+**CRITICAL: ALWAYS run research. Do NOT skip this phase.**
+
+Research prevents the most common failure mode: Actor writing code that doesn't integrate
+with the existing codebase (wrong imports, missing types, incompatible APIs).
 
 ```python
-# Conditional: Call if subtask touches 3+ existing files OR risk=high
-if requires_research(subtask):
-    Task(
-      subagent_type="research-agent",
-      description="Research for subtask [ID]",
-      prompt=f"""Query: [subtask description]
+Task(
+  subagent_type="research-agent",
+  description="Research for subtask [ID]",
+  prompt=f"""Query: [subtask description]
 File patterns: [relevant globs]
 Intent: locate
 Max tokens: 1500
@@ -329,11 +306,17 @@ Findings file: .map/{branch}/findings_{branch}.md
 
 DISTILLATION RULE: Write ONLY actionable findings to the file:
 - file paths + line ranges + function signatures
+- existing import patterns and module structure
+- build/compile configuration (tsconfig, setup.py, Cargo.toml, etc.)
 - NO raw search output, NO full file contents
 - Target: <1500 tokens in findings file
 This file is the SOLE research artifact passed to Actor and future steps."""
-    )
+)
 ```
+
+The ONLY exception: if the orchestrator returns `skip_reason` for step 2.2 (set by
+`resume_from_plan` when `/map-plan` already completed research). In that case, the
+findings file already exists.
 
 ### Phase: TEST_WRITER (2.25) — TDD Mode Only
 
@@ -462,11 +445,18 @@ Task(
 
 Protocol (execute in order):
 1. Read each file in MAP_Written — verify code exists and compiles/parses
-2. Check MAP_Contract compliance — does implementation satisfy the AAG assertion?
-3. Run tests: pytest/npm test/go test/cargo test
-4. Check inline contracts: preconditions, postconditions, invariants from packet
-5. Verify: no silent failures, no bare except, no hardcoded secrets
-6. Output: ONLY valid JSON per MonitorReviewOutput schema
+2. **BUILD GATE (MANDATORY):** Run the project build/compile command BEFORE any other checks:
+   - TypeScript: `npx tsc --noEmit` (or `npm run build`)
+   - Python: `python -m py_compile <files>` (or `python -m mypy <files>` if configured)
+   - Go: `go build ./...`
+   - Rust: `cargo check`
+   - If build fails → valid=false immediately, report compilation errors
+3. Check MAP_Contract compliance — does implementation satisfy the AAG assertion?
+4. Run tests: pytest/npm test/go test/cargo test
+5. Check inline contracts: preconditions, postconditions, invariants from packet
+6. Verify: no silent failures, no bare except, no hardcoded secrets
+7. Output: ONLY valid JSON per MonitorReviewOutput schema
+   - If build fails: valid=false + compilation errors
    - If MAP_Contract violated: valid=false + specific contract breach
    - If tests fail: valid=false + failure output
    - If all pass: valid=true + contract_compliant=true"""
@@ -567,13 +557,35 @@ Do not overwrite the previous review file; keep the loop history visible.
 
 ### Per-Wave Gates (after all subtasks in wave pass Monitor)
 
-After ALL subtasks in a wave have Monitor `valid=true`, run tests + linter ONCE for the entire wave:
+After ALL subtasks in a wave have Monitor `valid=true`, run build + tests + linter ONCE for the entire wave:
 
 ```bash
-# Run tests — capture exit code + output
+# 1. BUILD GATE (MANDATORY — run FIRST)
+BUILD_EXIT=0
+BUILD_OUTPUT=""
+if [ -f "tsconfig.json" ]; then
+  BUILD_OUTPUT=$(npx tsc --noEmit 2>&1); BUILD_EXIT=$?
+elif [ -f "package.json" ] && grep -q '"build"' package.json; then
+  BUILD_OUTPUT=$(npm run build 2>&1); BUILD_EXIT=$?
+elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
+  BUILD_OUTPUT=$(python -m py_compile $(git diff --name-only --diff-filter=AM -- '*.py') 2>&1); BUILD_EXIT=$?
+elif [ -f "go.mod" ]; then
+  BUILD_OUTPUT=$(go build ./... 2>&1); BUILD_EXIT=$?
+elif [ -f "Cargo.toml" ]; then
+  BUILD_OUTPUT=$(cargo check 2>&1); BUILD_EXIT=$?
+fi
+echo "$BUILD_OUTPUT"
+
+# If build fails, stop here — no point running tests on code that doesn't compile
+if [ "$BUILD_EXIT" -ne 0 ]; then
+  echo "BUILD FAILED — fix compilation errors before proceeding"
+  # Treat as wave gate failure (see Guard Pattern below)
+fi
+
+# 2. Run tests — capture exit code + output
 TESTS_EXIT=0
 TEST_OUTPUT=""
-if [ -f "pytest.ini" ] || [ -f "setup.py" ]; then
+if [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
   TEST_OUTPUT=$(pytest 2>&1); TESTS_EXIT=$?
 elif [ -f "package.json" ]; then
   TEST_OUTPUT=$(npm test 2>&1); TESTS_EXIT=$?
@@ -582,11 +594,11 @@ elif [ -f "go.mod" ]; then
 elif [ -f "Cargo.toml" ]; then
   TEST_OUTPUT=$(cargo test 2>&1); TESTS_EXIT=$?
 else
-  echo "No tests found, skipping gate"
+  echo "No tests found, skipping test gate"
 fi
 echo "$TEST_OUTPUT"
 
-# Run linter — capture exit code + output
+# 3. Run linter — capture exit code + output
 LINT_EXIT=0
 LINT_OUTPUT=""
 if command -v ruff &> /dev/null; then
@@ -596,7 +608,7 @@ elif command -v eslint &> /dev/null; then
 elif command -v golangci-lint &> /dev/null; then
   LINT_OUTPUT=$(golangci-lint run 2>&1); LINT_EXIT=$?
 else
-  echo "No linter found, skipping gate"
+  echo "No linter found, skipping lint gate"
 fi
 echo "$LINT_OUTPUT"
 ```
@@ -604,7 +616,7 @@ echo "$LINT_OUTPUT"
 **Guard Pattern Decision (per-wave):**
 
 ```
-IF TESTS_EXIT == 0 AND LINT_EXIT == 0:
+IF BUILD_EXIT == 0 AND TESTS_EXIT == 0 AND LINT_EXIT == 0:
   → Wave passed. Advance to next wave.
 
 ELSE (regression detected):

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -278,7 +278,7 @@ loop:
   for each subtask in WAVE.subtasks (one at a time):
     1. RESEARCH (2.2) — MANDATORY: run research-agent
     2. ACTOR (2.3) — implement subtask
-    3. MONITOR (2.4) — validate + BUILD GATE (see below)
+    3. MONITOR (2.4) — MANDATORY: validate + BUILD GATE (see below). NEVER skip.
     4. validate_step / advance to next subtask
 
   # After ALL subtasks in wave pass: run per-wave gates
@@ -429,7 +429,14 @@ Protocol:
 - If Actor reports diagnostics/errors — proceed directly to MONITOR.
 - Monitor will verify and report real issues. If `valid=false`, retry via Actor (not manual edits).
 
-### Phase: MONITOR (2.4)
+### Phase: MONITOR (2.4) — MANDATORY
+
+**CRITICAL: ALWAYS run Monitor after Actor. Do NOT skip this phase.**
+
+Monitor is the ONLY validation gate between Actor output and step completion.
+Even if tests already pass, Monitor checks contract compliance, code quality,
+security issues, and integration correctness that tests alone cannot verify.
+**Never skip Monitor because "tests pass" — passing tests is necessary but NOT sufficient.**
 
 ```python
 Task(

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -241,8 +241,8 @@ State is managed by the orchestrator via `step_state.json` (created automaticall
 
 ### Wave Computation (after INIT_STATE) — REQUIRED
 
-**IMPORTANT: Always compute waves after INIT_STATE.** Subtasks execute sequentially
-by default. Parallel execution is allowed only for small low-risk waves (see below).
+**IMPORTANT: Always compute waves after INIT_STATE.** Waves determine execution
+order from the dependency graph. Subtasks execute **sequentially by default**.
 
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 
@@ -308,22 +308,27 @@ loop:
   WAVE = get_wave_step()
   if WAVE.is_complete: goto final_verification
 
-  # 1. Run ALL Actors in parallel (one Agent per subtask)
+  # 1. Run ALL Research in parallel (one Agent per subtask) — MANDATORY
+  for each subtask in WAVE.subtasks (in parallel):
+    Agent(subagent_type="research-agent", prompt="Research subtask {subtask_id}...")
+
+  # 2. Run ALL Actors in parallel (one Agent per subtask)
   for each subtask in WAVE.subtasks (in parallel):
     Agent(subagent_type="actor", prompt="Implement subtask {subtask_id}...")
 
-  # 2. Run ALL Monitors in parallel (one Agent per subtask)
+  # 3. Run ALL Monitors in parallel (one Agent per subtask)
   for each subtask in WAVE.subtasks (in parallel):
     Agent(subagent_type="monitor", prompt="Validate subtask {subtask_id}...")
 
-  # 3. Record results and advance phases for EACH subtask:
+  # 4. Record results and advance phases for EACH subtask:
   for each subtask:
     echo '{"subtask_id":"ST-XXX","files":[...],"status":"valid",...}' \
       | python3 .map/scripts/map_step_runner.py record_subtask_result
+    python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.2
     python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.3
     python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.4
 
-  # 4. Run per-wave gates (build + tests + lint), then advance
+  # 5. Run per-wave gates (build + tests + lint), then advance
   python3 .map/scripts/map_orchestrator.py advance_wave
 ```
 
@@ -359,9 +364,10 @@ This file is the SOLE research artifact passed to Actor and future steps."""
 )
 ```
 
-The ONLY exception: if `/map-plan` already produced a findings file for this branch
-(`.map/<branch>/findings_<branch>.md` exists and has content). In that case, re-read
-the existing findings instead of re-running the research agent.
+**Re-use existing findings**: if `/map-plan` already produced a findings file for this
+branch (`.map/<branch>/findings_<branch>.md` exists and has content), the research agent
+should read and extend it rather than starting from scratch. RESEARCH still runs — it
+just builds on prior findings.
 
 ### Phase: TEST_WRITER (2.25) — TDD Mode Only
 
@@ -617,7 +623,7 @@ BUILD_EXIT=0
 BUILD_OUTPUT=""
 if [ -f "tsconfig.json" ]; then
   BUILD_OUTPUT=$(npx tsc --noEmit 2>&1); BUILD_EXIT=$?
-elif [ -f "package.json" ] && grep -q '"build"' package.json; then
+elif [ -f "package.json" ] && jq -e '.scripts.build' package.json > /dev/null 2>&1; then
   BUILD_OUTPUT=$(npm run build 2>&1); BUILD_EXIT=$?
 elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
   PY_FILES=$(git diff --name-only --diff-filter=AM -- '*.py')

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -26,6 +26,8 @@ State machine enforces sequencing, Python validates completion, hooks inject rem
 
 This is NOT a violation of MAP agent rules. Learning is decoupled into `/map-learn` (optional, run after workflow completes) to reduce token usage during execution.
 
+**Conditional agent:** Predictor is invoked only during stuck recovery (retry 3+, non-low-risk subtasks).
+
 ## State File
 
 Single source of truth: `.map/<branch>/step_state.json`
@@ -234,8 +236,8 @@ State is managed by the orchestrator via `step_state.json` (created automaticall
 
 ### Wave Computation (after INIT_STATE) — REQUIRED
 
-**IMPORTANT: Always compute waves and execute subtasks in parallel when possible.**
-This is not optional — wave computation must run after every INIT_STATE.
+**IMPORTANT: Always compute waves after INIT_STATE.** Subtasks execute sequentially
+by default. Parallel execution is allowed only for small low-risk waves (see below).
 
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 
@@ -314,9 +316,9 @@ This file is the SOLE research artifact passed to Actor and future steps."""
 )
 ```
 
-The ONLY exception: if the orchestrator returns `skip_reason` for step 2.2 (set by
-`resume_from_plan` when `/map-plan` already completed research). In that case, the
-findings file already exists.
+The ONLY exception: if `/map-plan` already produced a findings file for this branch
+(`.map/<branch>/findings_<branch>.md` exists and has content). In that case, re-read
+the existing findings instead of re-running the research agent.
 
 ### Phase: TEST_WRITER (2.25) — TDD Mode Only
 
@@ -568,7 +570,10 @@ if [ -f "tsconfig.json" ]; then
 elif [ -f "package.json" ] && grep -q '"build"' package.json; then
   BUILD_OUTPUT=$(npm run build 2>&1); BUILD_EXIT=$?
 elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
-  BUILD_OUTPUT=$(python -m py_compile $(git diff --name-only --diff-filter=AM -- '*.py') 2>&1); BUILD_EXIT=$?
+  PY_FILES=$(git diff --name-only --diff-filter=AM -- '*.py')
+  if [ -n "$PY_FILES" ]; then
+    BUILD_OUTPUT=$(echo "$PY_FILES" | xargs python -m py_compile 2>&1); BUILD_EXIT=$?
+  fi
 elif [ -f "go.mod" ]; then
   BUILD_OUTPUT=$(go build ./... 2>&1); BUILD_EXIT=$?
 elif [ -f "Cargo.toml" ]; then
@@ -576,38 +581,38 @@ elif [ -f "Cargo.toml" ]; then
 fi
 echo "$BUILD_OUTPUT"
 
-# If build fails, stop here — no point running tests on code that doesn't compile
+# If build fails, skip tests/lint — no point running them on code that doesn't compile
 if [ "$BUILD_EXIT" -ne 0 ]; then
   echo "BUILD FAILED — fix compilation errors before proceeding"
-  # Treat as wave gate failure (see Guard Pattern below)
+  TESTS_EXIT=1; LINT_EXIT=1  # Force gate failure
 fi
 
-# 2. Run tests — capture exit code + output
-TESTS_EXIT=0
+# 2. Run tests — only if build passed
+TESTS_EXIT=${TESTS_EXIT:-0}
 TEST_OUTPUT=""
-if [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
+if [ "$BUILD_EXIT" -eq 0 ] && { [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; }; then
   TEST_OUTPUT=$(pytest 2>&1); TESTS_EXIT=$?
-elif [ -f "package.json" ]; then
+elif [ "$BUILD_EXIT" -eq 0 ] && [ -f "package.json" ]; then
   TEST_OUTPUT=$(npm test 2>&1); TESTS_EXIT=$?
-elif [ -f "go.mod" ]; then
+elif [ "$BUILD_EXIT" -eq 0 ] && [ -f "go.mod" ]; then
   TEST_OUTPUT=$(go test ./... 2>&1); TESTS_EXIT=$?
-elif [ -f "Cargo.toml" ]; then
+elif [ "$BUILD_EXIT" -eq 0 ] && [ -f "Cargo.toml" ]; then
   TEST_OUTPUT=$(cargo test 2>&1); TESTS_EXIT=$?
-else
+elif [ "$BUILD_EXIT" -eq 0 ]; then
   echo "No tests found, skipping test gate"
 fi
 echo "$TEST_OUTPUT"
 
-# 3. Run linter — capture exit code + output
-LINT_EXIT=0
+# 3. Run linter — only if build passed
+LINT_EXIT=${LINT_EXIT:-0}
 LINT_OUTPUT=""
-if command -v ruff &> /dev/null; then
+if [ "$BUILD_EXIT" -eq 0 ] && command -v ruff &> /dev/null; then
   LINT_OUTPUT=$(ruff check . 2>&1); LINT_EXIT=$?
-elif command -v eslint &> /dev/null; then
+elif [ "$BUILD_EXIT" -eq 0 ] && command -v eslint &> /dev/null; then
   LINT_OUTPUT=$(eslint . 2>&1); LINT_EXIT=$?
-elif command -v golangci-lint &> /dev/null; then
+elif [ "$BUILD_EXIT" -eq 0 ] && command -v golangci-lint &> /dev/null; then
   LINT_OUTPUT=$(golangci-lint run 2>&1); LINT_EXIT=$?
-else
+elif [ "$BUILD_EXIT" -eq 0 ]; then
   echo "No linter found, skipping lint gate"
 fi
 echo "$LINT_OUTPUT"

--- a/.claude/commands/map-efficient.md
+++ b/.claude/commands/map-efficient.md
@@ -36,6 +36,11 @@ Written/read by `map_orchestrator.py`. Tracks: current phase, subtask states, wa
 retry counts, constraints, files changed per subtask. Used by `workflow-gate.py` for
 phase-based enforcement (Edit allowed only during ACTOR/APPLY/TEST_WRITER phases).
 
+**NEVER modify `step_state.json` directly.** Always use the orchestrator CLI
+(`map_orchestrator.py`, `map_step_runner.py`). Direct writes bypass validation and
+corrupt state transitions. If an orchestrator operation doesn't work — it's a bug,
+ask the user.
+
 ## Workflow Artifacts
 
 Branch-scoped markdown artifacts in `.map/<branch>/`:
@@ -264,11 +269,11 @@ WAVE=$(python3 .map/scripts/map_orchestrator.py get_wave_step)
 MODE=$(echo "$WAVE" | jq -r '.mode')
 ```
 
-**IMPORTANT:** Even when `mode` is `"parallel"`, prefer sequential execution unless the
-wave has ≤3 subtasks that are ALL low-risk AND create new files only. When in doubt,
-execute sequentially.
+**Two execution modes are supported:** sequential (default) and parallel (wave-based).
 
-**Sequential execution loop** (DEFAULT — use this):
+### Sequential execution loop (DEFAULT)
+
+Use when waves have >3 subtasks or subtasks modify existing files:
 
 ```
 loop:
@@ -276,9 +281,9 @@ loop:
   if WAVE.is_complete: goto final_verification
 
   for each subtask in WAVE.subtasks (one at a time):
-    1. RESEARCH (2.2) — MANDATORY: run research-agent
+    1. RESEARCH (2.2) — run research-agent
     2. ACTOR (2.3) — implement subtask
-    3. MONITOR (2.4) — MANDATORY: validate + BUILD GATE (see below). NEVER skip.
+    3. MONITOR (2.4) — MANDATORY: validate + BUILD GATE. NEVER skip.
     4. validate_step / advance to next subtask
 
   # After ALL subtasks in wave pass: run per-wave gates
@@ -288,6 +293,44 @@ loop:
 **DO NOT** write custom bash for-loops to iterate subtasks. Use the orchestrator:
 call `get_next_step` after each `validate_step` — it returns the next phase/subtask
 automatically. The state machine handles iteration.
+
+### Parallel execution loop (wave-based)
+
+Use when wave has ≤3 subtasks AND all are low-risk AND all create new files only.
+Also allowed for any wave size when the user explicitly requests parallel execution.
+
+**CRITICAL:** When running subtasks in parallel, use the **wave API** (`validate_wave_step`,
+`advance_wave`), NOT the sequential API (`validate_step`, `get_next_step`).
+The sequential API tracks only ONE `current_subtask_id` and will fail for parallel work.
+
+```
+loop:
+  WAVE = get_wave_step()
+  if WAVE.is_complete: goto final_verification
+
+  # 1. Run ALL Actors in parallel (one Agent per subtask)
+  for each subtask in WAVE.subtasks (in parallel):
+    Agent(subagent_type="actor", prompt="Implement subtask {subtask_id}...")
+
+  # 2. Run ALL Monitors in parallel (one Agent per subtask)
+  for each subtask in WAVE.subtasks (in parallel):
+    Agent(subagent_type="monitor", prompt="Validate subtask {subtask_id}...")
+
+  # 3. Record results and advance phases for EACH subtask:
+  for each subtask:
+    echo '{"subtask_id":"ST-XXX","files":[...],"status":"valid",...}' \
+      | python3 .map/scripts/map_step_runner.py record_subtask_result
+    python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.3
+    python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.4
+
+  # 4. Run per-wave gates (build + tests + lint), then advance
+  python3 .map/scripts/map_orchestrator.py advance_wave
+```
+
+**Key difference:** `validate_wave_step <subtask_id> <step_id>` works per-subtask
+and does NOT require `current_subtask_id` to match. After `advance_wave`, the state
+is synchronized for sequential API — you can switch back to `get_next_step` for
+subsequent waves.
 
 ### Phase: RESEARCH (2.2) — MANDATORY
 

--- a/.claude/commands/map-plan.md
+++ b/.claude/commands/map-plan.md
@@ -265,11 +265,26 @@ If interview was skipped (task is well-defined), still write `spec_<branch>.md` 
 - **Security Boundaries**: include if task touches auth/validation/user input
 - **Out of Scope**: explicitly state what is NOT being changed
 
+**Acceptance Criteria completeness rule:**
+
+If the source document (spec, issue, PRD, etc.) defines explicit acceptance criteria, enumerate ALL of them in the spec — either copy them verbatim or reference them by file + line range (e.g., `SPEC.md lines 2946-2988, 37 criteria`). Do NOT summarize N criteria as "key M" — the decomposer will treat M as the full scope, and uncovered criteria will silently drop from the plan.
+
+The same rule applies to result schema fields, invariants, and any other enumerated contract. If the source lists 20 fields in a result type, the spec must list all 20 or reference the authoritative list — not "key fields include X, Y, Z".
+
 This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
 
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
-**Skip if:** complexity < 5 (simple, well-defined tasks).
+**Skip if ALL of these are true:**
+- Source spec/requirements are under 200 lines
+- Fewer than 5 subtasks expected
+- No cross-cutting concerns involved (observability, security, concurrency, multi-service coordination)
+
+**ALWAYS run if ANY of these is true:**
+- Source spec/requirements exceed 500 lines
+- Source defines 10 or more acceptance criteria
+- Multiple subgraphs, services, or subsystems involved
+- Task includes concurrency, recovery, or multi-transport requirements
 
 After writing the spec, invoke Monitor agent to adversarially review it. The goal is to surface gaps, contradictions, and missing edge cases BEFORE decomposition.
 
@@ -358,6 +373,12 @@ Output requirements:
 - Identify dependencies between subtasks
 - Estimate complexity (low/medium/high)
 - Use architecture_graph_summary to map subtasks to affected modules
+
+Coverage requirements:
+- CRITICAL: Every acceptance criterion from the spec must appear as a validation_criteria in exactly one subtask. Do NOT silently drop spec criteria that seem minor.
+- For cross-cutting requirements (observability, error handling, budget tracking, structured logging), either create a dedicated subtask or explicitly add them as validation criteria to the subtask that implements the relevant infrastructure.
+- For each structured result type in the spec, verify ALL fields (including optional envelope fields like budget_state, deferred_work, recovery_state) are covered in validation criteria.
+- Output a `coverage_map` field: a dict mapping each spec AC identifier to the subtask ID that owns it, e.g. {{"MVP-AC-1": "ST-007", "MVP-AC-2": "ST-005", ...}}.
 """
 )
 ```
@@ -387,6 +408,34 @@ The blueprint JSON must include at minimum:
 ```
 
 If the decomposer returned structured JSON, save it directly. If it returned markdown, construct the JSON from the decomposed subtasks. **This step is mandatory** — without `blueprint.json`, `/map-efficient` cannot compute parallel execution waves.
+
+### Step 5.7: Decomposition Coverage Check
+
+Before writing the human-readable plan, verify the decomposition covers the full spec. The decomposer agent works with limited context and may silently drop requirements.
+
+**1. Acceptance criteria mapping:**
+For each acceptance criterion in the spec (or referenced source), identify which ST-XXX covers it. If an AC has no owner subtask, either add it to an existing subtask's validation_criteria or create a new subtask.
+
+**2. Result schema field check:**
+For each structured result type defined in the spec (e.g., IngestResult, ProjectSynthesisResult, ArchitectureRefreshResult, etc.), verify that ALL fields — including optional envelope fields like `budget_state`, `deferred_work`, `recovery_state` — appear in at least one subtask's validation criteria. Missing fields cause schema drift between implementation and spec.
+
+**3. Cross-cutting concerns scan:**
+Check whether these concerns have an explicit owner subtask or are distributed as validation criteria across subtasks:
+- Observability / structured logging
+- Error codes and structured error types
+- Concurrency / locking
+- Budget tracking and exhaustion
+- Recovery state for all write-capable workflows
+
+If any concern is orphaned (no subtask owns it), either create a dedicated subtask or explicitly add it as a deliverable to the most relevant existing subtask.
+
+**4. Invariant coverage:**
+For each invariant in the spec, verify at least one subtask's acceptance criteria would catch a violation.
+
+**5. Edge case / overflow rules:**
+Scan the spec for boundary conditions (format overflows, threshold transitions, fallback behaviors). Verify each has a corresponding test in at least one subtask's test_strategy.
+
+If gaps are found, update the decomposition (add validation criteria to existing subtasks or create new subtasks) BEFORE proceeding to Step 6.
 
 ### Step 6: Create Human-Readable Plan
 
@@ -432,6 +481,24 @@ Then use the **Write** tool to create `.map/<branch>/task_plan_<branch>.md` with
 
 1. ST-001 → ST-002 (ST-002 depends on ST-001)
 2. ST-003 (can run in parallel)
+
+## Spec Coverage
+
+Map every spec requirement to the subtask that owns its verification. This table is the primary review artifact — if a row has no owner, the plan has a gap.
+
+| Spec Section | Requirement ID | Description | Owner ST | Verified By |
+|-------------|---------------|-------------|----------|-------------|
+| MVP AC | AC-1 | [criterion text] | ST-XXX | [test or check] |
+| Invariant | INV-5 | [invariant text] | ST-YYY | [test or check] |
+| Result Schema | IngestResult.budget_state | [field exists and populated] | ST-ZZZ | [test] |
+| Cross-cutting | Observability | [structured logs with run_id] | ST-WWW | [test or check] |
+
+**Rules for this table:**
+- Every acceptance criterion from the spec MUST have a row
+- Every result schema field MUST have a row (group trivial fields if needed)
+- Every invariant MUST have a row
+- Cross-cutting concerns (observability, error codes, locking, budget) MUST have rows
+- If a row has no Owner ST, the plan is incomplete — add the requirement to a subtask before finalizing
 
 ## Notes
 
@@ -508,8 +575,10 @@ Print a clear checkpoint showing the plan is complete:
 WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ═══════════════════════════════════════════════════
 ✅ Deep interview completed (N decisions captured)
+✅ Devil's Advocate review completed (or skipped — state reason)
 ✅ Architecture graph written to spec_${BRANCH}.md
 ✅ Task decomposed into N subtasks with AAG contracts
+✅ Coverage check passed: M/M spec ACs mapped, 0 orphaned cross-cutting concerns
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ step_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
@@ -533,14 +602,15 @@ Next Steps:
 
 ```
 DISTILLATION CHECKLIST:
-  [x] task_plan_<branch>.md — has AAG contracts for every subtask
+  [x] task_plan_<branch>.md — has AAG contracts for every subtask + Spec Coverage table
   [x] step_state.json   — has aag_contracts map + subtask_sequence
-  [x] blueprint.json     — raw decomposer output for wave computation
-  [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
+  [x] blueprint.json     — raw decomposer output for wave computation (with coverage_map)
+  [x] spec_<branch>.md      — has architecture graph + decisions + COMPLETE acceptance criteria (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
 
 TARGET: Executor reads ≤4000 tokens of distilled state to start any subtask.
 If plan files exceed this, condense — remove redundant descriptions, keep AAG contracts + criteria.
+The Spec Coverage table in task_plan should NOT be condensed — it is the review contract.
 ```
 
 **This phase ends here.** Do NOT proceed to execution. The context should be flushed, and execution will start fresh with focused attention on individual subtasks.
@@ -646,8 +716,11 @@ A: Re-run /map-plan. It will overwrite task_plan_<branch>.md and reset step_stat
 
 This command succeeds when:
 - ✅ Deep interview completed (if scope warranted it) with spec_<branch>.md written
+- ✅ Spec acceptance criteria enumerated completely (not summarized)
+- ✅ Devil's Advocate review completed (if skip conditions not met)
 - ✅ Architecture graph written in spec_<branch>.md (for complexity >= 3)
-- ✅ task_plan_<branch>.md exists with AAG contracts for every subtask
+- ✅ Decomposition coverage check passed (Step 5.7) — no orphaned ACs, result fields, or cross-cutting concerns
+- ✅ task_plan_<branch>.md exists with AAG contracts for every subtask AND Spec Coverage table
 - ✅ step_state.json exists with valid subtask_sequence + aag_contracts map
 - ✅ CHECKPOINT shows subtask count and IDs
 - ✅ Context distilled (plan files self-contained for fresh session)

--- a/.claude/commands/map-task.md
+++ b/.claude/commands/map-task.md
@@ -85,7 +85,7 @@ Route to the appropriate executor based on `$PHASE`. All phases from `/map-effic
 
 - **RESEARCH (2.2)** — Call research-agent if needed
 - **ACTOR (2.3)** — Implement the subtask
-- **MONITOR (2.4)** — Validate implementation
+- **MONITOR (2.4)** — MANDATORY: Validate implementation. NEVER skip.
 
 Single-subtask execution must keep using the shared branch workspace artifacts rather than creating task-local side files:
 

--- a/.claude/commands/map-task.md
+++ b/.claude/commands/map-task.md
@@ -83,7 +83,7 @@ PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
 
 Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
 
-- **RESEARCH (2.2)** — Call research-agent if needed
+- **RESEARCH (2.2)** — MANDATORY: Gather context via research-agent. NEVER skip.
 - **ACTOR (2.3)** — Implement the subtask
 - **MONITOR (2.4)** — MANDATORY: Validate implementation. NEVER skip.
 

--- a/.claude/rules/learned/architecture-patterns.md
+++ b/.claude/rules/learned/architecture-patterns.md
@@ -14,3 +14,23 @@
   ```
 
 - **Monolith Decomposition: Extract Shared Helpers First** (2026-03-26): When decomposing a large Python module into submodules, always identify helpers shared by multiple extraction targets and extract them to a utility module FIRST, because copy-pasting helpers creates DRY violations that diverge silently. Re-export all extracted symbols from the original module to preserve backward compatibility. [workflow: map-learn-improvement]
+
+- **State Machine Transition Completeness: Reset All Sub-State Atomically** (2026-04-11): When implementing a state machine transition function, reset EVERY state variable owned by the departing state in a single atomic operation, not just the primary state indicator. Partial resets leave stale sub-state (e.g., pending_steps, current_step_id, retry_count) that corrupts the entering state's query results. [workflow: map-learn-bugfix]
+  ```python
+  # WRONG: advance_wave updates only the wave counter
+  def advance_wave(self):
+      self.current_wave += 1
+      # pending_steps / current_step_id still hold prior-wave values!
+
+  # CORRECT: atomically reset all sub-state owned by the wave context
+  def advance_wave(self):
+      self.current_wave += 1
+      self.pending_steps = []
+      self.current_step_id = None
+      self.completed_steps = []
+      self.retry_count = 0
+  ```
+
+- **Agentic Prompt Emphasis Uniformity** (2026-04-11): In multi-phase agentic prompts, every non-negotiable phase must carry identical emphasis markers (MANDATORY, CRITICAL). Selective marking — applying markers to some phases but not others — implicitly signals that unmarked phases are optional. Under cost or confidence pressure ("tests already passed"), agents skip unmarked phases. [workflow: map-learn-bugfix]
+
+- **Orchestrator Prompts Must Prohibit Direct State File Modification** (2026-04-11): When an orchestrator manages workflow state through a structured file (e.g., step_state.json), the agent prompt must contain an explicit NEVER-MODIFY rule naming the file. Without this rule, agents that encounter API limitations will write directly to the state file as a fallback, bypassing all validation the API maintains. The rule must specify what to do instead: call a specific API function, or stop and ask the user. [workflow: map-learn-bugfix]

--- a/.claude/rules/learned/implementation-patterns.md
+++ b/.claude/rules/learned/implementation-patterns.md
@@ -10,3 +10,18 @@ paths:
 - **Python Dataclass Type Validation** (2026-03-26): When building a dataclass from parsed YAML/JSON config, always add explicit type checking (isinstance in __post_init__ or pre-filter before construction), because Python dataclass type hints are documentation only — a string where int is expected passes silently and breaks downstream operations. [workflow: map-learn-improvement]
 
 - **Validation Functions Must Return None on Invalid** (2026-03-26): When writing a function named load_and_validate or similar, always return None (or raise) on invalid input and return data only on valid, because callers use `if result is not None:` as a validity signal — returning data on failure inverts the contract silently. [workflow: map-learn-improvement]
+
+- **Symmetric Read/Write Paths for Structured File Headers** (2026-04-11): When injecting metadata into structured text files, detect known header formats (YAML frontmatter `---`, shebangs `#!`, XML prolog) and insert AFTER the header block, never before it. The extraction path must search at the same position where the write path inserted. Asymmetric read/write paths cause silent metadata loss or duplicate entries on round-trip. Retain a fallback for files without the header to preserve backward compatibility. [workflow: map-learn-bugfix]
+  ```python
+  # WRONG: prepend unconditionally, corrupts YAML frontmatter
+  content = f"{COMMENT}\n{original}"
+
+  # CORRECT: detect boundary, inject after; extraction mirrors inject
+  def inject_after_frontmatter(content: str, comment: str) -> str:
+      if content.startswith("---"):
+          end = content.find("\n---\n", 3)
+          if end != -1:
+              pos = end + 5  # character after closing ---\n
+              return content[:pos] + comment + "\n" + content[pos:]
+      return comment + "\n" + content  # fallback: no frontmatter
+  ```

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -41,7 +41,7 @@ STEP PHASES (10 total, 8 standard + 2 TDD):
   1.55 REVIEW_PLAN        - User review + explicit approval checkpoint
   1.56 CHOOSE_MODE        - Auto-skipped (always batch mode)
   1.6  INIT_STATE         - Create step_state.json (single source of truth)
-  2.2  RESEARCH           - research-agent (conditional: 3+ existing files OR high risk)
+  2.2  RESEARCH           - research-agent (mandatory for all subtasks)
   2.25 TEST_WRITER        - TDD: write tests from spec (TDD mode only)
   2.26 TEST_FAIL_GATE     - TDD: verify tests fail without impl (TDD mode only)
   2.3  ACTOR              - Actor agent implementation
@@ -461,8 +461,8 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             "Single source of truth for workflow enforcement."
         ),
         "2.2": (
-            "Call Task(subagent_type='research-agent') if subtask touches "
-            "3+ existing files OR risk=high. Pass findings to Actor."
+            "Call Task(subagent_type='research-agent') to research the subtask. "
+            "MANDATORY for all subtasks. Pass findings to Actor."
         ),
         "2.25": (
             f"TDD TEST_WRITER: Call Task(subagent_type='actor') with "

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -1236,16 +1236,17 @@ def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
     }
 
 
-SKIPPABLE_STEPS = {"2.2", "2.25", "2.26"}
+SKIPPABLE_STEPS = {"2.25", "2.26"}
 
 
 def skip_step(step_id: str, branch: str) -> dict:
     """Skip a conditional step without executing it.
 
     Only steps that are defined as conditional can be skipped:
-      - 2.2 (RESEARCH): conditional on 3+ existing files or high risk
       - 2.25 (TEST_WRITER): TDD mode only, auto-skipped otherwise
       - 2.26 (TEST_FAIL_GATE): TDD mode only, auto-skipped otherwise
+
+    Note: RESEARCH (2.2) is NOT skippable — it is mandatory for all subtasks.
 
     Args:
         step_id: Step identifier to skip

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -976,7 +976,7 @@ def advance_wave(branch: str) -> dict:
 
     is_complete = state.current_wave_index >= len(state.execution_waves)
 
-    # Update subtask_index to track overall progress
+    # Update subtask_index and reset sequential state for next wave
     if not is_complete:
         next_wave = state.execution_waves[state.current_wave_index]
         if next_wave:
@@ -986,6 +986,15 @@ def advance_wave(branch: str) -> dict:
                 state.subtask_index = state.subtask_sequence.index(
                     state.current_subtask_id
                 )
+            # Reset sequential state so get_next_step works after advance_wave
+            step_order = _get_step_order(state.tdd_mode)
+            research_idx = step_order.index("2.2")
+            state.pending_steps = step_order[research_idx:]
+            state.completed_steps = []
+            state.skipped_steps = []
+            state.current_step_id = "2.2"
+            state.current_step_phase = "RESEARCH"
+            state.retry_count = 0
 
     state.save(state_file)
 

--- a/src/mapify_cli/delivery/managed_file_copier.py
+++ b/src/mapify_cli/delivery/managed_file_copier.py
@@ -165,6 +165,13 @@ def extract_metadata(content: str, ext: str) -> tuple[Optional[dict[str, Any]], 
                     try:
                         meta = json.loads(m.group(1))
                         clean = content[:after_fm] + rest[m.end() :]
+                        # If nothing followed the MAP-MANAGED comment (it was
+                        # at EOF) and clean ends with "\n---\n", the trailing
+                        # newline was injected by inject_metadata for the
+                        # frontmatter-at-EOF edge case.  Strip it to restore
+                        # the original content that had no trailing newline.
+                        if not rest[m.end() :] and clean.endswith("\n---\n"):
+                            clean = clean[:-1]
                         return meta, clean
                     except json.JSONDecodeError:
                         pass

--- a/src/mapify_cli/delivery/managed_file_copier.py
+++ b/src/mapify_cli/delivery/managed_file_copier.py
@@ -103,6 +103,17 @@ def inject_metadata(content: str, ext: str, version: str, template_hash: str) ->
 
     if ext == ".md":
         header = f"<!-- {_MANAGED_TAG}: {meta_json} -->\n"
+        # If content has YAML frontmatter (starts with ---), insert after
+        # closing --- to preserve frontmatter parsing by tools like Claude Code.
+        if content.startswith("---\n"):
+            end_idx = content.find("\n---\n", 3)
+            if end_idx != -1:
+                insert_pos = end_idx + 5  # after \n---\n
+                return content[:insert_pos] + header + content[insert_pos:]
+            # Edge case: closing --- at very end (no trailing newline)
+            end_idx = content.find("\n---", 3)
+            if end_idx != -1 and end_idx + 4 == len(content):
+                return content + "\n" + header
         return header + content
 
     if ext == ".py":
@@ -135,6 +146,7 @@ def extract_metadata(content: str, ext: str) -> tuple[Optional[dict[str, Any]], 
     Returns (None, original_content) if no metadata found.
     """
     if ext == ".md":
+        # Try at start of file (non-frontmatter .md files)
         m = _MD_PATTERN.match(content)
         if m:
             try:
@@ -142,6 +154,20 @@ def extract_metadata(content: str, ext: str) -> tuple[Optional[dict[str, Any]], 
                 return meta, content[m.end() :]
             except json.JSONDecodeError:
                 pass
+        # Try after YAML frontmatter (agent .md files with ---)
+        if content.startswith("---\n"):
+            end_idx = content.find("\n---\n", 3)
+            if end_idx != -1:
+                after_fm = end_idx + 5
+                rest = content[after_fm:]
+                m = _MD_PATTERN.match(rest)
+                if m:
+                    try:
+                        meta = json.loads(m.group(1))
+                        clean = content[:after_fm] + rest[m.end() :]
+                        return meta, clean
+                    except json.JSONDecodeError:
+                        pass
         return None, content
 
     if ext == ".py":

--- a/src/mapify_cli/templates/agents/actor.md
+++ b/src/mapify_cli/templates/agents/actor.md
@@ -416,7 +416,17 @@ VC1: <criterion text>
 - Tests: path/to/test_file.ext::test_name (or N/A with reason)
 ```
 
-## 7. Integration Notes (If Applicable)
+## 7. Downstream Consumption Check
+
+When implementing a component whose output is consumed by another component:
+
+- **Identify the consumer**: What reads your output? Verify your output populates ALL fields it expects.
+- **Self-bootstrap**: Does your code load its own dependencies from config/storage, or does it silently return empty results when input is not pre-populated by the caller?
+- **Stub replacement**: If implementing a real version of a placeholder, verify it is wired into the runtime — not just available as a standalone function.
+
+Skip this section for leaf components with no downstream consumers.
+
+## 8. Integration Notes (If Applicable)
 
 Only include if changes affect:
 - Database schema (migrations needed?)

--- a/src/mapify_cli/templates/agents/actor.md
+++ b/src/mapify_cli/templates/agents/actor.md
@@ -200,10 +200,15 @@ Task(
    - Use Read(path, offset=lines[0], limit=lines[1]-lines[0]+1)  # lines = [start, end], inclusive
    - Don't read all locations — only what you actually need
 
-## Skip Research If
+## Research Usage
 
-- Task is self-contained (new file, no dependencies)
-- Existing patterns from context already cover the need
+Research is run by the orchestrator BEFORE Actor is invoked. The findings file
+(`.map/<branch>/findings_<branch>.md`) contains distilled context. If it exists,
+read it before implementation — it has import patterns, module structure, and
+build configuration that prevent integration failures.
+
+Do NOT skip reading the findings file even for "new file" tasks — new files still
+need correct imports, types, and build configuration from the existing project.
 
 ---
 

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -39,10 +39,16 @@ You are a **validation agent**, NOT a code executor. Your role:
 
 **Verification sequence (execute in order):**
 1. Parse AAG contract from prompt — extract Actor, Action, Goal
-2. Verify Goal is achieved — trace code path to confirm the stated outcome
-3. Verify Action is implemented — check that the specified method/operation exists
-4. Verify scope — confirm changes stay within Actor's allowed_scope
-5. Run quality gates below
+2. **BUILD GATE (MANDATORY — run FIRST):** Run the project's build/compile command:
+   - TypeScript: `npx tsc --noEmit` (or `npm run build`)
+   - Python: `python -m py_compile <changed_files>` (or mypy if configured)
+   - Go: `go build ./...`
+   - Rust: `cargo check`
+   - If build/compile fails → `valid: false` immediately with compilation errors. Do NOT proceed to other checks.
+3. Verify Goal is achieved — trace code path to confirm the stated outcome
+4. Verify Action is implemented — check that the specified method/operation exists
+5. Verify scope — confirm changes stay within Actor's allowed_scope
+6. Run quality gates below
 
 **Deterministic REJECT rule:**
 If implementation deviates from the AAG contract — `valid: false` — regardless of how "clean" or "elegant" the code is. The contract IS the specification; aesthetic quality is irrelevant when the contract is violated.
@@ -50,8 +56,9 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 **Escalation Framework:**
 
 🔴 **AUTO-REJECT (valid: false, must fix):**
-1. **AAG contract violation** — implementation does not satisfy Actor -> Action -> Goal
-2. Missing error handling on network/database/file operations
+1. **Build/compile failure** — code does not compile (`tsc --noEmit`, `go build`, `cargo check`, `py_compile` fails)
+2. **AAG contract violation** — implementation does not satisfy Actor -> Action -> Goal
+3. Missing error handling on network/database/file operations
 3. No input validation on user-provided data
 4. SQL string concatenation (injection vulnerability)
 5. Hardcoded secrets (API keys, passwords, tokens)

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -288,8 +288,8 @@ IF detected_language != "unknown":
   → Consider language-specific static analysis tools
 
 PHASE 3: EXHAUSTIVE DIMENSION VALIDATION (ALWAYS)
-Execute validation protocol for each of the 10 dimensions sequentially.
-Do NOT skip dimensions based on early findings — complete ALL 10.
+Execute validation protocol for each of the 11 dimensions sequentially.
+Do NOT skip dimensions based on early findings — complete ALL 11.
 For each dimension: parse criteria → verify against code → record PASS/FAIL.
 Apply language-specific validation rules per dimension.
 
@@ -860,11 +860,11 @@ Include in JSON output when validation_criteria provided:
 
 </Monitor_Contract_Validation>
 
-<Monitor_10D_Validation_v2_9>
+<Monitor_11D_Validation_v3_0>
 
 ## 11-Dimension Quality Model
 
-Execute validation protocol for EACH dimension sequentially. Do NOT short-circuit — complete ALL 11 dimensions even if early rejections found. Output structured findings per dimension.
+Execute validation protocol for EACH dimension sequentially. Do NOT short-circuit — complete ALL 11 dimensions even if early rejections found. Output structured findings per dimension. **Exception:** BUILD GATE failure (step 2 of Verification sequence) is the single allowed short-circuit — if build/compile fails, set `valid: false` immediately without completing dimension checks.
 
 ### 1. CORRECTNESS
 
@@ -1422,7 +1422,7 @@ ELSE:
   → Verify self-bootstrapping from config/storage
 ```
 
-</Monitor_10D_Validation_v2_9>
+</Monitor_11D_Validation_v3_0>
 
 
 <Monitor_Severity_Matrix>
@@ -1957,7 +1957,7 @@ ARRAY POPULATION:
 - Ensure: passed_checks ∩ failed_checks = ∅ (no overlap)
 
 SPECIAL CASES:
-- If no issues found: all 10 categories go in passed_checks
+- If no issues found: all 11 categories go in passed_checks
 - If a dimension was skipped (large change): omit from both arrays
 ```
 
@@ -2065,6 +2065,7 @@ ELSE:
 | `external-deps` | Missing CRDs, undocumented dependencies | 8 |
 | `documentation` | Inconsistent with source, missing fields | 9 |
 | `research` | Missing research for unfamiliar patterns | 10 |
+| `integration` | Output not consumed downstream, stub in runtime | 11 |
 
 </Monitor_Decision_Rules>
 
@@ -2507,7 +2508,7 @@ def check_rate_limit(user_id, action, limit=100, window=3600):
 
 1. ✅ Did I use request_review for code implementations?
 2. ✅ Did I check for known issue patterns?
-3. ✅ Did I check all 10 validation dimensions systematically?
+3. ✅ Did I check all 11 validation dimensions systematically?
 4. ✅ Did I verify documentation against source of truth (if applicable)?
 5. ✅ Are all issues specific with location and actionable suggestions?
 6. ✅ Is severity classification correct per guidelines?

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -862,9 +862,9 @@ Include in JSON output when validation_criteria provided:
 
 <Monitor_10D_Validation_v2_9>
 
-## 10-Dimension Quality Model
+## 11-Dimension Quality Model
 
-Execute validation protocol for EACH dimension sequentially. Do NOT short-circuit — complete ALL 10 dimensions even if early rejections found. Output structured findings per dimension.
+Execute validation protocol for EACH dimension sequentially. Do NOT short-circuit — complete ALL 11 dimensions even if early rejections found. Output structured findings per dimension.
 
 ### 1. CORRECTNESS
 
@@ -1382,6 +1382,46 @@ ELSE:
 - Post-cutoff library + no research + outdated patterns
 </critical>
 
+### 11. INTEGRATION (When subtask has upstream/downstream dependencies)
+
+#### What to Check
+- Output consumed correctly by downstream components (not silently dropped)
+- Component self-bootstraps from config/storage (does not require caller to pre-populate dependencies)
+- Stubs/placeholders replaced by real implementations in the runtime entrypoint
+- Interface contracts between components are satisfied in both directions
+
+#### How to Check
+1. Identify downstream consumers of this subtask's output
+2. Trace the data path: does the output reach the consumer with the expected shape?
+3. Check if the component loads its own dependencies or silently returns empty/stub results
+4. Verify the runtime entrypoint uses the real implementation, not a placeholder
+
+#### Pass Criteria
+- Output is demonstrably consumed by at least one downstream component
+- Component works when invoked through the runtime entrypoint (not just direct calls)
+- No silent fallback to stub/empty results on missing dependencies
+
+#### Common Failures
+- Component writes to field A but consumer reads field B
+- Runtime entrypoint still wired to a stub despite real implementation existing
+- Component returns empty results when dependencies are not injected by test setup
+- Build/config failure masked as a successful stub response
+
+#### Severity Mapping
+- **Critical**: Runtime entrypoint returns stub/placeholder to end users
+- **High**: Component output not consumed by downstream (data silently lost)
+- **Medium**: Component requires caller injection instead of self-bootstrapping
+- **Low**: Interface contract undocumented but happens to work
+
+**Decision Framework**:
+```
+IF subtask has no downstream consumers AND no runtime entrypoint:
+  → Skip (leaf component)
+ELSE:
+  → Verify output reaches consumer through runtime path
+  → Verify self-bootstrapping from config/storage
+```
+
 </Monitor_10D_Validation_v2_9>
 
 
@@ -1403,6 +1443,7 @@ This table provides quick reference for severity classification per dimension. U
 | **8. External Deps** | Missing critical dependency documentation | Incomplete CRD/adapter docs | Missing version constraints | Minor config details |
 | **9. Documentation** | Contradicts tech-design/source of truth | Missing key fields/logic, wrong ownership | Minor inconsistencies | Formatting issues |
 | **10. Research** | N/A (rarely critical) | Complex problem + no research + wrong impl | Post-cutoff lib + outdated patterns | Missing citations only |
+| **11. Integration** | Runtime entrypoint returns stub to users | Output not consumed by downstream (data lost) | Requires caller injection instead of self-bootstrap | Interface contract undocumented |
 
 ### Severity Decision Tree
 
@@ -1561,8 +1602,8 @@ Do NOT invent issues to justify review effort. Empty `issues` array is valid.
           },
           "category": {
             "type": "string",
-            "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research"],
-            "description": "Maps to 10-dimension model: 1=correctness, 2=security, 3=code-quality, 4=performance, 5=testability, 6=cli-tool, 7=maintainability, 8=external-deps, 9=documentation, 10=research"
+            "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research", "integration"],
+            "description": "Maps to 11-dimension model: 1=correctness, 2=security, 3=code-quality, 4=performance, 5=testability, 6=cli-tool, 7=maintainability, 8=external-deps, 9=documentation, 10=research, 11=integration"
           },
           "title": {
             "type": "string",
@@ -1609,7 +1650,7 @@ Do NOT invent issues to justify review effort. Empty `issues` array is valid.
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research"]
+        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research", "integration"]
       },
       "description": "Dimensions that passed completely"
     },
@@ -1617,7 +1658,7 @@ Do NOT invent issues to justify review effort. Empty `issues` array is valid.
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research"]
+        "enum": ["correctness", "security", "code-quality", "performance", "testability", "cli-tool", "maintainability", "external-deps", "documentation", "research", "integration"]
       },
       "description": "Dimensions with issues"
     },

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -16,16 +16,17 @@ You are a Protocol-Driven Validation System. Your objective: verify that Actor's
 
 **CRITICAL: Monitor is READ-ONLY reviewer, NOT a code editor**
 
-You are a **validation agent**, NOT a code executor. Your role:
+You are a **validation agent**, NOT a code editor. Your role:
 
 - ✅ DO: Review Actor's code proposals and output JSON feedback
 - ✅ DO: Use Read tool to examine existing code for context
+- ✅ DO: Run read-only build/test commands (tsc --noEmit, go build, pytest, etc.) to verify code compiles and passes
 - ❌ NEVER: Use Edit or MultiEdit tools
 - ⚠️ EXCEPTION: Write tool is permitted ONLY for evidence artifacts (.map/ directory)
 - ❌ NEVER: Modify source files directly
 - ❌ NEVER: "Fix code for Actor" - only REPORT issues
 - 📋 WHY: workflow-gate.py will BLOCK Edit and non-evidence Write during monitor phase
-- 🔄 FLOW: Actor outputs → **You review** → Orchestrator applies (if approved)
+- 🔄 FLOW: Actor outputs → **You review + run build/tests** → Orchestrator applies (if approved)
 
 **Your output**: JSON with `valid: true|false` and `issues[]` array
 
@@ -59,13 +60,13 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 1. **Build/compile failure** — code does not compile (`tsc --noEmit`, `go build`, `cargo check`, `py_compile` fails)
 2. **AAG contract violation** — implementation does not satisfy Actor -> Action -> Goal
 3. Missing error handling on network/database/file operations
-3. No input validation on user-provided data
-4. SQL string concatenation (injection vulnerability)
-5. Hardcoded secrets (API keys, passwords, tokens)
-6. Silent failures (try/catch with empty handler)
-7. Deprecated APIs without migration plan
-8. Security score < 7 OR functionality score < 7
-9. **Missing intent comments** — non-obvious logic blocks without `# Intent: <why>` comments, or removal of existing intent comments that describe author's reasoning
+4. No input validation on user-provided data
+5. SQL string concatenation (injection vulnerability)
+6. Hardcoded secrets (API keys, passwords, tokens)
+7. Silent failures (try/catch with empty handler)
+8. Deprecated APIs without migration plan
+9. Security score < 7 OR functionality score < 7
+10. **Missing intent comments** — non-obvious logic blocks without `# Intent: <why>` comments, or removal of existing intent comments that describe author's reasoning
 
 🟡 **WARN (should address, not blocking):**
 1. Missing edge case tests (empty arrays, null values)

--- a/src/mapify_cli/templates/agents/task-decomposer.md
+++ b/src/mapify_cli/templates/agents/task-decomposer.md
@@ -278,12 +278,24 @@ Return **ONLY** valid JSON in this exact structure:
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
 
+### Integration & Runtime Bootstrapping Subtasks
+
+Feature subtasks implement components in isolation. To ensure they work together in the real runtime, you MUST also create:
+
+1. **Integration subtask** (one per runtime entrypoint): Wires real implementations into the runtime surface, replacing any stubs/placeholders. AAG contract must name the entrypoint and verify end-to-end data flow through it.
+   - Depends on ALL feature subtasks it integrates.
+
+2. **Bootstrapping subtask** (when components need external data at runtime): Ensures each workflow loads its own dependencies from configuration or persistent storage rather than requiring callers to pre-populate them.
+
+3. **Interface contracts between subtasks**: When subtask A produces output consumed by subtask B, document the data contract in BOTH subtasks' validation criteria so neither side can silently break it.
+
 ### Subtask Ordering
 
 Subtasks should be ordered by dependency:
 1. Foundation subtasks (no dependencies) first
 2. Dependent subtasks after their prerequisites
-3. Tests/docs can be parallel with implementation (same dependency level)
+3. Integration/wiring subtasks after ALL feature subtasks they integrate
+4. Tests/docs can be parallel with implementation (same dependency level)
 
 **CRITICAL**: If subtask B depends on subtask A, A must appear BEFORE B in the array.
 
@@ -528,6 +540,12 @@ When invoked with `mode: "re_decomposition"` from the orchestrator, you receive 
 - [ ] No placeholder values ("...", "TODO", "TBD")
 - [ ] Dependencies reference valid subtask IDs
 - [ ] Follows ordering constraint (dependencies before dependents)
+
+**Integration & Wiring**:
+- [ ] At least one integration subtask wires features into each runtime entrypoint
+- [ ] Interface contracts documented when one subtask produces output consumed by another
+- [ ] Bootstrapping subtask exists if components need data from disk/config at runtime
+- [ ] No subtask silently assumes its output is consumed — explicit consumer named in VC
 
 **Dependency Validation** (CRITICAL):
 - [ ] **Circular dependency check**: Verify dependency graph is acyclic (A→B→C→A is INVALID)

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -15,7 +15,7 @@ State machine enforces sequencing, Python validates completion, hooks inject rem
 2. Use exact `subagent_type` specified — never substitute
 3. Call each agent individually — no combining or skipping
 4. Max 5 retry iterations per subtask (note: /map-fast uses max 3)
-5. **Always batch mode, always parallel**: execution mode is always `batch` (no pauses). After INIT_STATE, always compute waves and execute independent subtasks in parallel (multiple `Task()` calls in one message). See "Wave Computation" section.
+5. **Always batch mode, sequential by default**: execution mode is always `batch` (no pauses). After INIT_STATE, compute waves but execute subtasks **one at a time** (sequential). Parallel execution within a wave is allowed ONLY when wave has ≤3 subtasks AND all are low-risk AND all create new files (no modifications to existing files). See "Wave Computation" section.
 6. After Monitor pass, record files changed in `step_state.json` for guard isolation.
 
 ## Intentional Agent Omissions
@@ -253,75 +253,52 @@ This reads the blueprint, builds a dependency graph, computes topological waves,
 and splits waves by file conflicts. The result is stored in `step_state.json`.
 If `blueprint.json` is missing (e.g., plan was created before v3.5), subtasks execute sequentially — this is safe but slower.
 
-**Wave execution**: If waves are computed, subtasks within a wave run their Actor
-and Monitor phases in parallel. Check wave status with:
+**Wave execution**: Subtasks execute **sequentially by default** (one at a time through
+the full RESEARCH → ACTOR → MONITOR cycle). This prevents accumulated errors that are
+hard to debug. Check wave status with:
 
 ```bash
 WAVE=$(python3 .map/scripts/map_orchestrator.py get_wave_step)
 MODE=$(echo "$WAVE" | jq -r '.mode')
 ```
 
-If `mode` is `"parallel"`, launch all actors in the wave in ONE message using
-multiple `Task()` calls, then all monitors in ONE message. If `mode` is
-`"sequential"`, use the standard single-subtask loop below.
+**IMPORTANT:** Even when `mode` is `"parallel"`, prefer sequential execution unless the
+wave has ≤3 subtasks that are ALL low-risk AND create new files only. When in doubt,
+execute sequentially.
 
-**Parallel wave execution loop**:
+**Sequential execution loop** (DEFAULT — use this):
 
 ```
 loop:
   WAVE = get_wave_step()
   if WAVE.is_complete: goto final_verification
 
-  if WAVE.mode == "sequential":
-    # Single subtask — same as standard behavior below
-    execute_current_sequential_loop()
-  else:
-    # === PARALLEL WAVE ===
-    # Phase A: Prep (sequential per subtask - lightweight)
-    for each subtask in WAVE.subtasks:
-      optional RESEARCH (if 3+ existing files or high risk)
+  for each subtask in WAVE.subtasks (one at a time):
+    1. RESEARCH (2.2) — MANDATORY: run research-agent
+    2. ACTOR (2.3) — implement subtask
+    3. MONITOR (2.4) — validate + BUILD GATE (see below)
+    4. validate_step / advance to next subtask
 
-    # Phase A.5: TDD phases (if --tdd mode)
-    # When TDD is enabled, run TEST_WRITER + TEST_FAIL_GATE per subtask
-    # BEFORE launching Actors. These run sequentially per subtask.
-    if TDD_FLAG:
-      for each subtask in WAVE.subtasks:
-        run TEST_WRITER (2.25) → validate_wave_step SUBTASK_ID "2.25"
-        run TEST_FAIL_GATE (2.26) → validate_wave_step SUBTASK_ID "2.26"
-
-    # Phase B: Parallel Actors
-    # Launch ALL Task(subagent_type="actor") calls in ONE message
-    # Example: Task(actor, "Implement ST-002") + Task(actor, "Implement ST-004")
-
-    # Phase C: Parallel Monitors
-    # After all actors return, launch ALL monitors in ONE message
-    # Example: Task(monitor, "Validate ST-002") + Task(monitor, "Validate ST-004")
-
-    # Phase D: Retry handling
-    # For each monitor that returned valid=false:
-    #   RETRY=$(python3 .map/scripts/map_orchestrator.py wave_monitor_failed $subtask_id --feedback "feedback")
-    #   If RETRY.status == "max_retries": escalate to user
-    #   Otherwise: re-run actor + monitor for that subtask (serially)
-
-    # Phase E: Per-wave gates
-    # Run tests + linter ONCE for the entire wave
-    # pytest / npm test / etc.
-
-    # Phase F: Advance wave — after all subtasks pass Monitor + per-wave gates
-    python3 .map/scripts/map_orchestrator.py advance_wave
+  # After ALL subtasks in wave pass: run per-wave gates
+  python3 .map/scripts/map_orchestrator.py advance_wave
 ```
 
-Linear DAGs naturally degrade to single-subtask waves (identical to current behavior).
+**DO NOT** write custom bash for-loops to iterate subtasks. Use the orchestrator:
+call `get_next_step` after each `validate_step` — it returns the next phase/subtask
+automatically. The state machine handles iteration.
 
-### Phase: RESEARCH (2.2)
+### Phase: RESEARCH (2.2) — MANDATORY
+
+**CRITICAL: ALWAYS run research. Do NOT skip this phase.**
+
+Research prevents the most common failure mode: Actor writing code that doesn't integrate
+with the existing codebase (wrong imports, missing types, incompatible APIs).
 
 ```python
-# Conditional: Call if subtask touches 3+ existing files OR risk=high
-if requires_research(subtask):
-    Task(
-      subagent_type="research-agent",
-      description="Research for subtask [ID]",
-      prompt=f"""Query: [subtask description]
+Task(
+  subagent_type="research-agent",
+  description="Research for subtask [ID]",
+  prompt=f"""Query: [subtask description]
 File patterns: [relevant globs]
 Intent: locate
 Max tokens: 1500
@@ -329,11 +306,17 @@ Findings file: .map/{branch}/findings_{branch}.md
 
 DISTILLATION RULE: Write ONLY actionable findings to the file:
 - file paths + line ranges + function signatures
+- existing import patterns and module structure
+- build/compile configuration (tsconfig, setup.py, Cargo.toml, etc.)
 - NO raw search output, NO full file contents
 - Target: <1500 tokens in findings file
 This file is the SOLE research artifact passed to Actor and future steps."""
-    )
+)
 ```
+
+The ONLY exception: if the orchestrator returns `skip_reason` for step 2.2 (set by
+`resume_from_plan` when `/map-plan` already completed research). In that case, the
+findings file already exists.
 
 ### Phase: TEST_WRITER (2.25) — TDD Mode Only
 
@@ -462,11 +445,18 @@ Task(
 
 Protocol (execute in order):
 1. Read each file in MAP_Written — verify code exists and compiles/parses
-2. Check MAP_Contract compliance — does implementation satisfy the AAG assertion?
-3. Run tests: pytest/npm test/go test/cargo test
-4. Check inline contracts: preconditions, postconditions, invariants from packet
-5. Verify: no silent failures, no bare except, no hardcoded secrets
-6. Output: ONLY valid JSON per MonitorReviewOutput schema
+2. **BUILD GATE (MANDATORY):** Run the project build/compile command BEFORE any other checks:
+   - TypeScript: `npx tsc --noEmit` (or `npm run build`)
+   - Python: `python -m py_compile <files>` (or `python -m mypy <files>` if configured)
+   - Go: `go build ./...`
+   - Rust: `cargo check`
+   - If build fails → valid=false immediately, report compilation errors
+3. Check MAP_Contract compliance — does implementation satisfy the AAG assertion?
+4. Run tests: pytest/npm test/go test/cargo test
+5. Check inline contracts: preconditions, postconditions, invariants from packet
+6. Verify: no silent failures, no bare except, no hardcoded secrets
+7. Output: ONLY valid JSON per MonitorReviewOutput schema
+   - If build fails: valid=false + compilation errors
    - If MAP_Contract violated: valid=false + specific contract breach
    - If tests fail: valid=false + failure output
    - If all pass: valid=true + contract_compliant=true"""
@@ -567,13 +557,35 @@ Do not overwrite the previous review file; keep the loop history visible.
 
 ### Per-Wave Gates (after all subtasks in wave pass Monitor)
 
-After ALL subtasks in a wave have Monitor `valid=true`, run tests + linter ONCE for the entire wave:
+After ALL subtasks in a wave have Monitor `valid=true`, run build + tests + linter ONCE for the entire wave:
 
 ```bash
-# Run tests — capture exit code + output
+# 1. BUILD GATE (MANDATORY — run FIRST)
+BUILD_EXIT=0
+BUILD_OUTPUT=""
+if [ -f "tsconfig.json" ]; then
+  BUILD_OUTPUT=$(npx tsc --noEmit 2>&1); BUILD_EXIT=$?
+elif [ -f "package.json" ] && grep -q '"build"' package.json; then
+  BUILD_OUTPUT=$(npm run build 2>&1); BUILD_EXIT=$?
+elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
+  BUILD_OUTPUT=$(python -m py_compile $(git diff --name-only --diff-filter=AM -- '*.py') 2>&1); BUILD_EXIT=$?
+elif [ -f "go.mod" ]; then
+  BUILD_OUTPUT=$(go build ./... 2>&1); BUILD_EXIT=$?
+elif [ -f "Cargo.toml" ]; then
+  BUILD_OUTPUT=$(cargo check 2>&1); BUILD_EXIT=$?
+fi
+echo "$BUILD_OUTPUT"
+
+# If build fails, stop here — no point running tests on code that doesn't compile
+if [ "$BUILD_EXIT" -ne 0 ]; then
+  echo "BUILD FAILED — fix compilation errors before proceeding"
+  # Treat as wave gate failure (see Guard Pattern below)
+fi
+
+# 2. Run tests — capture exit code + output
 TESTS_EXIT=0
 TEST_OUTPUT=""
-if [ -f "pytest.ini" ] || [ -f "setup.py" ]; then
+if [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
   TEST_OUTPUT=$(pytest 2>&1); TESTS_EXIT=$?
 elif [ -f "package.json" ]; then
   TEST_OUTPUT=$(npm test 2>&1); TESTS_EXIT=$?
@@ -582,11 +594,11 @@ elif [ -f "go.mod" ]; then
 elif [ -f "Cargo.toml" ]; then
   TEST_OUTPUT=$(cargo test 2>&1); TESTS_EXIT=$?
 else
-  echo "No tests found, skipping gate"
+  echo "No tests found, skipping test gate"
 fi
 echo "$TEST_OUTPUT"
 
-# Run linter — capture exit code + output
+# 3. Run linter — capture exit code + output
 LINT_EXIT=0
 LINT_OUTPUT=""
 if command -v ruff &> /dev/null; then
@@ -596,7 +608,7 @@ elif command -v eslint &> /dev/null; then
 elif command -v golangci-lint &> /dev/null; then
   LINT_OUTPUT=$(golangci-lint run 2>&1); LINT_EXIT=$?
 else
-  echo "No linter found, skipping gate"
+  echo "No linter found, skipping lint gate"
 fi
 echo "$LINT_OUTPUT"
 ```
@@ -604,7 +616,7 @@ echo "$LINT_OUTPUT"
 **Guard Pattern Decision (per-wave):**
 
 ```
-IF TESTS_EXIT == 0 AND LINT_EXIT == 0:
+IF BUILD_EXIT == 0 AND TESTS_EXIT == 0 AND LINT_EXIT == 0:
   → Wave passed. Advance to next wave.
 
 ELSE (regression detected):

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -278,7 +278,7 @@ loop:
   for each subtask in WAVE.subtasks (one at a time):
     1. RESEARCH (2.2) — MANDATORY: run research-agent
     2. ACTOR (2.3) — implement subtask
-    3. MONITOR (2.4) — validate + BUILD GATE (see below)
+    3. MONITOR (2.4) — MANDATORY: validate + BUILD GATE (see below). NEVER skip.
     4. validate_step / advance to next subtask
 
   # After ALL subtasks in wave pass: run per-wave gates
@@ -429,7 +429,14 @@ Protocol:
 - If Actor reports diagnostics/errors — proceed directly to MONITOR.
 - Monitor will verify and report real issues. If `valid=false`, retry via Actor (not manual edits).
 
-### Phase: MONITOR (2.4)
+### Phase: MONITOR (2.4) — MANDATORY
+
+**CRITICAL: ALWAYS run Monitor after Actor. Do NOT skip this phase.**
+
+Monitor is the ONLY validation gate between Actor output and step completion.
+Even if tests already pass, Monitor checks contract compliance, code quality,
+security issues, and integration correctness that tests alone cannot verify.
+**Never skip Monitor because "tests pass" — passing tests is necessary but NOT sufficient.**
 
 ```python
 Task(

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -241,8 +241,8 @@ State is managed by the orchestrator via `step_state.json` (created automaticall
 
 ### Wave Computation (after INIT_STATE) — REQUIRED
 
-**IMPORTANT: Always compute waves after INIT_STATE.** Subtasks execute sequentially
-by default. Parallel execution is allowed only for small low-risk waves (see below).
+**IMPORTANT: Always compute waves after INIT_STATE.** Waves determine execution
+order from the dependency graph. Subtasks execute **sequentially by default**.
 
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 
@@ -308,22 +308,27 @@ loop:
   WAVE = get_wave_step()
   if WAVE.is_complete: goto final_verification
 
-  # 1. Run ALL Actors in parallel (one Agent per subtask)
+  # 1. Run ALL Research in parallel (one Agent per subtask) — MANDATORY
+  for each subtask in WAVE.subtasks (in parallel):
+    Agent(subagent_type="research-agent", prompt="Research subtask {subtask_id}...")
+
+  # 2. Run ALL Actors in parallel (one Agent per subtask)
   for each subtask in WAVE.subtasks (in parallel):
     Agent(subagent_type="actor", prompt="Implement subtask {subtask_id}...")
 
-  # 2. Run ALL Monitors in parallel (one Agent per subtask)
+  # 3. Run ALL Monitors in parallel (one Agent per subtask)
   for each subtask in WAVE.subtasks (in parallel):
     Agent(subagent_type="monitor", prompt="Validate subtask {subtask_id}...")
 
-  # 3. Record results and advance phases for EACH subtask:
+  # 4. Record results and advance phases for EACH subtask:
   for each subtask:
     echo '{"subtask_id":"ST-XXX","files":[...],"status":"valid",...}' \
       | python3 .map/scripts/map_step_runner.py record_subtask_result
+    python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.2
     python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.3
     python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.4
 
-  # 4. Run per-wave gates (build + tests + lint), then advance
+  # 5. Run per-wave gates (build + tests + lint), then advance
   python3 .map/scripts/map_orchestrator.py advance_wave
 ```
 
@@ -359,9 +364,10 @@ This file is the SOLE research artifact passed to Actor and future steps."""
 )
 ```
 
-The ONLY exception: if `/map-plan` already produced a findings file for this branch
-(`.map/<branch>/findings_<branch>.md` exists and has content). In that case, re-read
-the existing findings instead of re-running the research agent.
+**Re-use existing findings**: if `/map-plan` already produced a findings file for this
+branch (`.map/<branch>/findings_<branch>.md` exists and has content), the research agent
+should read and extend it rather than starting from scratch. RESEARCH still runs — it
+just builds on prior findings.
 
 ### Phase: TEST_WRITER (2.25) — TDD Mode Only
 
@@ -617,7 +623,7 @@ BUILD_EXIT=0
 BUILD_OUTPUT=""
 if [ -f "tsconfig.json" ]; then
   BUILD_OUTPUT=$(npx tsc --noEmit 2>&1); BUILD_EXIT=$?
-elif [ -f "package.json" ] && grep -q '"build"' package.json; then
+elif [ -f "package.json" ] && jq -e '.scripts.build' package.json > /dev/null 2>&1; then
   BUILD_OUTPUT=$(npm run build 2>&1); BUILD_EXIT=$?
 elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
   PY_FILES=$(git diff --name-only --diff-filter=AM -- '*.py')

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -26,6 +26,8 @@ State machine enforces sequencing, Python validates completion, hooks inject rem
 
 This is NOT a violation of MAP agent rules. Learning is decoupled into `/map-learn` (optional, run after workflow completes) to reduce token usage during execution.
 
+**Conditional agent:** Predictor is invoked only during stuck recovery (retry 3+, non-low-risk subtasks).
+
 ## State File
 
 Single source of truth: `.map/<branch>/step_state.json`
@@ -234,8 +236,8 @@ State is managed by the orchestrator via `step_state.json` (created automaticall
 
 ### Wave Computation (after INIT_STATE) — REQUIRED
 
-**IMPORTANT: Always compute waves and execute subtasks in parallel when possible.**
-This is not optional — wave computation must run after every INIT_STATE.
+**IMPORTANT: Always compute waves after INIT_STATE.** Subtasks execute sequentially
+by default. Parallel execution is allowed only for small low-risk waves (see below).
 
 After INIT_STATE (1.6) completes, compute execution waves from the dependency DAG:
 
@@ -314,9 +316,9 @@ This file is the SOLE research artifact passed to Actor and future steps."""
 )
 ```
 
-The ONLY exception: if the orchestrator returns `skip_reason` for step 2.2 (set by
-`resume_from_plan` when `/map-plan` already completed research). In that case, the
-findings file already exists.
+The ONLY exception: if `/map-plan` already produced a findings file for this branch
+(`.map/<branch>/findings_<branch>.md` exists and has content). In that case, re-read
+the existing findings instead of re-running the research agent.
 
 ### Phase: TEST_WRITER (2.25) — TDD Mode Only
 
@@ -568,7 +570,10 @@ if [ -f "tsconfig.json" ]; then
 elif [ -f "package.json" ] && grep -q '"build"' package.json; then
   BUILD_OUTPUT=$(npm run build 2>&1); BUILD_EXIT=$?
 elif [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
-  BUILD_OUTPUT=$(python -m py_compile $(git diff --name-only --diff-filter=AM -- '*.py') 2>&1); BUILD_EXIT=$?
+  PY_FILES=$(git diff --name-only --diff-filter=AM -- '*.py')
+  if [ -n "$PY_FILES" ]; then
+    BUILD_OUTPUT=$(echo "$PY_FILES" | xargs python -m py_compile 2>&1); BUILD_EXIT=$?
+  fi
 elif [ -f "go.mod" ]; then
   BUILD_OUTPUT=$(go build ./... 2>&1); BUILD_EXIT=$?
 elif [ -f "Cargo.toml" ]; then
@@ -576,38 +581,38 @@ elif [ -f "Cargo.toml" ]; then
 fi
 echo "$BUILD_OUTPUT"
 
-# If build fails, stop here — no point running tests on code that doesn't compile
+# If build fails, skip tests/lint — no point running them on code that doesn't compile
 if [ "$BUILD_EXIT" -ne 0 ]; then
   echo "BUILD FAILED — fix compilation errors before proceeding"
-  # Treat as wave gate failure (see Guard Pattern below)
+  TESTS_EXIT=1; LINT_EXIT=1  # Force gate failure
 fi
 
-# 2. Run tests — capture exit code + output
-TESTS_EXIT=0
+# 2. Run tests — only if build passed
+TESTS_EXIT=${TESTS_EXIT:-0}
 TEST_OUTPUT=""
-if [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; then
+if [ "$BUILD_EXIT" -eq 0 ] && { [ -f "pytest.ini" ] || [ -f "setup.py" ] || [ -f "pyproject.toml" ]; }; then
   TEST_OUTPUT=$(pytest 2>&1); TESTS_EXIT=$?
-elif [ -f "package.json" ]; then
+elif [ "$BUILD_EXIT" -eq 0 ] && [ -f "package.json" ]; then
   TEST_OUTPUT=$(npm test 2>&1); TESTS_EXIT=$?
-elif [ -f "go.mod" ]; then
+elif [ "$BUILD_EXIT" -eq 0 ] && [ -f "go.mod" ]; then
   TEST_OUTPUT=$(go test ./... 2>&1); TESTS_EXIT=$?
-elif [ -f "Cargo.toml" ]; then
+elif [ "$BUILD_EXIT" -eq 0 ] && [ -f "Cargo.toml" ]; then
   TEST_OUTPUT=$(cargo test 2>&1); TESTS_EXIT=$?
-else
+elif [ "$BUILD_EXIT" -eq 0 ]; then
   echo "No tests found, skipping test gate"
 fi
 echo "$TEST_OUTPUT"
 
-# 3. Run linter — capture exit code + output
-LINT_EXIT=0
+# 3. Run linter — only if build passed
+LINT_EXIT=${LINT_EXIT:-0}
 LINT_OUTPUT=""
-if command -v ruff &> /dev/null; then
+if [ "$BUILD_EXIT" -eq 0 ] && command -v ruff &> /dev/null; then
   LINT_OUTPUT=$(ruff check . 2>&1); LINT_EXIT=$?
-elif command -v eslint &> /dev/null; then
+elif [ "$BUILD_EXIT" -eq 0 ] && command -v eslint &> /dev/null; then
   LINT_OUTPUT=$(eslint . 2>&1); LINT_EXIT=$?
-elif command -v golangci-lint &> /dev/null; then
+elif [ "$BUILD_EXIT" -eq 0 ] && command -v golangci-lint &> /dev/null; then
   LINT_OUTPUT=$(golangci-lint run 2>&1); LINT_EXIT=$?
-else
+elif [ "$BUILD_EXIT" -eq 0 ]; then
   echo "No linter found, skipping lint gate"
 fi
 echo "$LINT_OUTPUT"

--- a/src/mapify_cli/templates/commands/map-efficient.md
+++ b/src/mapify_cli/templates/commands/map-efficient.md
@@ -36,6 +36,11 @@ Written/read by `map_orchestrator.py`. Tracks: current phase, subtask states, wa
 retry counts, constraints, files changed per subtask. Used by `workflow-gate.py` for
 phase-based enforcement (Edit allowed only during ACTOR/APPLY/TEST_WRITER phases).
 
+**NEVER modify `step_state.json` directly.** Always use the orchestrator CLI
+(`map_orchestrator.py`, `map_step_runner.py`). Direct writes bypass validation and
+corrupt state transitions. If an orchestrator operation doesn't work — it's a bug,
+ask the user.
+
 ## Workflow Artifacts
 
 Branch-scoped markdown artifacts in `.map/<branch>/`:
@@ -264,11 +269,11 @@ WAVE=$(python3 .map/scripts/map_orchestrator.py get_wave_step)
 MODE=$(echo "$WAVE" | jq -r '.mode')
 ```
 
-**IMPORTANT:** Even when `mode` is `"parallel"`, prefer sequential execution unless the
-wave has ≤3 subtasks that are ALL low-risk AND create new files only. When in doubt,
-execute sequentially.
+**Two execution modes are supported:** sequential (default) and parallel (wave-based).
 
-**Sequential execution loop** (DEFAULT — use this):
+### Sequential execution loop (DEFAULT)
+
+Use when waves have >3 subtasks or subtasks modify existing files:
 
 ```
 loop:
@@ -276,9 +281,9 @@ loop:
   if WAVE.is_complete: goto final_verification
 
   for each subtask in WAVE.subtasks (one at a time):
-    1. RESEARCH (2.2) — MANDATORY: run research-agent
+    1. RESEARCH (2.2) — run research-agent
     2. ACTOR (2.3) — implement subtask
-    3. MONITOR (2.4) — MANDATORY: validate + BUILD GATE (see below). NEVER skip.
+    3. MONITOR (2.4) — MANDATORY: validate + BUILD GATE. NEVER skip.
     4. validate_step / advance to next subtask
 
   # After ALL subtasks in wave pass: run per-wave gates
@@ -288,6 +293,44 @@ loop:
 **DO NOT** write custom bash for-loops to iterate subtasks. Use the orchestrator:
 call `get_next_step` after each `validate_step` — it returns the next phase/subtask
 automatically. The state machine handles iteration.
+
+### Parallel execution loop (wave-based)
+
+Use when wave has ≤3 subtasks AND all are low-risk AND all create new files only.
+Also allowed for any wave size when the user explicitly requests parallel execution.
+
+**CRITICAL:** When running subtasks in parallel, use the **wave API** (`validate_wave_step`,
+`advance_wave`), NOT the sequential API (`validate_step`, `get_next_step`).
+The sequential API tracks only ONE `current_subtask_id` and will fail for parallel work.
+
+```
+loop:
+  WAVE = get_wave_step()
+  if WAVE.is_complete: goto final_verification
+
+  # 1. Run ALL Actors in parallel (one Agent per subtask)
+  for each subtask in WAVE.subtasks (in parallel):
+    Agent(subagent_type="actor", prompt="Implement subtask {subtask_id}...")
+
+  # 2. Run ALL Monitors in parallel (one Agent per subtask)
+  for each subtask in WAVE.subtasks (in parallel):
+    Agent(subagent_type="monitor", prompt="Validate subtask {subtask_id}...")
+
+  # 3. Record results and advance phases for EACH subtask:
+  for each subtask:
+    echo '{"subtask_id":"ST-XXX","files":[...],"status":"valid",...}' \
+      | python3 .map/scripts/map_step_runner.py record_subtask_result
+    python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.3
+    python3 .map/scripts/map_orchestrator.py validate_wave_step ST-XXX 2.4
+
+  # 4. Run per-wave gates (build + tests + lint), then advance
+  python3 .map/scripts/map_orchestrator.py advance_wave
+```
+
+**Key difference:** `validate_wave_step <subtask_id> <step_id>` works per-subtask
+and does NOT require `current_subtask_id` to match. After `advance_wave`, the state
+is synchronized for sequential API — you can switch back to `get_next_step` for
+subsequent waves.
 
 ### Phase: RESEARCH (2.2) — MANDATORY
 

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -435,6 +435,12 @@ For each invariant in the spec, verify at least one subtask's acceptance criteri
 **5. Edge case / overflow rules:**
 Scan the spec for boundary conditions (format overflows, threshold transitions, fallback behaviors). Verify each has a corresponding test in at least one subtask's test_strategy.
 
+**6. Integration test completeness:**
+If the plan contains a dedicated integration/e2e test subtask (typically the last one), verify that its validation criteria reference ALL MVP acceptance criteria — not just the ones it "owns" in the coverage_map. The integration test subtask validates the full contract end-to-end, not only its implementation scope. Compare the integration subtask's validation_criteria list against the complete set of MVP ACs; any missing AC must be added.
+
+**7. Reference accuracy:**
+Spot-check that any numbered references to invariants, decisions, or edge cases in validation criteria text match the actual numbering in the spec. The decomposer agent may generate plausible-sounding but incorrect reference numbers (e.g., "Invariant 11" when it should be "Decision 11"). At minimum, verify references in HIGH-risk subtasks (concurrency, recovery, security) and in the integration test subtask.
+
 If gaps are found, update the decomposition (add validation criteria to existing subtasks or create new subtasks) BEFORE proceeding to Step 6.
 
 ### Step 6: Create Human-Readable Plan

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -364,9 +364,15 @@ Break down this task into atomic, testable subtasks:
 
 {"Discovery notes from research-agent are available in this chat" if discovery_done else ""}
 
+Granularity rules:
+- One subtask = one independently testable unit of work, NOT one function or one class.
+- For a subgraph with N internal nodes, the subgraph as a whole is ONE subtask — internal node breakdown is an implementation detail for the executor.
+- Group tightly coupled code that cannot be meaningfully tested in isolation into a single subtask.
+- Do NOT create separate "assembly" or "wire together" subtasks — assembly is part of the subtask that builds the component.
+- Services that are only useful as dependencies of a subgraph belong in the same subtask as that subgraph, OR in a shared foundation subtask if used by multiple subgraphs.
+
 Output requirements:
 - Each subtask MUST include an aag_contract: "Actor -> Action(params) -> Goal"
-- Each subtask should be completable within ~4000 tokens (SFT comfort zone)
 - Include acceptance criteria for each
 - Each subtask should include an explicit verification approach (tests/commands)
 - Identify dependencies between subtasks

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -265,11 +265,26 @@ If interview was skipped (task is well-defined), still write `spec_<branch>.md` 
 - **Security Boundaries**: include if task touches auth/validation/user input
 - **Out of Scope**: explicitly state what is NOT being changed
 
+**Acceptance Criteria completeness rule:**
+
+If the source document (spec, issue, PRD, etc.) defines explicit acceptance criteria, enumerate ALL of them in the spec — either copy them verbatim or reference them by file + line range (e.g., `SPEC.md lines 2946-2988, 37 criteria`). Do NOT summarize N criteria as "key M" — the decomposer will treat M as the full scope, and uncovered criteria will silently drop from the plan.
+
+The same rule applies to result schema fields, invariants, and any other enumerated contract. If the source lists 20 fields in a result type, the spec must list all 20 or reference the authoritative list — not "key fields include X, Y, Z".
+
 This ensures every `/map-plan` run produces a spec, regardless of whether interview happened.
 
 ### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
 
-**Skip if:** complexity < 5 (simple, well-defined tasks).
+**Skip if ALL of these are true:**
+- Source spec/requirements are under 200 lines
+- Fewer than 5 subtasks expected
+- No cross-cutting concerns involved (observability, security, concurrency, multi-service coordination)
+
+**ALWAYS run if ANY of these is true:**
+- Source spec/requirements exceed 500 lines
+- Source defines 10 or more acceptance criteria
+- Multiple subgraphs, services, or subsystems involved
+- Task includes concurrency, recovery, or multi-transport requirements
 
 After writing the spec, invoke Monitor agent to adversarially review it. The goal is to surface gaps, contradictions, and missing edge cases BEFORE decomposition.
 
@@ -358,6 +373,12 @@ Output requirements:
 - Identify dependencies between subtasks
 - Estimate complexity (low/medium/high)
 - Use architecture_graph_summary to map subtasks to affected modules
+
+Coverage requirements:
+- CRITICAL: Every acceptance criterion from the spec must appear as a validation_criteria in exactly one subtask. Do NOT silently drop spec criteria that seem minor.
+- For cross-cutting requirements (observability, error handling, budget tracking, structured logging), either create a dedicated subtask or explicitly add them as validation criteria to the subtask that implements the relevant infrastructure.
+- For each structured result type in the spec, verify ALL fields (including optional envelope fields like budget_state, deferred_work, recovery_state) are covered in validation criteria.
+- Output a `coverage_map` field: a dict mapping each spec AC identifier to the subtask ID that owns it, e.g. {{"MVP-AC-1": "ST-007", "MVP-AC-2": "ST-005", ...}}.
 """
 )
 ```
@@ -387,6 +408,34 @@ The blueprint JSON must include at minimum:
 ```
 
 If the decomposer returned structured JSON, save it directly. If it returned markdown, construct the JSON from the decomposed subtasks. **This step is mandatory** — without `blueprint.json`, `/map-efficient` cannot compute parallel execution waves.
+
+### Step 5.7: Decomposition Coverage Check
+
+Before writing the human-readable plan, verify the decomposition covers the full spec. The decomposer agent works with limited context and may silently drop requirements.
+
+**1. Acceptance criteria mapping:**
+For each acceptance criterion in the spec (or referenced source), identify which ST-XXX covers it. If an AC has no owner subtask, either add it to an existing subtask's validation_criteria or create a new subtask.
+
+**2. Result schema field check:**
+For each structured result type defined in the spec (e.g., IngestResult, ProjectSynthesisResult, ArchitectureRefreshResult, etc.), verify that ALL fields — including optional envelope fields like `budget_state`, `deferred_work`, `recovery_state` — appear in at least one subtask's validation criteria. Missing fields cause schema drift between implementation and spec.
+
+**3. Cross-cutting concerns scan:**
+Check whether these concerns have an explicit owner subtask or are distributed as validation criteria across subtasks:
+- Observability / structured logging
+- Error codes and structured error types
+- Concurrency / locking
+- Budget tracking and exhaustion
+- Recovery state for all write-capable workflows
+
+If any concern is orphaned (no subtask owns it), either create a dedicated subtask or explicitly add it as a deliverable to the most relevant existing subtask.
+
+**4. Invariant coverage:**
+For each invariant in the spec, verify at least one subtask's acceptance criteria would catch a violation.
+
+**5. Edge case / overflow rules:**
+Scan the spec for boundary conditions (format overflows, threshold transitions, fallback behaviors). Verify each has a corresponding test in at least one subtask's test_strategy.
+
+If gaps are found, update the decomposition (add validation criteria to existing subtasks or create new subtasks) BEFORE proceeding to Step 6.
 
 ### Step 6: Create Human-Readable Plan
 
@@ -432,6 +481,24 @@ Then use the **Write** tool to create `.map/<branch>/task_plan_<branch>.md` with
 
 1. ST-001 → ST-002 (ST-002 depends on ST-001)
 2. ST-003 (can run in parallel)
+
+## Spec Coverage
+
+Map every spec requirement to the subtask that owns its verification. This table is the primary review artifact — if a row has no owner, the plan has a gap.
+
+| Spec Section | Requirement ID | Description | Owner ST | Verified By |
+|-------------|---------------|-------------|----------|-------------|
+| MVP AC | AC-1 | [criterion text] | ST-XXX | [test or check] |
+| Invariant | INV-5 | [invariant text] | ST-YYY | [test or check] |
+| Result Schema | IngestResult.budget_state | [field exists and populated] | ST-ZZZ | [test] |
+| Cross-cutting | Observability | [structured logs with run_id] | ST-WWW | [test or check] |
+
+**Rules for this table:**
+- Every acceptance criterion from the spec MUST have a row
+- Every result schema field MUST have a row (group trivial fields if needed)
+- Every invariant MUST have a row
+- Cross-cutting concerns (observability, error codes, locking, budget) MUST have rows
+- If a row has no Owner ST, the plan is incomplete — add the requirement to a subtask before finalizing
 
 ## Notes
 
@@ -508,8 +575,10 @@ Print a clear checkpoint showing the plan is complete:
 WORKFLOW CHECKPOINT: PLAN PHASE COMPLETE
 ═══════════════════════════════════════════════════
 ✅ Deep interview completed (N decisions captured)
+✅ Devil's Advocate review completed (or skipped — state reason)
 ✅ Architecture graph written to spec_${BRANCH}.md
 ✅ Task decomposed into N subtasks with AAG contracts
+✅ Coverage check passed: M/M spec ACs mapped, 0 orphaned cross-cutting concerns
 ✅ Blueprint saved to .map/${BRANCH}/blueprint.json
 ✅ step_state.json initialized (with aag_contracts map)
 ✅ Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md
@@ -533,14 +602,15 @@ Next Steps:
 
 ```
 DISTILLATION CHECKLIST:
-  [x] task_plan_<branch>.md — has AAG contracts for every subtask
+  [x] task_plan_<branch>.md — has AAG contracts for every subtask + Spec Coverage table
   [x] step_state.json   — has aag_contracts map + subtask_sequence
-  [x] blueprint.json     — raw decomposer output for wave computation
-  [x] spec_<branch>.md      — has architecture graph + decisions (if interview was done)
+  [x] blueprint.json     — raw decomposer output for wave computation (with coverage_map)
+  [x] spec_<branch>.md      — has architecture graph + decisions + COMPLETE acceptance criteria (if interview was done)
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
 
 TARGET: Executor reads ≤4000 tokens of distilled state to start any subtask.
 If plan files exceed this, condense — remove redundant descriptions, keep AAG contracts + criteria.
+The Spec Coverage table in task_plan should NOT be condensed — it is the review contract.
 ```
 
 **This phase ends here.** Do NOT proceed to execution. The context should be flushed, and execution will start fresh with focused attention on individual subtasks.
@@ -646,8 +716,11 @@ A: Re-run /map-plan. It will overwrite task_plan_<branch>.md and reset step_stat
 
 This command succeeds when:
 - ✅ Deep interview completed (if scope warranted it) with spec_<branch>.md written
+- ✅ Spec acceptance criteria enumerated completely (not summarized)
+- ✅ Devil's Advocate review completed (if skip conditions not met)
 - ✅ Architecture graph written in spec_<branch>.md (for complexity >= 3)
-- ✅ task_plan_<branch>.md exists with AAG contracts for every subtask
+- ✅ Decomposition coverage check passed (Step 5.7) — no orphaned ACs, result fields, or cross-cutting concerns
+- ✅ task_plan_<branch>.md exists with AAG contracts for every subtask AND Spec Coverage table
 - ✅ step_state.json exists with valid subtask_sequence + aag_contracts map
 - ✅ CHECKPOINT shows subtask count and IDs
 - ✅ Context distilled (plan files self-contained for fresh session)

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -210,6 +210,7 @@ Workflow execution limits. When no constraints specified, all default to null (u
 ```yaml
 constraints:
   max_files: null        # Maximum files Actor can modify per workflow (int or null)
+  max_subtasks: null     # Maximum subtasks in decomposition (int or null)
   time_budget: null      # Maximum minutes for entire workflow (int or null)
   scope_glob: null       # File glob restricting Actor's edit scope (string or null)
 ```
@@ -364,15 +365,9 @@ Break down this task into atomic, testable subtasks:
 
 {"Discovery notes from research-agent are available in this chat" if discovery_done else ""}
 
-Granularity rules:
-- One subtask = one independently testable unit of work, NOT one function or one class.
-- For a subgraph with N internal nodes, the subgraph as a whole is ONE subtask — internal node breakdown is an implementation detail for the executor.
-- Group tightly coupled code that cannot be meaningfully tested in isolation into a single subtask.
-- Do NOT create separate "assembly" or "wire together" subtasks — assembly is part of the subtask that builds the component.
-- Services that are only useful as dependencies of a subgraph belong in the same subtask as that subgraph, OR in a shared foundation subtask if used by multiple subgraphs.
-
 Output requirements:
 - Each subtask MUST include an aag_contract: "Actor -> Action(params) -> Goal"
+- Each subtask should be completable within ~4000 tokens (SFT comfort zone)
 - Include acceptance criteria for each
 - Each subtask should include an explicit verification approach (tests/commands)
 - Identify dependencies between subtasks
@@ -439,12 +434,6 @@ For each invariant in the spec, verify at least one subtask's acceptance criteri
 
 **5. Edge case / overflow rules:**
 Scan the spec for boundary conditions (format overflows, threshold transitions, fallback behaviors). Verify each has a corresponding test in at least one subtask's test_strategy.
-
-**6. Integration test completeness:**
-If the plan contains a dedicated integration/e2e test subtask (typically the last one), verify that its validation criteria reference ALL MVP acceptance criteria — not just the ones it "owns" in the coverage_map. The integration test subtask validates the full contract end-to-end, not only its implementation scope. Compare the integration subtask's validation_criteria list against the complete set of MVP ACs; any missing AC must be added.
-
-**7. Reference accuracy:**
-Spot-check that any numbered references to invariants, decisions, or edge cases in validation criteria text match the actual numbering in the spec. The decomposer agent may generate plausible-sounding but incorrect reference numbers (e.g., "Invariant 11" when it should be "Decision 11"). At minimum, verify references in HIGH-risk subtasks (concurrency, recovery, security) and in the integration test subtask.
 
 If gaps are found, update the decomposition (add validation criteria to existing subtasks or create new subtasks) BEFORE proceeding to Step 6.
 
@@ -563,6 +552,7 @@ Use the **Write** tool to create `.map/<branch>/step_state.json` with this struc
   },
   "constraints": {
     "max_files": null,
+    "max_subtasks": null,
     "time_budget": null,
     "scope_glob": null
   }
@@ -714,8 +704,8 @@ User: "Add JWT authentication with refresh tokens"
 
 ## Troubleshooting
 
-**Q: How many subtasks is the right number?**
-A: As many as the task naturally requires. Do not artificially cap or inflate the count. A bug fix may need 2 subtasks; a full-stack feature may need 30+. The right granularity is one subtask per independently testable unit of work.
+**Q: Task-decomposer created too many subtasks (10+)?**
+A: Subtasks are too granular. Ask task-decomposer to group related work into larger chunks (aim for 3-7 subtasks).
 
 **Q: User changed requirements after planning?**
 A: Re-run /map-plan. It will overwrite task_plan_<branch>.md and reset step_state.json.

--- a/src/mapify_cli/templates/commands/map-plan.md
+++ b/src/mapify_cli/templates/commands/map-plan.md
@@ -210,7 +210,6 @@ Workflow execution limits. When no constraints specified, all default to null (u
 ```yaml
 constraints:
   max_files: null        # Maximum files Actor can modify per workflow (int or null)
-  max_subtasks: null     # Maximum subtasks in decomposition (int or null)
   time_budget: null      # Maximum minutes for entire workflow (int or null)
   scope_glob: null       # File glob restricting Actor's edit scope (string or null)
 ```
@@ -558,7 +557,6 @@ Use the **Write** tool to create `.map/<branch>/step_state.json` with this struc
   },
   "constraints": {
     "max_files": null,
-    "max_subtasks": null,
     "time_budget": null,
     "scope_glob": null
   }
@@ -710,8 +708,8 @@ User: "Add JWT authentication with refresh tokens"
 
 ## Troubleshooting
 
-**Q: Task-decomposer created too many subtasks (10+)?**
-A: Subtasks are too granular. Ask task-decomposer to group related work into larger chunks (aim for 3-7 subtasks).
+**Q: How many subtasks is the right number?**
+A: As many as the task naturally requires. Do not artificially cap or inflate the count. A bug fix may need 2 subtasks; a full-stack feature may need 30+. The right granularity is one subtask per independently testable unit of work.
 
 **Q: User changed requirements after planning?**
 A: Re-run /map-plan. It will overwrite task_plan_<branch>.md and reset step_state.json.

--- a/src/mapify_cli/templates/commands/map-task.md
+++ b/src/mapify_cli/templates/commands/map-task.md
@@ -85,7 +85,7 @@ Route to the appropriate executor based on `$PHASE`. All phases from `/map-effic
 
 - **RESEARCH (2.2)** — Call research-agent if needed
 - **ACTOR (2.3)** — Implement the subtask
-- **MONITOR (2.4)** — Validate implementation
+- **MONITOR (2.4)** — MANDATORY: Validate implementation. NEVER skip.
 
 Single-subtask execution must keep using the shared branch workspace artifacts rather than creating task-local side files:
 

--- a/src/mapify_cli/templates/commands/map-task.md
+++ b/src/mapify_cli/templates/commands/map-task.md
@@ -83,7 +83,7 @@ PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
 
 Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
 
-- **RESEARCH (2.2)** — Call research-agent if needed
+- **RESEARCH (2.2)** — MANDATORY: Gather context via research-agent. NEVER skip.
 - **ACTOR (2.3)** — Implement the subtask
 - **MONITOR (2.4)** — MANDATORY: Validate implementation. NEVER skip.
 

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -41,7 +41,7 @@ STEP PHASES (10 total, 8 standard + 2 TDD):
   1.55 REVIEW_PLAN        - User review + explicit approval checkpoint
   1.56 CHOOSE_MODE        - Auto-skipped (always batch mode)
   1.6  INIT_STATE         - Create step_state.json (single source of truth)
-  2.2  RESEARCH           - research-agent (conditional: 3+ existing files OR high risk)
+  2.2  RESEARCH           - research-agent (mandatory for all subtasks)
   2.25 TEST_WRITER        - TDD: write tests from spec (TDD mode only)
   2.26 TEST_FAIL_GATE     - TDD: verify tests fail without impl (TDD mode only)
   2.3  ACTOR              - Actor agent implementation
@@ -461,8 +461,8 @@ def get_step_instruction(step_id: str, state: StepState) -> str:
             "Single source of truth for workflow enforcement."
         ),
         "2.2": (
-            "Call Task(subagent_type='research-agent') if subtask touches "
-            "3+ existing files OR risk=high. Pass findings to Actor."
+            "Call Task(subagent_type='research-agent') to research the subtask. "
+            "MANDATORY for all subtasks. Pass findings to Actor."
         ),
         "2.25": (
             f"TDD TEST_WRITER: Call Task(subagent_type='actor') with "

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -1236,16 +1236,17 @@ def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
     }
 
 
-SKIPPABLE_STEPS = {"2.2", "2.25", "2.26"}
+SKIPPABLE_STEPS = {"2.25", "2.26"}
 
 
 def skip_step(step_id: str, branch: str) -> dict:
     """Skip a conditional step without executing it.
 
     Only steps that are defined as conditional can be skipped:
-      - 2.2 (RESEARCH): conditional on 3+ existing files or high risk
       - 2.25 (TEST_WRITER): TDD mode only, auto-skipped otherwise
       - 2.26 (TEST_FAIL_GATE): TDD mode only, auto-skipped otherwise
+
+    Note: RESEARCH (2.2) is NOT skippable — it is mandatory for all subtasks.
 
     Args:
         step_id: Step identifier to skip

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -976,7 +976,7 @@ def advance_wave(branch: str) -> dict:
 
     is_complete = state.current_wave_index >= len(state.execution_waves)
 
-    # Update subtask_index to track overall progress
+    # Update subtask_index and reset sequential state for next wave
     if not is_complete:
         next_wave = state.execution_waves[state.current_wave_index]
         if next_wave:
@@ -986,6 +986,15 @@ def advance_wave(branch: str) -> dict:
                 state.subtask_index = state.subtask_sequence.index(
                     state.current_subtask_id
                 )
+            # Reset sequential state so get_next_step works after advance_wave
+            step_order = _get_step_order(state.tdd_mode)
+            research_idx = step_order.index("2.2")
+            state.pending_steps = step_order[research_idx:]
+            state.completed_steps = []
+            state.skipped_steps = []
+            state.current_step_id = "2.2"
+            state.current_step_phase = "RESEARCH"
+            state.retry_count = 0
 
     state.save(state_file)
 

--- a/tests/test_managed_file_copier.py
+++ b/tests/test_managed_file_copier.py
@@ -321,3 +321,80 @@ class TestDriftReport:
         assert report.has_drift
         assert len(report.drifted_files) == 1
         assert len(report.backed_up_files) == 1
+
+class TestFrontmatterPreservation:
+    """Tests that .md files with YAML frontmatter get MAP-MANAGED after closing ---."""
+
+    def test_inject_after_frontmatter(self):
+        src = "---\nname: actor\ndescription: test\n---\n\n# Content"
+        result = inject_metadata(src, ".md", "1.0.0", "abc123")
+        # Must start with --- (frontmatter intact)
+        assert result.startswith("---\n")
+        # MAP-MANAGED must come after closing ---
+        lines = result.split("\n")
+        fm_close_idx = None
+        for i, line in enumerate(lines):
+            if i > 0 and line == "---":
+                fm_close_idx = i
+                break
+        assert fm_close_idx is not None
+        # Next line after closing --- should be MAP-MANAGED comment
+        assert lines[fm_close_idx + 1].startswith("<!-- MAP-MANAGED:")
+        # Original content must be preserved
+        assert "# Content" in result
+
+    def test_inject_no_frontmatter_unchanged(self):
+        src = "# Just a heading\nNo frontmatter here."
+        result = inject_metadata(src, ".md", "1.0.0", "abc123")
+        # Should prepend as before (no frontmatter)
+        assert result.startswith("<!-- MAP-MANAGED:")
+
+    def test_extract_after_frontmatter_roundtrip(self):
+        original = "---\nname: monitor\ndescription: test agent\n---\n\n# Monitor"
+        injected = inject_metadata(original, ".md", "1.0.0", "abc123")
+        meta, clean = extract_metadata(injected, ".md")
+        assert meta is not None
+        assert meta["mapify_version"] == "1.0.0"
+        assert meta["template_hash"] == "abc123"
+        assert clean == original
+
+    def test_extract_legacy_prepended_still_works(self):
+        """Backward compat: files with MAP-MANAGED at start still extract."""
+        legacy = '<!-- MAP-MANAGED: {"mapify_version":"1.0.0","template_hash":"abc"} -->\n# Content'
+        meta, clean = extract_metadata(legacy, ".md")
+        assert meta is not None
+        assert meta["mapify_version"] == "1.0.0"
+        assert clean == "# Content"
+
+    def test_copy_managed_file_frontmatter(self, tmp_path):
+        src = tmp_path / "agent.md"
+        src.write_text("---\nname: actor\ndescription: Generates code\nmodel: sonnet\n---\n\n# Actor Agent\n")
+        dest = tmp_path / "output" / "actor.md"
+
+        result = copy_managed_file(src, dest, "3.6.0")
+        assert result.success
+        content = dest.read_text()
+        # File must start with --- for Claude Code to parse frontmatter
+        assert content.startswith("---\n")
+        assert "MAP-MANAGED" in content
+        assert "# Actor Agent" in content
+
+    def test_drift_detection_frontmatter(self, tmp_path):
+        """Drift detection works with frontmatter-aware metadata position."""
+        src = tmp_path / "agent.md"
+        original = "---\nname: test\n---\n\n# Content"
+        src.write_text(original)
+        template_hash = compute_hash(original)
+
+        dest = tmp_path / "dest.md"
+        dest.write_text(inject_metadata(original, ".md", "1.0.0", template_hash))
+
+        # No drift
+        result = detect_drift(src, dest)
+        assert not result.drifted
+
+        # User modifies
+        content = dest.read_text()
+        dest.write_text(content.replace("# Content", "# Modified by user"))
+        result = detect_drift(src, dest)
+        assert result.drifted

--- a/tests/test_managed_file_copier.py
+++ b/tests/test_managed_file_copier.py
@@ -398,3 +398,51 @@ class TestFrontmatterPreservation:
         dest.write_text(content.replace("# Content", "# Modified by user"))
         result = detect_drift(src, dest)
         assert result.drifted
+
+    def test_frontmatter_eof_no_trailing_newline_roundtrip(self):
+        """Regression: file ending with closing --- and no trailing newline.
+
+        inject_metadata must not alter the 'clean' content hash for templates
+        that end immediately after the closing frontmatter delimiter, otherwise
+        detect_drift reports false positives and triggers unnecessary backups.
+        """
+        original = "---\nname: test\ndescription: edge case\n---"
+        template_hash = compute_hash(original)
+
+        injected = inject_metadata(original, ".md", "1.0.0", template_hash)
+        meta, clean = extract_metadata(injected, ".md")
+
+        assert meta is not None
+        assert meta["template_hash"] == template_hash
+        assert clean == original, (
+            f"clean content differs from original after roundtrip: "
+            f"{clean!r} != {original!r}"
+        )
+        assert compute_hash(clean) == template_hash
+
+    def test_frontmatter_eof_no_trailing_newline_no_false_drift(self, tmp_path):
+        """Regression: no false drift for frontmatter-at-EOF templates."""
+        original = "---\nname: agent\n---"
+        src = tmp_path / "agent.md"
+        src.write_text(original)
+        template_hash = compute_hash(original)
+
+        dest = tmp_path / "dest.md"
+        dest.write_text(inject_metadata(original, ".md", "1.0.0", template_hash))
+
+        result = detect_drift(src, dest)
+        assert not result.drifted, (
+            f"False drift detected for frontmatter-at-EOF template: {result.reason}"
+        )
+
+    def test_frontmatter_with_trailing_newline_still_works(self):
+        """Ensure fix doesn't break the normal case (trailing newline present)."""
+        original = "---\nname: test\n---\n\n# Body content\n"
+        template_hash = compute_hash(original)
+
+        injected = inject_metadata(original, ".md", "1.0.0", template_hash)
+        meta, clean = extract_metadata(injected, ".md")
+
+        assert meta is not None
+        assert clean == original
+        assert compute_hash(clean) == template_hash

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -263,6 +263,34 @@ class TestAdvanceWave:
         result = map_orchestrator.advance_wave(branch_dir)
         assert result["status"] == "error"
 
+    def test_resets_sequential_state_for_next_wave(self, branch_dir, sample_blueprint):
+        """After advance_wave, sequential API (get_next_step) works for the new wave."""
+        map_orchestrator.set_waves(branch_dir, sample_blueprint)
+        state_file = Path(f".map/{branch_dir}/step_state.json")
+
+        # Simulate completing wave 0 — leave pending_steps empty
+        state = map_orchestrator.StepState.load(state_file)
+        state.pending_steps = []
+        state.completed_steps = ["2.2", "2.3", "2.4"]
+        state.current_step_id = "COMPLETE"
+        state.current_step_phase = "COMPLETE"
+        state.save(state_file)
+
+        # Advance to wave 1
+        result = map_orchestrator.advance_wave(branch_dir)
+        assert result["status"] == "success"
+        assert result["is_complete"] is False
+
+        # Sequential state must be reset so get_next_step works
+        state = map_orchestrator.StepState.load(state_file)
+        assert state.current_step_id == "2.2"
+        assert state.current_step_phase == "RESEARCH"
+        assert "2.2" in state.pending_steps
+        assert "2.3" in state.pending_steps
+        assert "2.4" in state.pending_steps
+        assert state.completed_steps == []
+        assert state.retry_count == 0
+
 
 class TestBackwardCompat:
     """Verify get_next_step works when execution_waves is empty."""


### PR DESCRIPTION
## Summary

- **RESEARCH phase now mandatory** — removed from `SKIPPABLE_STEPS`, removed actor's "Skip Research If" blanket permission. LLM was always deciding to skip research, causing Actor to write code that doesn't integrate with existing codebase (wrong imports, missing types)
- **BUILD GATE added** — Monitor now runs `tsc --noEmit` / `go build` / `cargo check` / `py_compile` before any other checks. Build failure = `valid: false` immediately. Also added to per-wave gates (runs before tests and linter)
- **Sequential execution by default** — replaced "always parallel" instruction with sequential subtask execution. Parallel only allowed for ≤3 low-risk new-file tasks. Prevents accumulated errors across batched subtasks
- **Simplified orchestrator loop** — replaced complex parallel wave loop with simple sequential pattern. Added explicit warning against writing custom bash for-loops (was causing parse errors)

Reported by user: map-efficient produced a 15-task TypeScript CLI project where `npm run build` failed with compilation errors despite all Monitor checks reporting `valid: true`.

## Test plan

- [x] Template sync tests pass (23/23)
- [x] CLI correctness tests pass (2/2) 
- [x] No new test failures (all failures are pre-existing: `readchar`/`dependency_graph` import issues)
- [ ] Manual test: run `/map-efficient` on a TypeScript project and verify build gate catches compilation errors