### PR TITLE
Harden MAP harness context gates

### DIFF
--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -88,6 +88,8 @@ You are a technical documentation expert specialized in architecture reviews and
 3. Quote exact line numbers for inconsistencies
 4. Check CRD installation responsibility explicitly
 5. Handle Fetch errors gracefully (continue review, log error)
+6. Verify documentation claims against source files, tests, schemas, and configs before approving or rewriting; source beats transcripts, summaries, commit messages, and stale docs
+7. For any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` documentation verdict, cite `path:line`, quote the source, and include confidence; otherwise mark `needs_investigation`
 
 **TOOL FAILURE BEHAVIOR**:
 - If Fetch is unavailable, MUST NOT attempt to infer or simulate external content

--- a/.claude/agents/evaluator.md
+++ b/.claude/agents/evaluator.md
@@ -24,10 +24,13 @@ last_updated: 2026-04-28
 ├─────────────────────────────────────────────────────────────────────┤
 │  NEVER: Inflate scores | Skip dimensions | Accept < 5 security      │
 │         Ignore Monitor findings | Give "proceed" when issues exist  │
+│         Dismiss findings without source citation and confidence       │
 ├─────────────────────────────────────────────────────────────────────┤
 │  OUTPUT: Dimension scores → Overall score → Recommendation → Next   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
+
+Evidence-first dismissal gate: any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` judgment requires `path:line` source evidence, a quote, and confidence. If source evidence is missing, classify it as `needs_investigation`, not dismissed. Source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs.
 
 ---
 

--- a/.claude/agents/final-verifier.md
+++ b/.claude/agents/final-verifier.md
@@ -61,6 +61,8 @@ Read `.map/<branch>/task_plan_<branch>.md` to extract:
 - Review integration points between subtasks
 - Verify ALL validation_criteria are met
 - Verify completed work still matches the blueprint's subtask contract metadata: no unjustified large subtask expansion, no mixed-concern drift, and every coverage_map owner has evidence
+- Treat source files, tests, schemas, and configs as authoritative over transcripts, summaries, commit messages, and stale docs
+- Any dismissal verdict (`false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, `not_applicable`) requires `path:line` source evidence, a quote, and confidence; otherwise record `needs_investigation`
 
 #### Noise Handling Protocol (Flaky Test Re-runs)
 When tests fail on first run, apply the confirmation policy:

--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -33,6 +33,8 @@ You are a **validation agent**, NOT a code editor. Your role:
 
 **Your output**: JSON with `valid: true|false` and `issues[]` array
 
+**Evidence-first dismissal gate:** Any verdict that dismisses work or findings as `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` must include source evidence first: `path:line`, quoted code/test/config text, and confidence. If you cannot cite source evidence, return `needs_investigation` instead of dismissing. Source files, tests, schemas, and configs are authoritative; transcripts, summaries, commit messages, and stale docs are advisory only.
+
 ---
 
 <Monitor_Contract_Verification_v2_9>

--- a/.claude/agents/predictor.md
+++ b/.claude/agents/predictor.md
@@ -104,6 +104,8 @@ CONFLICT (Category B: -0.10):
 
 **Key Principle**: Right-size your analysis. A typo fix needs 30 seconds; a public API change needs 5 minutes.
 
+**Evidence-first dismissal gate**: Any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` impact verdict must cite `path:line` source evidence, quote the source, and include confidence. If you cannot verify from source files, tests, schemas, or configs, mark the item `needs_investigation`; do not trust transcripts, summaries, commit messages, or stale docs over source.
+
 </quick_start>
 
 <map_integration>

--- a/.claude/hooks/post-compact-context.py
+++ b/.claude/hooks/post-compact-context.py
@@ -19,6 +19,15 @@ from pathlib import Path
 
 PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
 MAP_DIR = PROJECT_DIR / ".map"
+REPRIME_LIMIT = 1200
+
+STEP_REQUIRED_ACTIONS = {
+    "1.55": "Approve plan before execution state is initialized.",
+    "1.56": "Choose execution mode before implementation.",
+    "2.2": "Run research-agent before Actor if context gathering is required.",
+    "2.3": "Implement only the current subtask, then run Monitor.",
+    "2.4": "Run Monitor and treat valid=false as a hard stop.",
+}
 
 
 def sanitize_branch_name(branch: str) -> str:
@@ -48,6 +57,149 @@ def get_branch_name() -> str:
     return "default"
 
 
+def truncate_text(text: str, limit: int) -> str:
+    """Return a single-line string bounded to *limit* characters."""
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: max(0, limit - 3)].rstrip() + "..."
+
+
+def state_string(state: dict, key: str, default: str = "") -> str:
+    value = state.get(key)
+    if isinstance(value, str):
+        return value.strip()
+    return default
+
+
+def load_json(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def constraint_label(item: object) -> str | None:
+    if isinstance(item, str):
+        return truncate_text(item, 90)
+    if not isinstance(item, dict):
+        return None
+    cid = item.get("id")
+    desc = item.get("description")
+    if isinstance(cid, str) and isinstance(desc, str):
+        return truncate_text(f"{cid}: {desc}", 90)
+    if isinstance(cid, str):
+        return truncate_text(cid, 90)
+    if isinstance(desc, str):
+        return truncate_text(desc, 90)
+    return None
+
+
+def extract_coverage_tags(criteria: list[object]) -> list[str]:
+    tags: list[str] = []
+    for criterion in criteria:
+        if not isinstance(criterion, str):
+            continue
+        for tag in re.findall(r"\[([A-Z]+-\d+)\]", criterion):
+            if tag not in tags:
+                tags.append(tag)
+    return tags
+
+
+def load_blueprint_reprime(branch_dir: Path, subtask_id: str) -> list[str]:
+    blueprint = load_json(branch_dir / "blueprint.json")
+    if not blueprint:
+        return []
+
+    parts: list[str] = []
+    hard_constraints = blueprint.get("hard_constraints")
+    if isinstance(hard_constraints, list):
+        labels = [label for item in hard_constraints if (label := constraint_label(item))]
+        if labels:
+            parts.append("Hard constraints: " + "; ".join(labels[:4]))
+
+    subtasks = blueprint.get("subtasks")
+    if isinstance(subtasks, list) and subtask_id:
+        for item in subtasks:
+            if not isinstance(item, dict) or item.get("id") != subtask_id:
+                continue
+            title = item.get("title")
+            if isinstance(title, str) and title.strip():
+                parts.append(f"Current subtask: {subtask_id} - {truncate_text(title, 120)}")
+            criteria = item.get("validation_criteria")
+            if isinstance(criteria, list):
+                tags = extract_coverage_tags(criteria)
+                if tags:
+                    parts.append("Acceptance tags: " + ", ".join(tags[:8]))
+            break
+
+    return parts
+
+
+def load_retry_reprime(branch_dir: Path, subtask_id: str) -> str | None:
+    retry = load_json(branch_dir / "retry_quarantine.json")
+    if not retry:
+        return None
+    quarantines = retry.get("quarantines")
+    if not isinstance(quarantines, list):
+        return None
+    matches = [
+        item
+        for item in quarantines
+        if isinstance(item, dict)
+        and (not subtask_id or item.get("subtask_id") == subtask_id)
+    ]
+    if not matches:
+        return None
+    latest = matches[-1]
+    summary = latest.get("monitor_rejection_summary")
+    if isinstance(summary, str) and summary.strip():
+        return "Last Monitor rejection: " + truncate_text(summary, 180)
+    return None
+
+
+def build_reprime(branch: str, branch_dir: Path) -> str | None:
+    state = load_json(branch_dir / "step_state.json")
+    if not state:
+        return None
+
+    workflow = state_string(state, "workflow") or state_string(state, "workflow_name")
+    phase = state_string(state, "current_step_phase") or state_string(
+        state, "current_state"
+    )
+    step_id = state_string(state, "current_step_id")
+    subtask_id = state_string(state, "current_subtask_id")
+
+    lines = ["MAP RE-PRIME after compaction:"]
+    state_bits = []
+    if workflow:
+        state_bits.append(f"workflow={workflow}")
+    if step_id:
+        state_bits.append(f"step={step_id}")
+    if phase:
+        state_bits.append(f"phase={phase}")
+    if subtask_id:
+        state_bits.append(f"subtask={subtask_id}")
+    if state_bits:
+        lines.append("State: " + ", ".join(state_bits))
+
+    required = STEP_REQUIRED_ACTIONS.get(step_id)
+    if required:
+        lines.append("Required next action: " + required)
+
+    lines.extend(load_blueprint_reprime(branch_dir, subtask_id))
+    retry_line = load_retry_reprime(branch_dir, subtask_id)
+    if retry_line:
+        lines.append(retry_line)
+
+    lines.append(
+        "Authority: source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs."
+    )
+    lines.append(f"Workflow state: .map/{branch}/step_state.json")
+    return truncate_text("\n".join(lines), REPRIME_LIMIT)
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)
@@ -58,6 +210,10 @@ def main() -> None:
     branch_dir = MAP_DIR / branch
 
     parts = []
+
+    reprime = build_reprime(branch, branch_dir)
+    if reprime:
+        parts.append(reprime)
 
     # Check for saved transcript pointer
     pointer = branch_dir / "last-transcript.txt"

--- a/.claude/hooks/workflow-context-injector.py
+++ b/.claude/hooks/workflow-context-injector.py
@@ -98,6 +98,7 @@ def get_branch_name() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            cwd=Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())),
             timeout=1,
         )
         if result.returncode == 0:

--- a/.claude/hooks/workflow-context-injector.py
+++ b/.claude/hooks/workflow-context-injector.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 # Keep in sync with map_step_runner.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
+REMINDER_LIMIT = 700
 
 # Bash commands that don't need workflow reminders
 READONLY_COMMANDS = {
@@ -272,6 +273,71 @@ def load_goal_and_title(branch: str, subtask_id: str) -> tuple[str, str]:
     return (goal, title)
 
 
+def _constraint_label(item: object) -> str | None:
+    """Return a compact display label for a hard constraint entry."""
+    if isinstance(item, str):
+        return _truncate_at_word(" ".join(item.split()), 70)
+    if not isinstance(item, dict):
+        return None
+    cid = item.get("id")
+    desc = item.get("description")
+    if isinstance(cid, str) and isinstance(desc, str):
+        return _truncate_at_word(f"{cid}: {' '.join(desc.split())}", 70)
+    if isinstance(cid, str):
+        return _truncate_at_word(cid, 70)
+    if isinstance(desc, str):
+        return _truncate_at_word(" ".join(desc.split()), 70)
+    return None
+
+
+def _extract_coverage_tags(criteria: list[object]) -> list[str]:
+    tags: list[str] = []
+    for criterion in criteria:
+        if not isinstance(criterion, str):
+            continue
+        for tag in re.findall(r"\[([A-Z]+-\d+)\]", criterion):
+            if tag not in tags:
+                tags.append(tag)
+    return tags
+
+
+def load_subtask_contract_hints(branch: str, subtask_id: str) -> tuple[str, str]:
+    """Load compact hard-constraint and validation tag hints for edit-time reminders."""
+    if not subtask_id or subtask_id == "-":
+        return ("", "")
+
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    blueprint_file = project_dir / ".map" / branch / "blueprint.json"
+    try:
+        bp = json.loads(blueprint_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return ("", "")
+    if not isinstance(bp, dict):
+        return ("", "")
+
+    hard_hint = ""
+    hard_constraints = bp.get("hard_constraints")
+    if isinstance(hard_constraints, list):
+        labels = [label for item in hard_constraints if (label := _constraint_label(item))]
+        if labels:
+            hard_hint = " | HC: " + "; ".join(labels[:3])
+
+    tag_hint = ""
+    subtasks = bp.get("subtasks")
+    if isinstance(subtasks, list):
+        for item in subtasks:
+            if not isinstance(item, dict) or item.get("id") != subtask_id:
+                continue
+            criteria = item.get("validation_criteria")
+            if isinstance(criteria, list):
+                tags = _extract_coverage_tags(criteria)
+                if tags:
+                    tag_hint = " | VC: " + ", ".join(tags[:6])
+            break
+
+    return (hard_hint, tag_hint)
+
+
 def _truncate_at_word(text: str, limit: int) -> str:
     """Truncate text at word boundary, appending '...' within limit."""
     if len(text) <= limit:
@@ -285,7 +351,7 @@ def _truncate_at_word(text: str, limit: int) -> str:
 
 
 def format_reminder(state: dict, branch: str) -> str | None:
-    """Format terse workflow reminder (aim: ≤500 chars)."""
+    """Format terse workflow reminder (aim: ≤700 chars)."""
     if not state:
         return None
 
@@ -353,20 +419,25 @@ def format_reminder(state: dict, branch: str) -> str | None:
             goal_hint = f" | Goal: {goal}"
         if title:
             title_hint = f" {title}"
+    hard_hint, tag_hint = load_subtask_contract_hints(branch, subtask_id)
 
-    base = f"[MAP] {step_id} {step_phase}{goal_hint} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}"
+    authority_hint = " | Source>summary"
+    base = f"[MAP] {step_id} {step_phase}{goal_hint} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}{hard_hint}{tag_hint}{authority_hint}"
 
-    # Enforce 500-char limit: trim goal first, then word-boundary truncate
-    if len(base) > 500:
+    # Enforce limit: trim goal first, then constraint detail, then word-boundary truncate.
+    if len(base) > REMINDER_LIMIT:
         goal_hint = ""
-        base = f"[MAP] {step_id} {step_phase} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}"
-    if len(base) > 500:
-        base = _truncate_at_word(base, 500)
+        base = f"[MAP] {step_id} {step_phase} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}{hard_hint}{tag_hint}{authority_hint}"
+    if len(base) > REMINDER_LIMIT:
+        hard_hint = ""
+        base = f"[MAP] {step_id} {step_phase} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}{tag_hint}{authority_hint}"
+    if len(base) > REMINDER_LIMIT:
+        base = _truncate_at_word(base, REMINDER_LIMIT)
 
     if required:
         result = f"{base} | REQUIRED: {required}"
-        if len(result) > 500:
-            result = _truncate_at_word(result, 500)
+        if len(result) > REMINDER_LIMIT:
+            result = _truncate_at_word(result, REMINDER_LIMIT)
         return result
     return base
 

--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Optional
 
 EDITING_TOOLS = {"Edit", "Write", "MultiEdit"}
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
 
 # Phases where Edit/Write is expected (Actor applies code)
 EDITING_PHASES = {"ACTOR", "APPLY", "TEST_WRITER"}
@@ -95,7 +96,7 @@ def is_exempt_path(file_path: str) -> bool:
     resolved = (
         candidate.resolve(strict=False)
         if candidate.is_absolute()
-        else (Path.cwd().resolve() / candidate).resolve(strict=False)
+        else (PROJECT_DIR / candidate).resolve(strict=False)
     )
 
     # Allow ~/.claude/projects/*/memory/
@@ -109,7 +110,7 @@ def is_exempt_path(file_path: str) -> bool:
 
     # Allow .map/ and .claude/rules/learned/ (MAP-generated artifacts)
     try:
-        rel = resolved.relative_to(Path.cwd().resolve())
+        rel = resolved.relative_to(PROJECT_DIR)
     except ValueError:
         return False
 
@@ -150,6 +151,7 @@ def get_branch_name() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            cwd=PROJECT_DIR,
             timeout=1,
         )
         if result.returncode == 0:
@@ -164,7 +166,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
     Returns (allowed, error_message).
     """
-    step_file = Path(f".map/{branch}/step_state.json")
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not step_file.exists():
         return True, None  # No step state → fail-open
 
@@ -200,7 +202,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
 def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
     """Check constraints from step_state.json. Returns error or None."""
-    state_file = Path(f".map/{branch}/step_state.json")
+    state_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not state_file.exists():
         return None
 
@@ -224,9 +226,14 @@ def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
         )
         scope_glob = None
     if scope_glob and target_paths:
-        repo_root = Path.cwd().resolve()
+        repo_root = PROJECT_DIR
         for tp in target_paths:
-            resolved = Path(tp).resolve()
+            candidate = Path(tp)
+            resolved = (
+                candidate.resolve(strict=False)
+                if candidate.is_absolute()
+                else (repo_root / candidate).resolve(strict=False)
+            )
             try:
                 rel = str(resolved.relative_to(repo_root))
             except ValueError:

--- a/.claude/skills/map-check/SKILL.md
+++ b/.claude/skills/map-check/SKILL.md
@@ -143,6 +143,10 @@ Read these artifacts from disk:
 - .map/<branch>/artifact_manifest.json
 - verification/test/check artifacts present in the manifest
 
+Source authority: source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs. If a plan or transcript claim disagrees with source, report drift and trust source.
+
+Dismissal verdict gate: any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` claim requires `path:line` source evidence, a quote, and confidence. Without source evidence, output `needs_investigation`.
+
 For each subtask, check:
 1. acceptance criteria met
 2. code changes align with the subtask description

--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -56,6 +56,10 @@ parallel_tool_policy: single_review_fanout
 
 Use [Evidence-First Output Examples](../../references/map-output-examples.md). Evidence first: reviewers populate quote/evidence arrays before verdict, risk, or score fields.
 
+Source authority: source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs. If review bundle prose disagrees with source, report drift and trust source.
+
+Dismissal verdict gate: `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, and `not_applicable` require `path:line` source evidence, a quote, and confidence. Without that evidence, reviewers must return `needs_investigation`, not a dismissal.
+
 Monitor:
 - evidence: array of {file_path, line_range, quote, relevance}; populate this before verdict fields.
 - `valid`: boolean.

--- a/.codex/hooks/workflow-gate.py
+++ b/.codex/hooks/workflow-gate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Optional
 
 EDITING_TOOLS = {"Edit", "Write", "MultiEdit"}
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
 
 # Phases where Edit/Write is expected (Actor applies code)
 EDITING_PHASES = {"ACTOR", "APPLY", "TEST_WRITER"}
@@ -95,7 +96,7 @@ def is_exempt_path(file_path: str) -> bool:
     resolved = (
         candidate.resolve(strict=False)
         if candidate.is_absolute()
-        else (Path.cwd().resolve() / candidate).resolve(strict=False)
+        else (PROJECT_DIR / candidate).resolve(strict=False)
     )
 
     # Allow ~/.claude/projects/*/memory/
@@ -109,7 +110,7 @@ def is_exempt_path(file_path: str) -> bool:
 
     # Allow .map/ and .claude/rules/learned/ (MAP-generated artifacts)
     try:
-        rel = resolved.relative_to(Path.cwd().resolve())
+        rel = resolved.relative_to(PROJECT_DIR)
     except ValueError:
         return False
 
@@ -150,6 +151,7 @@ def get_branch_name() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            cwd=PROJECT_DIR,
             timeout=1,
         )
         if result.returncode == 0:
@@ -164,7 +166,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
     Returns (allowed, error_message).
     """
-    step_file = Path(f".map/{branch}/step_state.json")
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not step_file.exists():
         return True, None  # No step state → fail-open
 
@@ -200,7 +202,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
 def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
     """Check constraints from step_state.json. Returns error or None."""
-    state_file = Path(f".map/{branch}/step_state.json")
+    state_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not state_file.exists():
         return None
 
@@ -224,9 +226,14 @@ def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
         )
         scope_glob = None
     if scope_glob and target_paths:
-        repo_root = Path.cwd().resolve()
+        repo_root = PROJECT_DIR
         for tp in target_paths:
-            resolved = Path(tp).resolve()
+            candidate = Path(tp)
+            resolved = (
+                candidate.resolve(strict=False)
+                if candidate.is_absolute()
+                else (repo_root / candidate).resolve(strict=False)
+            )
             try:
                 rel = str(resolved.relative_to(repo_root))
             except ValueError:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Validation:
 ## How to work in this repo
 
 - Prefer deterministic tooling over “manual review”: run `make check` (or `make lint` / `make test`) after changes.
+- When changing scripts, hooks, CLIs, or generated provider surfaces, test both negative/no-op paths and positive paths with realistic inputs. A hook returning `{}` proves only the silent path; also build minimal state/artifacts that should trigger its intended output or side effect.
 - When changing user-facing behavior, also update relevant docs:
   - `README.md` (quick-start)
   - `docs/USAGE.md` (workflows and CLI usage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ include = [
     "src/mapify_cli/templates/**/*",
     "README.md",
 ]
+exclude = [
+    "**/__pycache__/**",
+    "**/*.pyc",
+    "**/*.pyo",
+    "**/.DS_Store",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mapify_cli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 ssl = ["truststore>=0.9.0"]
 test = [
     "pytest>=7.0.0",
+    "pytest-asyncio>=0.26.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "pyyaml>=6.0.0",
@@ -26,6 +27,7 @@ test = [
 ]
 dev = [
     "pytest>=7.0.0",
+    "pytest-asyncio>=0.26.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "pyyaml>=6.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,10 @@
 [pytest]
+asyncio_default_fixture_loop_scope = function
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short --strict-markers
+addopts = -v --tb=short --strict-markers -m "not slow"
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # Test dependencies for MAP Framework CLI
 pytest>=7.0.0
+pytest-asyncio>=0.26.0
 pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 pytest-watch>=4.2.0

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -6,6 +6,13 @@ cd "$repo_root"
 
 templates_root="src/mapify_cli/templates"
 
+clean_generated_artifacts() {
+    local root="$1"
+    [[ -d "$root" ]] || return 0
+    find "$root" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+    find "$root" \( -name '*.pyc' -o -name '.DS_Store' \) -type f -delete 2>/dev/null || true
+}
+
 mkdir -p "$templates_root/agents" "$templates_root/commands" "$templates_root/hooks" "$templates_root/references"
 
 cp -a .claude/agents/*.md "$templates_root/agents/"
@@ -20,16 +27,19 @@ fi
 cp -a .claude/hooks/* "$templates_root/hooks/"
 cp -a .claude/references/* "$templates_root/references/"
 cp -a .claude/settings.json .claude/workflow-rules.json .claude/ralph-loop-config.json "$templates_root/"
+clean_generated_artifacts "$templates_root/hooks"
+clean_generated_artifacts "$templates_root/references"
 
 # Sync skills directory (preserving nested structure)
 if [[ -d .claude/skills ]]; then
     # Use rsync for recursive sync with nested directories
     if command -v rsync &> /dev/null; then
-        rsync -a --delete .claude/skills/ "$templates_root/skills/"
+        rsync -a --delete --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' .claude/skills/ "$templates_root/skills/"
     else
         # Fallback: copy recursively
         rm -rf "$templates_root/skills"
         cp -a .claude/skills "$templates_root/skills"
+        clean_generated_artifacts "$templates_root/skills"
     fi
 else
     # If source directory is removed, clean up templates directory
@@ -41,6 +51,7 @@ fi
 # Sync .map/scripts/ → templates/map/scripts/
 mkdir -p "$templates_root/map/scripts"
 cp -a .map/scripts/*.py "$templates_root/map/scripts/"
+clean_generated_artifacts "$templates_root/map"
 
 # Sync .codex/ → templates/codex/
 if [[ -d .codex ]]; then
@@ -48,11 +59,11 @@ if [[ -d .codex ]]; then
 
     # Skills (preserve nested structure)
     if command -v rsync &> /dev/null; then
-        rsync -a --delete --exclude '__pycache__' .codex/skills/ "$templates_root/codex/skills/"
+        rsync -a --delete --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store' .codex/skills/ "$templates_root/codex/skills/"
     else
         rm -rf "$templates_root/codex/skills"
         cp -a .codex/skills "$templates_root/codex/skills"
-        find "$templates_root/codex/skills" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+        clean_generated_artifacts "$templates_root/codex/skills"
     fi
 
     # Agents
@@ -67,10 +78,13 @@ if [[ -d .codex ]]; then
     # Hooks directory
     if [[ -d .codex/hooks ]]; then
         find .codex/hooks -maxdepth 1 -type f | xargs -I{} cp -a {} "$templates_root/codex/hooks/"
+        clean_generated_artifacts "$templates_root/codex/hooks"
     fi
 
     # AGENTS.md
     [[ -f .codex/AGENTS.md ]] && cp -a .codex/AGENTS.md "$templates_root/codex/"
 fi
+
+clean_generated_artifacts "$templates_root"
 
 echo "✅ Synced .claude/*, .codex/*, and .map/scripts/* → $templates_root/"

--- a/src/mapify_cli/delivery/codex_copier.py
+++ b/src/mapify_cli/delivery/codex_copier.py
@@ -26,10 +26,14 @@ def _copy_tree(
     """
     count = 0
     dst_dir.mkdir(parents=True, exist_ok=True)
+    ignored_names = {"__pycache__", ".DS_Store"}
+    ignored_suffixes = {".pyc", ".pyo"}
     for src_file in src_dir.rglob("*"):
         if not src_file.is_file():
             continue
-        if "__pycache__" in src_file.parts:
+        if any(part in ignored_names for part in src_file.parts):
+            continue
+        if src_file.suffix in ignored_suffixes:
             continue
         rel = src_file.relative_to(src_dir)
         target = dst_dir / rel

--- a/src/mapify_cli/delivery/file_copier.py
+++ b/src/mapify_cli/delivery/file_copier.py
@@ -22,6 +22,21 @@ from mapify_cli.delivery.agent_generator import (
 )
 
 
+_IGNORED_TEMPLATE_NAMES = {"__pycache__", ".DS_Store"}
+_IGNORED_TEMPLATE_SUFFIXES = {".pyc", ".pyo"}
+
+
+def _ignore_generated_template_artifacts(
+    _directory: str, names: list[str]
+) -> set[str]:
+    """Ignore Python/cache artifacts if a dirty template tree reaches install time."""
+    ignored: set[str] = set()
+    for name in names:
+        if name in _IGNORED_TEMPLATE_NAMES or Path(name).suffix in _IGNORED_TEMPLATE_SUFFIXES:
+            ignored.add(name)
+    return ignored
+
+
 def _get_version() -> str:
     """Get current mapify-cli version for metadata injection."""
     try:
@@ -181,7 +196,12 @@ def create_skill_files(project_path: Path) -> int:
         for skill_template in skills_template_dir.iterdir():
             if skill_template.is_dir() and skill_template.name != "__pycache__":
                 target = skills_dir / skill_template.name
-                shutil.copytree(skill_template, target, dirs_exist_ok=True)
+                shutil.copytree(
+                    skill_template,
+                    target,
+                    dirs_exist_ok=True,
+                    ignore=_ignore_generated_template_artifacts,
+                )
                 count += 1
 
     return count
@@ -201,7 +221,12 @@ def _copy_map_path(src: Path, dest: Path) -> int:
                 file=sys.stderr,
             )
     if src.is_dir():
-        shutil.copytree(src, dest, dirs_exist_ok=True)
+        shutil.copytree(
+            src,
+            dest,
+            dirs_exist_ok=True,
+            ignore=_ignore_generated_template_artifacts,
+        )
     else:
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dest)

--- a/src/mapify_cli/templates/CLAUDE.md
+++ b/src/mapify_cli/templates/CLAUDE.md
@@ -29,6 +29,7 @@ Verification:
 ## How to work in this repo
 
 - Prefer deterministic tooling over “manual review”: run `make check` (or `make lint` / `make test`) after changes.
+- When changing scripts, hooks, CLIs, or generated provider surfaces, test both negative/no-op paths and positive paths with realistic inputs. A hook returning `{}` proves only the silent path; also build minimal state/artifacts that should trigger its intended output or side effect.
 - When changing user-facing behavior, also update relevant docs:
   - `README.md` (quick-start)
   - `docs/USAGE.md` (workflows and CLI usage)

--- a/src/mapify_cli/templates/agents/documentation-reviewer.md
+++ b/src/mapify_cli/templates/agents/documentation-reviewer.md
@@ -88,6 +88,8 @@ You are a technical documentation expert specialized in architecture reviews and
 3. Quote exact line numbers for inconsistencies
 4. Check CRD installation responsibility explicitly
 5. Handle Fetch errors gracefully (continue review, log error)
+6. Verify documentation claims against source files, tests, schemas, and configs before approving or rewriting; source beats transcripts, summaries, commit messages, and stale docs
+7. For any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` documentation verdict, cite `path:line`, quote the source, and include confidence; otherwise mark `needs_investigation`
 
 **TOOL FAILURE BEHAVIOR**:
 - If Fetch is unavailable, MUST NOT attempt to infer or simulate external content

--- a/src/mapify_cli/templates/agents/evaluator.md
+++ b/src/mapify_cli/templates/agents/evaluator.md
@@ -24,10 +24,13 @@ last_updated: 2026-04-28
 ├─────────────────────────────────────────────────────────────────────┤
 │  NEVER: Inflate scores | Skip dimensions | Accept < 5 security      │
 │         Ignore Monitor findings | Give "proceed" when issues exist  │
+│         Dismiss findings without source citation and confidence       │
 ├─────────────────────────────────────────────────────────────────────┤
 │  OUTPUT: Dimension scores → Overall score → Recommendation → Next   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
+
+Evidence-first dismissal gate: any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` judgment requires `path:line` source evidence, a quote, and confidence. If source evidence is missing, classify it as `needs_investigation`, not dismissed. Source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs.
 
 ---
 

--- a/src/mapify_cli/templates/agents/final-verifier.md
+++ b/src/mapify_cli/templates/agents/final-verifier.md
@@ -61,6 +61,8 @@ Read `.map/<branch>/task_plan_<branch>.md` to extract:
 - Review integration points between subtasks
 - Verify ALL validation_criteria are met
 - Verify completed work still matches the blueprint's subtask contract metadata: no unjustified large subtask expansion, no mixed-concern drift, and every coverage_map owner has evidence
+- Treat source files, tests, schemas, and configs as authoritative over transcripts, summaries, commit messages, and stale docs
+- Any dismissal verdict (`false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, `not_applicable`) requires `path:line` source evidence, a quote, and confidence; otherwise record `needs_investigation`
 
 #### Noise Handling Protocol (Flaky Test Re-runs)
 When tests fail on first run, apply the confirmation policy:

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -33,6 +33,8 @@ You are a **validation agent**, NOT a code editor. Your role:
 
 **Your output**: JSON with `valid: true|false` and `issues[]` array
 
+**Evidence-first dismissal gate:** Any verdict that dismisses work or findings as `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` must include source evidence first: `path:line`, quoted code/test/config text, and confidence. If you cannot cite source evidence, return `needs_investigation` instead of dismissing. Source files, tests, schemas, and configs are authoritative; transcripts, summaries, commit messages, and stale docs are advisory only.
+
 ---
 
 <Monitor_Contract_Verification_v2_9>

--- a/src/mapify_cli/templates/agents/predictor.md
+++ b/src/mapify_cli/templates/agents/predictor.md
@@ -104,6 +104,8 @@ CONFLICT (Category B: -0.10):
 
 **Key Principle**: Right-size your analysis. A typo fix needs 30 seconds; a public API change needs 5 minutes.
 
+**Evidence-first dismissal gate**: Any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` impact verdict must cite `path:line` source evidence, quote the source, and include confidence. If you cannot verify from source files, tests, schemas, or configs, mark the item `needs_investigation`; do not trust transcripts, summaries, commit messages, or stale docs over source.
+
 </quick_start>
 
 <map_integration>

--- a/src/mapify_cli/templates/codex/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/codex/hooks/workflow-gate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Optional
 
 EDITING_TOOLS = {"Edit", "Write", "MultiEdit"}
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
 
 # Phases where Edit/Write is expected (Actor applies code)
 EDITING_PHASES = {"ACTOR", "APPLY", "TEST_WRITER"}
@@ -95,7 +96,7 @@ def is_exempt_path(file_path: str) -> bool:
     resolved = (
         candidate.resolve(strict=False)
         if candidate.is_absolute()
-        else (Path.cwd().resolve() / candidate).resolve(strict=False)
+        else (PROJECT_DIR / candidate).resolve(strict=False)
     )
 
     # Allow ~/.claude/projects/*/memory/
@@ -109,7 +110,7 @@ def is_exempt_path(file_path: str) -> bool:
 
     # Allow .map/ and .claude/rules/learned/ (MAP-generated artifacts)
     try:
-        rel = resolved.relative_to(Path.cwd().resolve())
+        rel = resolved.relative_to(PROJECT_DIR)
     except ValueError:
         return False
 
@@ -150,6 +151,7 @@ def get_branch_name() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            cwd=PROJECT_DIR,
             timeout=1,
         )
         if result.returncode == 0:
@@ -164,7 +166,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
     Returns (allowed, error_message).
     """
-    step_file = Path(f".map/{branch}/step_state.json")
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not step_file.exists():
         return True, None  # No step state → fail-open
 
@@ -200,7 +202,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
 def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
     """Check constraints from step_state.json. Returns error or None."""
-    state_file = Path(f".map/{branch}/step_state.json")
+    state_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not state_file.exists():
         return None
 
@@ -224,9 +226,14 @@ def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
         )
         scope_glob = None
     if scope_glob and target_paths:
-        repo_root = Path.cwd().resolve()
+        repo_root = PROJECT_DIR
         for tp in target_paths:
-            resolved = Path(tp).resolve()
+            candidate = Path(tp)
+            resolved = (
+                candidate.resolve(strict=False)
+                if candidate.is_absolute()
+                else (repo_root / candidate).resolve(strict=False)
+            )
             try:
                 rel = str(resolved.relative_to(repo_root))
             except ValueError:

--- a/src/mapify_cli/templates/hooks/post-compact-context.py
+++ b/src/mapify_cli/templates/hooks/post-compact-context.py
@@ -19,6 +19,15 @@ from pathlib import Path
 
 PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
 MAP_DIR = PROJECT_DIR / ".map"
+REPRIME_LIMIT = 1200
+
+STEP_REQUIRED_ACTIONS = {
+    "1.55": "Approve plan before execution state is initialized.",
+    "1.56": "Choose execution mode before implementation.",
+    "2.2": "Run research-agent before Actor if context gathering is required.",
+    "2.3": "Implement only the current subtask, then run Monitor.",
+    "2.4": "Run Monitor and treat valid=false as a hard stop.",
+}
 
 
 def sanitize_branch_name(branch: str) -> str:
@@ -48,6 +57,149 @@ def get_branch_name() -> str:
     return "default"
 
 
+def truncate_text(text: str, limit: int) -> str:
+    """Return a single-line string bounded to *limit* characters."""
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: max(0, limit - 3)].rstrip() + "..."
+
+
+def state_string(state: dict, key: str, default: str = "") -> str:
+    value = state.get(key)
+    if isinstance(value, str):
+        return value.strip()
+    return default
+
+
+def load_json(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def constraint_label(item: object) -> str | None:
+    if isinstance(item, str):
+        return truncate_text(item, 90)
+    if not isinstance(item, dict):
+        return None
+    cid = item.get("id")
+    desc = item.get("description")
+    if isinstance(cid, str) and isinstance(desc, str):
+        return truncate_text(f"{cid}: {desc}", 90)
+    if isinstance(cid, str):
+        return truncate_text(cid, 90)
+    if isinstance(desc, str):
+        return truncate_text(desc, 90)
+    return None
+
+
+def extract_coverage_tags(criteria: list[object]) -> list[str]:
+    tags: list[str] = []
+    for criterion in criteria:
+        if not isinstance(criterion, str):
+            continue
+        for tag in re.findall(r"\[([A-Z]+-\d+)\]", criterion):
+            if tag not in tags:
+                tags.append(tag)
+    return tags
+
+
+def load_blueprint_reprime(branch_dir: Path, subtask_id: str) -> list[str]:
+    blueprint = load_json(branch_dir / "blueprint.json")
+    if not blueprint:
+        return []
+
+    parts: list[str] = []
+    hard_constraints = blueprint.get("hard_constraints")
+    if isinstance(hard_constraints, list):
+        labels = [label for item in hard_constraints if (label := constraint_label(item))]
+        if labels:
+            parts.append("Hard constraints: " + "; ".join(labels[:4]))
+
+    subtasks = blueprint.get("subtasks")
+    if isinstance(subtasks, list) and subtask_id:
+        for item in subtasks:
+            if not isinstance(item, dict) or item.get("id") != subtask_id:
+                continue
+            title = item.get("title")
+            if isinstance(title, str) and title.strip():
+                parts.append(f"Current subtask: {subtask_id} - {truncate_text(title, 120)}")
+            criteria = item.get("validation_criteria")
+            if isinstance(criteria, list):
+                tags = extract_coverage_tags(criteria)
+                if tags:
+                    parts.append("Acceptance tags: " + ", ".join(tags[:8]))
+            break
+
+    return parts
+
+
+def load_retry_reprime(branch_dir: Path, subtask_id: str) -> str | None:
+    retry = load_json(branch_dir / "retry_quarantine.json")
+    if not retry:
+        return None
+    quarantines = retry.get("quarantines")
+    if not isinstance(quarantines, list):
+        return None
+    matches = [
+        item
+        for item in quarantines
+        if isinstance(item, dict)
+        and (not subtask_id or item.get("subtask_id") == subtask_id)
+    ]
+    if not matches:
+        return None
+    latest = matches[-1]
+    summary = latest.get("monitor_rejection_summary")
+    if isinstance(summary, str) and summary.strip():
+        return "Last Monitor rejection: " + truncate_text(summary, 180)
+    return None
+
+
+def build_reprime(branch: str, branch_dir: Path) -> str | None:
+    state = load_json(branch_dir / "step_state.json")
+    if not state:
+        return None
+
+    workflow = state_string(state, "workflow") or state_string(state, "workflow_name")
+    phase = state_string(state, "current_step_phase") or state_string(
+        state, "current_state"
+    )
+    step_id = state_string(state, "current_step_id")
+    subtask_id = state_string(state, "current_subtask_id")
+
+    lines = ["MAP RE-PRIME after compaction:"]
+    state_bits = []
+    if workflow:
+        state_bits.append(f"workflow={workflow}")
+    if step_id:
+        state_bits.append(f"step={step_id}")
+    if phase:
+        state_bits.append(f"phase={phase}")
+    if subtask_id:
+        state_bits.append(f"subtask={subtask_id}")
+    if state_bits:
+        lines.append("State: " + ", ".join(state_bits))
+
+    required = STEP_REQUIRED_ACTIONS.get(step_id)
+    if required:
+        lines.append("Required next action: " + required)
+
+    lines.extend(load_blueprint_reprime(branch_dir, subtask_id))
+    retry_line = load_retry_reprime(branch_dir, subtask_id)
+    if retry_line:
+        lines.append(retry_line)
+
+    lines.append(
+        "Authority: source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs."
+    )
+    lines.append(f"Workflow state: .map/{branch}/step_state.json")
+    return truncate_text("\n".join(lines), REPRIME_LIMIT)
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)
@@ -58,6 +210,10 @@ def main() -> None:
     branch_dir = MAP_DIR / branch
 
     parts = []
+
+    reprime = build_reprime(branch, branch_dir)
+    if reprime:
+        parts.append(reprime)
 
     # Check for saved transcript pointer
     pointer = branch_dir / "last-transcript.txt"

--- a/src/mapify_cli/templates/hooks/workflow-context-injector.py
+++ b/src/mapify_cli/templates/hooks/workflow-context-injector.py
@@ -98,6 +98,7 @@ def get_branch_name() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            cwd=Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())),
             timeout=1,
         )
         if result.returncode == 0:

--- a/src/mapify_cli/templates/hooks/workflow-context-injector.py
+++ b/src/mapify_cli/templates/hooks/workflow-context-injector.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 # Keep in sync with map_step_runner.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
+REMINDER_LIMIT = 700
 
 # Bash commands that don't need workflow reminders
 READONLY_COMMANDS = {
@@ -272,6 +273,71 @@ def load_goal_and_title(branch: str, subtask_id: str) -> tuple[str, str]:
     return (goal, title)
 
 
+def _constraint_label(item: object) -> str | None:
+    """Return a compact display label for a hard constraint entry."""
+    if isinstance(item, str):
+        return _truncate_at_word(" ".join(item.split()), 70)
+    if not isinstance(item, dict):
+        return None
+    cid = item.get("id")
+    desc = item.get("description")
+    if isinstance(cid, str) and isinstance(desc, str):
+        return _truncate_at_word(f"{cid}: {' '.join(desc.split())}", 70)
+    if isinstance(cid, str):
+        return _truncate_at_word(cid, 70)
+    if isinstance(desc, str):
+        return _truncate_at_word(" ".join(desc.split()), 70)
+    return None
+
+
+def _extract_coverage_tags(criteria: list[object]) -> list[str]:
+    tags: list[str] = []
+    for criterion in criteria:
+        if not isinstance(criterion, str):
+            continue
+        for tag in re.findall(r"\[([A-Z]+-\d+)\]", criterion):
+            if tag not in tags:
+                tags.append(tag)
+    return tags
+
+
+def load_subtask_contract_hints(branch: str, subtask_id: str) -> tuple[str, str]:
+    """Load compact hard-constraint and validation tag hints for edit-time reminders."""
+    if not subtask_id or subtask_id == "-":
+        return ("", "")
+
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    blueprint_file = project_dir / ".map" / branch / "blueprint.json"
+    try:
+        bp = json.loads(blueprint_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return ("", "")
+    if not isinstance(bp, dict):
+        return ("", "")
+
+    hard_hint = ""
+    hard_constraints = bp.get("hard_constraints")
+    if isinstance(hard_constraints, list):
+        labels = [label for item in hard_constraints if (label := _constraint_label(item))]
+        if labels:
+            hard_hint = " | HC: " + "; ".join(labels[:3])
+
+    tag_hint = ""
+    subtasks = bp.get("subtasks")
+    if isinstance(subtasks, list):
+        for item in subtasks:
+            if not isinstance(item, dict) or item.get("id") != subtask_id:
+                continue
+            criteria = item.get("validation_criteria")
+            if isinstance(criteria, list):
+                tags = _extract_coverage_tags(criteria)
+                if tags:
+                    tag_hint = " | VC: " + ", ".join(tags[:6])
+            break
+
+    return (hard_hint, tag_hint)
+
+
 def _truncate_at_word(text: str, limit: int) -> str:
     """Truncate text at word boundary, appending '...' within limit."""
     if len(text) <= limit:
@@ -285,7 +351,7 @@ def _truncate_at_word(text: str, limit: int) -> str:
 
 
 def format_reminder(state: dict, branch: str) -> str | None:
-    """Format terse workflow reminder (aim: ≤500 chars)."""
+    """Format terse workflow reminder (aim: ≤700 chars)."""
     if not state:
         return None
 
@@ -353,20 +419,25 @@ def format_reminder(state: dict, branch: str) -> str | None:
             goal_hint = f" | Goal: {goal}"
         if title:
             title_hint = f" {title}"
+    hard_hint, tag_hint = load_subtask_contract_hints(branch, subtask_id)
 
-    base = f"[MAP] {step_id} {step_phase}{goal_hint} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}"
+    authority_hint = " | Source>summary"
+    base = f"[MAP] {step_id} {step_phase}{goal_hint} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}{hard_hint}{tag_hint}{authority_hint}"
 
-    # Enforce 500-char limit: trim goal first, then word-boundary truncate
-    if len(base) > 500:
+    # Enforce limit: trim goal first, then constraint detail, then word-boundary truncate.
+    if len(base) > REMINDER_LIMIT:
         goal_hint = ""
-        base = f"[MAP] {step_id} {step_phase} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}"
-    if len(base) > 500:
-        base = _truncate_at_word(base, 500)
+        base = f"[MAP] {step_id} {step_phase} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}{hard_hint}{tag_hint}{authority_hint}"
+    if len(base) > REMINDER_LIMIT:
+        hard_hint = ""
+        base = f"[MAP] {step_id} {step_phase} | ST: {subtask_id}{title_hint} ({progress}) | plan:{plan_ok} mode:{mode}{wave_hint}{diag_hint}{files_hint}{tag_hint}{authority_hint}"
+    if len(base) > REMINDER_LIMIT:
+        base = _truncate_at_word(base, REMINDER_LIMIT)
 
     if required:
         result = f"{base} | REQUIRED: {required}"
-        if len(result) > 500:
-            result = _truncate_at_word(result, 500)
+        if len(result) > REMINDER_LIMIT:
+            result = _truncate_at_word(result, REMINDER_LIMIT)
         return result
     return base
 

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Optional
 
 EDITING_TOOLS = {"Edit", "Write", "MultiEdit"}
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
 
 # Phases where Edit/Write is expected (Actor applies code)
 EDITING_PHASES = {"ACTOR", "APPLY", "TEST_WRITER"}
@@ -95,7 +96,7 @@ def is_exempt_path(file_path: str) -> bool:
     resolved = (
         candidate.resolve(strict=False)
         if candidate.is_absolute()
-        else (Path.cwd().resolve() / candidate).resolve(strict=False)
+        else (PROJECT_DIR / candidate).resolve(strict=False)
     )
 
     # Allow ~/.claude/projects/*/memory/
@@ -109,7 +110,7 @@ def is_exempt_path(file_path: str) -> bool:
 
     # Allow .map/ and .claude/rules/learned/ (MAP-generated artifacts)
     try:
-        rel = resolved.relative_to(Path.cwd().resolve())
+        rel = resolved.relative_to(PROJECT_DIR)
     except ValueError:
         return False
 
@@ -150,6 +151,7 @@ def get_branch_name() -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
+            cwd=PROJECT_DIR,
             timeout=1,
         )
         if result.returncode == 0:
@@ -164,7 +166,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
     Returns (allowed, error_message).
     """
-    step_file = Path(f".map/{branch}/step_state.json")
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not step_file.exists():
         return True, None  # No step state → fail-open
 
@@ -200,7 +202,7 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
 
 def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
     """Check constraints from step_state.json. Returns error or None."""
-    state_file = Path(f".map/{branch}/step_state.json")
+    state_file = PROJECT_DIR / ".map" / branch / "step_state.json"
     if not state_file.exists():
         return None
 
@@ -224,9 +226,14 @@ def check_constraints(branch: str, target_paths: list[str]) -> Optional[str]:
         )
         scope_glob = None
     if scope_glob and target_paths:
-        repo_root = Path.cwd().resolve()
+        repo_root = PROJECT_DIR
         for tp in target_paths:
-            resolved = Path(tp).resolve()
+            candidate = Path(tp)
+            resolved = (
+                candidate.resolve(strict=False)
+                if candidate.is_absolute()
+                else (repo_root / candidate).resolve(strict=False)
+            )
             try:
                 rel = str(resolved.relative_to(repo_root))
             except ValueError:

--- a/src/mapify_cli/templates/skills/map-check/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-check/SKILL.md
@@ -143,6 +143,10 @@ Read these artifacts from disk:
 - .map/<branch>/artifact_manifest.json
 - verification/test/check artifacts present in the manifest
 
+Source authority: source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs. If a plan or transcript claim disagrees with source, report drift and trust source.
+
+Dismissal verdict gate: any `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, or `not_applicable` claim requires `path:line` source evidence, a quote, and confidence. Without source evidence, output `needs_investigation`.
+
 For each subtask, check:
 1. acceptance criteria met
 2. code changes align with the subtask description

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -56,6 +56,10 @@ parallel_tool_policy: single_review_fanout
 
 Use [Evidence-First Output Examples](../../references/map-output-examples.md). Evidence first: reviewers populate quote/evidence arrays before verdict, risk, or score fields.
 
+Source authority: source files, tests, schemas, and configs beat transcripts, summaries, commit messages, and stale docs. If review bundle prose disagrees with source, report drift and trust source.
+
+Dismissal verdict gate: `false_positive`, `covered`, `out_of_scope`, `pre_existing`, `no_tests_needed`, `safe_to_skip`, and `not_applicable` require `path:line` source evidence, a quote, and confidence. Without that evidence, reviewers must return `needs_investigation`, not a dismissal.
+
 Monitor:
 - evidence: array of {file_path, line_range, quote, relevance}; populate this before verdict fields.
 - `valid`: boolean.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 """Shared pytest fixtures for all test files."""
 
 import os
+import sys
 
 import pytest
+
+
+sys.dont_write_bytecode = True
+os.environ.setdefault("PYTHONDONTWRITEBYTECODE", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/hooks/test_hook_inventory_smoke.py
+++ b/tests/hooks/test_hook_inventory_smoke.py
@@ -1,0 +1,324 @@
+"""Smoke every configured Claude hook on both silent and active paths.
+
+This is intentionally broader than the focused unit tests. It prevents a new
+hook from being wired into `.claude/settings.json` without a realistic smoke
+scenario that proves more than the silent `{}` path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parents[2]
+HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+
+
+@dataclass(frozen=True)
+class HookRun:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class HookCase:
+    name: str
+    payload: dict[str, object]
+    assert_result: Callable[[HookRun, Path], None]
+    cwd_factory: Callable[[Path], Path] | None = None
+    env_extra: dict[str, str] | None = None
+
+
+def _configured_hook_names() -> set[str]:
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
+    names: set[str] = set()
+    for event_entries in settings.get("hooks", {}).values():
+        for entry in event_entries:
+            for hook in entry.get("hooks", []):
+                command = hook.get("command", "")
+                if not isinstance(command, str):
+                    continue
+                for part in command.replace('"', "").split():
+                    if ".claude/hooks/" in part:
+                        names.add(Path(part).name)
+    return names
+
+
+def _run_hook(
+    hook_name: str,
+    payload: dict[str, object],
+    project: Path,
+    *,
+    cwd: Path | None = None,
+    env_extra: dict[str, str] | None = None,
+) -> HookRun:
+    hook_path = HOOKS_DIR / hook_name
+    command = ["bash", str(hook_path)] if hook_path.suffix == ".sh" else [sys.executable, str(hook_path)]
+    env = os.environ.copy()
+    env.update(
+        {
+            "CLAUDE_PROJECT_DIR": str(project),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        command,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        cwd=cwd or REPO_ROOT,
+        env=env,
+        check=False,
+        timeout=20,
+    )
+    return HookRun(proc.returncode, proc.stdout.strip(), proc.stderr.strip())
+
+
+def _json(stdout: str) -> dict[str, object]:
+    return json.loads(stdout or "{}")
+
+
+def _assert_noop(run: HookRun, _project: Path) -> None:
+    assert run.returncode == 0
+    assert run.stdout == "{}" or run.stdout == ""
+
+
+def _assert_deny(run: HookRun, _project: Path) -> None:
+    assert run.returncode == 0
+    payload = _json(run.stdout)
+    output = payload.get("hookSpecificOutput", {})
+    assert isinstance(output, dict)
+    assert output.get("permissionDecision") == "deny"
+
+
+def _assert_contains(*needles: str) -> Callable[[HookRun, Path], None]:
+    def _inner(run: HookRun, _project: Path) -> None:
+        assert run.returncode == 0
+        for needle in needles:
+            assert needle in run.stdout
+
+    return _inner
+
+
+def _assert_iteration_logged(run: HookRun, project: Path) -> None:
+    assert run.returncode == 0
+    assert run.stdout == "{}"
+    assert (project / ".map" / "default" / "iteration_log.jsonl").is_file()
+
+
+def _assert_restore_point(run: HookRun, project: Path) -> None:
+    assert run.returncode == 0
+    assert run.stdout == "{}"
+    assert (project / ".map" / "default" / "restore_point.json").is_file()
+
+
+def _assert_transcript_saved(run: HookRun, project: Path) -> None:
+    assert run.returncode == 0
+    assert run.stdout == "{}"
+    assert (project / ".map" / "default" / "last-transcript.txt").is_file()
+
+
+def _assert_end_turn_blocks_syntax(run: HookRun, _project: Path) -> None:
+    assert run.returncode == 2
+    assert "Python syntax error" in run.stderr
+
+
+def _make_dirty_git_repo(root: Path) -> Path:
+    worktree = root / "dirty-git"
+    worktree.mkdir()
+    subprocess.run(["git", "init"], cwd=worktree, capture_output=True, text=True, check=True)
+    (worktree / "bad.py").write_text("def broken(:\n", encoding="utf-8")
+    return worktree
+
+
+@pytest.fixture
+def hook_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    branch = project / ".map" / "default"
+    branch.mkdir(parents=True)
+    (project / ".claude").mkdir()
+    (project / ".claude" / "ralph-loop-config.json").write_text(
+        json.dumps(
+            {
+                "ralph_loop": {
+                    "thrashing_detection": {
+                        "window_size": 2,
+                        "same_file_repeat_threshold": 2,
+                        "effectiveness_threshold": 0.5,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / ".map" / "config.yaml").write_text(
+        "compression_policy: aggressive\n"
+        "compression_threshold_tokens: 1\n"
+        "compression_focus: preserve MAP workflow state\n",
+        encoding="utf-8",
+    )
+    (branch / "step_state.json").write_text(
+        json.dumps(
+            {
+                "workflow": "map-efficient",
+                "current_step_id": "2.3",
+                "current_step_phase": "ACTOR",
+                "current_subtask_id": "ST-001",
+                "subtask_index": 0,
+                "subtask_sequence": ["ST-001"],
+                "plan_approved": True,
+                "execution_mode": "batch",
+                "constraints": {"scope_glob": "src/*"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (branch / "blueprint.json").write_text(
+        json.dumps(
+            {
+                "hard_constraints": [
+                    {"id": "HC-1", "description": "Preserve retry behavior"}
+                ],
+                "subtasks": [
+                    {
+                        "id": "ST-001",
+                        "title": "Implement retry handling",
+                        "validation_criteria": ["VC1 [AC-1]: retry works"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (branch / "retry_quarantine.json").write_text(
+        json.dumps(
+            {
+                "quarantines": [
+                    {
+                        "subtask_id": "ST-001",
+                        "monitor_rejection_summary": "Actor forgot retry path.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (branch / "iteration_log.jsonl").write_text(
+        json.dumps({"tool": "Edit", "file": "src/retry.py", "effectiveness": 1.0})
+        + "\n",
+        encoding="utf-8",
+    )
+    (project / "transcript.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "usage": {"input_tokens": 1000, "output_tokens": 1000},
+                    "content": [{"type": "text", "text": "working"}],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+HOOK_CASES: dict[str, list[HookCase]] = {
+    "safety-guardrails.py": [
+        HookCase("deny-env", {"tool_name": "Edit", "tool_input": {"file_path": ".env"}}, _assert_deny),
+        HookCase("allow-src", {"tool_name": "Edit", "tool_input": {"file_path": "src/app.py"}}, _assert_noop),
+    ],
+    "workflow-gate.py": [
+        HookCase("allow-in-scope", {"tool_name": "Edit", "tool_input": {"file_path": "src/app.py"}}, _assert_noop),
+        HookCase("deny-out-of-scope", {"tool_name": "Edit", "tool_input": {"file_path": "docs/readme.md"}}, _assert_contains("scope_glob")),
+    ],
+    "workflow-context-injector.py": [
+        HookCase("inject-edit", {"tool_name": "Edit", "tool_input": {"file_path": "src/app.py"}}, _assert_contains("HC-1", "AC-1")),
+        HookCase("skip-readonly-bash", {"tool_name": "Bash", "tool_input": {"command": "ls"}}, _assert_noop),
+    ],
+    "ralph-iteration-logger.py": [
+        HookCase("log-edit", {"session_id": "s1", "tool_name": "Edit", "tool_input": {"file_path": "src/retry.py"}, "tool_response": {"success": True}}, _assert_iteration_logged),
+    ],
+    "ralph-context-pruner.py": [
+        HookCase("save-restore", {}, _assert_restore_point),
+    ],
+    "pre-compact-save-transcript.py": [
+        HookCase("save-transcript", {"transcript_path": "__PROJECT__/transcript.jsonl", "session_id": "s1"}, _assert_transcript_saved),
+        HookCase("missing-transcript", {"transcript_path": "__PROJECT__/missing.jsonl", "session_id": "s1"}, _assert_noop),
+    ],
+    "post-compact-context.py": [
+        HookCase("reprime", {}, _assert_contains("MAP RE-PRIME", "HC-1", "AC-1")),
+    ],
+    "detect-clarification-triggers.py": [
+        HookCase("inject", {"prompt": "Сделай webhook и уточняй если что-то непонятно"}, _assert_contains("additionalContext")),
+        HookCase("skip", {"prompt": "Fix typo"}, _assert_noop),
+    ],
+    "context-meter.py": [
+        HookCase("compact-nudge", {"transcript_path": "__PROJECT__/transcript.jsonl"}, _assert_contains("/compact"), env_extra={"PYTHONPATH": str(REPO_ROOT / "src")}),
+        HookCase("skip-missing-transcript", {"transcript_path": ""}, _assert_noop, env_extra={"PYTHONPATH": str(REPO_ROOT / "src")}),
+    ],
+    "end-of-turn.sh": [
+        HookCase("non-git-noop", {}, _assert_noop, cwd_factory=lambda project: project),
+        HookCase("syntax-block", {}, _assert_end_turn_blocks_syntax, cwd_factory=_make_dirty_git_repo),
+    ],
+}
+
+
+def _resolve_project_tokens(value: object, project: Path) -> object:
+    if isinstance(value, str):
+        return value.replace("__PROJECT__", str(project))
+    if isinstance(value, dict):
+        return {key: _resolve_project_tokens(val, project) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_resolve_project_tokens(item, project) for item in value]
+    return value
+
+
+def test_every_configured_hook_has_smoke_cases() -> None:
+    configured = _configured_hook_names()
+
+    assert configured == set(HOOK_CASES), (
+        "Every hook wired in .claude/settings.json needs explicit positive/no-op "
+        f"smoke cases. missing={sorted(configured - set(HOOK_CASES))} "
+        f"extra={sorted(set(HOOK_CASES) - configured)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("hook_name", "case"),
+    [
+        (hook_name, case)
+        for hook_name, cases in sorted(HOOK_CASES.items())
+        for case in cases
+    ],
+    ids=lambda value: value.name if isinstance(value, HookCase) else value,
+)
+def test_configured_hook_smoke_case(
+    hook_project: Path, hook_name: str, case: HookCase
+) -> None:
+    payload = _resolve_project_tokens(case.payload, hook_project)
+    assert isinstance(payload, dict)
+    cwd = case.cwd_factory(hook_project) if case.cwd_factory else None
+
+    run = _run_hook(
+        hook_name,
+        payload,
+        hook_project,
+        cwd=cwd,
+        env_extra=case.env_extra,
+    )
+
+    case.assert_result(run, hook_project)

--- a/tests/test_post_compact_context.py
+++ b/tests/test_post_compact_context.py
@@ -1,0 +1,93 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run_hook(tmp_project_dir: Path, stdin_payload: dict) -> tuple[int, str, str]:
+    hook_path = Path(".claude/hooks/post-compact-context.py")
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_project_dir)
+    proc = subprocess.run(
+        ["python3", str(hook_path)],
+        input=json.dumps(stdin_payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def test_post_compact_reprime_includes_state_constraints_and_authority(
+    tmp_path: Path,
+) -> None:
+    # post-compact-context.py resolves branches relative to CLAUDE_PROJECT_DIR;
+    # a temp project without git metadata intentionally falls back to default.
+    branch = "default"
+    branch_dir = tmp_path / ".map" / branch
+    branch_dir.mkdir(parents=True, exist_ok=True)
+    (branch_dir / "step_state.json").write_text(
+        json.dumps(
+            {
+                "workflow": "map-efficient",
+                "current_step_id": "2.3",
+                "current_step_phase": "ACTOR",
+                "current_subtask_id": "ST-001",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (branch_dir / "blueprint.json").write_text(
+        json.dumps(
+            {
+                "hard_constraints": [
+                    {"id": "HC-1", "description": "Preserve retry behavior"}
+                ],
+                "subtasks": [
+                    {
+                        "id": "ST-001",
+                        "title": "Implement retry handling",
+                        "validation_criteria": ["VC1 [AC-1]: retryable timeout"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (branch_dir / "retry_quarantine.json").write_text(
+        json.dumps(
+            {
+                "quarantines": [
+                    {
+                        "subtask_id": "ST-001",
+                        "monitor_rejection_summary": "Forgot the retryable timeout path.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code, out, err = _run_hook(tmp_path, {})
+
+    assert code == 0
+    assert err == ""
+    payload = json.loads(out)
+    additional = payload["hookSpecificOutput"]["additionalContext"]
+    assert "MAP RE-PRIME" in additional
+    assert "workflow=map-efficient" in additional
+    assert "phase=ACTOR" in additional
+    assert "Required next action" in additional
+    assert "HC-1" in additional
+    assert "AC-1" in additional
+    assert "Last Monitor rejection" in additional
+    assert "source files, tests, schemas, and configs beat" in additional
+
+
+def test_post_compact_reprime_remains_silent_without_artifacts(tmp_path: Path) -> None:
+    code, out, err = _run_hook(tmp_path, {})
+
+    assert code == 0
+    assert err == ""
+    assert out == "{}"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1193,6 +1193,66 @@ class TestRunHealthCloseoutWiring:
         )
 
 
+class TestEvidenceFirstVerdictContracts:
+    """Regression tests for source-backed dismissal verdict requirements."""
+
+    @pytest.fixture
+    def project_root(self):
+        return Path(__file__).parent.parent
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            Path(".claude/agents/monitor.md"),
+            Path(".claude/agents/evaluator.md"),
+            Path(".claude/agents/predictor.md"),
+            Path(".claude/agents/documentation-reviewer.md"),
+            Path(".claude/agents/final-verifier.md"),
+            Path(".claude/skills/map-review/SKILL.md"),
+            Path(".claude/skills/map-check/SKILL.md"),
+        ],
+    )
+    def test_verdict_dismissals_require_source_evidence(
+        self, project_root, relative_path
+    ):
+        content = (project_root / relative_path).read_text(encoding="utf-8")
+
+        for term in (
+            "false_positive",
+            "covered",
+            "out_of_scope",
+            "pre_existing",
+            "no_tests_needed",
+            "safe_to_skip",
+            "not_applicable",
+        ):
+            assert term in content
+        assert "path:line" in content
+        assert "confidence" in content
+        assert "needs_investigation" in content
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            Path(".claude/agents/monitor.md"),
+            Path(".claude/agents/evaluator.md"),
+            Path(".claude/agents/predictor.md"),
+            Path(".claude/agents/documentation-reviewer.md"),
+            Path(".claude/agents/final-verifier.md"),
+            Path(".claude/skills/map-review/SKILL.md"),
+            Path(".claude/skills/map-check/SKILL.md"),
+        ],
+    )
+    def test_source_artifacts_are_authoritative(self, project_root, relative_path):
+        content = (project_root / relative_path).read_text(encoding="utf-8").lower()
+
+        assert "source" in content
+        assert "tests" in content
+        assert "configs" in content
+        assert "transcripts" in content
+        assert "summaries" in content
+
+
 class TestEvidenceFirstPromptContracts:
     """Regression tests for evidence-grounded agent outputs.
 

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -14,7 +14,6 @@ See .claude/CLAUDE.md for the template synchronization process.
 
 import filecmp
 import json
-import subprocess
 import pytest
 from pathlib import Path
 
@@ -61,19 +60,12 @@ class TestTemplateArtifactHygiene:
     def test_shipped_templates_do_not_contain_generated_artifacts(
         self, templates_root
     ):
-        project_root = templates_root.parents[2]
-        result = subprocess.run(
-            ["git", "ls-files", "src/mapify_cli/templates"],
-            cwd=project_root,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=5,
-        )
         offenders = [
-            Path(path).relative_to("src/mapify_cli/templates")
-            for path in result.stdout.splitlines()
-            if _is_disallowed_template_artifact(Path(path))
+            relative_path
+            for path in templates_root.rglob("*")
+            if _is_disallowed_template_artifact(
+                relative_path := path.relative_to(templates_root)
+            )
         ]
 
         assert not offenders, (

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -14,8 +14,73 @@ See .claude/CLAUDE.md for the template synchronization process.
 
 import filecmp
 import json
+import subprocess
 import pytest
 from pathlib import Path
+
+
+DISALLOWED_TEMPLATE_DIR_NAMES = {
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+}
+DISALLOWED_TEMPLATE_FILE_NAMES = {
+    ".DS_Store",
+    "agent_metrics.jsonl",
+    "playbook.db",
+    "session.log",
+    "current_context.txt",
+}
+DISALLOWED_TEMPLATE_SUFFIXES = {
+    ".pyc",
+    ".pyo",
+    ".log",
+    ".db",
+    ".sqlite",
+    ".sqlite3",
+    ".pkl",
+}
+
+
+def _is_disallowed_template_artifact(path: Path) -> bool:
+    if any(part in DISALLOWED_TEMPLATE_DIR_NAMES for part in path.parts):
+        return True
+    if path.name in DISALLOWED_TEMPLATE_FILE_NAMES:
+        return True
+    return path.suffix in DISALLOWED_TEMPLATE_SUFFIXES
+
+
+class TestTemplateArtifactHygiene:
+    """Generated/cache artifacts must never ship through mapify templates."""
+
+    @pytest.fixture
+    def templates_root(self):
+        return Path(__file__).parent.parent / "src" / "mapify_cli" / "templates"
+
+    def test_shipped_templates_do_not_contain_generated_artifacts(
+        self, templates_root
+    ):
+        project_root = templates_root.parents[2]
+        result = subprocess.run(
+            ["git", "ls-files", "src/mapify_cli/templates"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        offenders = [
+            Path(path).relative_to("src/mapify_cli/templates")
+            for path in result.stdout.splitlines()
+            if _is_disallowed_template_artifact(Path(path))
+        ]
+
+        assert not offenders, (
+            "Generated/cache artifacts tracked in shipped templates: "
+            + ", ".join(str(path) for path in sorted(offenders))
+            + ". Run make sync-templates after cleaning template inputs."
+        )
 
 
 class TestTemplateSynchronization:

--- a/tests/test_workflow_context_injector.py
+++ b/tests/test_workflow_context_injector.py
@@ -45,17 +45,7 @@ def hook_mod():
 
 @pytest.fixture(scope="session")
 def branch_name():
-    return (
-        subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=2,
-        )
-        .stdout.strip()
-        .replace("/", "-")
-    )
+    return "default"
 
 
 def test_injects_for_edit_when_step_state_exists(
@@ -98,6 +88,58 @@ def test_injects_for_edit_when_step_state_exists(
     assert state["hook_injection"]["tool_name"] == "Edit"
     assert state["hook_injection"]["additional_context_chars"] == len(additional)
     assert state["hook_injection_counts"]["injected"] == 1
+
+
+def test_uses_claude_project_dir_for_branch_detection(tmp_path: Path) -> None:
+    """A non-git CLAUDE_PROJECT_DIR should use default, not the caller cwd branch."""
+    branch = "default"
+    state_dir = tmp_path / ".map" / branch
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "step_state.json").write_text(
+        json.dumps(
+            {
+                "workflow": "map-efficient",
+                "current_step_id": "2.3",
+                "current_step_phase": "ACTOR",
+                "current_subtask_id": "ST-001",
+                "subtask_index": 0,
+                "subtask_sequence": ["ST-001"],
+                "plan_approved": True,
+                "execution_mode": "batch",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "blueprint.json").write_text(
+        json.dumps(
+            {
+                "hard_constraints": [
+                    {"id": "HC-1", "description": "Preserve retry behavior"}
+                ],
+                "subtasks": [
+                    {
+                        "id": "ST-001",
+                        "title": "Implement retry handling",
+                        "validation_criteria": ["VC1 [AC-1]: retryable timeout"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code, out, err = _run_hook(
+        tmp_path, {"tool_name": "Edit", "tool_input": {"file_path": "src/retry.py"}}
+    )
+
+    assert code == 0
+    assert err == ""
+    payload = json.loads(out)
+    additional = payload["hookSpecificOutput"]["additionalContext"]
+    assert "2.3" in additional
+    assert "ACTOR" in additional
+    assert "HC-1" in additional
+    assert "AC-1" in additional
 
 
 def test_skips_for_readonly_bash(tmp_path: Path) -> None:

--- a/tests/test_workflow_context_injector.py
+++ b/tests/test_workflow_context_injector.py
@@ -487,7 +487,7 @@ class TestLoadGoalAndTitle:
 
 
 class TestFormatReminderTruncation:
-    """Tests for format_reminder progressive 500-char truncation."""
+    """Tests for format_reminder progressive bounded truncation."""
 
     def _make_state(self, **overrides):
         base = {
@@ -503,7 +503,7 @@ class TestFormatReminderTruncation:
         return base
 
     def test_result_within_500_chars(self, hook_mod, tmp_path, branch_name):
-        """Basic reminder should be well under 500 chars."""
+        """Basic reminder should be well under the edit-time reminder cap."""
         os.environ["CLAUDE_PROJECT_DIR"] = str(tmp_path)
         try:
             state = self._make_state()
@@ -512,7 +512,7 @@ class TestFormatReminderTruncation:
             os.environ.pop("CLAUDE_PROJECT_DIR", None)
 
         assert result is not None
-        assert len(result) <= 500
+        assert len(result) <= hook_mod.REMINDER_LIMIT
 
     def test_includes_goal_when_plan_exists(self, hook_mod, tmp_path, branch_name):
         branch = branch_name
@@ -548,14 +548,14 @@ class TestFormatReminderTruncation:
 
         assert "My task title" in result
 
-    def test_hard_truncates_at_500(self, hook_mod, tmp_path, branch_name):
-        """When base string exceeds 500 chars even after dropping goal, hard-truncate."""
+    def test_hard_truncates_at_limit(self, hook_mod, tmp_path, branch_name):
+        """When base string exceeds the reminder cap, hard-truncate."""
         branch = branch_name
         state_dir = tmp_path / ".map" / branch
         state_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create a title long enough to push past 500 chars even without goal
-        bp = {"subtasks": [{"id": "ST-001", "title": "X" * 480}]}
+        # Create a title long enough to push past the cap even without goal.
+        bp = {"subtasks": [{"id": "ST-001", "title": "X" * 780}]}
         (state_dir / "blueprint.json").write_text(json.dumps(bp))
 
         os.environ["CLAUDE_PROJECT_DIR"] = str(tmp_path)
@@ -566,19 +566,19 @@ class TestFormatReminderTruncation:
             os.environ.pop("CLAUDE_PROJECT_DIR", None)
 
         assert result is not None
-        assert len(result) <= 500
+        assert len(result) <= hook_mod.REMINDER_LIMIT
         assert result.endswith("...")
 
-    def test_drops_goal_first_when_over_500(self, hook_mod, tmp_path, branch_name):
+    def test_drops_goal_first_when_over_limit(self, hook_mod, tmp_path, branch_name):
         """Goal hint is dropped first before hard truncation."""
         branch = branch_name
         state_dir = tmp_path / ".map" / branch
         state_dir.mkdir(parents=True, exist_ok=True)
 
-        # Title that takes ~430 chars, goal that would push it past 500
+        # Title that takes most of the budget; goal would push it past the cap.
         plan = "## Goal\nSome goal text.\n\n## Done"
         (state_dir / f"task_plan_{branch}.md").write_text(plan)
-        bp = {"subtasks": [{"id": "ST-001", "title": "Y" * 430}]}
+        bp = {"subtasks": [{"id": "ST-001", "title": "Y" * 630}]}
         (state_dir / "blueprint.json").write_text(json.dumps(bp))
 
         os.environ["CLAUDE_PROJECT_DIR"] = str(tmp_path)
@@ -589,9 +589,46 @@ class TestFormatReminderTruncation:
             os.environ.pop("CLAUDE_PROJECT_DIR", None)
 
         assert result is not None
-        assert len(result) <= 500
+        assert len(result) <= hook_mod.REMINDER_LIMIT
         # Goal should have been dropped
         assert "Goal:" not in result
+
+    def test_includes_hard_constraints_and_validation_tags(
+        self, hook_mod, tmp_path, branch_name
+    ):
+        branch = branch_name
+        state_dir = tmp_path / ".map" / branch
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        bp = {
+            "hard_constraints": [
+                {"id": "HC-1", "description": "Preserve retry behavior"}
+            ],
+            "subtasks": [
+                {
+                    "id": "ST-001",
+                    "title": "Implement retry handling",
+                    "validation_criteria": [
+                        "VC1 [AC-1]: retryable timeout returns guidance",
+                        "VC2 [AC-2]: non-retryable errors stay fatal",
+                    ],
+                }
+            ],
+        }
+        (state_dir / "blueprint.json").write_text(json.dumps(bp))
+
+        os.environ["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+        try:
+            state = self._make_state()
+            result = hook_mod.format_reminder(state, branch)
+        finally:
+            os.environ.pop("CLAUDE_PROJECT_DIR", None)
+
+        assert result is not None
+        assert "HC-1" in result
+        assert "AC-1" in result
+        assert "AC-2" in result
+        assert "Source>summary" in result
 
     def test_no_goal_or_title_when_subtask_is_dash(
         self, hook_mod, tmp_path, branch_name
@@ -608,14 +645,14 @@ class TestFormatReminderTruncation:
         assert "Goal:" not in result
 
     def test_required_suffix_truncated(self, hook_mod, tmp_path, branch_name):
-        """REQUIRED suffix should also be truncated to 500 chars total at word boundary."""
+        """REQUIRED suffix should also be truncated at word boundary."""
         branch = branch_name
         state_dir = tmp_path / ".map" / branch
         state_dir.mkdir(parents=True, exist_ok=True)
 
         # Use word-spaced title so truncation can find a word boundary
-        # "word " * 90 = 450 chars, plus prefix + REQUIRED pushes well past 500
-        long_title = ("word " * 90).strip()
+        # Long title plus REQUIRED pushes past the reminder cap.
+        long_title = ("word " * 150).strip()
         bp = {"subtasks": [{"id": "ST-001", "title": long_title}]}
         (state_dir / "blueprint.json").write_text(json.dumps(bp))
 
@@ -631,15 +668,5 @@ class TestFormatReminderTruncation:
             os.environ.pop("CLAUDE_PROJECT_DIR", None)
 
         assert result is not None
-        assert len(result) <= 500
+        assert len(result) <= hook_mod.REMINDER_LIMIT
         assert result.endswith("...")
-        # Word-boundary truncation: should not cut mid-word.
-        # The text before "..." ends at a space (rfind finds last space),
-        # so the remaining text should end with a non-alphanumeric char
-        # (space, pipe, paren) rather than cutting "wor..." mid-word.
-        before_ellipsis = result[:-3]
-        assert not before_ellipsis[
-            -1
-        ].isalpha(), (
-            f"Truncation cut mid-word; last char before '...': {before_ellipsis[-1]!r}"
-        )

--- a/tests/test_workflow_gate.py
+++ b/tests/test_workflow_gate.py
@@ -8,6 +8,7 @@ outside of Actor-related phases. Uses step_state.json as source of truth.
 """
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import Tuple
@@ -114,6 +115,21 @@ class TestWorkflowGate:
             capture_output=True,
             text=True,
             cwd=tmp_path,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def run_hook_with_project_dir(
+        self, input_data: dict, project_dir: Path
+    ) -> Tuple[int, str, str]:
+        env = os.environ.copy()
+        env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+        result = subprocess.run(
+            ["python3", str(self.HOOK_PATH)],
+            input=json.dumps(input_data),
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env=env,
         )
         return result.returncode, result.stdout, result.stderr
 
@@ -453,6 +469,56 @@ class TestWorkflowGate:
                 "tool_name": "Edit",
                 "tool_input": {"file_path": str(tmp_path / "src" / "foo.py")},
             },
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
+
+    def test_uses_claude_project_dir_for_state_and_scope(
+        self, tmp_path: Path
+    ) -> None:
+        """Generated-project hooks must read state relative to CLAUDE_PROJECT_DIR."""
+        map_dir = tmp_path / ".map" / "default"
+        map_dir.mkdir(parents=True, exist_ok=True)
+        (map_dir / "step_state.json").write_text(
+            json.dumps(
+                {
+                    "current_step_phase": "MONITOR",
+                    "current_subtask_id": "ST-001",
+                    "subtask_phases": {},
+                    "constraints": {"scope_glob": "src/*"},
+                }
+            )
+        )
+
+        code, stdout, _ = self.run_hook_with_project_dir(
+            {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}},
+            tmp_path,
+        )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "MONITOR" in reason
+
+        (map_dir / "step_state.json").write_text(
+            json.dumps(
+                {
+                    "current_step_phase": "ACTOR",
+                    "current_subtask_id": "ST-001",
+                    "subtask_phases": {},
+                    "constraints": {"scope_glob": "src/*"},
+                }
+            )
+        )
+        code, stdout, _ = self.run_hook_with_project_dir(
+            {"tool_name": "Edit", "tool_input": {"file_path": "docs/foo.md"}},
+            tmp_path,
+        )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "scope_glob" in reason
+
+        code, stdout, _ = self.run_hook_with_project_dir(
+            {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}},
             tmp_path,
         )
         assert code == 0


### PR DESCRIPTION
## Summary
- add template hygiene guardrails to keep cache/generated artifacts out of shipped MAP templates and package builds
- add post-compact MAP re-prime context with workflow state, constraints, acceptance tags, and retry rejection reminders
- inject current subtask hard constraints and validation tags before edit/write operations
- require source-cited evidence for dismissal verdicts across review/check agents and skills

## Validation
- make check
- python -m mapify_cli.skill_ir src/mapify_cli/templates/skills src/mapify_cli/templates/codex/skills
- git diff --check