### PR TITLE
Close shipped LEARN ergonomics plan item

### DIFF
--- a/docs/improvement-done.md
+++ b/docs/improvement-done.md
@@ -68,6 +68,16 @@
 - Added focused metadata lint coverage in `tests/test_skills.py` for description length, supported frontmatter keys, broken `map-*` description references, and manual-skill argument hints.
 - Synced the `.claude/skills/` changes into `src/mapify_cli/templates/skills/`, updated `README.md` and `docs/USAGE.md`, and confirmed the repo-built `uv run mapify init ...` flow emits the new skill frontmatter.
 
+## LEARN as a philosophical requirement with soft runtime ergonomics [2604.035]
+
+- Date: 2026-05-17
+- Decision: rejected as an active-plan parent because every executable child slice needed for the promised soft-LEARN payoff is already implemented and recorded below.
+- Repo evidence: `docs/improvement-done.md` records `2604.035-1`, `2604.035-2`, and `2604.035-3` as shipped child slices for learning handoff artifacts, zero-argument `/map-learn`, learning adoption metrics, deferred-usage tracking, and repeated learned-rule violation tracking.
+- Repo evidence: `.map/scripts/map_step_runner.py` writes `.map/<branch>/learning-handoff.md`, `.json`, and `learning-metrics.json`, records handoff generation/consumption metrics, and records repeated learned-rule violation summaries during `write_learning_handoff`.
+- Repo evidence: `.claude/skills/map-efficient/SKILL.md`, `.claude/skills/map-debug/SKILL.md`, `.claude/skills/map-check/SKILL.md`, and `.claude/skills/map-review/SKILL.md` already write learning handoffs at closeout, while `.claude/skills/map-learn/SKILL.md` already documents zero-argument handoff loading.
+- Repo evidence: README, `docs/USAGE.md`, `docs/ARCHITECTURE.md`, and `docs/roadmap.md` already document soft runtime learning, learning handoff artifacts, learning metrics, and repeated-rule signals.
+- No runtime change was needed; this loop removed the stale parent section so future improvement-plan loops do not reselect the already-shipped LEARN ergonomics bundle.
+
 ## Learning handoff artifacts and zero-argument `/map-learn` [2604.035-1]
 
 - Date: 2026-04-12

--- a/docs/improvement-loop-log.md
+++ b/docs/improvement-loop-log.md
@@ -1,3 +1,15 @@
+## 2026-05-17 - LEARN as a philosophical requirement with soft runtime ergonomics [2604.035]
+
+- Decision: `rejected`
+- Branch: `codex/2604-035-close-learn-parent`
+- Baseline: The parent item remained active in `docs/improvement-plan.md`, but its executable child slices `2604.035-1`, `2604.035-2`, and `2604.035-3` were already recorded as shipped and the runtime/docs evidence showed the soft-LEARN user payoff was live.
+- Forward Change: Removed the stale active parent section and recorded the exact `[2604.035]` heading in `docs/improvement-done.md` with repo-grounded evidence instead of rebuilding the learning handoff, zero-argument `/map-learn`, metrics, or repeated-rule tracking behavior.
+- Decisive Validation: the improvement-plan-loop idea indexer, focused learning handoff regression tests, and repo evidence searches verified the parent is no longer active while shipped learning artifacts remain covered.
+- Review Result: Diff review confirmed this is a ledger-only stale-parent closure with no runtime or template mutations.
+- Next Trigger: Reuse this learning whenever an active umbrella item says to use child slices and all children are already shipped in `docs/*-done.md`.
+- Reusable Learnings:
+  - review-check: `Before selecting an active umbrella item, compare its proposed changes against shipped child slice ids in docs/*-done.md; if all value-bearing children are already complete, close the parent with evidence rather than executing it again.`
+
 ## 2026-05-17 - Detached reviewer context and worktree-assisted review [2604.037]
 
 - Decision: `rejected`

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -214,24 +214,6 @@
 - If MAP later adds more task skills, evaluate whether some should use `context: fork` and `agent` to isolate long procedures into subagent execution, as supported by the official docs.
 
 
-## LEARN as a philosophical requirement with soft runtime ergonomics [2604.035]
-
-**Benefit Hypothesis**: Treating `LEARN` as a required part of the MAP philosophy, while keeping runtime ergonomics soft and token-aware, will preserve the long-term memory benefits of the framework without making users feel forced into extra token spend on every workflow. The measurable target is higher voluntary `/map-learn` adoption on meaningful tasks and fewer repeated Monitor findings in subsequent sessions.
-**Confidence**: 0.85
-**Reasoning**: The philosophy document treats `LEARN` as a first-class stage in `SPEC → PLAN → TEST → CODE → REVIEW → LEARN`, explicitly stating that reusable project memory is the output of the pipeline and that re-explaining the same gotchas a week later means `LEARN` failed. At the same time, MAP users are cost-sensitive and often skip optional post-processing when it burns extra tokens. So the gap is real, but the fix should not be hard enforcement. MAP’s runtime still treats learning as a weak afterthought: `README.md` canonical flows end at `/map-review`, `docs/ARCHITECTURE.md` repeatedly calls learning “optional via /map-learn”, and `map-efficient`, `map-debug`, `map-release`, `map-resume`, and `map-fast` all frame `/map-learn` as a generic suggestion rather than a normal, cheap closeout path.
-**Why Not Already Tried**: MAP intentionally decoupled Reflector from execution to save tokens and keep implementation loops faster. That optimization was correct for token economy, but it left the system without a lightweight bridge between “LEARN matters” and “users do not want mandatory extra spend”.
-
-**Execution note:** Do not execute this umbrella item directly. Use the child slices below.
-
-### Proposed Changes
-
-- Keep `LEARN` mandatory in philosophy/docs, but do not block workflow completion on `/map-learn` or require an explicit skip confirmation.
-- Generate a branch-scoped `learning_handoff_<branch>.md` or `.json` artifact automatically at the end of `/map-efficient`, `/map-debug`, `/map-review`, and `/map-check`, so the expensive part becomes optional execution, not manual reconstruction of context.
-- Make `/map-learn` cheap and ergonomic: support prefilled invocation from the generated handoff and encourage batched learning across several workflows instead of per-run mandatory reflection.
-- Update canonical docs (`README.md`, `docs/USAGE.md`, `docs/ARCHITECTURE.md`) to say: philosophically the cycle ends with `LEARN`, but runtime leaves it to the user when to pay that cost.
-- Add metrics for learn adoption, deferred learn usage, and repeated learned-rule violations, so MAP can improve uptake without turning learning into a hard gate.
-
-
 ## Clean-session TEST→CODE handoff for TDD workflows [2604.036]
 
 **Benefit Hypothesis**: Forcing test authoring and implementation to happen in separate sessions/contexts will reduce “tests that merely bless the implementation”, catch spec misunderstandings earlier, and improve contract quality on risky subtasks. The measurable target is fewer trivial/pass-without-code tests and fewer post-implementation revisions caused by weak test contracts.

--- a/docs/learned/review-checks.md
+++ b/docs/learned/review-checks.md
@@ -3,4 +3,4 @@
 <!-- IMPROVEMENT-PLAN-LOOP: promoted from loop learnings. Edit freely and commit with the project. -->
 
 - **Reconcile secondary ledgers when closing stale plan items** (2026-05-17): When reviewing a stale-plan closure, verify roadmap/status docs do not still list the same idea id as open because future loops can rediscover it as active work. [workflow: improvement-plan-loop]
-
+- **Close completed umbrella parents from shipped child evidence** (2026-05-17): Before selecting an active umbrella item, compare its proposed changes against shipped child slice ids in `docs/*-done.md`; if all value-bearing children are already complete, close the parent with evidence rather than executing it again. [workflow: improvement-plan-loop]


### PR DESCRIPTION
## Summary
- remove stale active parent item 2604.035 from docs/improvement-plan.md
- record the parent closure in docs/improvement-done.md with shipped child-slice evidence
- add loop log and learned review check for closing completed umbrella parents

## Validation
- python /Users/azalio/.config/opencode/skills/improvement-plan-loop/scripts/idea_index.py .
- pytest tests/test_map_step_runner.py::test_write_learning_handoff_creates_artifacts_and_manifest tests/test_map_step_runner.py::test_write_learning_handoff_records_repeated_rule_violations tests/test_map_step_runner.py::test_map_step_runner_cli_write_learning_handoff_records_repeated_violation_smoke -v
- python /Users/azalio/.config/opencode/skills/repo-learning-capture/scripts/capture_learning.py --repo . --handoff /var/folders/3j/zmvdy5_56bjcg1kmrx05dltcf7yldq/T/opencode/learning-handoff-2604.035.md
- git diff --check
- pytest -m "not slow"

Full pytest was attempted and progressed through deterministic tests plus the first live Claude SDK e2e tests, then exceeded the 15-minute tool timeout at TestMapEfficientE2E::test_efficient_produces_code_changes.