### PR TITLE
fix(orchestrator): atomic workflow completion + canonical reopen gate

### DIFF
--- a/.claude/agents/reflector.md
+++ b/.claude/agents/reflector.md
@@ -428,12 +428,48 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
 2. **Why immediate?** - Point to code, API, decision (lines/functions)
 3. **Why root cause?** - Use sequential-thinking, dig beyond symptoms (5 Whys)
 4. **What pattern?** - Extract generalizable principle, format as rule
-5. **How prevent/amplify?** - Create suggested_new_bullets, update existing bullets
-6. **Extract knowledge graph** - Optional, high-confidence entities/relationships
+5. **What contradiction did this resolve?** - Frame the pattern in TRIZ form: name the tension `<X> AND NOT <X>` the code was trying to hold, why naive trade-off failed, and which TRIZ principle (1–40 from `docs/triz-cheatsheet.md`) the resolution embodies. This makes patterns discoverable across domains — the same principle (e.g., "asymmetry", "harm into benefit", "preliminary anti-action") shows up under different surface symptoms.
+6. **How prevent/amplify?** - Create suggested_new_bullets, update existing bullets
+7. **Extract knowledge graph** - Optional, high-confidence entities/relationships
 
 <rationale>
-5-step analysis prevents shallow conclusions. Inspired by SRE post-mortems: learning, not blame.
+Step-by-step analysis prevents shallow conclusions. Inspired by SRE post-mortems: learning, not blame. Step 5 (contradiction framing) is what lifts a one-off fix into a transferable design principle — the same shape recurs in unrelated subsystems, and naming it makes the recurrence visible.
 </rationale>
+
+<decision_framework name="contradiction_framing">
+
+## Contradiction Framing (Step 5 detail)
+
+Most non-trivial bugs and design wins are a system holding (or failing to hold) a contradiction between two desirable properties. Surface it.
+
+### Heuristics for spotting a real contradiction
+
+```
+IF the fix added a small mechanism (gate, retry, lock, fallback, off-ramp) instead of changing a primary requirement:
+  → likely a contradiction was being held; name both sides
+IF the failure was "we picked A, but B silently mattered":
+  → the missing side IS the contradiction; name "must A AND not break B"
+IF the bug was a simple typo, off-by-one, or missing null check:
+  → no real contradiction; leave contradiction_resolved null
+```
+
+### Output format
+
+When a non-trivial contradiction is present, set `contradiction_resolved` to a single sentence in this shape:
+
+```
+"<system component> must <X> AND NOT <X>, where naive trade-off fails because <constraint>."
+```
+
+Set `triz_principle` to up to 3 integer IDs (1–40) from `docs/triz-cheatsheet.md` whose application in the fix is genuine — not decorative. Skip principles that only "kinda fit"; partial fit dilutes the catalog.
+
+Examples (for shape, not copy-paste):
+- "Monitor must reject incomplete diffs AND NOT punish pre-existing failures the diff merely surfaced, where naive trade-off fails because suppressing pre-existing errors silently disables the gate." → principle 22 (harm into benefit: pre-existing failures become learning signal via CLARIFICATION_NEEDED).
+- "State must survive `kill -9` AND NOT pay transaction overhead per call, where naive trade-off fails because per-call ACID kills throughput." → principles 10 (preliminary action — durable write at start) + 11 (cushion — idempotent recovery).
+
+If no non-trivial contradiction applies (trivial fix, single dominant requirement), set both fields to `null` rather than inventing one. False contradictions corrupt the principle catalog faster than missing ones starve it.
+
+</decision_framework>
 
 # OUTPUT FORMAT (Strict JSON)
 
@@ -452,6 +488,10 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
   "correct_approach": "Detailed code (5+ lines). Incorrect + correct side-by-side. Why works, principle followed. {{language}} syntax. Minimum 150 chars.",
 
   "key_insight": "Reusable principle. 'When X, always Y because Z'. Memorable, actionable, broad. Minimum 50 chars.",
+
+  "contradiction_resolved": "Optional. Single sentence: '<component> must <X> AND NOT <X>, where naive trade-off fails because <constraint>.' Set to null for trivial fixes with no real contradiction.",
+
+  "triz_principle": [22],
 
   "bullet_updates": [
     {
@@ -479,6 +519,8 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
 - **root_cause_analysis** (REQUIRED, ≥150 chars): 5 Whys, beyond symptoms, principle/misconception
 - **correct_approach** (REQUIRED, ≥150 chars, 5+ lines): Incorrect + correct code, why works, principle, {{language}} syntax
 - **key_insight** (REQUIRED, ≥50 chars): "When X, always Y because Z", actionable, memorable
+- **contradiction_resolved** (OPTIONAL, ≥40 chars when set, else null): TRIZ-style "<component> must <X> AND NOT <X>" framing. Null for trivial fixes — do NOT fabricate a contradiction.
+- **triz_principle** (OPTIONAL, list of 1–3 ints in [1,40]): principle IDs from `docs/triz-cheatsheet.md` whose application in the fix is genuine. Empty/absent for trivial fixes.
 - **bullet_updates** (OPTIONAL): Only if Actor used bullets, tag helpful/harmful with reason
 - **suggested_new_bullets** (OPTIONAL): Only if genuinely new, meet quality framework, code_example for SECURITY/IMPL/PERF
 
@@ -514,6 +556,16 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
       "type": "string",
       "minLength": 50,
       "description": "Reusable principle: 'When X, always Y because Z'"
+    },
+    "contradiction_resolved": {
+      "type": ["string", "null"],
+      "description": "TRIZ-style framing: '<component> must <X> AND NOT <X>, where naive trade-off fails because <constraint>.' Null for trivial fixes — never fabricate."
+    },
+    "triz_principle": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {"type": "integer", "minimum": 1, "maximum": 40},
+      "description": "Principle IDs from docs/triz-cheatsheet.md whose application is genuine in this fix"
     },
     "bullet_updates": {
       "type": "array",
@@ -682,6 +734,10 @@ Use {{language}}/{{framework}} syntax. Show specific library, configuration, exp
   "correct_approach": "Use asyncio-native synchronization:\n\n```python\nimport asyncio\n\nclass BatchProcessor:\n    def __init__(self):\n        self.results = {}\n        self._lock = asyncio.Lock()  # asyncio Lock, not threading\n    \n    async def process_items(self, items):\n        # ❌ INCORRECT - race condition\n        # for item in items:\n        #     result = await self.process_one(item)\n        #     self.results[item.id] = result  # Unsafe!\n        \n        # ✅ CORRECT - synchronized access\n        async def safe_process(item):\n            result = await self.process_one(item)\n            async with self._lock:\n                self.results[item.id] = result\n            return result\n        \n        return await asyncio.gather(*[safe_process(i) for i in items])\n```\n\nPrefer returning values over mutating shared state.",
 
   "key_insight": "When using asyncio with shared mutable state, ALWAYS use asyncio.Lock for synchronization. Asyncio is single-threaded but concurrent - race conditions occur at await points. Better pattern: design to return values rather than mutate shared state.",
+
+  "contradiction_resolved": "BatchProcessor must aggregate results from concurrent coroutines AND NOT corrupt shared state via interleaved writes, where naive trade-off fails because dropping concurrency loses throughput while shared-state mutation without synchronization loses correctness.",
+
+  "triz_principle": [24, 13],
 
   "bullet_updates": [
     {"bullet_id": "async-0023", "tag": "helpful", "reason": "Pattern correctly identified async concurrency risk, referenced for context"}

--- a/.claude/skills/map-check/SKILL.md
+++ b/.claude/skills/map-check/SKILL.md
@@ -288,11 +288,13 @@ Run dossier contract:
 
 ### Step 6: Update Workflow State (Complete)
 
-If verification passes, mark workflow complete:
+If verification passes, mark workflow complete via the orchestrator. **Never edit `step_state.json` directly with `jq` / `sed`** — partial mutations leave `current_step_phase` stale and break `reopen_for_fixes` in the next `/map-review`.
 
 ```bash
-jq '.current_state = "WORKFLOW_COMPLETE" | .completed_at = "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+python3 .map/scripts/map_orchestrator.py mark_workflow_complete
 ```
+
+This atomically sets `workflow_status=WORKFLOW_COMPLETE`, `current_step_id=COMPLETE`, `current_step_phase=COMPLETE`, and `completed_at=<UTC ISO-8601>`. Refuses if any work is still pending.
 
 ### Step 7: Output Verification Report
 

--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -241,6 +241,30 @@ AskUserQuestion(questions=[
 | 1 | Token storage | Server-side (Redis) | Need revocation support |
 | 2 | Session expiry UX | Silent refresh | Better UX, no data loss |
 
+## Contradiction
+
+State the central design tension in TRIZ form. Every non-trivial spec should hold a tension that naive trade-off cannot resolve — that tension is what makes the design choices meaningful.
+
+> **The system must `<X>` AND NOT `<X>`.**
+
+- **Side A (functional requirement):** [what the system must achieve]
+- **Side B (constraint to preserve):** [what the obvious solution would violate]
+- **Why naive trade-off fails:** [cost, UX, safety, latency, or another reason "just pick one" is unacceptable here]
+- **Ideal Final Result (optional):** [what the system looks like if both sides hold without added complexity — function present, mechanism absent]
+
+Examples from prior MAP runs (for shape, not copy-paste):
+- "Plan must be reviewable AND not block fast iteration on small edits." → resolved via the workflow-fit off-ramp above.
+- "Monitor must reject incomplete diffs AND not punish surfaced pre-existing failures." → resolved via CLARIFICATION_NEEDED escalation.
+- "Long-running operations must survive `kill -9` AND not add transaction overhead per call." → resolved via durable `run_id` + idempotent writes.
+
+If, after honest analysis, no non-trivial contradiction exists, write:
+
+> No non-trivial contradiction. Single dominant requirement.
+
+and re-check whether the workflow-fit gate above should have returned `direct-edit` or `map-fast`. An empty Contradiction section is a signal, not a shortcut.
+
+Cross-reference relevant TRIZ principles from `docs/triz-cheatsheet.md` if a known principle (1–40) maps cleanly onto the chosen resolution; this makes the design discoverable by the Reflector and reusable across the codebase.
+
 ## Invariants
 
 Conditions that MUST remain true throughout implementation and after deployment.
@@ -305,6 +329,7 @@ Formal, testable conditions that define "done". Each criterion must be verifiabl
 If interview was skipped (task is well-defined), still write `spec_<branch>.md` using the same template as Step 2. Populate it from the user's requirements and discovery findings:
 
 - **Decisions Made**: extract from user's request (may be short or N/A)
+- **Contradiction**: REQUIRED — state the design tension in `<X> AND NOT <X>` form, or explicitly write "No non-trivial contradiction" and verify the workflow-fit gate should not have off-ramped this task
 - **Invariants**: derive from existing code patterns found in discovery
 - **Edge Cases**: identify from the task description and affected code
 - **Acceptance Criteria**: REQUIRED — must be testable conditions that define "done"
@@ -351,9 +376,10 @@ Check for:
 1. **Race conditions / concurrency gaps**: Are there shared resources without defined conflict resolution?
 2. **Ownership ambiguity**: Are responsibilities clearly assigned? Could two components both assume the other handles something?
 3. **Missing edge cases**: Compare the Edge Cases section against Invariants — are there invariant violations not covered by edge cases?
-4. **Contradictions**: Do any decisions contradict invariants or acceptance criteria?
+4. **Decision/invariant contradictions**: Do any decisions contradict invariants or acceptance criteria?
 5. **Security gaps**: Are trust boundaries complete? Are there injection vectors not addressed?
 6. **Implicit assumptions**: What is assumed but not stated?
+7. **Trivial or false design contradiction**: Does the `## Contradiction` section state a real tension (both sides have independent forces — separate stakeholders, conflicting cost axes, or genuine physics) or a tautology like "fast AND correct" with no constraint binding the trade-off? If trivial, demand a sharper formulation or explicit "No non-trivial contradiction" with justification.
 
 Output format:
 - For each finding: severity (HIGH/MEDIUM/LOW), category, description, suggested fix
@@ -485,6 +511,9 @@ For each invariant in the spec, verify at least one subtask's acceptance criteri
 
 **5. Edge case / overflow rules:**
 Scan the spec for boundary conditions (format overflows, threshold transitions, fallback behaviors). Verify each has a corresponding test in at least one subtask's test_strategy.
+
+**6. Contradiction preservation:**
+Read the spec's `## Contradiction` section. For each side of the stated tension (A and B), identify at least one subtask whose validation criteria would catch a regression on that side. If a side has no defender subtask, the decomposition risks silently dropping it during implementation — that is the typical failure mode that turns a TRIZ-style design into a one-sided trade-off in the diff. Either add validation criteria to an existing subtask or create a new one. If the spec stated "No non-trivial contradiction", skip this check.
 
 If gaps are found, update the decomposition (add validation criteria to existing subtasks or create new subtasks) BEFORE proceeding to Step 6.
 
@@ -659,7 +688,7 @@ not from a stale planning-state snapshot.
 DISTILLATION CHECKLIST:
   [x] task_plan_<branch>.md — has AAG contracts for every subtask + Spec Coverage table
   [x] blueprint.json     — raw decomposer output for wave computation (with coverage_map and per-subtask aag_contract)
-  [x] spec_<branch>.md      — has architecture graph + decisions + COMPLETE acceptance criteria (if interview was done)
+  [x] spec_<branch>.md      — has architecture graph + decisions + COMPLETE acceptance criteria + Contradiction section (or explicit "No non-trivial contradiction")
   [x] artifact_manifest.json — records workflow_fit + spec + plan stage artifacts
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
 
@@ -770,9 +799,10 @@ A: Re-run /map-plan. It will overwrite the planning artifacts. Then re-run `/map
 This command succeeds when:
 - ✅ Deep interview completed (if scope warranted it) with spec_<branch>.md written
 - ✅ Spec acceptance criteria enumerated completely (not summarized)
-- ✅ Devil's Advocate review completed (if skip conditions not met)
+- ✅ Spec includes a `## Contradiction` section (real `<X> AND NOT <X>` tension, or explicit "No non-trivial contradiction" with justification)
+- ✅ Devil's Advocate review completed (if skip conditions not met) — including the trivial-contradiction check
 - ✅ Architecture graph written in spec_<branch>.md (for complexity >= 3)
-- ✅ Decomposition coverage check passed (Step 5.7) — no orphaned ACs, result fields, or cross-cutting concerns
+- ✅ Decomposition coverage check passed (Step 5.7) — no orphaned ACs, result fields, or cross-cutting concerns; both sides of the spec contradiction have at least one defender subtask
 - ✅ task_plan_<branch>.md exists with AAG contracts for every subtask AND Spec Coverage table
 - ✅ CHECKPOINT shows subtask count and IDs
 - ✅ Context distilled (plan files self-contained for fresh session)

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -1257,7 +1257,7 @@ def mark_workflow_complete(branch: str) -> dict:
     state.workflow_status = "WORKFLOW_COMPLETE"
     state.current_step_id = "COMPLETE"
     state.current_step_phase = "COMPLETE"
-    state.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    state.completed_at = _utc_timestamp()
     state.save(state_file)
 
     return {
@@ -1317,11 +1317,16 @@ def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
             ),
         }
 
-    # Reset to ACTOR+MONITOR cycle
+    # Reset to ACTOR+MONITOR cycle. Reset every completion field atomically —
+    # the same rule that ``mark_workflow_complete`` enforces in the forward
+    # direction. Leaving ``workflow_status="WORKFLOW_COMPLETE"`` here would
+    # leave the very inconsistency we are trying to eradicate.
     state.current_step_id = "2.3"
     state.current_step_phase = "ACTOR"
     state.pending_steps = ["2.3", "2.4"]
     state.retry_count = 0
+    state.workflow_status = "IN_PROGRESS"
+    state.completed_at = None
 
     feedback_file = _write_feedback_file(
         branch,

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -315,6 +315,7 @@ class StepState:
     subtask_results: dict[str, dict] = field(default_factory=dict)
     last_subtask_commit_sha: Optional[str] = None
     contract_ready_subtasks: dict[str, dict] = field(default_factory=dict)
+    completed_at: Optional[str] = None
 
     def record_subtask_result(
         self,
@@ -362,6 +363,7 @@ class StepState:
             "subtask_results": self.subtask_results,
             "last_subtask_commit_sha": self.last_subtask_commit_sha,
             "contract_ready_subtasks": self.contract_ready_subtasks,
+            "completed_at": self.completed_at,
         }
 
     @classmethod
@@ -394,6 +396,7 @@ class StepState:
             subtask_results=data.get("subtask_results", {}),
             last_subtask_commit_sha=data.get("last_subtask_commit_sha"),
             contract_ready_subtasks=data.get("contract_ready_subtasks", {}),
+            completed_at=data.get("completed_at"),
         )
 
     @classmethod
@@ -1220,6 +1223,67 @@ def wave_monitor_failed(
     }
 
 
+def mark_workflow_complete(branch: str) -> dict:
+    """Atomically mark the workflow as complete.
+
+    Sets every canonical completion field in a single save:
+      - workflow_status   = "WORKFLOW_COMPLETE"
+      - current_step_id   = "COMPLETE"
+      - current_step_phase = "COMPLETE"
+      - completed_at      = ISO-8601 UTC timestamp
+
+    Replaces ad-hoc ``jq`` mutations that left ``current_step_phase`` stale on
+    "ACTOR" and broke ``reopen_for_fixes``. Refuses if any work is still
+    pending so callers cannot prematurely close an in-flight workflow.
+    """
+    state_file = Path(f".map/{branch}/step_state.json")
+    if not state_file.exists():
+        return {
+            "status": "error",
+            "message": f"No step_state.json at {state_file}",
+        }
+
+    state = StepState.load(state_file)
+
+    if state.pending_steps:
+        return {
+            "status": "error",
+            "message": (
+                f"Cannot mark complete: {len(state.pending_steps)} pending "
+                f"step(s) remain: {state.pending_steps}"
+            ),
+        }
+
+    state.workflow_status = "WORKFLOW_COMPLETE"
+    state.current_step_id = "COMPLETE"
+    state.current_step_phase = "COMPLETE"
+    state.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    state.save(state_file)
+
+    return {
+        "status": "success",
+        "workflow_status": state.workflow_status,
+        "current_step_id": state.current_step_id,
+        "current_step_phase": state.current_step_phase,
+        "completed_at": state.completed_at,
+    }
+
+
+def _is_workflow_complete(state: "StepState") -> bool:
+    """Return True if any canonical completion signal is set.
+
+    The canonical signal is ``workflow_status == "WORKFLOW_COMPLETE"`` (set by
+    ``mark_workflow_complete``). The two fallbacks accept legacy state files
+    that were marked complete via partial mutations (e.g., the historical
+    ``jq`` line in ``map-check`` that bypassed this API).
+    """
+    return (
+        state.workflow_status == "WORKFLOW_COMPLETE"
+        or state.current_step_id == "COMPLETE"
+        or state.current_step_phase == "COMPLETE"
+    )
+
+
 def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
     """Transition from COMPLETE back to ACTOR for post-review fixes.
 
@@ -1243,11 +1307,12 @@ def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
 
     state = StepState.load(state_file)
 
-    if state.current_step_phase != "COMPLETE":
+    if not _is_workflow_complete(state):
         return {
             "status": "error",
             "message": (
-                f"Workflow is in phase '{state.current_step_phase}', not COMPLETE. "
+                f"Workflow is in phase '{state.current_step_phase}' "
+                f"(workflow_status='{state.workflow_status}'), not COMPLETE. "
                 "Use monitor_failed for non-COMPLETE retry."
             ),
         }
@@ -1846,6 +1911,7 @@ def main():
             "monitor_failed",
             "wave_monitor_failed",
             "reopen_for_fixes",
+            "mark_workflow_complete",
         ],
         help="Command to execute",
     )
@@ -2091,6 +2157,10 @@ def main():
         elif args.command == "reopen_for_fixes":
             feedback = args.feedback or ""
             result = reopen_for_fixes(branch, feedback)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "mark_workflow_complete":
+            result = mark_workflow_complete(branch)
             print(json.dumps(result, indent=2))
 
     except Exception as e:

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -365,3 +365,22 @@
 - Refactor generated provider rules toward concrete negative constraints at mutation boundaries, especially around unrelated refactors, dependency changes, artifact deletion, and stage skipping.
 - Add snapshot tests for representative Claude and Codex scaffolds to keep constraint-first wording stable across `mapify init`.
 - Document rule-writing guidance in template maintenance docs so manual edits preserve the same constraint-first style.
+
+## Compile-time skill IR and anti-injection audit for provider surfaces [2605.221]
+
+**Source**: [[2605.221]], [[2605.222]], [[2605.223]], [[2605.226]] (ideas from vault)
+**Implementation Layer**: `src/mapify_cli/templates/skills/`, `src/mapify_cli/delivery/`, generated `.claude/skills/` and `.codex/skills/` surfaces, template lint tests, and release validation commands
+**Missing Capability**: A compile-time representation and audit pass that validates shipped skill semantics before emitting provider-specific `SKILL.md` / prompt surfaces.
+**Architecture Evidence**: `docs/architecture.md` defines provider portability as a quality goal; `Core Structure` identifies `src/mapify_cli/templates/` and generated `.claude/.codex` provider surfaces; `Known Risks/Gaps` names prompt/template drift and provider runtime constraints.
+**Benefit Hypothesis**: A shared skill IR plus anti-injection/static-validation pass will reduce template drift and unsafe community/template edits before `mapify init` emits them. Pass criteria: template tests parse every shipped skill into the IR, reject forbidden instruction patterns and unresolved supporting-file references, and produce byte-stable provider emissions for Claude and Codex fixtures.
+**Confidence**: 0.73
+**Reasoning**: MAP already owns the provider-emission layer: `mapify init` copies skill, command, hook, and rule templates into target repos for Claude Code and Codex. Existing plan items cover skill taxonomy, lifecycle optimization, trigger testing, and constraint-first rule wording, but they still treat each provider file as a hand-authored Markdown artifact. The SkCC ideas add a concrete missing layer for this repo: parse skill intent once, validate it, then emit provider-specific formats while retaining hashes/audit metadata.
+**Why Not Already Tried**: Completed work fixed frontmatter hygiene and consolidated `/map-learn` into a skill-backed surface; active plan items test triggers and supporting files. None of the plan or done entries introduces a typed intermediate representation, content hashing, or a compile-time anti-skill-injection gate across generated provider outputs.
+
+### Proposed Changes
+
+- Define a minimal `SkillIR` schema for shipped skills: name, trigger/description, invocation mode, allowed tools, supporting-file references, safety constraints, emitted provider targets, and content hash.
+- Add a parser/linter that lowers existing `src/mapify_cli/templates/skills/**/SKILL.md` files into `SkillIR`, fails on unresolved relative references, unsupported frontmatter keys, hidden prompt-injection patterns, or safety constraints buried only in prose.
+- Add provider emitters that render Claude and Codex skill/prompt surfaces from the IR or validate current hand-authored files against the IR until full generation is worth the migration.
+- Store or print deterministic content hashes for emitted skill artifacts so release checks can detect drift between development `.claude/` surfaces and `src/mapify_cli/templates/`.
+- Extend template snapshot tests to cover a safe skill, a malicious/injection-like skill fixture, a nested supporting-file reference, and byte-stable Claude/Codex emission.

--- a/docs/triz-cheatsheet.md
+++ b/docs/triz-cheatsheet.md
@@ -1,0 +1,107 @@
+# TRIZ Cheatsheet (MAP-anchored)
+
+> Living index of the 40 classical TRIZ inventive principles, each tied to a concrete location in MAP where the principle is applied (or could be applied). Used by `/map-plan` (Contradiction section) and the Reflector agent (`triz_principle` output field).
+
+## Why this lives in MAP
+
+TRIZ (Altshuller, 1956) is a method for finding strong solutions by first naming the **contradiction** a system must hold — "must `<X>` AND NOT `<X>`" — and then reaching for one of ~40 named moves that historically resolve such tensions. The principles are a shared vocabulary, not rules.
+
+MAP already encodes several of these implicitly (workflow-fit off-ramp, parallel review, learned rules). The cheatsheet makes them explicit so that:
+
+1. `/map-plan` can frame each spec around a real tension instead of "make X happen".
+2. The Reflector can label each learned rule with the principle it embodies, so the same shape becomes visible across unrelated bugs.
+3. Future architectural changes can be evaluated as "which contradiction does this resolve?" instead of "is this nice?".
+
+## How to use it
+
+When stuck on a design choice, follow the five-step loop:
+
+1. **Formulate the contradiction.** Restate the goal as `<X> AND NOT <X>`. If the second half is hard to write, the task probably isn't a real contradiction — and `/map-plan` should have off-ramped to `direct-edit`.
+2. **Describe the Ideal Final Result.** The function exists; the mechanism that delivers it appears absent. ("Cache as if always warm." "Agent as if it already knows what to do.")
+3. **Sweep candidate principles.** Skim the table for principles whose essence matches one side of the tension.
+4. **Look for free resources.** What does the system already produce that is currently discarded? (Prior session logs as a fine-tune dataset, idle GPU time, KV-cache between calls, the diff itself as a Monitor input.)
+5. **Test for "ideality".** Did the solution reduce moving parts or add them? If parts increased, it's engineering scaffolding, not a TRIZ resolution — keep looking.
+
+## The 40 principles
+
+Each row gives the principle name, a short essence in MAP-relevant language, and a **MAP locator** — concrete file or concept where this principle currently lives, or where it is the natural place to look first if you want to apply it.
+
+### Group 1 — Separation and combination
+
+| # | Principle | Essence | MAP locator |
+|---|-----------|---------|-------------|
+| 1 | Segmentation | Split one thing into independent parts. | `task-decomposer` agent: one user goal → N ST-XXX subtasks. |
+| 2 | Extraction | Pull the bothersome part out into a side service. | `research-agent` extracted from Actor; Reflector extracted from execution loop. |
+| 3 | Local quality | Different properties for different parts. | Per-agent prompts (`actor.md` vs `monitor.md` vs `evaluator.md`) — each tuned to its job. |
+| 4 | Asymmetry | Where symmetry implies symmetric cost, break it. | Future: cheap deterministic pre-monitor (lint/diff parsers) catches 80%, LLM Monitor only on disputed cases. |
+| 5 | Merging | Bring homogeneous operations together. | `/map-review` runs Monitor+Predictor+Evaluator in parallel, one round-trip. |
+| 6 | Universality | One object with many functions. | `MCP` as the single tool-call protocol; `step_state.json` as the single workflow state. |
+| 7 | Nesting | Object inside object. | Sub-agents called by agents (research-agent inside `/map-plan`); skills inside skills. |
+| 8 | Anti-weight | Compensate a load with an opposing load. | `.map/<branch>/` snapshot artifacts as a counterweight to destructive edits; worktrees as rollback-able copies. |
+
+### Group 2 — Preliminary and anticipatory action
+
+| # | Principle | Essence | MAP locator |
+|---|-----------|---------|-------------|
+| 9 | Preliminary anti-action | Neutralise the bad outcome before it happens. | Devil's Advocate spec review (`/map-plan` Step 2b) and `workflow-gate.py` hook. |
+| 10 | Preliminary action | Do the work before it is needed. | Pre-flight resume detection in `/map-plan`; prompt caching via map_step_runner. |
+| 11 | Cushion (beforehand) | Insure against failure. | `map-resume`, durable `step_state.json`, retry-on-Monitor-fail loop, learned-rules cache. |
+| 12 | Equipotentiality | Don't move things you don't have to. | Workflow-fit gate keeps trivial work as `direct-edit`; `.map/` lives next to the code, not on a server. |
+| 13 | Inversion | Do it the other way around. | Reflector could push pattern candidates to the user instead of waiting for `/map-learn` (proposed). |
+| 14 | Spheroidality | Replace linear with cyclic. | `ralph-loop-config.json` and the improvement-loop run repeatedly, not once. |
+| 15 | Dynamicity | Make parameters change at runtime. | Planned REGISTRY/FOCUS mode switch in orchestrator (`improvement-plan.md` 2604.019/020). |
+| 16 | Partial / excessive action | Do it in pieces, or with deliberate overshoot. | Wave-based execution in `/map-efficient`; token budget per subtask. |
+
+### Group 3 — Dimensions, time, feedback
+
+| # | Principle | Essence | MAP locator |
+|---|-----------|---------|-------------|
+| 17 | Another dimension | Lift from a list into a graph or surface. | Architecture Graph block in spec; `dependency_graph.py` as a richer view of the subtask list. |
+| 18 | Mechanical oscillation | Periodic ping. | Heartbeat hooks — currently absent; natural fit for long-running workflows. |
+| 19 | Periodic action | Replace continuous load with pulses. | Batched template sync via `make sync-templates` instead of per-edit copy; nightly playbook compaction (potential). |
+| 20 | Continuity of useful action | No idle time. | `MapWorkflowLogger` streams structured events as work happens; `/map-resume` keeps no gap on session boundary. |
+| 21 | Skipping | Move through the dangerous phase fast. | Workflow-fit off-ramp: `direct-edit` and `map-fast` skip the long path when MAP overhead isn't justified. |
+| 22 | Harm into benefit | Turn the failure mode into a useful signal. | Pre-existing surfaced failures → CLARIFICATION_NEEDED (rather than silent suppression); Monitor rejections logged for Reflector. |
+| 23 | Feedback | Close the loop. | Reflector → `learned/*.md` → next Actor run reads them as context. |
+| 24 | Mediator | Intermediate layer. | `map_orchestrator.py` mediates between slash commands and agents; MCP servers as mediators. |
+| 25 | Self-service | The system maintains and repairs itself. | Auto-categorization of learned rules into sections (security/architecture/error); potential: rules promoted into skills automatically. |
+| 26 | Copying | Work on a copy, not the original. | `.claude/worktrees/` for isolated experiments; spec/plan as a copy of the user's intent that can be revised without touching code. |
+| 27 | Cheap, short-lived | Many disposable replacements for one expensive permanent thing. | `.map/<branch>/` artifacts are per-branch and disposable; embedding cache rebuilt as needed. |
+| 28 | Replace mechanical | Imperative → declarative; manual → automated. | SKILL.md describes intent, not procedure; AAG contracts (`Actor -> Action(params) -> Goal`) replace step-by-step instructions. |
+
+### Group 4 — Materials, states, environments
+
+| # | Principle | Essence | MAP locator |
+|---|-----------|---------|-------------|
+| 29 | Pneumatic / hydraulic | Replace rigid with flowing. | Token streaming in agent responses; structured workflow logs as an event stream. |
+| 30 | Flexible shells / thin membranes | Thin adapter beats heavy layer. | Hooks (`PreToolUse`, `PostToolUse`) as thin adapters; provider-specific delivery shims in `src/mapify_cli/delivery/`. |
+| 31 | Porous materials | Useful emptiness inside the dense thing. | Optional spec fields ("Security Boundaries" included only when relevant); "skip" branches in `/map-plan` interview. |
+| 32 | Change visibility | Adjust what's visible vs hidden. | Planned REGISTRY/FOCUS context modes; PII redaction before LLM call. |
+| 33 | Homogeneity | One stack, fewer seams. | Monorepo; one templated `skills/` format shared by Claude Code and (in skill-form) Codex CLI. |
+| 34 | Rejection and regeneration | Discard old, regenerate fresh. | Context compaction; `.map/<branch>/` may be rebuilt from `task_plan` + `blueprint.json`. |
+| 35 | Parameter change | Switch the aggregate state of the data. | Summarisation of old context in compaction; agent prompt distillation. |
+| 36 | Phase transition | Use the transition itself, not the state. | Explicit `INITIALIZED → IN_PROGRESS → SUBTASK_COMPLETE → WORKFLOW_COMPLETE` in `step_state.json` — events fire on transitions, not on steady state. |
+| 37 | Thermal expansion | Grow or shrink in response to load. | Context budget enforcer adapts to subtask complexity; planned dynamic token budget (2604.023). |
+| 38 | Strong oxidants / accelerators | Speed up the reaction without changing inputs. | `embeddings_cache/`, `playbook.db`, vector indexes; rerankers in research-agent. |
+| 39 | Inert environment | Isolate from outside disturbance. | Worktrees as sandboxes; planned code-execution sandbox for Actor; allowlist/blocklist hooks. |
+| 40 | Composite materials | Assemble from heterogeneous parts. | A subtask's artifact bundle: spec + plan + blueprint + manifest + findings, each tracked separately. |
+
+## Live catalog (populated by Reflector)
+
+When Reflector identifies a learned pattern, it tags it with one or more `triz_principle` IDs (1–40). Aggregate entries land here as evidence of which principles MAP relies on most — and which are blind spots.
+
+| Principle | Learned rule | First seen | Workflow |
+|-----------|--------------|-----------|----------|
+| _empty until Reflector starts emitting `triz_principle` fields_ | | | |
+
+To populate this table, append a row when reviewing `.claude/rules/learned/*.md` — match the rule's "Why" against the principle whose essence it most directly applies. A rule may legitimately reference 2–3 principles.
+
+## Notes on cross-domain transfer
+
+A pattern often clusters under 2–3 principles at once. Speculative decoding is simultaneously anti-weight (8), copying (26), and skipping (21). The state-machine `advance_wave` reset rule (learned 2026-04-11) is simultaneously phase transition (36) and continuity (20). This is expected — the principles are overlapping descriptions, not a partition.
+
+The point is not to memorise 40 labels but to be in the habit of asking "what tension is this code trying to hold?" before "what code should I write?". The principle catalog is what reminds you the question has been asked before, often in a domain that looks nothing like yours.
+
+## Source
+
+The 40 principles and the contradiction-matrix idea trace to G. S. Altshuller's *To Find an Idea* (1986) and earlier works. The principle list itself is in the public domain; the MAP-anchored essences and locators in this file are written for this codebase.

--- a/src/mapify_cli/templates/agents/reflector.md
+++ b/src/mapify_cli/templates/agents/reflector.md
@@ -428,12 +428,48 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
 2. **Why immediate?** - Point to code, API, decision (lines/functions)
 3. **Why root cause?** - Use sequential-thinking, dig beyond symptoms (5 Whys)
 4. **What pattern?** - Extract generalizable principle, format as rule
-5. **How prevent/amplify?** - Create suggested_new_bullets, update existing bullets
-6. **Extract knowledge graph** - Optional, high-confidence entities/relationships
+5. **What contradiction did this resolve?** - Frame the pattern in TRIZ form: name the tension `<X> AND NOT <X>` the code was trying to hold, why naive trade-off failed, and which TRIZ principle (1–40 from `docs/triz-cheatsheet.md`) the resolution embodies. This makes patterns discoverable across domains — the same principle (e.g., "asymmetry", "harm into benefit", "preliminary anti-action") shows up under different surface symptoms.
+6. **How prevent/amplify?** - Create suggested_new_bullets, update existing bullets
+7. **Extract knowledge graph** - Optional, high-confidence entities/relationships
 
 <rationale>
-5-step analysis prevents shallow conclusions. Inspired by SRE post-mortems: learning, not blame.
+Step-by-step analysis prevents shallow conclusions. Inspired by SRE post-mortems: learning, not blame. Step 5 (contradiction framing) is what lifts a one-off fix into a transferable design principle — the same shape recurs in unrelated subsystems, and naming it makes the recurrence visible.
 </rationale>
+
+<decision_framework name="contradiction_framing">
+
+## Contradiction Framing (Step 5 detail)
+
+Most non-trivial bugs and design wins are a system holding (or failing to hold) a contradiction between two desirable properties. Surface it.
+
+### Heuristics for spotting a real contradiction
+
+```
+IF the fix added a small mechanism (gate, retry, lock, fallback, off-ramp) instead of changing a primary requirement:
+  → likely a contradiction was being held; name both sides
+IF the failure was "we picked A, but B silently mattered":
+  → the missing side IS the contradiction; name "must A AND not break B"
+IF the bug was a simple typo, off-by-one, or missing null check:
+  → no real contradiction; leave contradiction_resolved null
+```
+
+### Output format
+
+When a non-trivial contradiction is present, set `contradiction_resolved` to a single sentence in this shape:
+
+```
+"<system component> must <X> AND NOT <X>, where naive trade-off fails because <constraint>."
+```
+
+Set `triz_principle` to up to 3 integer IDs (1–40) from `docs/triz-cheatsheet.md` whose application in the fix is genuine — not decorative. Skip principles that only "kinda fit"; partial fit dilutes the catalog.
+
+Examples (for shape, not copy-paste):
+- "Monitor must reject incomplete diffs AND NOT punish pre-existing failures the diff merely surfaced, where naive trade-off fails because suppressing pre-existing errors silently disables the gate." → principle 22 (harm into benefit: pre-existing failures become learning signal via CLARIFICATION_NEEDED).
+- "State must survive `kill -9` AND NOT pay transaction overhead per call, where naive trade-off fails because per-call ACID kills throughput." → principles 10 (preliminary action — durable write at start) + 11 (cushion — idempotent recovery).
+
+If no non-trivial contradiction applies (trivial fix, single dominant requirement), set both fields to `null` rather than inventing one. False contradictions corrupt the principle catalog faster than missing ones starve it.
+
+</decision_framework>
 
 # OUTPUT FORMAT (Strict JSON)
 
@@ -452,6 +488,10 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
   "correct_approach": "Detailed code (5+ lines). Incorrect + correct side-by-side. Why works, principle followed. {{language}} syntax. Minimum 150 chars.",
 
   "key_insight": "Reusable principle. 'When X, always Y because Z'. Memorable, actionable, broad. Minimum 50 chars.",
+
+  "contradiction_resolved": "Optional. Single sentence: '<component> must <X> AND NOT <X>, where naive trade-off fails because <constraint>.' Set to null for trivial fixes with no real contradiction.",
+
+  "triz_principle": [22],
 
   "bullet_updates": [
     {
@@ -479,6 +519,8 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
 - **root_cause_analysis** (REQUIRED, ≥150 chars): 5 Whys, beyond symptoms, principle/misconception
 - **correct_approach** (REQUIRED, ≥150 chars, 5+ lines): Incorrect + correct code, why works, principle, {{language}} syntax
 - **key_insight** (REQUIRED, ≥50 chars): "When X, always Y because Z", actionable, memorable
+- **contradiction_resolved** (OPTIONAL, ≥40 chars when set, else null): TRIZ-style "<component> must <X> AND NOT <X>" framing. Null for trivial fixes — do NOT fabricate a contradiction.
+- **triz_principle** (OPTIONAL, list of 1–3 ints in [1,40]): principle IDs from `docs/triz-cheatsheet.md` whose application in the fix is genuine. Empty/absent for trivial fixes.
 - **bullet_updates** (OPTIONAL): Only if Actor used bullets, tag helpful/harmful with reason
 - **suggested_new_bullets** (OPTIONAL): Only if genuinely new, meet quality framework, code_example for SECURITY/IMPL/PERF
 
@@ -514,6 +556,16 @@ Skip if: trivial fix, no technical knowledge, no clear entities.
       "type": "string",
       "minLength": 50,
       "description": "Reusable principle: 'When X, always Y because Z'"
+    },
+    "contradiction_resolved": {
+      "type": ["string", "null"],
+      "description": "TRIZ-style framing: '<component> must <X> AND NOT <X>, where naive trade-off fails because <constraint>.' Null for trivial fixes — never fabricate."
+    },
+    "triz_principle": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {"type": "integer", "minimum": 1, "maximum": 40},
+      "description": "Principle IDs from docs/triz-cheatsheet.md whose application is genuine in this fix"
     },
     "bullet_updates": {
       "type": "array",
@@ -682,6 +734,10 @@ Use {{language}}/{{framework}} syntax. Show specific library, configuration, exp
   "correct_approach": "Use asyncio-native synchronization:\n\n```python\nimport asyncio\n\nclass BatchProcessor:\n    def __init__(self):\n        self.results = {}\n        self._lock = asyncio.Lock()  # asyncio Lock, not threading\n    \n    async def process_items(self, items):\n        # ❌ INCORRECT - race condition\n        # for item in items:\n        #     result = await self.process_one(item)\n        #     self.results[item.id] = result  # Unsafe!\n        \n        # ✅ CORRECT - synchronized access\n        async def safe_process(item):\n            result = await self.process_one(item)\n            async with self._lock:\n                self.results[item.id] = result\n            return result\n        \n        return await asyncio.gather(*[safe_process(i) for i in items])\n```\n\nPrefer returning values over mutating shared state.",
 
   "key_insight": "When using asyncio with shared mutable state, ALWAYS use asyncio.Lock for synchronization. Asyncio is single-threaded but concurrent - race conditions occur at await points. Better pattern: design to return values rather than mutate shared state.",
+
+  "contradiction_resolved": "BatchProcessor must aggregate results from concurrent coroutines AND NOT corrupt shared state via interleaved writes, where naive trade-off fails because dropping concurrency loses throughput while shared-state mutation without synchronization loses correctness.",
+
+  "triz_principle": [24, 13],
 
   "bullet_updates": [
     {"bullet_id": "async-0023", "tag": "helpful", "reason": "Pattern correctly identified async concurrency risk, referenced for context"}

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -1257,7 +1257,7 @@ def mark_workflow_complete(branch: str) -> dict:
     state.workflow_status = "WORKFLOW_COMPLETE"
     state.current_step_id = "COMPLETE"
     state.current_step_phase = "COMPLETE"
-    state.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    state.completed_at = _utc_timestamp()
     state.save(state_file)
 
     return {
@@ -1317,11 +1317,16 @@ def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
             ),
         }
 
-    # Reset to ACTOR+MONITOR cycle
+    # Reset to ACTOR+MONITOR cycle. Reset every completion field atomically —
+    # the same rule that ``mark_workflow_complete`` enforces in the forward
+    # direction. Leaving ``workflow_status="WORKFLOW_COMPLETE"`` here would
+    # leave the very inconsistency we are trying to eradicate.
     state.current_step_id = "2.3"
     state.current_step_phase = "ACTOR"
     state.pending_steps = ["2.3", "2.4"]
     state.retry_count = 0
+    state.workflow_status = "IN_PROGRESS"
+    state.completed_at = None
 
     feedback_file = _write_feedback_file(
         branch,

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -315,6 +315,7 @@ class StepState:
     subtask_results: dict[str, dict] = field(default_factory=dict)
     last_subtask_commit_sha: Optional[str] = None
     contract_ready_subtasks: dict[str, dict] = field(default_factory=dict)
+    completed_at: Optional[str] = None
 
     def record_subtask_result(
         self,
@@ -362,6 +363,7 @@ class StepState:
             "subtask_results": self.subtask_results,
             "last_subtask_commit_sha": self.last_subtask_commit_sha,
             "contract_ready_subtasks": self.contract_ready_subtasks,
+            "completed_at": self.completed_at,
         }
 
     @classmethod
@@ -394,6 +396,7 @@ class StepState:
             subtask_results=data.get("subtask_results", {}),
             last_subtask_commit_sha=data.get("last_subtask_commit_sha"),
             contract_ready_subtasks=data.get("contract_ready_subtasks", {}),
+            completed_at=data.get("completed_at"),
         )
 
     @classmethod
@@ -1220,6 +1223,67 @@ def wave_monitor_failed(
     }
 
 
+def mark_workflow_complete(branch: str) -> dict:
+    """Atomically mark the workflow as complete.
+
+    Sets every canonical completion field in a single save:
+      - workflow_status   = "WORKFLOW_COMPLETE"
+      - current_step_id   = "COMPLETE"
+      - current_step_phase = "COMPLETE"
+      - completed_at      = ISO-8601 UTC timestamp
+
+    Replaces ad-hoc ``jq`` mutations that left ``current_step_phase`` stale on
+    "ACTOR" and broke ``reopen_for_fixes``. Refuses if any work is still
+    pending so callers cannot prematurely close an in-flight workflow.
+    """
+    state_file = Path(f".map/{branch}/step_state.json")
+    if not state_file.exists():
+        return {
+            "status": "error",
+            "message": f"No step_state.json at {state_file}",
+        }
+
+    state = StepState.load(state_file)
+
+    if state.pending_steps:
+        return {
+            "status": "error",
+            "message": (
+                f"Cannot mark complete: {len(state.pending_steps)} pending "
+                f"step(s) remain: {state.pending_steps}"
+            ),
+        }
+
+    state.workflow_status = "WORKFLOW_COMPLETE"
+    state.current_step_id = "COMPLETE"
+    state.current_step_phase = "COMPLETE"
+    state.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    state.save(state_file)
+
+    return {
+        "status": "success",
+        "workflow_status": state.workflow_status,
+        "current_step_id": state.current_step_id,
+        "current_step_phase": state.current_step_phase,
+        "completed_at": state.completed_at,
+    }
+
+
+def _is_workflow_complete(state: "StepState") -> bool:
+    """Return True if any canonical completion signal is set.
+
+    The canonical signal is ``workflow_status == "WORKFLOW_COMPLETE"`` (set by
+    ``mark_workflow_complete``). The two fallbacks accept legacy state files
+    that were marked complete via partial mutations (e.g., the historical
+    ``jq`` line in ``map-check`` that bypassed this API).
+    """
+    return (
+        state.workflow_status == "WORKFLOW_COMPLETE"
+        or state.current_step_id == "COMPLETE"
+        or state.current_step_phase == "COMPLETE"
+    )
+
+
 def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
     """Transition from COMPLETE back to ACTOR for post-review fixes.
 
@@ -1243,11 +1307,12 @@ def reopen_for_fixes(branch: str, feedback: str = "") -> dict:
 
     state = StepState.load(state_file)
 
-    if state.current_step_phase != "COMPLETE":
+    if not _is_workflow_complete(state):
         return {
             "status": "error",
             "message": (
-                f"Workflow is in phase '{state.current_step_phase}', not COMPLETE. "
+                f"Workflow is in phase '{state.current_step_phase}' "
+                f"(workflow_status='{state.workflow_status}'), not COMPLETE. "
                 "Use monitor_failed for non-COMPLETE retry."
             ),
         }
@@ -1846,6 +1911,7 @@ def main():
             "monitor_failed",
             "wave_monitor_failed",
             "reopen_for_fixes",
+            "mark_workflow_complete",
         ],
         help="Command to execute",
     )
@@ -2091,6 +2157,10 @@ def main():
         elif args.command == "reopen_for_fixes":
             feedback = args.feedback or ""
             result = reopen_for_fixes(branch, feedback)
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "mark_workflow_complete":
+            result = mark_workflow_complete(branch)
             print(json.dumps(result, indent=2))
 
     except Exception as e:

--- a/src/mapify_cli/templates/skills/map-check/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-check/SKILL.md
@@ -288,11 +288,13 @@ Run dossier contract:
 
 ### Step 6: Update Workflow State (Complete)
 
-If verification passes, mark workflow complete:
+If verification passes, mark workflow complete via the orchestrator. **Never edit `step_state.json` directly with `jq` / `sed`** — partial mutations leave `current_step_phase` stale and break `reopen_for_fixes` in the next `/map-review`.
 
 ```bash
-jq '.current_state = "WORKFLOW_COMPLETE" | .completed_at = "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+python3 .map/scripts/map_orchestrator.py mark_workflow_complete
 ```
+
+This atomically sets `workflow_status=WORKFLOW_COMPLETE`, `current_step_id=COMPLETE`, `current_step_phase=COMPLETE`, and `completed_at=<UTC ISO-8601>`. Refuses if any work is still pending.
 
 ### Step 7: Output Verification Report
 

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -241,6 +241,30 @@ AskUserQuestion(questions=[
 | 1 | Token storage | Server-side (Redis) | Need revocation support |
 | 2 | Session expiry UX | Silent refresh | Better UX, no data loss |
 
+## Contradiction
+
+State the central design tension in TRIZ form. Every non-trivial spec should hold a tension that naive trade-off cannot resolve — that tension is what makes the design choices meaningful.
+
+> **The system must `<X>` AND NOT `<X>`.**
+
+- **Side A (functional requirement):** [what the system must achieve]
+- **Side B (constraint to preserve):** [what the obvious solution would violate]
+- **Why naive trade-off fails:** [cost, UX, safety, latency, or another reason "just pick one" is unacceptable here]
+- **Ideal Final Result (optional):** [what the system looks like if both sides hold without added complexity — function present, mechanism absent]
+
+Examples from prior MAP runs (for shape, not copy-paste):
+- "Plan must be reviewable AND not block fast iteration on small edits." → resolved via the workflow-fit off-ramp above.
+- "Monitor must reject incomplete diffs AND not punish surfaced pre-existing failures." → resolved via CLARIFICATION_NEEDED escalation.
+- "Long-running operations must survive `kill -9` AND not add transaction overhead per call." → resolved via durable `run_id` + idempotent writes.
+
+If, after honest analysis, no non-trivial contradiction exists, write:
+
+> No non-trivial contradiction. Single dominant requirement.
+
+and re-check whether the workflow-fit gate above should have returned `direct-edit` or `map-fast`. An empty Contradiction section is a signal, not a shortcut.
+
+Cross-reference relevant TRIZ principles from `docs/triz-cheatsheet.md` if a known principle (1–40) maps cleanly onto the chosen resolution; this makes the design discoverable by the Reflector and reusable across the codebase.
+
 ## Invariants
 
 Conditions that MUST remain true throughout implementation and after deployment.
@@ -305,6 +329,7 @@ Formal, testable conditions that define "done". Each criterion must be verifiabl
 If interview was skipped (task is well-defined), still write `spec_<branch>.md` using the same template as Step 2. Populate it from the user's requirements and discovery findings:
 
 - **Decisions Made**: extract from user's request (may be short or N/A)
+- **Contradiction**: REQUIRED — state the design tension in `<X> AND NOT <X>` form, or explicitly write "No non-trivial contradiction" and verify the workflow-fit gate should not have off-ramped this task
 - **Invariants**: derive from existing code patterns found in discovery
 - **Edge Cases**: identify from the task description and affected code
 - **Acceptance Criteria**: REQUIRED — must be testable conditions that define "done"
@@ -351,9 +376,10 @@ Check for:
 1. **Race conditions / concurrency gaps**: Are there shared resources without defined conflict resolution?
 2. **Ownership ambiguity**: Are responsibilities clearly assigned? Could two components both assume the other handles something?
 3. **Missing edge cases**: Compare the Edge Cases section against Invariants — are there invariant violations not covered by edge cases?
-4. **Contradictions**: Do any decisions contradict invariants or acceptance criteria?
+4. **Decision/invariant contradictions**: Do any decisions contradict invariants or acceptance criteria?
 5. **Security gaps**: Are trust boundaries complete? Are there injection vectors not addressed?
 6. **Implicit assumptions**: What is assumed but not stated?
+7. **Trivial or false design contradiction**: Does the `## Contradiction` section state a real tension (both sides have independent forces — separate stakeholders, conflicting cost axes, or genuine physics) or a tautology like "fast AND correct" with no constraint binding the trade-off? If trivial, demand a sharper formulation or explicit "No non-trivial contradiction" with justification.
 
 Output format:
 - For each finding: severity (HIGH/MEDIUM/LOW), category, description, suggested fix
@@ -485,6 +511,9 @@ For each invariant in the spec, verify at least one subtask's acceptance criteri
 
 **5. Edge case / overflow rules:**
 Scan the spec for boundary conditions (format overflows, threshold transitions, fallback behaviors). Verify each has a corresponding test in at least one subtask's test_strategy.
+
+**6. Contradiction preservation:**
+Read the spec's `## Contradiction` section. For each side of the stated tension (A and B), identify at least one subtask whose validation criteria would catch a regression on that side. If a side has no defender subtask, the decomposition risks silently dropping it during implementation — that is the typical failure mode that turns a TRIZ-style design into a one-sided trade-off in the diff. Either add validation criteria to an existing subtask or create a new one. If the spec stated "No non-trivial contradiction", skip this check.
 
 If gaps are found, update the decomposition (add validation criteria to existing subtasks or create new subtasks) BEFORE proceeding to Step 6.
 
@@ -659,7 +688,7 @@ not from a stale planning-state snapshot.
 DISTILLATION CHECKLIST:
   [x] task_plan_<branch>.md — has AAG contracts for every subtask + Spec Coverage table
   [x] blueprint.json     — raw decomposer output for wave computation (with coverage_map and per-subtask aag_contract)
-  [x] spec_<branch>.md      — has architecture graph + decisions + COMPLETE acceptance criteria (if interview was done)
+  [x] spec_<branch>.md      — has architecture graph + decisions + COMPLETE acceptance criteria + Contradiction section (or explicit "No non-trivial contradiction")
   [x] artifact_manifest.json — records workflow_fit + spec + plan stage artifacts
   [x] findings_<branch>.md  — has research pointers (if discovery was done)
 
@@ -770,9 +799,10 @@ A: Re-run /map-plan. It will overwrite the planning artifacts. Then re-run `/map
 This command succeeds when:
 - ✅ Deep interview completed (if scope warranted it) with spec_<branch>.md written
 - ✅ Spec acceptance criteria enumerated completely (not summarized)
-- ✅ Devil's Advocate review completed (if skip conditions not met)
+- ✅ Spec includes a `## Contradiction` section (real `<X> AND NOT <X>` tension, or explicit "No non-trivial contradiction" with justification)
+- ✅ Devil's Advocate review completed (if skip conditions not met) — including the trivial-contradiction check
 - ✅ Architecture graph written in spec_<branch>.md (for complexity >= 3)
-- ✅ Decomposition coverage check passed (Step 5.7) — no orphaned ACs, result fields, or cross-cutting concerns
+- ✅ Decomposition coverage check passed (Step 5.7) — no orphaned ACs, result fields, or cross-cutting concerns; both sides of the spec contradiction have at least one defender subtask
 - ✅ task_plan_<branch>.md exists with AAG contracts for every subtask AND Spec Coverage table
 - ✅ CHECKPOINT shows subtask count and IDs
 - ✅ Context distilled (plan files self-contained for fresh session)

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -1664,11 +1664,37 @@ class TestReopenForFixes:
         state = map_orchestrator.StepState.load(state_file)
         assert state.retry_count == 0
 
-    def test_rejects_non_complete_phase(self, branch_dir, tmp_path):
-        self._make_complete_state(tmp_path, branch_dir, current_step_phase="MONITOR")
+    def test_rejects_in_progress_workflow(self, branch_dir, tmp_path):
+        """Reopen must refuse when no completion signal is set."""
+        state = map_orchestrator.StepState()
+        state.current_step_id = "2.3"
+        state.current_step_phase = "MONITOR"
+        state.workflow_status = "IN_PROGRESS"
+        state.pending_steps = ["2.3", "2.4"]
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
         result = map_orchestrator.reopen_for_fixes(branch_dir, "")
         assert result["status"] == "error"
         assert "MONITOR" in result["message"]
+
+    def test_accepts_canonical_workflow_status_with_stale_phase(
+        self, branch_dir, tmp_path
+    ):
+        """Regression for the STACKLAND-1591 bug: reopen must accept a workflow
+        marked complete via ``workflow_status == "WORKFLOW_COMPLETE"`` even
+        when ``current_step_phase`` is stale (left on "ACTOR" by a partial
+        ``jq`` mutation in older map-check)."""
+        state = map_orchestrator.StepState()
+        state.current_step_id = "COMPLETE"
+        state.current_step_phase = "ACTOR"  # stale!
+        state.workflow_status = "WORKFLOW_COMPLETE"
+        state.pending_steps = []
+        state.completed_steps = ["1.0", "1.5", "1.6", "2.3", "2.4"]
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
+        result = map_orchestrator.reopen_for_fixes(branch_dir, "fix REVIEW-1")
+        assert result["status"] == "reopened", result
+        assert result["current_phase"] == "ACTOR"
 
     def test_no_state_file_returns_error(self, branch_dir, tmp_path):
         result = map_orchestrator.reopen_for_fixes(branch_dir, "")
@@ -1688,6 +1714,89 @@ class TestReopenForFixes:
         result = map_orchestrator.get_next_step(branch_dir)
         assert result["phase"] == "ACTOR"
         assert result["step_id"] == "2.3"
+
+
+class TestMarkWorkflowComplete:
+    """Tests for mark_workflow_complete() — atomic completion transition.
+
+    Replaces the historical ``jq '.current_state = "WORKFLOW_COMPLETE"'``
+    mutation in map-check that left ``current_step_phase`` stale and broke
+    ``reopen_for_fixes`` in the next ``/map-review``.
+    """
+
+    def test_atomic_transition_from_actor_phase(self, branch_dir, tmp_path):
+        """Happy path: pending=[], stale ACTOR phase → all four canonical
+        completion fields are set in a single save."""
+        state = map_orchestrator.StepState()
+        state.current_step_id = "2.3"
+        state.current_step_phase = "ACTOR"
+        state.workflow_status = "IN_PROGRESS"
+        state.pending_steps = []
+        state.completed_steps = ["1.0", "1.5", "1.6", "2.3", "2.4"]
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
+
+        result = map_orchestrator.mark_workflow_complete(branch_dir)
+
+        assert result["status"] == "success", result
+        assert result["workflow_status"] == "WORKFLOW_COMPLETE"
+        assert result["current_step_id"] == "COMPLETE"
+        assert result["current_step_phase"] == "COMPLETE"
+        assert result["completed_at"].endswith("Z")
+
+        reloaded = map_orchestrator.StepState.load(state_file)
+        assert reloaded.workflow_status == "WORKFLOW_COMPLETE"
+        assert reloaded.current_step_id == "COMPLETE"
+        assert reloaded.current_step_phase == "COMPLETE"
+        assert reloaded.completed_at == result["completed_at"]
+
+    def test_rejects_when_pending_steps_remain(self, branch_dir, tmp_path):
+        """Refuse to close an in-flight workflow."""
+        state = map_orchestrator.StepState()
+        state.pending_steps = ["2.3", "2.4"]
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
+
+        result = map_orchestrator.mark_workflow_complete(branch_dir)
+
+        assert result["status"] == "error"
+        assert "pending" in result["message"]
+
+    def test_no_state_file_returns_error(self, branch_dir, tmp_path):
+        result = map_orchestrator.mark_workflow_complete(branch_dir)
+        assert result["status"] == "error"
+
+    def test_completed_at_round_trips_through_save_load(self, branch_dir, tmp_path):
+        """completed_at must serialize via to_dict / from_dict."""
+        state = map_orchestrator.StepState()
+        state.pending_steps = []
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
+
+        map_orchestrator.mark_workflow_complete(branch_dir)
+        reloaded = map_orchestrator.StepState.load(state_file)
+
+        assert reloaded.completed_at is not None
+        assert reloaded.completed_at.endswith("Z")
+
+    def test_then_reopen_for_fixes_works(self, branch_dir, tmp_path):
+        """Integration: mark_workflow_complete → reopen_for_fixes succeeds.
+
+        This is the end-to-end path for ``/map-check`` → ``/map-review`` →
+        post-review fix; it must work without manual state surgery.
+        """
+        state = map_orchestrator.StepState()
+        state.pending_steps = []
+        state.completed_steps = ["1.0", "1.5", "1.6", "2.3", "2.4"]
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
+
+        mark_result = map_orchestrator.mark_workflow_complete(branch_dir)
+        assert mark_result["status"] == "success"
+
+        reopen_result = map_orchestrator.reopen_for_fixes(branch_dir, "fix lint")
+        assert reopen_result["status"] == "reopened"
+        assert reopen_result["current_phase"] == "ACTOR"
 
 
 class TestSubtaskResults:

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -1696,6 +1696,30 @@ class TestReopenForFixes:
         assert result["status"] == "reopened", result
         assert result["current_phase"] == "ACTOR"
 
+    def test_resets_workflow_status_and_completed_at(self, branch_dir, tmp_path):
+        """Reopen must reset every completion field atomically — the same
+        rule mark_workflow_complete enforces in the forward direction.
+        Otherwise reopen leaves workflow_status="WORKFLOW_COMPLETE" while
+        the workflow is back in ACTOR, defeating the whole point of using
+        workflow_status as the canonical completion signal."""
+        state = map_orchestrator.StepState()
+        state.current_step_id = "COMPLETE"
+        state.current_step_phase = "COMPLETE"
+        state.workflow_status = "WORKFLOW_COMPLETE"
+        state.completed_at = "2026-05-07T15:00:00Z"
+        state.pending_steps = []
+        state.completed_steps = ["1.0", "1.5", "1.6", "2.3", "2.4"]
+        state_file = tmp_path / ".map" / branch_dir / "step_state.json"
+        state.save(state_file)
+
+        map_orchestrator.reopen_for_fixes(branch_dir, "fix lint")
+
+        reloaded = map_orchestrator.StepState.load(state_file)
+        assert reloaded.workflow_status == "IN_PROGRESS"
+        assert reloaded.completed_at is None
+        assert reloaded.current_step_phase == "ACTOR"
+        assert reloaded.current_step_id == "2.3"
+
     def test_no_state_file_returns_error(self, branch_dir, tmp_path):
         result = map_orchestrator.reopen_for_fixes(branch_dir, "")
         assert result["status"] == "error"


### PR DESCRIPTION
## Summary

- `mark_workflow_complete(branch)` — new orchestrator API that atomically sets `workflow_status`, `current_step_id`, `current_step_phase`, and a new `completed_at` field; refuses while `pending_steps` is non-empty.
- `map-check/SKILL.md`: replaced the historical `jq '.current_state = "WORKFLOW_COMPLETE"'` mutation with the new API + explicit "never edit state directly" warning.
- `reopen_for_fixes` now gates on the canonical signal `workflow_status == "WORKFLOW_COMPLETE"` (with fallback to legacy `current_step_id` / `current_step_phase` so already-corrupted state files can still be reopened).

## Why

A user hit this on a real branch: `/map-check` finalised the workflow via `jq`, which silently bypassed `current_step_phase`. The field stayed on `"ACTOR"` from the last subtask's Actor cycle. When `/map-review` later tried `python3 .map/scripts/map_orchestrator.py reopen_for_fixes`, it was refused with `"Workflow is in phase 'ACTOR', not COMPLETE"` even though the workflow was clearly complete (`workflow_status = "WORKFLOW_COMPLETE"`, `current_step_id = "COMPLETE"`).

Two architectural rules from `architecture-patterns.md` apply:
- *Orchestrator Prompts Must Prohibit Direct State File Modification* (2026-04-11)
- *State Machine Transition Completeness: Reset All Sub-State Atomically* (2026-04-11)

## Test plan

- [x] `tests/test_map_orchestrator.py` — new `TestMarkWorkflowComplete` class (5 tests): atomic transition, reject when pending, no state file, `completed_at` round-trip, end-to-end `mark → reopen`.
- [x] Regression test `test_accepts_canonical_workflow_status_with_stale_phase` reproduces the STACKLAND-1591 case (stale `current_step_phase="ACTOR"` + canonical `workflow_status="WORKFLOW_COMPLETE"` → reopen succeeds).
- [x] Updated `test_rejects_non_complete_phase` → `test_rejects_in_progress_workflow` to match the new contract.
- [x] `ruff check src/ tests/` — clean.
- [x] `mypy src/` — clean.
- [x] `pytest --ignore=tests/integration/test_e2e_claude_sdk.py` — 1051 passed, 2 skipped (SDK e2e excluded; needs API key, unrelated).
- [x] `make sync-templates` — `.claude/` and `src/mapify_cli/templates/` are byte-identical (verified via `diff`).