### PR TITLE
Add cross-subtask regression gate to map-efficient

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -838,6 +838,25 @@ For each `VCn:` criterion:
   - **Code evidence** (where in code the behavior is implemented), and
   - **Test evidence** (where in tests it is asserted).
 
+### Cross-Subtask Regression Rule (Shared-File Edits)
+
+Your view is scoped to ONE subtask's contract — you cannot see regressions
+this change induces on *prior* subtasks' code. When the subtask edits a file
+that an earlier subtask in the same plan already modified, a `-k`-filtered or
+single-module test run is INSUFFICIENT evidence: the canonical miss is a
+change to a shared pipeline file that breaks a stub/no-op path another
+subtask owns, surfacing only at the final full gate.
+
+- The orchestrator exposes the deterministic signal:
+  `python3 .map/scripts/map_step_runner.py detect_cross_subtask_regression_risk <branch> <subtask_id>`.
+  When it returns `recommended_gate == "full_suite"` (current diff overlaps a
+  prior subtask's files, or the diff couldn't be computed), the `test_output`
+  you were handed MUST be from a FULL-suite run.
+- If the test evidence is scoped (a `-k` subset, a single test file) while the
+  subtask edits a shared file, do NOT approve on that evidence: set
+  `valid: false` (or `recommendation: needs_investigation`) and require a
+  full-suite run before the subtask is recorded.
+
 ### Contract Assertion Patterns
 
 | Criterion Type | How to Verify | Example |

--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -383,7 +383,7 @@ Return JSON with valid, summary, issues, files_changed, tests_run, and escalatio
   named subtask. Use `--dry-run` to preview the diff before writing.
 - If `valid=false`, write `code-review-N.md`, run `python3 .map/scripts/map_orchestrator.py monitor_failed --feedback "<feedback>"`, inspect `retry_isolation`, and invoke Predictor only when stuck/high-risk escalation rules apply.
 - If `retry_isolation=clean_retry_required`, run `python3 .map/scripts/map_step_runner.py validate_retry_quarantine` before the next Actor call. The next Actor prompt must use CLEAN_RETRY mode from `.map/<branch>/retry_quarantine.json` and must not reuse the rejected approach unless the quarantine artifact preserves it.
-- Treat test failures after Monitor approval as Monitor failure.
+- Treat test failures after Monitor approval as Monitor failure. **Cross-subtask regression gate (MANDATORY):** before the test gate, run `detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID"`; if `recommended_gate == "full_suite"` you MUST run the FULL suite (never a `-k` subset) before commit / `record_subtask_result` — per-subtask Monitor is blind to regressions on prior subtasks' code. Recipe: [efficient-reference.md](efficient-reference.md).
 
 ### Phase: ADVANCE_SUBTASK (synthetic boundary)
 
@@ -403,7 +403,7 @@ Every Monitor failure must create a durable `code-review-N.md` with exact issue,
 
 ### Per-Wave Gates (after all subtasks in wave pass Monitor)
 
-Run build first, then tests, then linter. If build fails, skip tests/lint and reopen the owning subtask.
+Run build first, then tests, then linter. If build fails, skip tests/lint and reopen the owning subtask. Run the FULL test suite (not a `-k` subset) whenever any subtask in the wave tripped the cross-subtask regression gate (`recommended_gate == "full_suite"`) — a parallel wave that edits a shared file is the highest-risk case for a regression no single subtask's scoped run can see.
 
 ## Step 2a: Validate Step Completion
 

--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -88,6 +88,36 @@ If `truncated: true`:
 3. Cross-check `files_changed` against `git diff --name-only`. Files
    declared but not in the diff = Actor said it changed them but didn't.
 
+## Cross-subtask regression gate
+
+Per-subtask Monitor validates only the current subtask's contract and the
+files it touched — it is structurally blind to regressions this change induces
+on *prior* subtasks' code. The canonical miss (run `new-road-quantum`): ST-009
+edited `chunked_review_pipeline.py`, a file seven earlier subtasks shared, and
+broke a stub-path test that only surfaced at the final full-suite gate, eight
+subtasks later.
+
+Before the post-Monitor test gate, ask the deterministic detector whether a
+scoped run is safe:
+
+```bash
+RISK=$(python3 .map/scripts/map_step_runner.py \
+  detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID")
+echo "$RISK"   # inspect shared_source_files / prior_owners / reason
+GATE=$(echo "$RISK" | jq -r '.recommended_gate')
+```
+
+- `recommended_gate == "full_suite"` — the current diff overlaps a file a
+  prior subtask owned, OR the diff couldn't be computed (git error, fail-safe).
+  You MUST run the FULL test suite (never a `-k`-filtered subset) before
+  commit / `record_subtask_result`. A scoped run cannot catch a cross-subtask
+  regression and is exactly how this bug class reaches the final gate.
+- `recommended_gate == "scoped"` — no overlap with prior subtasks; a targeted
+  run is sufficient. (Overlap on test-only files stays `scoped` — a shared
+  test edit can't regress another subtask's production code.)
+
+It is read-only and exits 0 always; callers branch on `recommended_gate`.
+
 ## Pre-flight test baseline
 
 Snapshot pre-existing failures BEFORE any subtask executes so later

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -6631,7 +6631,13 @@ def _current_subtask_changed_files(
     if status_result.returncode != 0:
         return None
     if diff_result is not None and diff_result.returncode != 0:
-        diff_result = None  # bad auto-resolved base → porcelain-only
+        # A base_ref was resolved (last_subtask_commit_sha or HEAD) but its
+        # diff failed — e.g. a stale SHA after a rebase. We cannot determine
+        # this subtask's committed surface, and porcelain alone would miss
+        # committed work (reporting an empty change set on a clean worktree).
+        # Fail safe to "unknown" so the caller forces a full gate, matching
+        # this function's documented contract.
+        return None
 
     changed: set[str] = set()
     if diff_result is not None:

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -38,7 +38,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Mapping, Optional, cast
+from typing import Callable, Iterable, Mapping, Optional, cast
 
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
@@ -638,7 +638,8 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
         f"- Status: {report.get('status') or 'unknown'}",
         f"- Consumed required inputs: {consumed}/{required}",
     ]
-    for item in report.get("required_artifacts", []):
+    required_artifacts = report.get("required_artifacts", [])
+    for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
         status = "consumed" if item.get("consumed") else "missing"
@@ -1978,7 +1979,6 @@ def _extract_acceptance_tags(text: object) -> set[str]:
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
-    branch_name: str,
     extra_artifacts: Optional[Mapping[str, str]] = None,
 ) -> dict[str, str]:
     """Collect review/verification artifact text that can prove acceptance tags."""
@@ -2056,7 +2056,7 @@ def build_acceptance_coverage_report(
         if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
     }
     evidence_texts = _collect_acceptance_evidence_texts(
-        branch_dir, branch_name, extra_artifacts=extra_artifacts
+        branch_dir, extra_artifacts=extra_artifacts
     )
     evidence_tags_by_source = {
         source: _extract_acceptance_tags(text)
@@ -2073,7 +2073,11 @@ def build_acceptance_coverage_report(
             if isinstance(owner_subtask, dict)
             else []
         )
-        criterion_texts = [item for item in criteria if isinstance(item, str)]
+        criterion_texts = (
+            [item for item in criteria if isinstance(item, str)]
+            if isinstance(criteria, list)
+            else []
+        )
         validation_criteria_cited = any(
             f"[{requirement}]" in item for item in criterion_texts
         )
@@ -2201,6 +2205,8 @@ def _as_dict(value: object) -> dict[str, object]:
 
 def _as_int(value: object) -> int:
     """Best-effort integer coercion for counters loaded from JSON artifacts."""
+    if not isinstance(value, (int, float, str)):
+        return 0
     try:
         return int(value or 0)
     except (TypeError, ValueError):
@@ -2429,7 +2435,9 @@ def write_run_health_report(
     }
 
 
-def _load_run_health_schema_validator() -> tuple[object, object] | tuple[None, None]:
+def _load_run_health_schema_validator() -> tuple[
+    object, Optional[Callable[[object, object], tuple[bool, list[str]]]]
+]:
     """Return optional package schema validator for generated-project installs."""
     try:
         import importlib as _importlib
@@ -6539,6 +6547,244 @@ def validate_mutation_boundary(
     return report
 
 
+_TEST_DIR_SEGMENTS = {"tests", "test", "testing", "__tests__", "spec", "specs"}
+
+
+def _is_test_path(path: str) -> bool:
+    """Heuristic: does this repo-relative path look like a test file?
+
+    Used only to lower the regression-risk signal for files that two
+    subtasks both touched but that cannot themselves cause a regression in
+    another subtask's production code (a shared *test* edit is far less
+    dangerous than a shared *source* edit). Conventions covered: a ``tests/``
+    / ``test/`` / ``__tests__/`` path segment, ``test_*`` / ``*_test`` base
+    names, and ``*.test.*`` / ``*.spec.*`` suffixes (pytest, go test, jest).
+    """
+    norm = path.replace("\\", "/")
+    parts = [p for p in norm.split("/") if p]
+    if not parts:
+        return False
+    base = parts[-1]
+    if any(seg in _TEST_DIR_SEGMENTS for seg in parts[:-1]):
+        return True
+    if re.match(r"(?:test_.+|.+_test)\.[A-Za-z0-9]+$", base):
+        return True
+    if re.search(r"\.(?:test|spec)\.[A-Za-z0-9]+$", base):
+        return True
+    return False
+
+
+def _current_subtask_changed_files(
+    branch_name: str, subtask_id: str, project_dir: Path
+) -> Optional[set[str]]:
+    """Files touched by the in-flight subtask since the prior subtask commit.
+
+    Mirrors ``validate_mutation_boundary``'s diff strategy (commit-range diff
+    against ``last_subtask_commit_sha`` — falling back to ``HEAD`` — unioned
+    with ``git status --porcelain`` for uncommitted work, minus the framework
+    ``.map/`` / ``.codex/`` paths and the per-subtask baseline). Returns
+    ``None`` on any git failure so callers can fail safe to a full gate
+    instead of silently assuming "no changes".
+    """
+    base_ref: Optional[str] = None
+    state_file = project_dir / ".map" / branch_name / "step_state.json"
+    if state_file.exists():
+        try:
+            state_data = json.loads(state_file.read_text(encoding="utf-8"))
+            last_sha = state_data.get("last_subtask_commit_sha")
+            if isinstance(last_sha, str) and last_sha:
+                base_ref = last_sha
+        except (json.JSONDecodeError, OSError):
+            pass
+    if not base_ref:
+        head_probe = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if head_probe.returncode == 0:
+            base_ref = "HEAD"
+
+    try:
+        if base_ref:
+            diff_result = subprocess.run(
+                ["git", "diff", "--name-only", base_ref],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        else:
+            diff_result = None
+        status_result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if status_result.returncode != 0:
+        return None
+    if diff_result is not None and diff_result.returncode != 0:
+        diff_result = None  # bad auto-resolved base → porcelain-only
+
+    changed: set[str] = set()
+    if diff_result is not None:
+        changed.update(
+            line.strip() for line in diff_result.stdout.splitlines() if line.strip()
+        )
+    for raw in status_result.stdout.splitlines():
+        if len(raw) >= 4:
+            path = raw[3:].strip()
+            if " -> " in path:
+                path = path.split(" -> ", 1)[1]
+            if path:
+                changed.add(path)
+
+    changed = {
+        p for p in changed
+        if not p.startswith(".map/") and not p.startswith(".codex/")
+    }
+
+    baseline_path = _subtask_baseline_path(branch_name, subtask_id, project_dir)
+    if baseline_path.exists():
+        try:
+            baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
+            raw_baseline = baseline_data.get("files", [])
+            if isinstance(raw_baseline, list):
+                baseline_set = {
+                    str(p) for p in raw_baseline if isinstance(p, str)
+                }
+                changed -= baseline_set
+        except (json.JSONDecodeError, OSError):
+            pass
+    return changed
+
+
+def detect_cross_subtask_regression_risk(
+    branch: str, subtask_id: str
+) -> dict:
+    """Flag when the in-flight subtask edits files that prior subtasks owned.
+
+    Per-subtask Monitor validates only the current subtask's contract and the
+    files it touched — it is structurally blind to regressions this change
+    induces on *other* subtasks' code. The canonical failure (run
+    ``new-road-quantum``): ST-009 edited ``chunked_review_pipeline.py``, which
+    seven earlier subtasks had also edited, and broke a stub-path test that
+    only surfaced at the final full-suite gate, eight subtasks later.
+
+    This is the deterministic signal the skill uses to decide between a
+    ``-k``-scoped test run and the full suite: when the current diff overlaps a
+    file a prior subtask changed, a scoped run cannot see the regression, so
+    the full suite is mandatory before recording the subtask.
+
+    Returns::
+        {
+          "status": "ok" | "unknown",
+          "subtask_id": str,
+          "at_risk": bool,
+          "recommended_gate": "full_suite" | "scoped",
+          "shared_files": [str],          # all overlapping files
+          "shared_source_files": [str],   # non-test overlap (drives at_risk)
+          "shared_test_files": [str],     # test-only overlap (weaker signal)
+          "prior_owners": {file: [ST-id]},
+          "current_changed_files": [str],
+          "reason": str,
+        }
+
+    ``status="unknown"`` with ``at_risk=true`` / ``recommended_gate=
+    "full_suite"`` is the fail-safe when the current diff cannot be computed
+    (git error): the gate defaults to thorough rather than silently scoped.
+    """
+    branch_name = _sanitize_branch(branch)
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+    prior_owners: dict[str, list[str]] = {}
+    state_file = project_dir / ".map" / branch_name / "step_state.json"
+    if state_file.exists():
+        try:
+            state_data = json.loads(state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            state_data = {}
+        results = state_data.get("subtask_results")
+        if isinstance(results, dict):
+            for prior_id, result in results.items():
+                if prior_id == subtask_id or not isinstance(result, dict):
+                    continue
+                files = result.get("files_changed")
+                if not isinstance(files, list):
+                    continue
+                for path in files:
+                    if isinstance(path, str) and path.strip():
+                        prior_owners.setdefault(path, [])
+                        if prior_id not in prior_owners[path]:
+                            prior_owners[path].append(prior_id)
+
+    current = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+    if current is None:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "at_risk": True,
+            "recommended_gate": "full_suite",
+            "shared_files": [],
+            "shared_source_files": [],
+            "shared_test_files": [],
+            "prior_owners": prior_owners,
+            "current_changed_files": [],
+            "reason": (
+                "Could not compute the current subtask diff (git unavailable "
+                "or not a repo). Defaulting to full_suite as a fail-safe — a "
+                "scoped run could hide a cross-subtask regression."
+            ),
+        }
+
+    shared = sorted(p for p in current if p in prior_owners)
+    shared_test = [p for p in shared if _is_test_path(p)]
+    shared_source = [p for p in shared if not _is_test_path(p)]
+    at_risk = bool(shared_source)
+
+    if at_risk:
+        offenders = ", ".join(
+            f"{p} (also: {', '.join(prior_owners[p])})" for p in shared_source
+        )
+        reason = (
+            f"Subtask edits {len(shared_source)} source file(s) prior subtasks "
+            f"already modified: {offenders}. Run the FULL test suite (no -k "
+            "filter) before recording — a scoped run cannot catch a regression "
+            "this change induces on prior subtasks' code or stub/no-op paths."
+        )
+    elif shared_test:
+        reason = (
+            f"Overlap only on test file(s): {', '.join(shared_test)}. Low "
+            "regression risk to production code; a scoped run is acceptable, "
+            "but re-run the affected test modules in full."
+        )
+    else:
+        reason = (
+            "No overlap with files changed by prior subtasks — a scoped test "
+            "run is sufficient for this subtask."
+        )
+
+    return {
+        "status": "ok",
+        "subtask_id": subtask_id,
+        "at_risk": at_risk,
+        "recommended_gate": "full_suite" if at_risk else "scoped",
+        "shared_files": shared,
+        "shared_source_files": shared_source,
+        "shared_test_files": shared_test,
+        "prior_owners": {p: prior_owners[p] for p in shared},
+        "current_changed_files": sorted(current),
+        "reason": reason,
+    }
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 
@@ -7259,6 +7505,15 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
         if report.get("status") == "error":
             sys.exit(1)
+
+    elif func_name == "detect_cross_subtask_regression_risk" and len(sys.argv) >= 4:
+        # CLI: detect_cross_subtask_regression_risk <branch> <subtask_id>
+        # Read-only. Exit 0 always (callers branch on the `at_risk` /
+        # `recommended_gate` fields, like detect_truncated_agent_output) so a
+        # shell pipeline can decide full-suite vs scoped without `set -e`
+        # tripping on an advisory signal.
+        report = detect_cross_subtask_regression_risk(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
 
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:
         # CLI: detect_already_done <branch> <subtask_id> [--since-ref REF]

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -838,6 +838,25 @@ For each `VCn:` criterion:
   - **Code evidence** (where in code the behavior is implemented), and
   - **Test evidence** (where in tests it is asserted).
 
+### Cross-Subtask Regression Rule (Shared-File Edits)
+
+Your view is scoped to ONE subtask's contract — you cannot see regressions
+this change induces on *prior* subtasks' code. When the subtask edits a file
+that an earlier subtask in the same plan already modified, a `-k`-filtered or
+single-module test run is INSUFFICIENT evidence: the canonical miss is a
+change to a shared pipeline file that breaks a stub/no-op path another
+subtask owns, surfacing only at the final full gate.
+
+- The orchestrator exposes the deterministic signal:
+  `python3 .map/scripts/map_step_runner.py detect_cross_subtask_regression_risk <branch> <subtask_id>`.
+  When it returns `recommended_gate == "full_suite"` (current diff overlaps a
+  prior subtask's files, or the diff couldn't be computed), the `test_output`
+  you were handed MUST be from a FULL-suite run.
+- If the test evidence is scoped (a `-k` subset, a single test file) while the
+  subtask edits a shared file, do NOT approve on that evidence: set
+  `valid: false` (or `recommendation: needs_investigation`) and require a
+  full-suite run before the subtask is recorded.
+
 ### Contract Assertion Patterns
 
 | Criterion Type | How to Verify | Example |

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -6631,7 +6631,13 @@ def _current_subtask_changed_files(
     if status_result.returncode != 0:
         return None
     if diff_result is not None and diff_result.returncode != 0:
-        diff_result = None  # bad auto-resolved base → porcelain-only
+        # A base_ref was resolved (last_subtask_commit_sha or HEAD) but its
+        # diff failed — e.g. a stale SHA after a rebase. We cannot determine
+        # this subtask's committed surface, and porcelain alone would miss
+        # committed work (reporting an empty change set on a clean worktree).
+        # Fail safe to "unknown" so the caller forces a full gate, matching
+        # this function's documented contract.
+        return None
 
     changed: set[str] = set()
     if diff_result is not None:

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -38,7 +38,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Mapping, Optional, cast
+from typing import Callable, Iterable, Mapping, Optional, cast
 
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
@@ -638,7 +638,8 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
         f"- Status: {report.get('status') or 'unknown'}",
         f"- Consumed required inputs: {consumed}/{required}",
     ]
-    for item in report.get("required_artifacts", []):
+    required_artifacts = report.get("required_artifacts", [])
+    for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
         status = "consumed" if item.get("consumed") else "missing"
@@ -1978,7 +1979,6 @@ def _extract_acceptance_tags(text: object) -> set[str]:
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
-    branch_name: str,
     extra_artifacts: Optional[Mapping[str, str]] = None,
 ) -> dict[str, str]:
     """Collect review/verification artifact text that can prove acceptance tags."""
@@ -2056,7 +2056,7 @@ def build_acceptance_coverage_report(
         if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
     }
     evidence_texts = _collect_acceptance_evidence_texts(
-        branch_dir, branch_name, extra_artifacts=extra_artifacts
+        branch_dir, extra_artifacts=extra_artifacts
     )
     evidence_tags_by_source = {
         source: _extract_acceptance_tags(text)
@@ -2073,7 +2073,11 @@ def build_acceptance_coverage_report(
             if isinstance(owner_subtask, dict)
             else []
         )
-        criterion_texts = [item for item in criteria if isinstance(item, str)]
+        criterion_texts = (
+            [item for item in criteria if isinstance(item, str)]
+            if isinstance(criteria, list)
+            else []
+        )
         validation_criteria_cited = any(
             f"[{requirement}]" in item for item in criterion_texts
         )
@@ -2201,6 +2205,8 @@ def _as_dict(value: object) -> dict[str, object]:
 
 def _as_int(value: object) -> int:
     """Best-effort integer coercion for counters loaded from JSON artifacts."""
+    if not isinstance(value, (int, float, str)):
+        return 0
     try:
         return int(value or 0)
     except (TypeError, ValueError):
@@ -2429,7 +2435,9 @@ def write_run_health_report(
     }
 
 
-def _load_run_health_schema_validator() -> tuple[object, object] | tuple[None, None]:
+def _load_run_health_schema_validator() -> tuple[
+    object, Optional[Callable[[object, object], tuple[bool, list[str]]]]
+]:
     """Return optional package schema validator for generated-project installs."""
     try:
         import importlib as _importlib
@@ -6539,6 +6547,244 @@ def validate_mutation_boundary(
     return report
 
 
+_TEST_DIR_SEGMENTS = {"tests", "test", "testing", "__tests__", "spec", "specs"}
+
+
+def _is_test_path(path: str) -> bool:
+    """Heuristic: does this repo-relative path look like a test file?
+
+    Used only to lower the regression-risk signal for files that two
+    subtasks both touched but that cannot themselves cause a regression in
+    another subtask's production code (a shared *test* edit is far less
+    dangerous than a shared *source* edit). Conventions covered: a ``tests/``
+    / ``test/`` / ``__tests__/`` path segment, ``test_*`` / ``*_test`` base
+    names, and ``*.test.*`` / ``*.spec.*`` suffixes (pytest, go test, jest).
+    """
+    norm = path.replace("\\", "/")
+    parts = [p for p in norm.split("/") if p]
+    if not parts:
+        return False
+    base = parts[-1]
+    if any(seg in _TEST_DIR_SEGMENTS for seg in parts[:-1]):
+        return True
+    if re.match(r"(?:test_.+|.+_test)\.[A-Za-z0-9]+$", base):
+        return True
+    if re.search(r"\.(?:test|spec)\.[A-Za-z0-9]+$", base):
+        return True
+    return False
+
+
+def _current_subtask_changed_files(
+    branch_name: str, subtask_id: str, project_dir: Path
+) -> Optional[set[str]]:
+    """Files touched by the in-flight subtask since the prior subtask commit.
+
+    Mirrors ``validate_mutation_boundary``'s diff strategy (commit-range diff
+    against ``last_subtask_commit_sha`` — falling back to ``HEAD`` — unioned
+    with ``git status --porcelain`` for uncommitted work, minus the framework
+    ``.map/`` / ``.codex/`` paths and the per-subtask baseline). Returns
+    ``None`` on any git failure so callers can fail safe to a full gate
+    instead of silently assuming "no changes".
+    """
+    base_ref: Optional[str] = None
+    state_file = project_dir / ".map" / branch_name / "step_state.json"
+    if state_file.exists():
+        try:
+            state_data = json.loads(state_file.read_text(encoding="utf-8"))
+            last_sha = state_data.get("last_subtask_commit_sha")
+            if isinstance(last_sha, str) and last_sha:
+                base_ref = last_sha
+        except (json.JSONDecodeError, OSError):
+            pass
+    if not base_ref:
+        head_probe = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if head_probe.returncode == 0:
+            base_ref = "HEAD"
+
+    try:
+        if base_ref:
+            diff_result = subprocess.run(
+                ["git", "diff", "--name-only", base_ref],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        else:
+            diff_result = None
+        status_result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if status_result.returncode != 0:
+        return None
+    if diff_result is not None and diff_result.returncode != 0:
+        diff_result = None  # bad auto-resolved base → porcelain-only
+
+    changed: set[str] = set()
+    if diff_result is not None:
+        changed.update(
+            line.strip() for line in diff_result.stdout.splitlines() if line.strip()
+        )
+    for raw in status_result.stdout.splitlines():
+        if len(raw) >= 4:
+            path = raw[3:].strip()
+            if " -> " in path:
+                path = path.split(" -> ", 1)[1]
+            if path:
+                changed.add(path)
+
+    changed = {
+        p for p in changed
+        if not p.startswith(".map/") and not p.startswith(".codex/")
+    }
+
+    baseline_path = _subtask_baseline_path(branch_name, subtask_id, project_dir)
+    if baseline_path.exists():
+        try:
+            baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
+            raw_baseline = baseline_data.get("files", [])
+            if isinstance(raw_baseline, list):
+                baseline_set = {
+                    str(p) for p in raw_baseline if isinstance(p, str)
+                }
+                changed -= baseline_set
+        except (json.JSONDecodeError, OSError):
+            pass
+    return changed
+
+
+def detect_cross_subtask_regression_risk(
+    branch: str, subtask_id: str
+) -> dict:
+    """Flag when the in-flight subtask edits files that prior subtasks owned.
+
+    Per-subtask Monitor validates only the current subtask's contract and the
+    files it touched — it is structurally blind to regressions this change
+    induces on *other* subtasks' code. The canonical failure (run
+    ``new-road-quantum``): ST-009 edited ``chunked_review_pipeline.py``, which
+    seven earlier subtasks had also edited, and broke a stub-path test that
+    only surfaced at the final full-suite gate, eight subtasks later.
+
+    This is the deterministic signal the skill uses to decide between a
+    ``-k``-scoped test run and the full suite: when the current diff overlaps a
+    file a prior subtask changed, a scoped run cannot see the regression, so
+    the full suite is mandatory before recording the subtask.
+
+    Returns::
+        {
+          "status": "ok" | "unknown",
+          "subtask_id": str,
+          "at_risk": bool,
+          "recommended_gate": "full_suite" | "scoped",
+          "shared_files": [str],          # all overlapping files
+          "shared_source_files": [str],   # non-test overlap (drives at_risk)
+          "shared_test_files": [str],     # test-only overlap (weaker signal)
+          "prior_owners": {file: [ST-id]},
+          "current_changed_files": [str],
+          "reason": str,
+        }
+
+    ``status="unknown"`` with ``at_risk=true`` / ``recommended_gate=
+    "full_suite"`` is the fail-safe when the current diff cannot be computed
+    (git error): the gate defaults to thorough rather than silently scoped.
+    """
+    branch_name = _sanitize_branch(branch)
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+    prior_owners: dict[str, list[str]] = {}
+    state_file = project_dir / ".map" / branch_name / "step_state.json"
+    if state_file.exists():
+        try:
+            state_data = json.loads(state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            state_data = {}
+        results = state_data.get("subtask_results")
+        if isinstance(results, dict):
+            for prior_id, result in results.items():
+                if prior_id == subtask_id or not isinstance(result, dict):
+                    continue
+                files = result.get("files_changed")
+                if not isinstance(files, list):
+                    continue
+                for path in files:
+                    if isinstance(path, str) and path.strip():
+                        prior_owners.setdefault(path, [])
+                        if prior_id not in prior_owners[path]:
+                            prior_owners[path].append(prior_id)
+
+    current = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+    if current is None:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "at_risk": True,
+            "recommended_gate": "full_suite",
+            "shared_files": [],
+            "shared_source_files": [],
+            "shared_test_files": [],
+            "prior_owners": prior_owners,
+            "current_changed_files": [],
+            "reason": (
+                "Could not compute the current subtask diff (git unavailable "
+                "or not a repo). Defaulting to full_suite as a fail-safe — a "
+                "scoped run could hide a cross-subtask regression."
+            ),
+        }
+
+    shared = sorted(p for p in current if p in prior_owners)
+    shared_test = [p for p in shared if _is_test_path(p)]
+    shared_source = [p for p in shared if not _is_test_path(p)]
+    at_risk = bool(shared_source)
+
+    if at_risk:
+        offenders = ", ".join(
+            f"{p} (also: {', '.join(prior_owners[p])})" for p in shared_source
+        )
+        reason = (
+            f"Subtask edits {len(shared_source)} source file(s) prior subtasks "
+            f"already modified: {offenders}. Run the FULL test suite (no -k "
+            "filter) before recording — a scoped run cannot catch a regression "
+            "this change induces on prior subtasks' code or stub/no-op paths."
+        )
+    elif shared_test:
+        reason = (
+            f"Overlap only on test file(s): {', '.join(shared_test)}. Low "
+            "regression risk to production code; a scoped run is acceptable, "
+            "but re-run the affected test modules in full."
+        )
+    else:
+        reason = (
+            "No overlap with files changed by prior subtasks — a scoped test "
+            "run is sufficient for this subtask."
+        )
+
+    return {
+        "status": "ok",
+        "subtask_id": subtask_id,
+        "at_risk": at_risk,
+        "recommended_gate": "full_suite" if at_risk else "scoped",
+        "shared_files": shared,
+        "shared_source_files": shared_source,
+        "shared_test_files": shared_test,
+        "prior_owners": {p: prior_owners[p] for p in shared},
+        "current_changed_files": sorted(current),
+        "reason": reason,
+    }
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 
@@ -7259,6 +7505,15 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
         if report.get("status") == "error":
             sys.exit(1)
+
+    elif func_name == "detect_cross_subtask_regression_risk" and len(sys.argv) >= 4:
+        # CLI: detect_cross_subtask_regression_risk <branch> <subtask_id>
+        # Read-only. Exit 0 always (callers branch on the `at_risk` /
+        # `recommended_gate` fields, like detect_truncated_agent_output) so a
+        # shell pipeline can decide full-suite vs scoped without `set -e`
+        # tripping on an advisory signal.
+        report = detect_cross_subtask_regression_risk(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
 
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:
         # CLI: detect_already_done <branch> <subtask_id> [--since-ref REF]

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -383,7 +383,7 @@ Return JSON with valid, summary, issues, files_changed, tests_run, and escalatio
   named subtask. Use `--dry-run` to preview the diff before writing.
 - If `valid=false`, write `code-review-N.md`, run `python3 .map/scripts/map_orchestrator.py monitor_failed --feedback "<feedback>"`, inspect `retry_isolation`, and invoke Predictor only when stuck/high-risk escalation rules apply.
 - If `retry_isolation=clean_retry_required`, run `python3 .map/scripts/map_step_runner.py validate_retry_quarantine` before the next Actor call. The next Actor prompt must use CLEAN_RETRY mode from `.map/<branch>/retry_quarantine.json` and must not reuse the rejected approach unless the quarantine artifact preserves it.
-- Treat test failures after Monitor approval as Monitor failure.
+- Treat test failures after Monitor approval as Monitor failure. **Cross-subtask regression gate (MANDATORY):** before the test gate, run `detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID"`; if `recommended_gate == "full_suite"` you MUST run the FULL suite (never a `-k` subset) before commit / `record_subtask_result` — per-subtask Monitor is blind to regressions on prior subtasks' code. Recipe: [efficient-reference.md](efficient-reference.md).
 
 ### Phase: ADVANCE_SUBTASK (synthetic boundary)
 
@@ -403,7 +403,7 @@ Every Monitor failure must create a durable `code-review-N.md` with exact issue,
 
 ### Per-Wave Gates (after all subtasks in wave pass Monitor)
 
-Run build first, then tests, then linter. If build fails, skip tests/lint and reopen the owning subtask.
+Run build first, then tests, then linter. If build fails, skip tests/lint and reopen the owning subtask. Run the FULL test suite (not a `-k` subset) whenever any subtask in the wave tripped the cross-subtask regression gate (`recommended_gate == "full_suite"`) — a parallel wave that edits a shared file is the highest-risk case for a regression no single subtask's scoped run can see.
 
 ## Step 2a: Validate Step Completion
 

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -88,6 +88,36 @@ If `truncated: true`:
 3. Cross-check `files_changed` against `git diff --name-only`. Files
    declared but not in the diff = Actor said it changed them but didn't.
 
+## Cross-subtask regression gate
+
+Per-subtask Monitor validates only the current subtask's contract and the
+files it touched — it is structurally blind to regressions this change induces
+on *prior* subtasks' code. The canonical miss (run `new-road-quantum`): ST-009
+edited `chunked_review_pipeline.py`, a file seven earlier subtasks shared, and
+broke a stub-path test that only surfaced at the final full-suite gate, eight
+subtasks later.
+
+Before the post-Monitor test gate, ask the deterministic detector whether a
+scoped run is safe:
+
+```bash
+RISK=$(python3 .map/scripts/map_step_runner.py \
+  detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID")
+echo "$RISK"   # inspect shared_source_files / prior_owners / reason
+GATE=$(echo "$RISK" | jq -r '.recommended_gate')
+```
+
+- `recommended_gate == "full_suite"` — the current diff overlaps a file a
+  prior subtask owned, OR the diff couldn't be computed (git error, fail-safe).
+  You MUST run the FULL test suite (never a `-k`-filtered subset) before
+  commit / `record_subtask_result`. A scoped run cannot catch a cross-subtask
+  regression and is exactly how this bug class reaches the final gate.
+- `recommended_gate == "scoped"` — no overlap with prior subtasks; a targeted
+  run is sufficient. (Overlap on test-only files stays `scoped` — a shared
+  test edit can't regress another subtask's production code.)
+
+It is read-only and exits 0 always; callers branch on `recommended_gate`.
+
 ## Pre-flight test baseline
 
 Snapshot pre-existing failures BEFORE any subtask executes so later

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import types
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -57,7 +58,7 @@ def branch_workspace(tmp_path, monkeypatch):
     return workspace
 
 
-def _valid_run_health_payload() -> dict[str, object]:
+def _valid_run_health_payload() -> dict[str, Any]:
     artifact_entry = {
         "kind": "state",
         "path": ".map/test-branch/step_state.json",
@@ -3384,7 +3385,7 @@ class TestBlueprintContractCrossRepoDetection:
             }],
         }
 
-    def test_warns_on_cross_repo_path(self, branch_workspace, monkeypatch, tmp_path):
+    def test_warns_on_cross_repo_path(self, branch_workspace, monkeypatch):
         repo = branch_workspace.parents[1]
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
         # Create a real file in current repo so we don't trigger drift warning.
@@ -4229,6 +4230,185 @@ class TestValidateMutationBoundary:
         )
         report = json.loads(result.stdout)
         assert report["status"] == "error"
+
+
+class TestDetectCrossSubtaskRegressionRisk:
+    """detect_cross_subtask_regression_risk flags when the in-flight subtask
+    edits files that a PRIOR subtask owned — the signal the skill uses to
+    force a full test suite (vs a -k subset) so a cross-subtask regression
+    can't slip past per-subtask Monitor to the final gate.
+    """
+
+    def _init_git(self, root: Path) -> None:
+        subprocess.run(["git", "init"], cwd=root, capture_output=True, check=False)
+        subprocess.run(
+            ["git", "config", "user.email", "t@t.com"], cwd=root, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "t"], cwd=root, capture_output=True
+        )
+        # An initial commit so HEAD resolves (base_ref fallback).
+        (root / ".seed").write_text("seed\n")
+        subprocess.run(["git", "add", "."], cwd=root, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=root, capture_output=True
+        )
+
+    def _write_state(self, branch_dir: Path, subtask_results: dict) -> None:
+        (branch_dir / "step_state.json").write_text(
+            json.dumps({"subtask_results": subtask_results})
+        )
+
+    def test_shared_source_file_is_at_risk_full_suite(
+        self, branch_workspace, monkeypatch
+    ):
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(
+            branch_workspace,
+            {"ST-001": {"files_changed": ["src/pipeline.py"]}},
+        )
+        # Current subtask (ST-002) edits the SAME source file. Stage it so
+        # `git status --porcelain` reports the full path (untracked-only
+        # directories collapse to `src/`).
+        (repo / "src").mkdir()
+        (repo / "src" / "pipeline.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-002"
+        )
+        assert report["status"] == "ok", report
+        assert report["at_risk"] is True
+        assert report["recommended_gate"] == "full_suite"
+        assert "src/pipeline.py" in report["shared_source_files"]
+        assert report["prior_owners"]["src/pipeline.py"] == ["ST-001"]
+
+    def test_disjoint_files_not_at_risk_scoped(self, branch_workspace, monkeypatch):
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(
+            branch_workspace,
+            {"ST-001": {"files_changed": ["src/other.py"]}},
+        )
+        (repo / "src").mkdir()
+        (repo / "src" / "pipeline.py").write_text("x = 1\n")  # different file
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-002"
+        )
+        assert report["status"] == "ok", report
+        assert report["at_risk"] is False
+        assert report["recommended_gate"] == "scoped"
+        assert report["shared_files"] == []
+
+    def test_shared_test_only_file_is_not_at_risk(
+        self, branch_workspace, monkeypatch
+    ):
+        """Two subtasks editing the same TEST file is a weak signal — it can't
+        regress another subtask's production code, so stay scoped."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(
+            branch_workspace,
+            {"ST-001": {"files_changed": ["tests/test_pipeline.py"]}},
+        )
+        (repo / "tests").mkdir()
+        (repo / "tests" / "test_pipeline.py").write_text("def test_x(): pass\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-002"
+        )
+        assert report["at_risk"] is False
+        assert report["recommended_gate"] == "scoped"
+        assert "tests/test_pipeline.py" in report["shared_test_files"]
+        assert report["shared_source_files"] == []
+
+    def test_no_prior_subtasks_not_at_risk(self, branch_workspace, monkeypatch):
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace, {})
+        (repo / "src").mkdir()
+        (repo / "src" / "pipeline.py").write_text("x = 1\n")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-001"
+        )
+        assert report["at_risk"] is False
+        assert report["recommended_gate"] == "scoped"
+
+    def test_current_subtask_excluded_from_prior_owners(
+        self, branch_workspace, monkeypatch
+    ):
+        """A subtask's own prior record (e.g. on a retry) must not count as a
+        cross-subtask collision with itself."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(
+            branch_workspace,
+            {"ST-002": {"files_changed": ["src/pipeline.py"]}},
+        )
+        (repo / "src").mkdir()
+        (repo / "src" / "pipeline.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-002"
+        )
+        assert "src/pipeline.py" in report["current_changed_files"]
+        assert report["at_risk"] is False
+        assert report["shared_files"] == []
+
+    def test_git_failure_fails_safe_to_full_suite(
+        self, branch_workspace, monkeypatch
+    ):
+        """No git repo → diff can't be computed → unknown + full_suite, never a
+        silent scoped pass."""
+        repo = branch_workspace.parents[1]  # NOT a git repo
+        self._write_state(
+            branch_workspace,
+            {"ST-001": {"files_changed": ["src/pipeline.py"]}},
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-002"
+        )
+        assert report["status"] == "unknown", report
+        assert report["at_risk"] is True
+        assert report["recommended_gate"] == "full_suite"
+
+    def test_cli_exits_zero_and_emits_json(self, branch_workspace):
+        """CLI is advisory: exit 0 always so shell callers branch on the
+        `recommended_gate` field without `set -e` tripping."""
+        self._init_git(branch_workspace.parents[1])
+        self._write_state(branch_workspace, {})
+        runner = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "mapify_cli" / "templates" / "map" / "scripts" / "map_step_runner.py"
+        )
+        repo = branch_workspace.parents[1]
+        env = {
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "CLAUDE_PROJECT_DIR": str(repo),
+        }
+        result = subprocess.run(
+            [sys.executable, str(runner),
+             "detect_cross_subtask_regression_risk", "test-branch", "ST-001"],
+            capture_output=True, text=True, cwd=str(repo), env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads(result.stdout)
+        assert report["recommended_gate"] in {"full_suite", "scoped"}
+
+    def test_is_test_path_heuristic(self):
+        assert map_step_runner._is_test_path("tests/test_x.py")
+        assert map_step_runner._is_test_path("pkg/foo_test.go")
+        assert map_step_runner._is_test_path("web/button.spec.ts")
+        assert map_step_runner._is_test_path("a/__tests__/b.js")
+        assert not map_step_runner._is_test_path("src/pipeline.py")
+        assert not map_step_runner._is_test_path("contest.py")
 
 
 class TestGetSubtaskCli:

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -4240,24 +4240,55 @@ class TestDetectCrossSubtaskRegressionRisk:
     """
 
     def _init_git(self, root: Path) -> None:
-        subprocess.run(["git", "init"], cwd=root, capture_output=True, check=False)
+        subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)
         subprocess.run(
-            ["git", "config", "user.email", "t@t.com"], cwd=root, capture_output=True
+            ["git", "config", "user.email", "t@t.com"], cwd=root, capture_output=True, check=True
         )
         subprocess.run(
-            ["git", "config", "user.name", "t"], cwd=root, capture_output=True
+            ["git", "config", "user.name", "t"], cwd=root, capture_output=True, check=True
         )
-        # An initial commit so HEAD resolves (base_ref fallback).
+        # An initial commit so HEAD resolves (base_ref). Assert it lands — a
+        # swallowed commit failure would leave HEAD unresolved and let the
+        # detector fall through to porcelain-only, silently weakening the tests.
         (root / ".seed").write_text("seed\n")
-        subprocess.run(["git", "add", "."], cwd=root, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=root, capture_output=True, check=True)
         subprocess.run(
-            ["git", "commit", "-m", "init"], cwd=root, capture_output=True
+            ["git", "commit", "-m", "init"], cwd=root, capture_output=True, check=True
         )
+        head = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=root, capture_output=True, text=True,
+        )
+        assert head.returncode == 0, "test setup: initial commit produced no resolvable HEAD"
 
     def _write_state(self, branch_dir: Path, subtask_results: dict) -> None:
         (branch_dir / "step_state.json").write_text(
             json.dumps({"subtask_results": subtask_results})
         )
+
+    def test_stale_base_ref_fails_safe_to_full_suite(
+        self, branch_workspace, monkeypatch
+    ):
+        """A stale last_subtask_commit_sha (e.g. after a rebase) makes
+        `git diff <sha>` fail. The detector must fail safe to full_suite rather
+        than report 'scoped' from porcelain alone on a clean worktree."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        (branch_workspace / "step_state.json").write_text(
+            json.dumps(
+                {
+                    "subtask_results": {"ST-001": {"files_changed": ["src/pipeline.py"]}},
+                    "last_subtask_commit_sha": "0" * 40,  # nonexistent commit
+                }
+            )
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_cross_subtask_regression_risk(
+            "test-branch", "ST-002"
+        )
+        assert report["status"] == "unknown", report
+        assert report["at_risk"] is True
+        assert report["recommended_gate"] == "full_suite"
 
     def test_shared_source_file_is_at_risk_full_suite(
         self, branch_workspace, monkeypatch


### PR DESCRIPTION
## Summary
- Adds a deterministic `detect_cross_subtask_regression_risk` helper to `map_step_runner.py` that flags when the in-flight subtask edits files a **prior** subtask already owned — the gap that let ST-009 (run `new-road-quantum`) break a stub-path test that only surfaced at the final full-suite gate, eight subtasks later.
- Per-subtask Monitor is scoped to one subtask's contract + touched files, so it cannot see cross-subtask regressions. The detector returns `recommended_gate: full_suite | scoped` so the workflow forces a FULL suite (never a `-k` subset) when the diff overlaps a prior subtask's source files. Test-only overlap stays `scoped`; a git failure fails safe to `full_suite`.
- Wires it as a MANDATORY gate in `map-efficient` (SKILL + efficient-reference) and adds a Cross-Subtask Regression Rule to `monitor.md`.
- Fixes pre-existing Pyright diagnostics surfaced in the touched files (type narrowings in `map_step_runner.py`; test payload typing).

## Why
Verified against the real `.map/new-road-quantum` run: the framework reliably catches in-scope issues but is blind to regressions a subtask induces on other subtasks' code — only the final gate caught ST-009. This closes that structural gap deterministically.

## Test plan
- [x] `pytest` — 1609 passed (8 new `TestDetectCrossSubtaskRegressionRisk` cases: shared source → full_suite, disjoint → scoped, test-only → scoped, git-failure → fail-safe full_suite, self-exclusion, CLI exit-0, `_is_test_path` heuristic)
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] `pyright` on changed files — 0 errors / 0 warnings / 0 informations
- [x] templates in parity (`.map/scripts` + `.claude/` synced to `src/mapify_cli/templates/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)