### PR TITLE
feat(skills): add /map-explain for deep code/PR/project walkthroughs

### DIFF
--- a/.claude/skills/map-explain/SKILL.md
+++ b/.claude/skills/map-explain/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: map-explain
+description: |
+  Deep code/PR explanation that builds a complete mental model — not a summary. Walks through problem, entities, execution flow, data flow, every important line with rationale, side effects, assumptions, and breakage modes. For PRs, also explains before/after behavior and how the diff changes runtime behavior. With no arguments, explains the current branch's diff against `origin/main` (fallback `origin/master`) — or, when run on `main`/`master`, explains the project as a whole. Use when learning unfamiliar code, onboarding to a module, or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
+disable-model-invocation: true
+argument-hint: "[file path | symbol | PR ref | code snippet] (empty = branch diff vs origin/main; or project overview when on main/master)"
+---
+# MAP Explain
+
+**Target:** $ARGUMENTS
+
+## Default target (when $ARGUMENTS is empty)
+
+Pick mode by inspecting the current branch and its relation to the upstream base:
+
+```bash
+# 1. Pick the upstream base: prefer origin/main, fall back to origin/master.
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+
+# 2. Refresh the base so the comparison reflects what would actually merge.
+git fetch origin "${BASE#origin/}" --quiet
+
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+```
+
+Then choose **one** of the two modes below and follow it.
+
+### Mode A — Project overview (current branch is `main` or `master`, OR `HEAD` == `$BASE`)
+
+There is no branch diff to explain — explain the project as a whole instead. Produce a single project-level walkthrough that follows the 10 sections below at the **repository** level, not at a single-file level:
+
+- Section 1 (problem): what this repository exists to do — derive from `README.md` first, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
+- Section 2 (entities): the top-level modules / packages / services that make up the project (read the top-level directory listing, primary entry points, and any package/manifest files like `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- Section 3 (how they differ): the responsibility boundary between those entities — what each one owns and what it explicitly does NOT do.
+- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle — whichever applies). Trace from entry point through the main code paths.
+- Section 5 (data flow): what data moves between the entities — file formats, schemas, IPC, state files, databases.
+- Sections 6–7: do NOT try to cover every line in the repo. Instead, pick the 3–6 most architecturally load-bearing files/functions and walk those.
+- Section 8 (state & side effects): what the project writes to disk, the network, or shared services; what survives across runs.
+- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
+- Section 10 (breakage modes): what kinds of changes routinely break this project, based on `CONTRIBUTING.md`, `CHANGELOG.md`, recent commit messages, or learned-patterns docs if present.
+
+Skip the "For PRs, also explain" section in this mode — there is no diff.
+
+Useful commands to bootstrap:
+
+```bash
+ls -la
+git --no-pager log --oneline -n 20
+# Read these in order if present:
+#   README.md, CLAUDE.md, docs/ARCHITECTURE.md, docs/USAGE.md, CONTRIBUTING.md
+```
+
+### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
+
+The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — also produce the "For PRs, also explain" section.
+
+```bash
+# Three-dot diff = "what this branch changed relative to base".
+git --no-pager diff --stat "$BASE"...HEAD
+git --no-pager log --oneline "$BASE"..HEAD
+git --no-pager diff "$BASE"...HEAD
+```
+
+### Edge cases (apply to both modes)
+
+- If neither `origin/main` nor `origin/master` exists, stop and report it — do not silently fall back to `HEAD~1`.
+- If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
+
+Explain it so I can build a complete mental model of it, not just a summary.
+
+I want you to teach it step by step:
+
+1. what problem it solves,
+2. what entities exist,
+3. how they differ,
+4. how execution flows,
+5. how data flows,
+6. what every important line does,
+7. why each non-trivial line is needed,
+8. what state changes and side effects happen,
+9. what assumptions the code relies on,
+10. what could break if I modify it.
+
+## Rules
+
+- do not use terms before explaining them;
+- do not skip "obvious" lines;
+- do not hide behind abstractions or jargon;
+- separate intuition, exact mechanism, and practical meaning;
+- if something is inferred rather than explicit, mark it clearly.
+
+## For PRs, also explain
+
+- what behavior likely existed before,
+- what behavior exists after,
+- and how the diff changes runtime behavior.
+
+## End with
+
+- key insights,
+- common misunderstandings,
+- and a short precise summary.
+
+## How to apply
+
+1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase to find the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
+2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
+3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
+4. **Mark inferences.** When asserting something the source does not directly state (e.g., "this is likely called from the request handler"), prefix it with `Inferred:` so the reader knows the confidence level.
+5. **Quote, do not paraphrase, the lines you explain.** Use `file:line` references so the reader can navigate.
+6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target's behavior.
+
+## Examples
+
+```
+/map-explain                                          # on a feature branch: explain its diff vs origin/main; on main/master: explain the project
+/map-explain src/mapify_cli/orchestrator.py
+/map-explain map_step_runner.create_review_bundle
+/map-explain #108
+/map-explain HEAD~1..HEAD
+```

--- a/.claude/skills/map-explain/SKILL.md
+++ b/.claude/skills/map-explain/SKILL.md
@@ -3,7 +3,7 @@ name: map-explain
 description: |
   Deep walkthrough that builds a mental model of code, a diff, or the project — flow, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
 disable-model-invocation: true
-argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch diff vs origin/main, or project overview on main/master]"
+argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch diff vs origin/main (fallback origin/master), or project overview on main/master]"
 ---
 # MAP Explain
 

--- a/.claude/skills/map-explain/SKILL.md
+++ b/.claude/skills/map-explain/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: map-explain
 description: |
-  Deep code/PR explanation that builds a complete mental model — not a summary. Walks through problem, entities, execution flow, data flow, every important line with rationale, side effects, assumptions, and breakage modes. For PRs, also explains before/after behavior and how the diff changes runtime behavior. With no arguments, explains the current branch's diff against `origin/main` (fallback `origin/master`) — or, when run on `main`/`master`, explains the project as a whole. Use when learning unfamiliar code, onboarding to a module, or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
+  Deep walkthrough that builds a mental model of code, a diff, or the project — flow, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
 disable-model-invocation: true
-argument-hint: "[file path | symbol | PR ref | code snippet] (empty = branch diff vs origin/main; or project overview when on main/master)"
+argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch diff vs origin/main, or project overview on main/master]"
 ---
 # MAP Explain
 
@@ -18,7 +18,14 @@ Pick mode by inspecting the current branch and its relation to the upstream base
 BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
        || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
 
-# 2. Refresh the base so the comparison reflects what would actually merge.
+# 2. Stop early if neither base exists — do not run a fetch/diff against an
+#    empty ref (otherwise `git fetch origin ""` raises a confusing error).
+if [ -z "$BASE" ]; then
+  echo "map-explain: neither origin/main nor origin/master exists; aborting." >&2
+  exit 1
+fi
+
+# 3. Refresh the base so the comparison reflects what would actually merge.
 git fetch origin "${BASE#origin/}" --quiet
 
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
@@ -64,7 +71,6 @@ git --no-pager diff "$BASE"...HEAD
 
 ### Edge cases (apply to both modes)
 
-- If neither `origin/main` nor `origin/master` exists, stop and report it — do not silently fall back to `HEAD~1`.
 - If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
 
 Explain it so I can build a complete mental model of it, not just a summary.
@@ -120,3 +126,10 @@ I want you to teach it step by step:
 /map-explain #108
 /map-explain HEAD~1..HEAD
 ```
+
+## Troubleshooting
+
+- **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
+- **"HEAD == $BASE"** — the current branch already matches the upstream base, so there is no diff. The skill falls into Mode A (project overview); if that is not what you wanted, check `git status` and confirm your commits are on this branch.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) instead of the full branch diff so each line can be explained without truncation.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see un-marked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/.claude/skills/skill-rules.json
+++ b/.claude/skills/skill-rules.json
@@ -85,6 +85,30 @@
         ]
       }
     },
+    "map-explain": {
+      "type": "manual",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Deep code/PR explanation that builds a complete mental model — problem, entities, execution and data flow, line-by-line rationale, side effects, assumptions, breakage modes; for PRs also before/after behavior.",
+      "promptTriggers": {
+        "keywords": [
+          "map-explain",
+          "explain this code",
+          "explain this pr",
+          "explain this diff",
+          "mental model",
+          "walk me through",
+          "line by line"
+        ],
+        "intentPatterns": [
+          "map-explain",
+          "explain.*(code|file|function|class|module|pr|diff|commit)",
+          "(walk|teach) me through",
+          "build.*mental model",
+          "line.by.line"
+        ]
+      }
+    },
     "map-efficient": {
       "type": "manual",
       "enforcement": "manual",

--- a/.codex/skills/map-explain/SKILL.md
+++ b/.codex/skills/map-explain/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: map-explain
+description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, line-by-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
+---
+
+# $map-explain — Deep Walkthrough
+
+**Purpose:** Build a complete mental model of a target (code, diff, or the whole repository). This skill ONLY teaches — it does NOT plan or execute.
+
+**When to use:**
+- Learning unfamiliar code or onboarding to a module
+- Auditing a diff before merge
+- Bootstrapping a new contributor on an existing project
+
+**Related skills:** `$map-plan` (decomposition before execution), `$map-fast` (small implementations), `$map-check` (post-execution verification).
+
+---
+
+## Target resolution
+
+The skill takes a single argument. Resolve it as follows:
+
+- **File path** (`src/foo/bar.py`) → read the entire file with `shell_command` and treat it as the target.
+- **Symbol** (`module.function`, `ClassName.method`) → grep the repo with `shell_command` to find the definition and primary call sites.
+- **PR ref** (`#123`, branch name, commit SHA) → fetch the diff via `gh pr diff` or `git show`.
+- **Inline snippet** → treat the snippet itself as the target.
+- **Empty / no argument** → fall back to one of the two default modes below.
+
+## Default modes (when no argument is passed)
+
+Resolve the upstream base, then pick mode A or B.
+
+```
+shell_command:
+  cmd: |
+    # 1. Pick the upstream base: prefer origin/main, fall back to origin/master.
+    BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+           || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+
+    # 2. Stop early if neither base exists — avoid `git fetch origin ""`.
+    if [ -z "$BASE" ]; then
+      echo "map-explain: neither origin/main nor origin/master exists; aborting." >&2
+      exit 1
+    fi
+
+    # 3. Refresh the base so the comparison reflects what would actually merge.
+    git fetch origin "${BASE#origin/}" --quiet
+    echo "BASE=$BASE"
+    echo "CURRENT=$(git rev-parse --abbrev-ref HEAD)"
+```
+
+### Mode A — Project overview (current branch is `main`/`master`, OR `HEAD` == `$BASE`)
+
+No branch diff to explain — walk the **whole repository**. Map the 10 sections below onto the project, not a single file:
+
+- Section 1 (problem): what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
+- Section 2 (entities): top-level modules / packages / services. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- Section 3 (how they differ): responsibility boundaries — what each entity owns and explicitly does NOT do.
+- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- Section 5 (data flow): how data moves between entities — file formats, schemas, IPC, state files, databases.
+- Sections 6–7: pick the 3–6 most load-bearing files/functions and walk those line by line. Do NOT try to cover every line in the repo.
+- Section 8 (state & side effects): what the project writes to disk, network, or shared services; what survives across runs.
+- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
+- Section 10 (breakage modes): kinds of changes that routinely break this project — derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, or learned-patterns docs.
+
+Skip the "For PRs, also explain" section in this mode — no diff exists.
+
+Bootstrap commands:
+
+```
+shell_command:
+  cmd: |
+    ls -la
+    git --no-pager log --oneline -n 20
+    # Read these in order if present:
+    #   README.md, AGENTS.md, CLAUDE.md, docs/ARCHITECTURE.md, docs/USAGE.md, CONTRIBUTING.md
+```
+
+### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
+
+The target is the current branch's diff against the upstream base. Treat it like a PR and **also** produce the "For PRs, also explain" section.
+
+```
+shell_command:
+  cmd: |
+    BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+           || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+    # Three-dot diff = "what this branch changed relative to base".
+    git --no-pager diff --stat "$BASE"...HEAD
+    git --no-pager log --oneline "$BASE"..HEAD
+    git --no-pager diff "$BASE"...HEAD
+```
+
+---
+
+## What the explanation must contain
+
+Teach the target step by step:
+
+1. what problem it solves,
+2. what entities exist,
+3. how they differ,
+4. how execution flows,
+5. how data flows,
+6. what every important line does,
+7. why each non-trivial line is needed,
+8. what state changes and side effects happen,
+9. what assumptions the code relies on,
+10. what could break if I modify it.
+
+### Rules
+
+- do not use terms before explaining them;
+- do not skip "obvious" lines;
+- do not hide behind abstractions or jargon;
+- separate intuition, exact mechanism, and practical meaning;
+- if something is inferred rather than explicit, prefix it with `Inferred:`.
+
+### For PRs / diffs, also explain
+
+- what behavior likely existed before,
+- what behavior exists after,
+- and how the diff changes runtime behavior.
+
+### End with
+
+- key insights,
+- common misunderstandings,
+- a short precise summary.
+
+---
+
+## How to apply
+
+1. **Locate the target** per the rules above (file / symbol / PR ref / snippet / empty).
+2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
+3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
+4. **Mark inferences** with `Inferred:` so the reader knows the confidence level.
+5. **Quote, do not paraphrase,** the lines you explain. Use `file:line` references.
+6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target.
+
+---
+
+## Examples
+
+```
+$map-explain                                          # feature branch → diff vs origin/main; on main/master → project overview
+$map-explain src/mapify_cli/orchestrator.py
+$map-explain map_step_runner.create_review_bundle
+$map-explain #108
+$map-explain HEAD~1..HEAD
+```
+
+---
+
+## Troubleshooting
+
+- **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
+- **`HEAD == $BASE`** — the current branch already matches the upstream base; there is no diff. The skill falls into Mode A (project overview); if that's not what you wanted, check `git status` and confirm your commits are on this branch.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so each line can be explained without truncation.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/.codex/skills/map-explain/SKILL.md
+++ b/.codex/skills/map-explain/SKILL.md
@@ -85,6 +85,11 @@ shell_command:
   cmd: |
     BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
            || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+    if [ -z "$BASE" ]; then
+      echo "map-explain: neither origin/main nor origin/master exists; aborting." >&2
+      exit 1
+    fi
+    git fetch origin "${BASE#origin/}" --quiet
     # Three-dot diff = "what this branch changed relative to base".
     git --no-pager diff --stat "$BASE"...HEAD
     git --no-pager log --oneline "$BASE"..HEAD

--- a/src/mapify_cli/templates/codex/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-explain/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: map-explain
+description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, line-by-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
+---
+
+# $map-explain — Deep Walkthrough
+
+**Purpose:** Build a complete mental model of a target (code, diff, or the whole repository). This skill ONLY teaches — it does NOT plan or execute.
+
+**When to use:**
+- Learning unfamiliar code or onboarding to a module
+- Auditing a diff before merge
+- Bootstrapping a new contributor on an existing project
+
+**Related skills:** `$map-plan` (decomposition before execution), `$map-fast` (small implementations), `$map-check` (post-execution verification).
+
+---
+
+## Target resolution
+
+The skill takes a single argument. Resolve it as follows:
+
+- **File path** (`src/foo/bar.py`) → read the entire file with `shell_command` and treat it as the target.
+- **Symbol** (`module.function`, `ClassName.method`) → grep the repo with `shell_command` to find the definition and primary call sites.
+- **PR ref** (`#123`, branch name, commit SHA) → fetch the diff via `gh pr diff` or `git show`.
+- **Inline snippet** → treat the snippet itself as the target.
+- **Empty / no argument** → fall back to one of the two default modes below.
+
+## Default modes (when no argument is passed)
+
+Resolve the upstream base, then pick mode A or B.
+
+```
+shell_command:
+  cmd: |
+    # 1. Pick the upstream base: prefer origin/main, fall back to origin/master.
+    BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+           || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+
+    # 2. Stop early if neither base exists — avoid `git fetch origin ""`.
+    if [ -z "$BASE" ]; then
+      echo "map-explain: neither origin/main nor origin/master exists; aborting." >&2
+      exit 1
+    fi
+
+    # 3. Refresh the base so the comparison reflects what would actually merge.
+    git fetch origin "${BASE#origin/}" --quiet
+    echo "BASE=$BASE"
+    echo "CURRENT=$(git rev-parse --abbrev-ref HEAD)"
+```
+
+### Mode A — Project overview (current branch is `main`/`master`, OR `HEAD` == `$BASE`)
+
+No branch diff to explain — walk the **whole repository**. Map the 10 sections below onto the project, not a single file:
+
+- Section 1 (problem): what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
+- Section 2 (entities): top-level modules / packages / services. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- Section 3 (how they differ): responsibility boundaries — what each entity owns and explicitly does NOT do.
+- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- Section 5 (data flow): how data moves between entities — file formats, schemas, IPC, state files, databases.
+- Sections 6–7: pick the 3–6 most load-bearing files/functions and walk those line by line. Do NOT try to cover every line in the repo.
+- Section 8 (state & side effects): what the project writes to disk, network, or shared services; what survives across runs.
+- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
+- Section 10 (breakage modes): kinds of changes that routinely break this project — derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, or learned-patterns docs.
+
+Skip the "For PRs, also explain" section in this mode — no diff exists.
+
+Bootstrap commands:
+
+```
+shell_command:
+  cmd: |
+    ls -la
+    git --no-pager log --oneline -n 20
+    # Read these in order if present:
+    #   README.md, AGENTS.md, CLAUDE.md, docs/ARCHITECTURE.md, docs/USAGE.md, CONTRIBUTING.md
+```
+
+### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
+
+The target is the current branch's diff against the upstream base. Treat it like a PR and **also** produce the "For PRs, also explain" section.
+
+```
+shell_command:
+  cmd: |
+    BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+           || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+    # Three-dot diff = "what this branch changed relative to base".
+    git --no-pager diff --stat "$BASE"...HEAD
+    git --no-pager log --oneline "$BASE"..HEAD
+    git --no-pager diff "$BASE"...HEAD
+```
+
+---
+
+## What the explanation must contain
+
+Teach the target step by step:
+
+1. what problem it solves,
+2. what entities exist,
+3. how they differ,
+4. how execution flows,
+5. how data flows,
+6. what every important line does,
+7. why each non-trivial line is needed,
+8. what state changes and side effects happen,
+9. what assumptions the code relies on,
+10. what could break if I modify it.
+
+### Rules
+
+- do not use terms before explaining them;
+- do not skip "obvious" lines;
+- do not hide behind abstractions or jargon;
+- separate intuition, exact mechanism, and practical meaning;
+- if something is inferred rather than explicit, prefix it with `Inferred:`.
+
+### For PRs / diffs, also explain
+
+- what behavior likely existed before,
+- what behavior exists after,
+- and how the diff changes runtime behavior.
+
+### End with
+
+- key insights,
+- common misunderstandings,
+- a short precise summary.
+
+---
+
+## How to apply
+
+1. **Locate the target** per the rules above (file / symbol / PR ref / snippet / empty).
+2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
+3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
+4. **Mark inferences** with `Inferred:` so the reader knows the confidence level.
+5. **Quote, do not paraphrase,** the lines you explain. Use `file:line` references.
+6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target.
+
+---
+
+## Examples
+
+```
+$map-explain                                          # feature branch → diff vs origin/main; on main/master → project overview
+$map-explain src/mapify_cli/orchestrator.py
+$map-explain map_step_runner.create_review_bundle
+$map-explain #108
+$map-explain HEAD~1..HEAD
+```
+
+---
+
+## Troubleshooting
+
+- **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
+- **`HEAD == $BASE`** — the current branch already matches the upstream base; there is no diff. The skill falls into Mode A (project overview); if that's not what you wanted, check `git status` and confirm your commits are on this branch.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so each line can be explained without truncation.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/src/mapify_cli/templates/codex/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-explain/SKILL.md
@@ -85,6 +85,11 @@ shell_command:
   cmd: |
     BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
            || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+    if [ -z "$BASE" ]; then
+      echo "map-explain: neither origin/main nor origin/master exists; aborting." >&2
+      exit 1
+    fi
+    git fetch origin "${BASE#origin/}" --quiet
     # Three-dot diff = "what this branch changed relative to base".
     git --no-pager diff --stat "$BASE"...HEAD
     git --no-pager log --oneline "$BASE"..HEAD

--- a/src/mapify_cli/templates/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-explain/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: map-explain
+description: |
+  Deep code/PR explanation that builds a complete mental model — not a summary. Walks through problem, entities, execution flow, data flow, every important line with rationale, side effects, assumptions, and breakage modes. For PRs, also explains before/after behavior and how the diff changes runtime behavior. With no arguments, explains the current branch's diff against `origin/main` (fallback `origin/master`) — or, when run on `main`/`master`, explains the project as a whole. Use when learning unfamiliar code, onboarding to a module, or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
+disable-model-invocation: true
+argument-hint: "[file path | symbol | PR ref | code snippet] (empty = branch diff vs origin/main; or project overview when on main/master)"
+---
+# MAP Explain
+
+**Target:** $ARGUMENTS
+
+## Default target (when $ARGUMENTS is empty)
+
+Pick mode by inspecting the current branch and its relation to the upstream base:
+
+```bash
+# 1. Pick the upstream base: prefer origin/main, fall back to origin/master.
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+
+# 2. Refresh the base so the comparison reflects what would actually merge.
+git fetch origin "${BASE#origin/}" --quiet
+
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+```
+
+Then choose **one** of the two modes below and follow it.
+
+### Mode A — Project overview (current branch is `main` or `master`, OR `HEAD` == `$BASE`)
+
+There is no branch diff to explain — explain the project as a whole instead. Produce a single project-level walkthrough that follows the 10 sections below at the **repository** level, not at a single-file level:
+
+- Section 1 (problem): what this repository exists to do — derive from `README.md` first, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
+- Section 2 (entities): the top-level modules / packages / services that make up the project (read the top-level directory listing, primary entry points, and any package/manifest files like `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- Section 3 (how they differ): the responsibility boundary between those entities — what each one owns and what it explicitly does NOT do.
+- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle — whichever applies). Trace from entry point through the main code paths.
+- Section 5 (data flow): what data moves between the entities — file formats, schemas, IPC, state files, databases.
+- Sections 6–7: do NOT try to cover every line in the repo. Instead, pick the 3–6 most architecturally load-bearing files/functions and walk those.
+- Section 8 (state & side effects): what the project writes to disk, the network, or shared services; what survives across runs.
+- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
+- Section 10 (breakage modes): what kinds of changes routinely break this project, based on `CONTRIBUTING.md`, `CHANGELOG.md`, recent commit messages, or learned-patterns docs if present.
+
+Skip the "For PRs, also explain" section in this mode — there is no diff.
+
+Useful commands to bootstrap:
+
+```bash
+ls -la
+git --no-pager log --oneline -n 20
+# Read these in order if present:
+#   README.md, CLAUDE.md, docs/ARCHITECTURE.md, docs/USAGE.md, CONTRIBUTING.md
+```
+
+### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
+
+The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — also produce the "For PRs, also explain" section.
+
+```bash
+# Three-dot diff = "what this branch changed relative to base".
+git --no-pager diff --stat "$BASE"...HEAD
+git --no-pager log --oneline "$BASE"..HEAD
+git --no-pager diff "$BASE"...HEAD
+```
+
+### Edge cases (apply to both modes)
+
+- If neither `origin/main` nor `origin/master` exists, stop and report it — do not silently fall back to `HEAD~1`.
+- If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
+
+Explain it so I can build a complete mental model of it, not just a summary.
+
+I want you to teach it step by step:
+
+1. what problem it solves,
+2. what entities exist,
+3. how they differ,
+4. how execution flows,
+5. how data flows,
+6. what every important line does,
+7. why each non-trivial line is needed,
+8. what state changes and side effects happen,
+9. what assumptions the code relies on,
+10. what could break if I modify it.
+
+## Rules
+
+- do not use terms before explaining them;
+- do not skip "obvious" lines;
+- do not hide behind abstractions or jargon;
+- separate intuition, exact mechanism, and practical meaning;
+- if something is inferred rather than explicit, mark it clearly.
+
+## For PRs, also explain
+
+- what behavior likely existed before,
+- what behavior exists after,
+- and how the diff changes runtime behavior.
+
+## End with
+
+- key insights,
+- common misunderstandings,
+- and a short precise summary.
+
+## How to apply
+
+1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase to find the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
+2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
+3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
+4. **Mark inferences.** When asserting something the source does not directly state (e.g., "this is likely called from the request handler"), prefix it with `Inferred:` so the reader knows the confidence level.
+5. **Quote, do not paraphrase, the lines you explain.** Use `file:line` references so the reader can navigate.
+6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target's behavior.
+
+## Examples
+
+```
+/map-explain                                          # on a feature branch: explain its diff vs origin/main; on main/master: explain the project
+/map-explain src/mapify_cli/orchestrator.py
+/map-explain map_step_runner.create_review_bundle
+/map-explain #108
+/map-explain HEAD~1..HEAD
+```

--- a/src/mapify_cli/templates/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-explain/SKILL.md
@@ -3,7 +3,7 @@ name: map-explain
 description: |
   Deep walkthrough that builds a mental model of code, a diff, or the project — flow, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
 disable-model-invocation: true
-argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch diff vs origin/main, or project overview on main/master]"
+argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch diff vs origin/main (fallback origin/master), or project overview on main/master]"
 ---
 # MAP Explain
 

--- a/src/mapify_cli/templates/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-explain/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: map-explain
 description: |
-  Deep code/PR explanation that builds a complete mental model — not a summary. Walks through problem, entities, execution flow, data flow, every important line with rationale, side effects, assumptions, and breakage modes. For PRs, also explains before/after behavior and how the diff changes runtime behavior. With no arguments, explains the current branch's diff against `origin/main` (fallback `origin/master`) — or, when run on `main`/`master`, explains the project as a whole. Use when learning unfamiliar code, onboarding to a module, or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
+  Deep walkthrough that builds a mental model of code, a diff, or the project — flow, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff. Do NOT use to plan or implement; use map-plan or map-efficient.
 disable-model-invocation: true
-argument-hint: "[file path | symbol | PR ref | code snippet] (empty = branch diff vs origin/main; or project overview when on main/master)"
+argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch diff vs origin/main, or project overview on main/master]"
 ---
 # MAP Explain
 
@@ -18,7 +18,14 @@ Pick mode by inspecting the current branch and its relation to the upstream base
 BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
        || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
 
-# 2. Refresh the base so the comparison reflects what would actually merge.
+# 2. Stop early if neither base exists — do not run a fetch/diff against an
+#    empty ref (otherwise `git fetch origin ""` raises a confusing error).
+if [ -z "$BASE" ]; then
+  echo "map-explain: neither origin/main nor origin/master exists; aborting." >&2
+  exit 1
+fi
+
+# 3. Refresh the base so the comparison reflects what would actually merge.
 git fetch origin "${BASE#origin/}" --quiet
 
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
@@ -64,7 +71,6 @@ git --no-pager diff "$BASE"...HEAD
 
 ### Edge cases (apply to both modes)
 
-- If neither `origin/main` nor `origin/master` exists, stop and report it — do not silently fall back to `HEAD~1`.
 - If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
 
 Explain it so I can build a complete mental model of it, not just a summary.
@@ -120,3 +126,10 @@ I want you to teach it step by step:
 /map-explain #108
 /map-explain HEAD~1..HEAD
 ```
+
+## Troubleshooting
+
+- **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
+- **"HEAD == $BASE"** — the current branch already matches the upstream base, so there is no diff. The skill falls into Mode A (project overview); if that is not what you wanted, check `git status` and confirm your commits are on this branch.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) instead of the full branch diff so each line can be explained without truncation.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see un-marked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/src/mapify_cli/templates/skills/skill-rules.json
+++ b/src/mapify_cli/templates/skills/skill-rules.json
@@ -85,6 +85,30 @@
         ]
       }
     },
+    "map-explain": {
+      "type": "manual",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Deep code/PR explanation that builds a complete mental model — problem, entities, execution and data flow, line-by-line rationale, side effects, assumptions, breakage modes; for PRs also before/after behavior.",
+      "promptTriggers": {
+        "keywords": [
+          "map-explain",
+          "explain this code",
+          "explain this pr",
+          "explain this diff",
+          "mental model",
+          "walk me through",
+          "line by line"
+        ],
+        "intentPatterns": [
+          "map-explain",
+          "explain.*(code|file|function|class|module|pr|diff|commit)",
+          "(walk|teach) me through",
+          "build.*mental model",
+          "line.by.line"
+        ]
+      }
+    },
     "map-efficient": {
       "type": "manual",
       "enforcement": "manual",

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -249,6 +249,7 @@ class TestCodexTemplateSynchronization:
         ("skills/map-plan/SKILL.md", "skills/map-plan/SKILL.md"),
         ("skills/map-fast/SKILL.md", "skills/map-fast/SKILL.md"),
         ("skills/map-check/SKILL.md", "skills/map-check/SKILL.md"),
+        ("skills/map-explain/SKILL.md", "skills/map-explain/SKILL.md"),
         ("agents/researcher.toml", "agents/researcher.toml"),
         ("agents/decomposer.toml", "agents/decomposer.toml"),
         ("agents/monitor.toml", "agents/monitor.toml"),


### PR DESCRIPTION
## Summary

- Add a passive `/map-explain` skill that walks the reader through code, a diff, or the project across 10 sections (problem, entities, execution flow, data flow, line-by-line rationale, side effects, assumptions, breakage modes), and adds a before/after section for diffs.
- With no arguments the skill picks mode automatically: **branch diff** vs `origin/main`/`origin/master` on a feature branch, or **project overview** when run on `main`/`master` (or when HEAD == base).
- Registered in `.claude/skills/skill-rules.json` and mirrored to `src/mapify_cli/templates/skills/` so it ships through `mapify init`.

## Test plan

- [x] `python -m pytest tests/test_template_sync.py -q` — 43 passed, 1 skipped
- [x] `.claude/skills/map-explain/SKILL.md` and the template copy diff-clean after `make sync-templates`
- [ ] Manual smoke: invoke `/map-explain` on a feature branch (should fetch base and diff against `origin/main`)
- [ ] Manual smoke: invoke `/map-explain` on `main` (should produce a repository-level overview)
- [ ] Manual smoke: invoke `/map-explain <file>` (should walk a single file)