### PR TITLE
feat: ship 2604.031 skill frontmatter hygiene

### DIFF
--- a/.claude/skills/map-learn/SKILL.md
+++ b/.claude/skills/map-learn/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: map-learn
-description: Extract and preserve lessons from completed workflows. Use when you want to capture patterns after /map-efficient, /map-debug, or /map-fast completes. Do NOT use for active workflow execution or trivial tasks with no reusable patterns.
+description: >-
+  Capture reusable lessons after a completed MAP workflow. Use when a MAP
+  run has finished and you want rules written to
+  `.claude/rules/learned/` from a workflow summary or handoff. Do NOT use
+  during active implementation.
 disable-model-invocation: true
+argument-hint: "[workflow-summary]"
 ---
 
 # MAP Learn - Post-Workflow Learning with Persistence

--- a/.claude/skills/map-planning/SKILL.md
+++ b/.claude/skills/map-planning/SKILL.md
@@ -2,12 +2,10 @@
 name: map-planning
 version: "1.0.0"
 description: >-
-  File-based planning for MAP Framework with branch-scoped task tracking
-  in .map/ directory. Use when user says "create a plan", "track progress",
-  "show task status", or needs persistent planning across agent sessions.
-  Prevents goal drift via automatic plan synchronization. Do NOT use for
-  workflow selection (use map-workflows-guide) or CLI errors (use
-  map-cli-reference).
+  Branch-scoped MAP planning in `.map/`. Use when the user needs a
+  persistent task plan, progress tracking, or resume support across
+  sessions. Keeps focus synced before edits. Do NOT use for tiny one-shot
+  tasks.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 metadata:
   author: azalio

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ claude
 | `/map-tdd` | Test-first implementation workflow |
 | `/map-release` | Package release workflow |
 | `/map-resume` | Resume interrupted workflows |
-| `/map-learn` | Extract lessons after workflow completion |
+| `/map-learn` | Extract lessons after workflow completion; optional `[workflow-summary]` |
 
 [Detailed usage and options →](docs/USAGE.md)
 
@@ -69,7 +69,7 @@ Canonical MAP flows:
 
 These workflows maintain branch-scoped artifacts like `code-review-001.md`, `qa-001.md`, `verification-summary.md`, `pr-draft.md`, `artifact_manifest.json`, and run dossiers under `.map/<branch>/`. Targeted TDD flows also persist `test_contract_ST-00N.md` and `test_handoff_ST-00N.json` so `/map-task` can resume implementation from a clean red-phase handoff.
 
-`LEARN` is still the philosophical end of the MAP cycle, but runtime keeps it soft: `/map-efficient`, `/map-debug`, `/map-check`, and `/map-review` now write `learning-handoff.md` / `.json` under `.map/<branch>/`, so `/map-learn` can run immediately or later without rebuilding context by hand.
+`LEARN` is still the philosophical end of the MAP cycle, but runtime keeps it soft: `/map-efficient`, `/map-debug`, `/map-check`, and `/map-review` now write `learning-handoff.md` / `.json` under `.map/<branch>/`, so `/map-learn [workflow-summary]` can run immediately with an explicit summary or later with no argument by auto-loading the generated handoff.
 
 ## How It Works
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -15,7 +15,7 @@ For long-running work, the canonical MAP flows maintain branch-scoped artifacts 
 /map-efficient implement the approved plan
 /map-check
 /map-review
-/map-learn   # immediately, or later from the generated handoff
+/map-learn [workflow-summary]   # optional; omit to auto-load the generated handoff
 ```
 
 ### Full TDD flow
@@ -47,7 +47,7 @@ In targeted TDD, `/map-tdd ST-001` now stops after the red phase once it has wri
 
 Philosophically, MAP still ends with `LEARN`. Runtime keeps that step soft and token-aware by auto-writing `.map/<branch>/learning-handoff.md` and `.json` after `/map-efficient`, `/map-debug`, `/map-check`, and `/map-review`, so `/map-learn` can auto-load the workflow context with no manual reconstruction. The same handoff write also updates `learning-metrics.json` with repeated learned-rule violation signals when current findings overlap existing rules, so teams can tell whether saved lessons are actually reducing repeat mistakes.
 
-Implementation note: `/map-learn` is now maintained skill-first. The canonical slash surface lives in `.claude/skills/map-learn/SKILL.md`; MAP no longer ships a duplicate `.claude/commands/map-learn.md`, so there is only one place to update the learning workflow.
+Implementation note: `/map-learn` is now maintained skill-first. The canonical slash surface lives in `.claude/skills/map-learn/SKILL.md`; MAP no longer ships a duplicate `.claude/commands/map-learn.md`, so there is only one place to update the learning workflow. The slash surface now advertises an optional `[workflow-summary]` argument, but zero-argument mode still auto-loads `.map/<branch>/learning-handoff.md` when present.
 
 ## Navigation
 

--- a/docs/improvement-done.md
+++ b/docs/improvement-done.md
@@ -1,5 +1,13 @@
 # MAP Framework Improvement Done
 
+## Official-frontmatter hygiene for MAP skills [2604.031]
+
+- Date: 2026-04-13
+- Shortened the shipped `map-planning` and `map-learn` skill descriptions to stay under Claude's 250-character listing limit, while removing stale references to non-shipped `map-*` surfaces from frontmatter.
+- Added `argument-hint: "[workflow-summary]"` to the skill-backed `/map-learn` surface so manual invocation now advertises its optional workflow summary input without changing zero-argument handoff loading.
+- Added focused metadata lint coverage in `tests/test_skills.py` for description length, supported frontmatter keys, broken `map-*` description references, and manual-skill argument hints.
+- Synced the `.claude/skills/` changes into `src/mapify_cli/templates/skills/`, updated `README.md` and `docs/USAGE.md`, and confirmed the repo-built `uv run mapify init ...` flow emits the new skill frontmatter.
+
 ## Learning handoff artifacts and zero-argument `/map-learn` [2604.035-1]
 
 - Date: 2026-04-12

--- a/docs/improvement-loop-log.md
+++ b/docs/improvement-loop-log.md
@@ -1,0 +1,14 @@
+## 2026-04-13 - Official-frontmatter hygiene for MAP skills [2604.031]
+
+- Decision: `implemented`
+- Branch: `codex/2604-031-skill-frontmatter`
+- Baseline: `map-planning` shipped with a 371-character description that referenced non-existent `map-workflows-guide` and `map-cli-reference` surfaces, `map-learn` had no argument hint for manual invocation, and no test failed on those metadata regressions.
+- Forward Change: Shortening the two shipped skill descriptions, adding `argument-hint: "[workflow-summary]"` to `map-learn`, and adding dedicated metadata lint tests closed the actual UX gaps without pulling the whole stale skill taxonomy into scope.
+- Decisive Validation: `pytest tests/test_skills.py tests/test_template_sync.py tests/test_command_templates.py -v` passed, and `uv run mapify init <new-dir> --no-git --mcp none` generated the updated skill frontmatter in a throwaway project.
+- Next Trigger: Reuse this learning whenever a change touches `.claude/skills/`, `src/mapify_cli/templates/skills/`, or the installer copy path and you need to prove the generated project reflects the branch state.
+- Reusable Learnings:
+  - command: `uv run mapify init <new-dir> --no-git --mcp none`
+  - invariant: `When changing shipped skill metadata, keep descriptions under 250 characters and make every map-* reference resolve to a real shipped command or skill.`
+  - gotcha: `The globally installed mapify binary can lag behind the branch under test and show stale templates even when the repo diff is correct.`
+  - review-check: `For manual slash skills, always verify the frontmatter exposes an argument hint before shipping catalog changes.`
+

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -213,22 +213,6 @@
 - Update `workflow-rules.json` and command docs to reflect that “small/simple/quick” workflows should bias toward lower effort and minimal orchestration, while planning/review/release workflows intentionally permit more reasoning depth.
 
 
-## Official-frontmatter hygiene for MAP skills [2604.031]
-
-**Benefit Hypothesis**: Bringing MAP skill metadata in line with the official Claude Code skill frontmatter guidance will improve discoverability, autocomplete quality, and trigger accuracy, while reducing misleading or truncated descriptions. The immediate target is more reliable manual invocation and better automatic loading decisions.
-**Confidence**: 0.82
-**Reasoning**: The official skills docs define a broader frontmatter surface than the older open-standard validator: `disable-model-invocation`, `allowed-tools`, `hooks`, `argument-hint`, `user-invocable`, `paths`, `model`, `effort`, and `context` are all valid Claude Code fields. That means MAP’s use of `disable-model-invocation`, `allowed-tools`, and skill-local hooks is legitimate. The real issue is metadata quality. The docs also note that descriptions longer than 250 characters are truncated in the skill listing. MAP’s `map-planning` description is currently 371 characters, which means part of its trigger guidance is likely being cut off in the UI/context. It also references `map-workflows-guide` and `map-cli-reference`, which are not actually shipped in the current skill set.
-**Why Not Already Tried**: Existing MAP work focused on capability and orchestration, not on the UX and trigger behavior of the skill catalog itself. The platform guidance on description truncation and invocation-control fields is also newer than many command-era prompt patterns.
-
-### Proposed Changes
-
-- Shorten every skill description to front-load the core use case within the first 150-200 characters, and keep the total under the official 250-character truncation threshold.
-- Remove references to non-shipped skills from frontmatter descriptions, especially in `map-planning`. If those skills are planned, reference docs or concepts instead of unresolved skill names.
-- Add `argument-hint` to manually invoked task skills. For example, `map-learn` should advertise something like `[workflow-summary]` so `/map-learn` is easier to use correctly from the slash menu.
-- Review whether `user-invocable` and `paths` would improve future MAP skills. Reference skills that should load automatically but not clutter the slash menu can use `user-invocable: false`, while file-scoped skills can use `paths` for more precise activation.
-- Add a metadata lint pass for names, description length, missing/broken cross-skill references, and unsupported frontmatter relative to MAP’s chosen target runtime.
-
-
 ## Explicit reference-vs-task skill architecture [2604.032]
 
 **Benefit Hypothesis**: Reclassifying MAP skills according to the official Claude Code split between reference content and task content will reduce conceptual confusion, improve skill authoring discipline, and make MAP’s documentation match actual runtime behavior. This should lower accidental misuse of skills and make it easier to decide when a new behavior belongs in a skill versus a subagent or command.

--- a/docs/learned/commands.md
+++ b/docs/learned/commands.md
@@ -1,0 +1,6 @@
+# Command Patterns (Learned)
+
+<!-- IMPROVEMENT-PLAN-LOOP: promoted from loop learnings. Edit freely and commit with the project. -->
+
+- **Use repo-built init for template verification** (2026-04-13): When validating shipped MAP templates, always run `uv run mapify init <new-dir> --no-git --mcp none` because the globally installed `mapify` binary may still reflect an older release instead of the branch you are reviewing. [workflow: improvement-plan-loop]
+

--- a/docs/learned/testing-strategies.md
+++ b/docs/learned/testing-strategies.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "**/test_*"
+  - "**/tests/**"
+  - "**/*_test.*"
+  - "**/*.test.*"
+---
+
+# Testing Strategies (Learned)
+
+<!-- IMPROVEMENT-PLAN-LOOP: promoted from loop learnings. Edit freely and commit with the project. -->
+
+- **Lint skill metadata, not just sync** (2026-04-13): When testing shipped skill frontmatter, always cover description length, unresolved `map-*` references, and manual-skill argument hints because template sync alone does not catch slash-menu UX regressions. [workflow: improvement-plan-loop]
+

--- a/src/mapify_cli/templates/skills/map-learn/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-learn/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: map-learn
-description: Extract and preserve lessons from completed workflows. Use when you want to capture patterns after /map-efficient, /map-debug, or /map-fast completes. Do NOT use for active workflow execution or trivial tasks with no reusable patterns.
+description: >-
+  Capture reusable lessons after a completed MAP workflow. Use when a MAP
+  run has finished and you want rules written to
+  `.claude/rules/learned/` from a workflow summary or handoff. Do NOT use
+  during active implementation.
 disable-model-invocation: true
+argument-hint: "[workflow-summary]"
 ---
 
 # MAP Learn - Post-Workflow Learning with Persistence

--- a/src/mapify_cli/templates/skills/map-planning/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-planning/SKILL.md
@@ -2,12 +2,10 @@
 name: map-planning
 version: "1.0.0"
 description: >-
-  File-based planning for MAP Framework with branch-scoped task tracking
-  in .map/ directory. Use when user says "create a plan", "track progress",
-  "show task status", or needs persistent planning across agent sessions.
-  Prevents goal drift via automatic plan synchronization. Do NOT use for
-  workflow selection (use map-workflows-guide) or CLI errors (use
-  map-cli-reference).
+  Branch-scoped MAP planning in `.map/`. Use when the user needs a
+  persistent task plan, progress tracking, or resume support across
+  sessions. Keeps focus synced before edits. Do NOT use for tiny one-shot
+  tasks.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 metadata:
   author: azalio

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,10 +1,13 @@
 """
 Tests for MAP Framework skill structure, frontmatter, and trigger compliance.
 
-Validates that all skills follow the Anthropic Skills Guide best practices:
+Validates that shipped skills keep a clean, Claude-compatible metadata surface:
 - Valid YAML frontmatter with --- delimiters
 - Descriptions include trigger phrases ("Use when")
 - Descriptions include negative triggers ("Do NOT use")
+- Descriptions stay within the Claude skill listing truncation limit
+- Frontmatter only uses the MAP-supported key set
+- map-* references in descriptions resolve to shipped commands or skills
 - Skill folder names use kebab-case
 - No README.md inside skill folders (per Anthropic guide)
 - skill-rules.json has entries for all skills
@@ -17,6 +20,22 @@ from pathlib import Path
 
 import pytest
 import yaml
+
+SUPPORTED_FRONTMATTER_FIELDS = {
+    "allowed-tools",
+    "argument-hint",
+    "context",
+    "description",
+    "disable-model-invocation",
+    "effort",
+    "hooks",
+    "metadata",
+    "model",
+    "name",
+    "paths",
+    "user-invocable",
+    "version",
+}
 
 
 class TestSkillStructure:
@@ -35,6 +54,10 @@ class TestSkillStructure:
         return project_root / "src" / "mapify_cli" / "templates" / "skills"
 
     @pytest.fixture
+    def templates_commands_dir(self, project_root):
+        return project_root / "src" / "mapify_cli" / "templates" / "commands"
+
+    @pytest.fixture
     def skill_folders(self, skills_dir):
         """Return list of skill folder names (excluding files)."""
         if not skills_dir.exists():
@@ -51,6 +74,13 @@ class TestSkillStructure:
         if not rules_file.exists():
             pytest.skip("skill-rules.json doesn't exist")
         return json.loads(rules_file.read_text())
+
+    @pytest.fixture
+    def known_map_surfaces(self, skill_folders, templates_commands_dir):
+        command_names = {
+            path.stem for path in templates_commands_dir.glob("map-*.md")
+        }
+        return set(skill_folders) | command_names
 
     def _parse_frontmatter(self, skill_md_path: Path) -> dict:
         """Parse YAML frontmatter from a SKILL.md file."""
@@ -156,6 +186,62 @@ class TestSkillStructure:
             assert has_negative, (
                 f"Skill '{folder}' description doesn't include negative triggers. "
                 f"Add 'Do NOT use for ...' to the description."
+            )
+
+    def test_descriptions_fit_claude_skill_listing_limit(
+        self, skills_dir, skill_folders
+    ):
+        """Descriptions should stay under the 250-char Claude listing limit."""
+        for folder in skill_folders:
+            skill_file = skills_dir / folder / "SKILL.md"
+            fm = self._parse_frontmatter(skill_file)
+            desc = fm.get("description", "")
+            assert len(desc) <= 250, (
+                f"Skill '{folder}' description is {len(desc)} chars; "
+                "keep it at or under 250 chars to avoid UI truncation."
+            )
+
+    def test_frontmatter_uses_supported_fields(self, skills_dir, skill_folders):
+        """Skill frontmatter should stay within MAP's supported key set."""
+        for folder in skill_folders:
+            skill_file = skills_dir / folder / "SKILL.md"
+            fm = self._parse_frontmatter(skill_file)
+            unsupported = sorted(set(fm) - SUPPORTED_FRONTMATTER_FIELDS)
+            assert not unsupported, (
+                f"Skill '{folder}' uses unsupported frontmatter fields: "
+                f"{', '.join(unsupported)}"
+            )
+
+    def test_description_map_references_resolve(
+        self, skills_dir, skill_folders, known_map_surfaces
+    ):
+        """map-* references in descriptions should point at shipped surfaces."""
+        for folder in skill_folders:
+            skill_file = skills_dir / folder / "SKILL.md"
+            fm = self._parse_frontmatter(skill_file)
+            desc = fm.get("description", "")
+            referenced = set(re.findall(r"\b(map-[a-z0-9-]+)\b", desc))
+            unknown = sorted(referenced - known_map_surfaces)
+            assert not unknown, (
+                f"Skill '{folder}' references non-shipped MAP surfaces in its "
+                f"description: {', '.join(unknown)}"
+            )
+
+    def test_manual_skills_advertise_argument_hint(self, skills_dir, skill_folders):
+        """Manual slash skills should expose an argument hint for the UI."""
+        for folder in skill_folders:
+            skill_file = skills_dir / folder / "SKILL.md"
+            fm = self._parse_frontmatter(skill_file)
+            if not fm.get("disable-model-invocation"):
+                continue
+            hint = fm.get("argument-hint", "")
+            assert hint, (
+                f"Skill '{folder}' disables model invocation but has no "
+                "argument-hint for manual use."
+            )
+            assert hint.startswith("[") and hint.endswith("]"), (
+                f"Skill '{folder}' argument-hint '{hint}' should document the "
+                "manual invocation shape."
             )
 
     # --- Content section tests ---


### PR DESCRIPTION
## Summary
- shorten the shipped map-planning and map-learn skill descriptions and remove broken map-* references
- add an argument hint for the manual /map-learn surface and document the optional workflow summary input
- add metadata lint coverage plus loop-learning records for future skill-template work

## Validation
- pytest tests/test_skills.py tests/test_template_sync.py tests/test_command_templates.py -v
- uv run mapify init <new-dir> --no-git --mcp none