### PR TITLE
Small fixes and README updates

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -28,7 +28,7 @@ configuration to take effect. Without trust, `.codex/` files are ignored.
 MAP uses a workflow gate hook that restricts file-modifying commands during
 research and review phases. This prevents accidental edits while exploring.
 
-**Note:** Hooks require `codex_hooks = true` in config.toml and are not
+**Note:** Hooks require `hooks = true` in config.toml and are not
 supported on Windows.
 
 ## Getting Started

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,7 @@
 
 [features]
 # Enable hooks for MAP workflow enforcement
-codex_hooks = true
+hooks = true
 
 [agents.decomposer]
 description = "Breaks complex goals into atomic, testable subtasks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,15 @@ jobs:
         which ruff > /dev/null 2>&1 && ruff check src/ tests/ || echo "Ruff not installed, skipping"
         which mypy > /dev/null 2>&1 && mypy src/ || echo "Mypy not installed, skipping"
 
+    - name: Run Codex provider regression checks
+      run: |
+        python -m pytest -v \
+          tests/test_template_sync.py::TestCodexTemplateSynchronization \
+          tests/test_mapify_cli.py::TestCodexProvider
+
     - name: Run tests
       run: |
-        python -m pytest -v --cov=mapify_cli --cov-report=xml
+        python -m pytest -v -m "not slow" --cov=mapify_cli --cov-report=xml
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ mapify init . --provider codex
 codex
 ```
 
+Then enable the Codex hook manually: run `/hooks`, select `PreToolUse`, press `t` to toggle it on, then press `Esc`.
+
 Pick a context-compression policy if you want non-default behaviour
 (`auto` is the default; see [docs/USAGE.md#context-budget-policy](docs/USAGE.md)):
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ codex
 
 Then enable the Codex hook manually: run `/hooks`, select `PreToolUse`, press `t` to toggle it on, then press `Esc`.
 
-If you use Codex before `0.129.0`, either start it with `codex --enable codex_hooks` or upgrade Codex first. Upgrading is recommended.
+If your Codex version does not support the `hooks` feature key yet, either start it with `codex --enable codex_hooks` or upgrade Codex first. Upgrading is recommended.
 
 Pick a context-compression policy if you want non-default behaviour
 (`auto` is the default; see [docs/USAGE.md#context-budget-policy](docs/USAGE.md)):
@@ -101,7 +101,7 @@ When a task has unclear behavior, multiple files, or real review risk, run the f
 
 Direct `/map-efficient` is for already-scoped tasks. If you are unsure, start with `/map-plan`.
 
-Codex users should omit the slash: type `map-plan`, `map-fast`, or `map-check` instead of `/map-plan`, `/map-fast`, or `/map-check`. See the [Usage Guide](docs/USAGE.md#codex-cli-provider) for provider details.
+Codex users should invoke MAP skills with `$`: type `$map-plan`, `$map-fast`, or `$map-check` instead of `/map-plan`, `/map-fast`, or `/map-check`. See the [Usage Guide](docs/USAGE.md#codex-cli-provider) for provider details.
 
 ## What Success Looks Like
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ codex
 
 Then enable the Codex hook manually: run `/hooks`, select `PreToolUse`, press `t` to toggle it on, then press `Esc`.
 
+If you use Codex before `0.129.0`, either start it with `codex --enable codex_hooks` or upgrade Codex first. Upgrading is recommended.
+
 Pick a context-compression policy if you want non-default behaviour
 (`auto` is the default; see [docs/USAGE.md#context-budget-policy](docs/USAGE.md)):
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ When a task has unclear behavior, multiple files, or real review risk, run the f
 
 Direct `/map-efficient` is for already-scoped tasks. If you are unsure, start with `/map-plan`.
 
-Codex projects expose three MAP skills today: `$map-plan`, `$map-fast`, and `$map-check`. See the [Usage Guide](docs/USAGE.md#codex-cli-provider) for provider details.
+Codex users should omit the slash: type `map-plan`, `map-fast`, or `map-check` instead of `/map-plan`, `/map-fast`, or `/map-check`. See the [Usage Guide](docs/USAGE.md#codex-cli-provider) for provider details.
 
 ## What Success Looks Like
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -173,6 +173,14 @@ Esc
 
 This toggles the `PreToolUse` hook on so MAP's workflow gate can run before tool calls.
 
+If you use Codex before `0.129.0`, either start Codex with the hooks feature enabled:
+
+```bash
+codex --enable codex_hooks
+```
+
+or upgrade Codex first. Upgrading is recommended.
+
 ### MCP Server Configuration
 
 Choose which MCP servers to enable:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -173,7 +173,7 @@ Esc
 
 This toggles the `PreToolUse` hook on so MAP's workflow gate can run before tool calls.
 
-If you use Codex before `0.129.0`, either start Codex with the hooks feature enabled:
+If your Codex version does not support the `hooks` feature key yet, either start Codex with the deprecated hooks feature alias enabled:
 
 ```bash
 codex --enable codex_hooks
@@ -181,7 +181,7 @@ codex --enable codex_hooks
 
 or upgrade Codex first. Upgrading is recommended.
 
-Codex MAP commands do not start with `/`. Type `map-plan`, `map-fast`, or `map-check` instead of `/map-plan`, `/map-fast`, or `/map-check`.
+Codex MAP skills do not start with `/`. Type `$map-plan`, `$map-fast`, or `$map-check` instead of `/map-plan`, `/map-fast`, or `/map-check`.
 
 ### MCP Server Configuration
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -155,6 +155,24 @@ This will:
 
 **Note:** MAP Framework is designed for Claude Code. All generated agents and commands are optimized for the Claude Code CLI.
 
+### Codex CLI Installation
+
+```bash
+mapify init . --provider codex
+codex
+```
+
+After Codex starts, enable the installed hook manually:
+
+```text
+/hooks
+PreToolUse
+t
+Esc
+```
+
+This toggles the `PreToolUse` hook on so MAP's workflow gate can run before tool calls.
+
 ### MCP Server Configuration
 
 Choose which MCP servers to enable:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -181,6 +181,8 @@ codex --enable codex_hooks
 
 or upgrade Codex first. Upgrading is recommended.
 
+Codex MAP commands do not start with `/`. Type `map-plan`, `map-fast`, or `map-check` instead of `/map-plan`, `/map-fast`, or `/map-check`.
+
 ### MCP Server Configuration
 
 Choose which MCP servers to enable:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -131,7 +131,7 @@ Esc
 
 This toggles the `PreToolUse` hook on so MAP's workflow gate can run before tool calls.
 
-If you use Codex before `0.129.0`, either start Codex with the hooks feature enabled:
+If your Codex version does not support the `hooks` feature key yet, either start Codex with the deprecated hooks feature alias enabled:
 
 ```bash
 codex --enable codex_hooks
@@ -151,12 +151,12 @@ This creates a `.codex/` layout instead of `.claude/`:
 ### Using MAP with Codex
 
 ```bash
-map-plan    # Plan and decompose complex tasks
-map-fast    # Quick implementation with minimal validation
-map-check   # Quality gates and verification
+$map-plan    # Plan and decompose complex tasks
+$map-fast    # Quick implementation with minimal validation
+$map-check   # Quality gates and verification
 ```
 
-Codex MAP commands do not start with `/`. Type `map-plan`, not `/map-plan`.
+Codex MAP skills do not start with `/`. Type `$map-plan`, not `/map-plan`.
 
 ### Diagnostics
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -151,10 +151,12 @@ This creates a `.codex/` layout instead of `.claude/`:
 ### Using MAP with Codex
 
 ```bash
-$map-plan    # Plan and decompose complex tasks
-$map-fast    # Quick implementation with minimal validation
-$map-check   # Quality gates and verification
+map-plan    # Plan and decompose complex tasks
+map-fast    # Quick implementation with minimal validation
+map-check   # Quality gates and verification
 ```
+
+Codex MAP commands do not start with `/`. Type `map-plan`, not `/map-plan`.
 
 ### Diagnostics
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -131,6 +131,14 @@ Esc
 
 This toggles the `PreToolUse` hook on so MAP's workflow gate can run before tool calls.
 
+If you use Codex before `0.129.0`, either start Codex with the hooks feature enabled:
+
+```bash
+codex --enable codex_hooks
+```
+
+or upgrade Codex first. Upgrading is recommended.
+
 This creates a `.codex/` layout instead of `.claude/`:
 - `.codex/skills/map-plan/SKILL.md` — main planning skill
 - `.codex/skills/map-fast/SKILL.md` — quick implementation

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -120,6 +120,17 @@ MAP Framework supports OpenAI's Codex CLI as an alternative to Claude Code.
 mapify init . --provider codex
 ```
 
+After starting Codex, enable the installed hook manually:
+
+```text
+/hooks
+PreToolUse
+t
+Esc
+```
+
+This toggles the `PreToolUse` hook on so MAP's workflow gate can run before tool calls.
+
 This creates a `.codex/` layout instead of `.claude/`:
 - `.codex/skills/map-plan/SKILL.md` — main planning skill
 - `.codex/skills/map-fast/SKILL.md` — quick implementation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "truststore>=0.9.0",
 ]
 
 [project.scripts]

--- a/src/mapify_cli/templates/codex/AGENTS.md
+++ b/src/mapify_cli/templates/codex/AGENTS.md
@@ -28,7 +28,7 @@ configuration to take effect. Without trust, `.codex/` files are ignored.
 MAP uses a workflow gate hook that restricts file-modifying commands during
 research and review phases. This prevents accidental edits while exploring.
 
-**Note:** Hooks require `codex_hooks = true` in config.toml and are not
+**Note:** Hooks require `hooks = true` in config.toml and are not
 supported on Windows.
 
 ## Getting Started

--- a/src/mapify_cli/templates/codex/config.toml
+++ b/src/mapify_cli/templates/codex/config.toml
@@ -2,7 +2,7 @@
 
 [features]
 # Enable hooks for MAP workflow enforcement
-codex_hooks = true
+hooks = true
 
 [agents.decomposer]
 description = "Breaks complex goals into atomic, testable subtasks"

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -1181,6 +1181,11 @@ class TestCodexProvider:
         )
         # Either a real file with content or a symlink to CLAUDE.md
         assert agents_md.is_symlink() or len(content) > 0, "AGENTS.md must be non-empty"
+        if not agents_md.is_symlink():
+            assert "$map-plan" in content, "Codex AGENTS.md must document skill invocation with $"
+            assert "codex_hooks" not in content, (
+                "Codex AGENTS.md must not document deprecated codex_hooks"
+            )
 
     # ------------------------------------------------------------------ #
     # AC-5: config.toml, agents/*.toml, hooks/workflow-gate.py exist      #
@@ -1190,6 +1195,13 @@ class TestCodexProvider:
         """AC-5: config.toml and at least one agent TOML and the hook script must exist."""
         codex_dir = codex_project / ".codex"
         assert (codex_dir / "config.toml").exists(), ".codex/config.toml must exist"
+        config_text = (codex_dir / "config.toml").read_text(encoding="utf-8")
+        assert "hooks = true" in config_text, (
+            "Codex config must enable canonical hooks feature"
+        )
+        assert "codex_hooks" not in config_text, (
+            "Codex config must not use deprecated codex_hooks feature alias"
+        )
         toml_files = list((codex_dir / "agents").glob("*.toml"))
         assert (
             len(toml_files) > 0


### PR DESCRIPTION
1. Renamed deprecated codex_hooks to hooks
2. Covered codex-specific installation steps in documenation
3. Add missed python dependency
