### PR TITLE
Add per-subtask token accounting + /map-tokenreport skill

### DIFF
--- a/.claude/hooks/map-token-meter.py
+++ b/.claude/hooks/map-token-meter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+MAP Token Meter - SubagentStop + Stop hook.
+
+Reads the ``transcript_path`` Claude Code hands the hook and attributes that
+transcript's per-turn token ``usage`` (input / output / cache_creation /
+cache_read) to the active MAP subtask, phase, and agent. The heavy lifting —
+parsing, dedup-by-msg_id, attribution, and the token_accounting.json rollup —
+lives in ``.map/scripts/map_step_runner.py`` so the logic is identical whether
+it runs in this repo or a generated project (the hook cannot rely on the
+``mapify_cli`` package being importable in installed projects).
+
+Wired on two events:
+    SubagentStop : Claude Code passes BOTH ``transcript_path`` (the parent
+                   session) AND ``agent_transcript_path`` (the sub-agent's own
+                   transcript under ``<session>/subagents/agent-*.jsonl``). The
+                   sub-agent's tokens — 80%+ of a run — live only in the latter,
+                   so we read ``agent_transcript_path`` here and attribute them
+                   to ``agent_type`` (e.g. actor / monitor / research-agent).
+    Stop         : ``transcript_path`` is the main session transcript — sweeps
+                   the orchestrator's own driving turns.
+
+A single per-branch msg_id cache makes both safe to fire repeatedly without
+double-counting (the parent and sub-agent transcripts hold disjoint msg_ids).
+
+Exit codes:
+    0 - Always. Token metering is advisory and must never block a turn.
+
+Output:
+    ``{}`` (silent). The side effect is the token_log.jsonl / token_accounting
+    .json artifacts the runner writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+RUNNER = PROJECT_DIR / ".map" / "scripts" / "map_step_runner.py"
+
+
+def _sanitize_branch(branch: str) -> str:
+    sanitized = branch.replace("/", "-")
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "-", sanitized)
+    sanitized = re.sub(r"-+", "-", sanitized).strip("-")
+    if ".." in sanitized or sanitized.startswith("."):
+        return "default"
+    return sanitized or "default"
+
+
+def _get_branch() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_DIR,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return _sanitize_branch(result.stdout.strip())
+    except Exception:
+        pass
+    return "default"
+
+
+def _silent() -> None:
+    sys.stdout.write("{}")
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        _silent()
+        return
+
+    # SubagentStop carries the sub-agent's own transcript in
+    # ``agent_transcript_path``; prefer it so we meter the sub-agent's tokens
+    # (the parent ``transcript_path`` would only re-sweep the orchestrator).
+    # Fall back to ``transcript_path`` for the Stop event (main session).
+    agent_transcript = input_data.get("agent_transcript_path", "")
+    if agent_transcript:
+        transcript_path = agent_transcript
+        # agent_type is the real sub-agent name (actor/monitor/...); empty
+        # lets the runner fall back to the active-phase mapping.
+        agent = str(input_data.get("agent_type", "") or "")
+    else:
+        transcript_path = input_data.get("transcript_path", "")
+        # Main-session driving turns belong to the orchestrator, not a phase
+        # sub-agent, so label them explicitly rather than by current phase.
+        agent = "orchestrator"
+
+    if not transcript_path or not RUNNER.is_file():
+        _silent()
+        return
+
+    branch = _get_branch()
+    command = [
+        sys.executable,
+        str(RUNNER),
+        "record_token_event",
+        branch,
+        "--transcript",
+        str(transcript_path),
+    ]
+    if agent:
+        command += ["--agent", agent]
+    try:
+        subprocess.run(
+            command,
+            cwd=PROJECT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        # Advisory only — never surface a metering failure to the turn.
+        pass
+    _silent()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -133,6 +133,19 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "description": "MAP Token Meter - attribute sub-agent token usage to the active subtask",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/map-token-meter.py",
+            "timeout": 5,
+            "description": "Reads the finished sub-agent transcript and records input/output/cache tokens to .map/<branch>/token_log.jsonl + token_accounting.json"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "description": "Lightweight quality gates - only critical issues",
@@ -142,6 +155,17 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/end-of-turn.sh",
             "timeout": 30,
             "description": "Auto-fixes silently, only reports secrets/syntax errors"
+          }
+        ]
+      },
+      {
+        "description": "MAP Token Meter - sweep main-session token usage at turn end",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/map-token-meter.py",
+            "timeout": 5,
+            "description": "Records main-session input/output/cache tokens (dedup by msg_id) into the branch token accounting artifacts"
           }
         ]
       }

--- a/.claude/skills/map-tokenreport/SKILL.md
+++ b/.claude/skills/map-tokenreport/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: map-tokenreport
+description: |
+  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
+effort: low
+disable-model-invocation: true
+argument-hint: "[branch]"
+---
+# /map-tokenreport - Token Accounting Report
+
+Purpose: surface how many tokens (and how much money) the current branch's MAP
+run spent, attributed to the subtask, phase, and agent that spent them.
+Read-only reporting — this skill does not plan, implement, or run quality
+gates.
+
+The numbers come from the `map-token-meter` hook (wired on `SubagentStop` and
+`Stop`), which reads each Claude Code transcript's per-turn `usage` block and
+appends attributed rows to `.map/<branch>/token_log.jsonl`, rolled up into
+`.map/<branch>/token_accounting.json`. This skill just renders that rollup.
+
+## What it shows
+
+- **input / output** tokens, **cache_read** (cheap cache hits) and
+  **cache_creation** (cache writes) — tracked separately because they bill at
+  very different rates.
+- **est_cost_usd** — priced per model via `MODEL_TOKEN_PRICES` in
+  `map_step_runner.py` (estimate, not a billing source of truth).
+- **cache_hit_ratio** = `cache_read / (input + cache_read)` — how well prompt
+  caching is paying off.
+- Breakdowns by subtask, by agent (actor / monitor / research-agent /
+  orchestrator / ...), and by phase.
+
+## Steps
+
+### Step 1: Resolve the branch
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+```
+
+If the user passed an explicit branch argument, use it instead of the detected
+one.
+
+### Step 2: Render the report
+
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH"
+```
+
+`token_report` re-reads `token_log.jsonl`, rebuilds `token_accounting.json`,
+and prints a per-subtask table plus a TOTAL line with the cache-hit ratio and
+estimated cost. It is idempotent and read-only against your code.
+
+### Step 3: Optional — inspect the raw rollup
+
+For the per-agent / per-phase split (the table only shows per-subtask), read
+the JSON directly:
+
+```bash
+jq '{aggregate, by_agent, by_phase}' ".map/${BRANCH}/token_accounting.json"
+```
+
+### Step 4: Summarize
+
+Report the totals (input / output / cache), the cache-hit ratio, and the
+estimated cost. Call out the most expensive subtask or agent, and a low
+cache-hit ratio if present (it usually means prompt-cache churn worth
+investigating). Then STOP — do not change code from this skill.
+
+## Examples
+
+Report token usage for the current branch:
+
+```text
+/map-tokenreport
+```
+
+Report for a specific branch:
+
+```text
+/map-tokenreport feat/add-multiply
+```
+
+Typical output:
+
+```text
+Token accounting — feat-add-multiply (93 assistant turns)
+
+subtask              input      output     cache_rd    cache_cr     $cost
+-------------------------------------------------------------------------
+ST-001                 183     150,879   14,085,841     792,780     47.31
+-------------------------------------------------------------------------
+TOTAL                  183     150,879   14,085,841     792,780     47.31
+
+cache hit ratio: 100.0%   est cost: $47.31
+```
+
+## Troubleshooting
+
+- **`token_accounting.json` does not exist / report is empty.** The
+  `map-token-meter` hook has not fired for this branch yet. It records on
+  `SubagentStop` and `Stop`, so a brand-new branch with no completed turns has
+  nothing to show. Confirm the hook is wired in `.claude/settings.json`
+  (`SubagentStop` and `Stop` entries) and that `.map/<branch>/token_log.jsonl`
+  exists.
+- **Everything is attributed to `orchestrator` / `unattributed`.** Those turns
+  ran outside a MAP subtask (e.g. direct edits, or before `step_state.json` had
+  a `current_subtask_id`). Per-subtask attribution appears once a
+  `/map-efficient` run sets the active subtask.
+- **Cost looks high relative to raw input.** That is expected when most input
+  is cached: `cache_creation` is the dominant cost on cache-heavy runs. Compare
+  `cache_creation` vs `cache_read` and the cache-hit ratio to see where the
+  spend goes.
+- **Unknown model in cost estimate.** `MODEL_TOKEN_PRICES` falls back to the
+  default model price for unrecognized model ids; update that table in
+  `map_step_runner.py` when a new model ships.

--- a/.claude/skills/skill-rules.json
+++ b/.claude/skills/skill-rules.json
@@ -277,6 +277,28 @@
           "(test.first|tdd|spec.driven).*(workflow|develop)"
         ]
       }
+    },
+    "map-tokenreport": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Render per-subtask/agent token accounting (tokens, cache, cost, cache-hit ratio) for the current branch.",
+      "promptTriggers": {
+        "keywords": [
+          "map-tokenreport",
+          "token report",
+          "token usage",
+          "token accounting",
+          "run cost",
+          "cache hit ratio"
+        ],
+        "intentPatterns": [
+          "map-tokenreport",
+          "(token|run).*(report|usage|accounting|cost|spent)",
+          "cache.hit.ratio"
+        ]
+      }
     }
   }
 }

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -591,23 +591,45 @@ def _extract_turn_usage(entry: object) -> Optional[dict[str, object]]:
     }
 
 
-def _iter_new_usage(transcript_path: Path, seen_ids: set[str]) -> list[dict[str, object]]:
-    """Usage dicts for assistant turns whose msg_id is not already in seen_ids.
+def _iter_new_usage(
+    transcript_path: Path, seen_ids: set[str], start_offset: int = 0
+) -> tuple[list[dict[str, object]], int]:
+    """New assistant-usage dicts from a transcript, read incrementally.
 
-    Entries with an empty msg_id (cannot dedup safely) and malformed JSON lines
-    are skipped; a missing/unreadable transcript yields []. The dedup is what
-    makes re-firing hooks and the Stop-time sweep over the main transcript safe
-    to call repeatedly without double-counting.
+    Reads only the bytes after ``start_offset`` (transcripts are append-only
+    JSONL) so a repeatedly-firing Stop/SubagentStop hook does not re-parse the
+    whole multi-MB file each turn. Returns ``(usages, new_offset)`` where
+    ``new_offset`` advances only past the last COMPLETE line — a partial line
+    from a concurrent append is left for the next call. ``msg_id`` dedup against
+    ``seen_ids`` is kept as a safety net (e.g. if the file is rotated and the
+    offset resets). Entries with an empty msg_id or malformed JSON are skipped;
+    a missing/unreadable transcript returns ``([], start_offset)``.
     """
     path = Path(transcript_path)
-    if not path.is_file():
-        return []
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
-        return []
+        if not path.is_file():
+            return [], start_offset
+        size = path.stat().st_size
+    except OSError:
+        return [], start_offset
+    # A stored offset past EOF means the file was truncated/rotated — restart.
+    offset = start_offset if 0 <= start_offset <= size else 0
+    try:
+        with path.open("rb") as handle:
+            handle.seek(offset)
+            chunk = handle.read()
+    except OSError:
+        return [], start_offset
+
+    last_newline = chunk.rfind(b"\n")
+    if last_newline == -1:
+        # No complete line yet beyond the offset.
+        return [], offset
+    complete = chunk[: last_newline + 1]
+    new_offset = offset + len(complete)
+
     out: list[dict[str, object]] = []
-    for raw in lines:
+    for raw in complete.decode("utf-8", errors="replace").splitlines():
         raw = raw.strip()
         if not raw:
             continue
@@ -622,28 +644,39 @@ def _iter_new_usage(transcript_path: Path, seen_ids: set[str]) -> list[dict[str,
         if not mid or mid in seen_ids:
             continue
         out.append(usage)
-    return out
+    return out, new_offset
 
 
 def _token_meter_cache_path(branch_name: str) -> Path:
     return get_branch_dir(branch_name) / TOKEN_METER_CACHE_NAME
 
 
-def _load_seen_ids(branch_name: str) -> set[str]:
+def _load_meter_cache(branch_name: str) -> tuple[dict[str, int], set[str]]:
+    """Return (per-transcript byte offsets, seen msg_ids) from the meter cache."""
     data = _read_json_file(_token_meter_cache_path(branch_name))
+    offsets: dict[str, int] = {}
+    seen: set[str] = set()
     if isinstance(data, dict):
-        ids = data.get("seen_ids")
-        if isinstance(ids, list):
-            return {str(x) for x in ids if isinstance(x, str)}
-    return set()
+        raw_offsets = data.get("offsets")
+        if isinstance(raw_offsets, dict):
+            for key, value in raw_offsets.items():
+                if isinstance(key, str) and isinstance(value, int) and value >= 0:
+                    offsets[key] = value
+        raw_seen = data.get("seen_ids")
+        if isinstance(raw_seen, list):
+            seen = {str(x) for x in raw_seen if isinstance(x, str)}
+    return offsets, seen
 
 
-def _save_seen_ids(branch_name: str, seen_ids: set[str]) -> None:
-    # Bound the cache so a long run can't grow it without limit.
+def _save_meter_cache(
+    branch_name: str, offsets: dict[str, int], seen_ids: set[str]
+) -> None:
+    # Offsets are the primary dedup; seen_ids is a bounded safety net (a long
+    # run never re-reads old lines, so a lexicographic trim cannot double-count).
     trimmed = sorted(seen_ids)[-_SEEN_ID_CACHE_LIMIT:]
     _write_json_file(
         _token_meter_cache_path(branch_name),
-        {"seen_ids": trimmed, "updated_at": _utc_timestamp()},
+        {"offsets": offsets, "seen_ids": trimmed, "updated_at": _utc_timestamp()},
     )
 
 
@@ -676,7 +709,10 @@ def record_token_event(
     (subtask/phase) falls back to step_state and agent to the phase mapping
     when callers don't pass them explicitly. Returns the totals just recorded.
     """
-    branch_name = branch or get_branch_name()
+    # Sanitize an explicit branch the same way MAP does elsewhere — the value
+    # becomes a path segment via get_branch_dir, so an unsanitized argument
+    # (e.g. "../../tmp") would escape the .map tree.
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     if not transcript_path:
         return {"status": "error", "reason": "transcript_path required"}
 
@@ -685,10 +721,20 @@ def record_token_event(
     phase = phase or cur_phase or ""
     agent = agent or _PHASE_TO_AGENT.get(phase, "orchestrator")
 
-    seen = _load_seen_ids(branch_name)
-    new_usages = _iter_new_usage(Path(transcript_path), seen)
+    transcript_key = str(transcript_path)
+    offsets, seen = _load_meter_cache(branch_name)
+    start_offset = offsets.get(transcript_key, 0)
+    new_usages, new_offset = _iter_new_usage(
+        Path(transcript_path), seen, start_offset
+    )
     totals: dict[str, int] = {field: 0 for field in _TOKEN_FIELDS}
+
     if not new_usages:
+        # Still persist an advanced offset so non-usage lines (user turns) are
+        # not re-scanned next call.
+        if new_offset != start_offset:
+            offsets[transcript_key] = new_offset
+            _save_meter_cache(branch_name, offsets, seen)
         return {
             "status": "success",
             "recorded": 0,
@@ -720,7 +766,8 @@ def record_token_event(
     except OSError as exc:
         return {"status": "error", "reason": str(exc)}
 
-    _save_seen_ids(branch_name, seen)
+    offsets[transcript_key] = new_offset
+    _save_meter_cache(branch_name, offsets, seen)
     _rebuild_token_accounting(branch_name)
     return {
         "status": "success",
@@ -743,7 +790,7 @@ def _rebuild_token_accounting(branch: Optional[str] = None) -> dict[str, object]
     ``cache_hit_ratio`` (cache_read / (input + cache_read)) and
     ``est_cost_usd``. Returns the written payload.
     """
-    branch_name = branch or get_branch_name()
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
     by_subtask: dict[str, dict[str, float]] = {}
     by_agent: dict[str, dict[str, float]] = {}
@@ -816,7 +863,7 @@ def _rebuild_token_accounting(branch: Optional[str] = None) -> dict[str, object]
 
 def token_report(branch: Optional[str] = None) -> str:
     """Render a per-subtask token table (input/output/cache/cost) as text."""
-    branch_name = branch or get_branch_name()
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     payload = _rebuild_token_accounting(branch_name)
     aggregate = cast(dict[str, float], payload["aggregate"])
     by_subtask = cast(dict[str, dict[str, float]], payload["by_subtask"])

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -38,7 +38,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Mapping, Optional, cast
+from typing import Callable, Iterable, Mapping, Optional, cast
 
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
@@ -483,6 +483,379 @@ def record_token_budget_decision(
         return {"status": "error", "path": str(artifact_path), "reason": str(exc)}
 
 
+# ---------------------------------------------------------------------------
+# Per-subtask token accounting (input / output / cache).
+#
+# Distinct from record_token_budget_decision above (which logs prompt-PATH
+# budget decisions). This block reads the Claude Code transcript's per-turn
+# ``usage`` block and attributes input/output/cache tokens to the active
+# subtask/phase/agent so a run produces token_accounting.json with cost and
+# cache-hit-ratio rollups. Self-contained on stdlib (no mapify_cli import) so
+# the shipped .map/scripts/ copy works in generated projects where the
+# mapify_cli package is absent.
+# ---------------------------------------------------------------------------
+
+TOKEN_LOG_NAME = "token_log.jsonl"
+TOKEN_ACCOUNTING_NAME = "token_accounting.json"
+TOKEN_METER_CACHE_NAME = ".token-meter-cache.json"
+_SEEN_ID_CACHE_LIMIT = 5000
+
+_TOKEN_FIELDS = ("input", "output", "cache_creation", "cache_read")
+
+# Price per 1M tokens (USD). Update as provider pricing changes; an unknown
+# model falls back to the default entry so cost stays an estimate, never a
+# crash. cache_creation is the ~1.25x write multiplier and cache_read the
+# ~0.1x hit multiplier of the input price.
+MODEL_TOKEN_PRICES: dict[str, dict[str, float]] = {
+    "claude-opus-4-7": {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+    "claude-opus-4-6": {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+    "claude-sonnet-4-6": {"input": 3.0, "output": 15.0, "cache_creation": 3.75, "cache_read": 0.3},
+    "claude-sonnet-4-5": {"input": 3.0, "output": 15.0, "cache_creation": 3.75, "cache_read": 0.3},
+    "claude-haiku-4-5": {"input": 1.0, "output": 5.0, "cache_creation": 1.25, "cache_read": 0.1},
+}
+_DEFAULT_PRICE_MODEL = "claude-opus-4-7"
+
+# step_state phase -> MAP agent name. Claude Code does not put subagent_type on
+# the hook stdin, so attribution falls back to the active phase.
+_PHASE_TO_AGENT = {
+    "DECOMPOSE": "task-decomposer",
+    "RESEARCH": "research-agent",
+    "ACTOR": "actor",
+    "MONITOR": "monitor",
+    "PREDICT": "predictor",
+}
+
+
+def _model_price(model: str) -> dict[str, float]:
+    """Resolve a price row for a model id, tolerating real-world id shapes.
+
+    Transcript model ids carry a date suffix on some models but not others
+    (e.g. ``claude-haiku-4-5-20251001`` vs ``claude-opus-4-7``). Match in
+    order: exact key, then the id with a trailing ``-YYYYMMDD`` stripped, then
+    a known key that prefixes the id; finally the default. Without this a
+    date-suffixed haiku id would silently fall back to Opus pricing (~15x the
+    real cost).
+    """
+    if model in MODEL_TOKEN_PRICES:
+        return MODEL_TOKEN_PRICES[model]
+    stripped = re.sub(r"-\d{8}$", "", model)
+    if stripped in MODEL_TOKEN_PRICES:
+        return MODEL_TOKEN_PRICES[stripped]
+    for known in MODEL_TOKEN_PRICES:
+        if model.startswith(known):
+            return MODEL_TOKEN_PRICES[known]
+    return MODEL_TOKEN_PRICES[_DEFAULT_PRICE_MODEL]
+
+
+def _token_cost(usage: Mapping[str, int], model: str) -> float:
+    """Best-effort USD cost for one usage record under the model's price."""
+    price = _model_price(model)
+    total = 0.0
+    for field in _TOKEN_FIELDS:
+        total += usage.get(field, 0) / 1_000_000 * price.get(field, 0.0)
+    return round(total, 6)
+
+
+def _extract_turn_usage(entry: object) -> Optional[dict[str, object]]:
+    """Pull one assistant turn's full usage from a transcript JSONL entry.
+
+    Returns a flat dict (input/output/cache_creation/cache_read as ints, plus
+    ``model`` and a stable ``msg_id`` for dedup), or None when the entry is not
+    an assistant message carrying a ``usage`` block.
+    """
+    if not isinstance(entry, dict):
+        return None
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return None
+    if message.get("role") != "assistant" and entry.get("type") != "assistant":
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    def _int(key: str) -> int:
+        try:
+            return int(usage.get(key, 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    msg_id = message.get("id") or entry.get("uuid") or ""
+    return {
+        "input": _int("input_tokens"),
+        "output": _int("output_tokens"),
+        "cache_creation": _int("cache_creation_input_tokens"),
+        "cache_read": _int("cache_read_input_tokens"),
+        "model": str(message.get("model") or ""),
+        "msg_id": str(msg_id),
+    }
+
+
+def _iter_new_usage(transcript_path: Path, seen_ids: set[str]) -> list[dict[str, object]]:
+    """Usage dicts for assistant turns whose msg_id is not already in seen_ids.
+
+    Entries with an empty msg_id (cannot dedup safely) and malformed JSON lines
+    are skipped; a missing/unreadable transcript yields []. The dedup is what
+    makes re-firing hooks and the Stop-time sweep over the main transcript safe
+    to call repeatedly without double-counting.
+    """
+    path = Path(transcript_path)
+    if not path.is_file():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    out: list[dict[str, object]] = []
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        usage = _extract_turn_usage(entry)
+        if usage is None:
+            continue
+        mid = str(usage["msg_id"])
+        if not mid or mid in seen_ids:
+            continue
+        out.append(usage)
+    return out
+
+
+def _token_meter_cache_path(branch_name: str) -> Path:
+    return get_branch_dir(branch_name) / TOKEN_METER_CACHE_NAME
+
+
+def _load_seen_ids(branch_name: str) -> set[str]:
+    data = _read_json_file(_token_meter_cache_path(branch_name))
+    if isinstance(data, dict):
+        ids = data.get("seen_ids")
+        if isinstance(ids, list):
+            return {str(x) for x in ids if isinstance(x, str)}
+    return set()
+
+
+def _save_seen_ids(branch_name: str, seen_ids: set[str]) -> None:
+    # Bound the cache so a long run can't grow it without limit.
+    trimmed = sorted(seen_ids)[-_SEEN_ID_CACHE_LIMIT:]
+    _write_json_file(
+        _token_meter_cache_path(branch_name),
+        {"seen_ids": trimmed, "updated_at": _utc_timestamp()},
+    )
+
+
+def _current_token_attribution(branch_name: str) -> tuple[Optional[str], str]:
+    """Return (current_subtask_id, current_step_phase) from step_state."""
+    data = _read_json_file(get_branch_dir(branch_name) / "step_state.json")
+    if not isinstance(data, dict):
+        return (None, "")
+    sid = data.get("current_subtask_id")
+    phase = data.get("current_step_phase")
+    return (
+        sid if isinstance(sid, str) else None,
+        phase if isinstance(phase, str) else "",
+    )
+
+
+def record_token_event(
+    branch: Optional[str] = None,
+    *,
+    transcript_path: str = "",
+    agent: str = "",
+    phase: str = "",
+    subtask_id: str = "",
+) -> dict[str, object]:
+    """Attribute new transcript token usage to the active subtask and log it.
+
+    Parses assistant ``usage`` blocks from ``transcript_path`` that the
+    per-branch dedup cache hasn't seen, appends one attributed row per turn to
+    ``token_log.jsonl``, then rebuilds ``token_accounting.json``. Attribution
+    (subtask/phase) falls back to step_state and agent to the phase mapping
+    when callers don't pass them explicitly. Returns the totals just recorded.
+    """
+    branch_name = branch or get_branch_name()
+    if not transcript_path:
+        return {"status": "error", "reason": "transcript_path required"}
+
+    cur_subtask, cur_phase = _current_token_attribution(branch_name)
+    subtask_id = subtask_id or cur_subtask or "unattributed"
+    phase = phase or cur_phase or ""
+    agent = agent or _PHASE_TO_AGENT.get(phase, "orchestrator")
+
+    seen = _load_seen_ids(branch_name)
+    new_usages = _iter_new_usage(Path(transcript_path), seen)
+    totals: dict[str, int] = {field: 0 for field in _TOKEN_FIELDS}
+    if not new_usages:
+        return {
+            "status": "success",
+            "recorded": 0,
+            "subtask_id": subtask_id,
+            "phase": phase,
+            "agent": agent,
+            **totals,
+        }
+
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = _utc_timestamp()
+    try:
+        with log_path.open("a", encoding="utf-8") as handle:
+            for usage in new_usages:
+                row = {
+                    "ts": timestamp,
+                    "subtask_id": subtask_id,
+                    "phase": phase,
+                    "agent": agent,
+                    "model": str(usage["model"]),
+                    "msg_id": str(usage["msg_id"]),
+                    **{field: int(usage[field]) for field in _TOKEN_FIELDS},  # type: ignore[arg-type]
+                }
+                handle.write(json.dumps(row) + "\n")
+                for field in _TOKEN_FIELDS:
+                    totals[field] += int(usage[field])  # type: ignore[arg-type]
+                seen.add(str(usage["msg_id"]))
+    except OSError as exc:
+        return {"status": "error", "reason": str(exc)}
+
+    _save_seen_ids(branch_name, seen)
+    _rebuild_token_accounting(branch_name)
+    return {
+        "status": "success",
+        "recorded": len(new_usages),
+        "subtask_id": subtask_id,
+        "phase": phase,
+        "agent": agent,
+        **totals,
+    }
+
+
+def _empty_token_bucket() -> dict[str, float]:
+    return {field: 0 for field in _TOKEN_FIELDS}
+
+
+def _rebuild_token_accounting(branch: Optional[str] = None) -> dict[str, object]:
+    """Roll token_log.jsonl up into token_accounting.json.
+
+    Groups by subtask, agent, and phase, plus an aggregate carrying
+    ``cache_hit_ratio`` (cache_read / (input + cache_read)) and
+    ``est_cost_usd``. Returns the written payload.
+    """
+    branch_name = branch or get_branch_name()
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    by_subtask: dict[str, dict[str, float]] = {}
+    by_agent: dict[str, dict[str, float]] = {}
+    by_phase: dict[str, dict[str, float]] = {}
+    aggregate: dict[str, float] = _empty_token_bucket()
+    total_cost = 0.0
+    event_count = 0
+
+    if log_path.is_file():
+        try:
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            lines = []
+        for raw in lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            event_count += 1
+            model = str(row.get("model") or "")
+            usage: dict[str, int] = {}
+            for field in _TOKEN_FIELDS:
+                try:
+                    usage[field] = int(row.get(field, 0) or 0)
+                except (TypeError, ValueError):
+                    usage[field] = 0
+            row_cost = _token_cost(usage, model)
+            total_cost += row_cost
+            for dim_key, dim in (
+                (str(row.get("subtask_id") or "unattributed"), by_subtask),
+                (str(row.get("agent") or "unknown"), by_agent),
+                (str(row.get("phase") or "unknown"), by_phase),
+            ):
+                bucket = dim.setdefault(
+                    dim_key, {**_empty_token_bucket(), "est_cost_usd": 0.0}
+                )
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(
+                    bucket.get("est_cost_usd", 0.0) + row_cost, 6
+                )
+            for field in _TOKEN_FIELDS:
+                aggregate[field] += usage[field]
+
+    cache_read = aggregate["cache_read"]
+    cacheable = aggregate["input"] + cache_read
+    aggregate["cache_hit_ratio"] = (
+        round(cache_read / cacheable, 4) if cacheable else 0.0
+    )
+    aggregate["est_cost_usd"] = round(total_cost, 4)
+
+    payload: dict[str, object] = {
+        "schema_version": "1.0",
+        "branch": branch_name,
+        "updated_at": _utc_timestamp(),
+        "event_count": event_count,
+        "aggregate": aggregate,
+        "by_subtask": by_subtask,
+        "by_agent": by_agent,
+        "by_phase": by_phase,
+    }
+    _write_json_file(get_branch_dir(branch_name) / TOKEN_ACCOUNTING_NAME, payload)
+    return payload
+
+
+def token_report(branch: Optional[str] = None) -> str:
+    """Render a per-subtask token table (input/output/cache/cost) as text."""
+    branch_name = branch or get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload["aggregate"])
+    by_subtask = cast(dict[str, dict[str, float]], payload["by_subtask"])
+
+    header = (
+        f"{'subtask':<18}{'input':>13}{'output':>12}"
+        f"{'cache_rd':>13}{'cache_cr':>12}{'$cost':>10}"
+    )
+    rows = [
+        f"Token accounting — {branch_name} "
+        f"({payload['event_count']} assistant turns)",
+        "",
+        header,
+        "-" * len(header),
+    ]
+
+    def _fmt(label: str, bucket: Mapping[str, float]) -> str:
+        return (
+            f"{label:<18}"
+            f"{int(bucket.get('input', 0)):>13,}"
+            f"{int(bucket.get('output', 0)):>12,}"
+            f"{int(bucket.get('cache_read', 0)):>13,}"
+            f"{int(bucket.get('cache_creation', 0)):>12,}"
+            f"{bucket.get('est_cost_usd', 0.0):>10.2f}"
+        )
+
+    for sid in sorted(by_subtask):
+        rows.append(_fmt(sid, by_subtask[sid]))
+    rows.append("-" * len(header))
+    rows.append(_fmt("TOTAL", aggregate))
+    rows.append("")
+    ratio = float(aggregate.get("cache_hit_ratio", 0.0)) * 100
+    rows.append(
+        f"cache hit ratio: {ratio:.1f}%   "
+        f"est cost: ${float(aggregate.get('est_cost_usd', 0.0)):.2f}"
+    )
+    return "\n".join(rows) + "\n"
+
+
 def _prior_stage_file_entry(
     key: str,
     label: str,
@@ -638,7 +1011,8 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
         f"- Status: {report.get('status') or 'unknown'}",
         f"- Consumed required inputs: {consumed}/{required}",
     ]
-    for item in report.get("required_artifacts", []):
+    required_artifacts = report.get("required_artifacts", [])
+    for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
         status = "consumed" if item.get("consumed") else "missing"
@@ -1978,7 +2352,6 @@ def _extract_acceptance_tags(text: object) -> set[str]:
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
-    branch_name: str,
     extra_artifacts: Optional[Mapping[str, str]] = None,
 ) -> dict[str, str]:
     """Collect review/verification artifact text that can prove acceptance tags."""
@@ -2056,7 +2429,7 @@ def build_acceptance_coverage_report(
         if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
     }
     evidence_texts = _collect_acceptance_evidence_texts(
-        branch_dir, branch_name, extra_artifacts=extra_artifacts
+        branch_dir, extra_artifacts=extra_artifacts
     )
     evidence_tags_by_source = {
         source: _extract_acceptance_tags(text)
@@ -2073,7 +2446,11 @@ def build_acceptance_coverage_report(
             if isinstance(owner_subtask, dict)
             else []
         )
-        criterion_texts = [item for item in criteria if isinstance(item, str)]
+        criterion_texts = (
+            [item for item in criteria if isinstance(item, str)]
+            if isinstance(criteria, list)
+            else []
+        )
         validation_criteria_cited = any(
             f"[{requirement}]" in item for item in criterion_texts
         )
@@ -2201,6 +2578,8 @@ def _as_dict(value: object) -> dict[str, object]:
 
 def _as_int(value: object) -> int:
     """Best-effort integer coercion for counters loaded from JSON artifacts."""
+    if not isinstance(value, (int, float, str)):
+        return 0
     try:
         return int(value or 0)
     except (TypeError, ValueError):
@@ -2429,7 +2808,9 @@ def write_run_health_report(
     }
 
 
-def _load_run_health_schema_validator() -> tuple[object, object] | tuple[None, None]:
+def _load_run_health_schema_validator() -> tuple[
+    object, Optional[Callable[[object, object], tuple[bool, list[str]]]]
+]:
     """Return optional package schema validator for generated-project installs."""
     try:
         import importlib as _importlib
@@ -7259,6 +7640,35 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
         if report.get("status") == "error":
             sys.exit(1)
+
+    elif func_name == "record_token_event":
+        # CLI: record_token_event <branch> --transcript <path>
+        #        [--agent A] [--phase P] [--subtask ST-NNN]
+        # Advisory token meter: exit 0 always so the SubagentStop/Stop hooks
+        # never block the turn. Dedups by msg_id via the per-branch cache.
+        def _opt_value(flag: str) -> str:
+            if flag in sys.argv:
+                pos = sys.argv.index(flag)
+                if pos + 1 < len(sys.argv):
+                    return sys.argv[pos + 1]
+            return ""
+
+        tok_branch = (
+            sys.argv[2] if len(sys.argv) >= 3 and not sys.argv[2].startswith("--") else ""
+        )
+        report = record_token_event(
+            tok_branch or None,
+            transcript_path=_opt_value("--transcript"),
+            agent=_opt_value("--agent"),
+            phase=_opt_value("--phase"),
+            subtask_id=_opt_value("--subtask"),
+        )
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "token_report":
+        # CLI: token_report [branch]
+        tok_branch = sys.argv[2] if len(sys.argv) >= 3 else None
+        print(token_report(tok_branch))
 
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:
         # CLI: detect_already_done <branch> <subtask_id> [--since-ref REF]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-subtask token accounting**: a new `map-token-meter` hook (wired on
+  `SubagentStop` and `Stop`) reads each transcript's per-turn `usage` and
+  attributes input/output/cache-creation/cache-read tokens to the active
+  subtask, phase, and agent. Rows append to `.map/<branch>/token_log.jsonl`
+  (deduplicated by message id) and roll up into `token_accounting.json` with
+  `by_subtask`/`by_agent`/`by_phase` buckets, `est_cost_usd` (priced per model
+  in `MODEL_TOKEN_PRICES`), and `cache_hit_ratio`. Inspect via
+  `python3 .map/scripts/map_step_runner.py token_report <branch>`. The
+  parsing/recording/rollup logic is self-contained in `map_step_runner.py`
+  (stdlib only) so it works in generated projects without `mapify_cli`
+  importable; the meter is advisory and never blocks a turn.
+
 ## [3.10.0] - 2026-05-19
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,7 @@ The remainder of this file contains the deeper implementation dive (workflow-spe
 - Provider scaffolding generated into a target repo (`.claude/` for Claude Code, `.codex/` for Codex CLI, plus `.map/` scripts/artifacts)
 - Run artifacts (plans, contracts, verification summaries, review dossiers, learning handoffs) written under `.map/<branch>/`
 - Context-budget, compression, clean-retry, run-health, review-bundle, and prior-stage-consumption contracts surfaced through MAP settings, hooks, templates, and `.map/scripts/`
+- Per-subtask token accounting: the `map-token-meter` hook (SubagentStop/Stop) attributes transcript `usage` to the active subtask/phase/agent in `.map/<branch>/token_log.jsonl`, rolled up (with cost and cache-hit ratio) into `token_accounting.json`; logic is self-contained in `.map/scripts/map_step_runner.py` so it runs without the `mapify_cli` package present
 - Skill/template audit surfaces such as `SkillIR`, prompt-tone checks, mutation-boundary checks, and dependency/task validation helpers
 - Optional MCP configuration wiring when supported by the provider runtime
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -457,6 +457,34 @@ unmodified. Operators handle context size via the `/compact` opt-in
 described above — the `MAP_CONTEXT_BLOCK_BUDGET_TOKENS` env var that
 previously capped Actor's block has no effect any more.
 
+### Token accounting (per-subtask cost)
+
+Separately from the compaction nudge above, MAP records how many tokens a
+run actually spent and attributes them to the subtask/phase/agent that
+spent them. The `map-token-meter` hook fires on `SubagentStop` (the
+actor/monitor/research sub-agents, where most tokens go) and `Stop` (the
+main session); it reads each transcript's per-turn `usage` block and appends
+attributed rows to `.map/<branch>/token_log.jsonl`, deduplicated by message
+id so re-fired hooks never double-count.
+
+The rollup lands in `.map/<branch>/token_accounting.json` — totals plus
+`by_subtask` / `by_agent` / `by_phase`, an `est_cost_usd` estimate (priced
+per model in `MODEL_TOKEN_PRICES`), and `cache_hit_ratio`
+(`cache_read / (input + cache_read)`) so you can see how well prompt caching
+is paying off. Print a table any time:
+
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH"
+# subtask      input   output  cache_rd  cache_cr   $cost
+# ST-001     1,203,448  91,204  978,113   42,008     12.41
+# ...        cache hit ratio: 68.2%   est cost: $41.07
+```
+
+Input, output, cache-read, and cache-creation tokens are tracked
+separately because they bill at very different rates; the report makes a
+runaway uncached subtask or a low cache-hit ratio obvious at a glance. The
+meter is advisory — its hooks always exit 0 and never block a turn.
+
 ### What is Context Compaction?
 
 Context compaction occurs when Claude's conversation memory reaches its limit. When this happens:

--- a/src/mapify_cli/templates/hooks/map-token-meter.py
+++ b/src/mapify_cli/templates/hooks/map-token-meter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+MAP Token Meter - SubagentStop + Stop hook.
+
+Reads the ``transcript_path`` Claude Code hands the hook and attributes that
+transcript's per-turn token ``usage`` (input / output / cache_creation /
+cache_read) to the active MAP subtask, phase, and agent. The heavy lifting —
+parsing, dedup-by-msg_id, attribution, and the token_accounting.json rollup —
+lives in ``.map/scripts/map_step_runner.py`` so the logic is identical whether
+it runs in this repo or a generated project (the hook cannot rely on the
+``mapify_cli`` package being importable in installed projects).
+
+Wired on two events:
+    SubagentStop : Claude Code passes BOTH ``transcript_path`` (the parent
+                   session) AND ``agent_transcript_path`` (the sub-agent's own
+                   transcript under ``<session>/subagents/agent-*.jsonl``). The
+                   sub-agent's tokens — 80%+ of a run — live only in the latter,
+                   so we read ``agent_transcript_path`` here and attribute them
+                   to ``agent_type`` (e.g. actor / monitor / research-agent).
+    Stop         : ``transcript_path`` is the main session transcript — sweeps
+                   the orchestrator's own driving turns.
+
+A single per-branch msg_id cache makes both safe to fire repeatedly without
+double-counting (the parent and sub-agent transcripts hold disjoint msg_ids).
+
+Exit codes:
+    0 - Always. Token metering is advisory and must never block a turn.
+
+Output:
+    ``{}`` (silent). The side effect is the token_log.jsonl / token_accounting
+    .json artifacts the runner writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+RUNNER = PROJECT_DIR / ".map" / "scripts" / "map_step_runner.py"
+
+
+def _sanitize_branch(branch: str) -> str:
+    sanitized = branch.replace("/", "-")
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "-", sanitized)
+    sanitized = re.sub(r"-+", "-", sanitized).strip("-")
+    if ".." in sanitized or sanitized.startswith("."):
+        return "default"
+    return sanitized or "default"
+
+
+def _get_branch() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_DIR,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return _sanitize_branch(result.stdout.strip())
+    except Exception:
+        pass
+    return "default"
+
+
+def _silent() -> None:
+    sys.stdout.write("{}")
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        _silent()
+        return
+
+    # SubagentStop carries the sub-agent's own transcript in
+    # ``agent_transcript_path``; prefer it so we meter the sub-agent's tokens
+    # (the parent ``transcript_path`` would only re-sweep the orchestrator).
+    # Fall back to ``transcript_path`` for the Stop event (main session).
+    agent_transcript = input_data.get("agent_transcript_path", "")
+    if agent_transcript:
+        transcript_path = agent_transcript
+        # agent_type is the real sub-agent name (actor/monitor/...); empty
+        # lets the runner fall back to the active-phase mapping.
+        agent = str(input_data.get("agent_type", "") or "")
+    else:
+        transcript_path = input_data.get("transcript_path", "")
+        # Main-session driving turns belong to the orchestrator, not a phase
+        # sub-agent, so label them explicitly rather than by current phase.
+        agent = "orchestrator"
+
+    if not transcript_path or not RUNNER.is_file():
+        _silent()
+        return
+
+    branch = _get_branch()
+    command = [
+        sys.executable,
+        str(RUNNER),
+        "record_token_event",
+        branch,
+        "--transcript",
+        str(transcript_path),
+    ]
+    if agent:
+        command += ["--agent", agent]
+    try:
+        subprocess.run(
+            command,
+            cwd=PROJECT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        # Advisory only — never surface a metering failure to the turn.
+        pass
+    _silent()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -591,23 +591,45 @@ def _extract_turn_usage(entry: object) -> Optional[dict[str, object]]:
     }
 
 
-def _iter_new_usage(transcript_path: Path, seen_ids: set[str]) -> list[dict[str, object]]:
-    """Usage dicts for assistant turns whose msg_id is not already in seen_ids.
+def _iter_new_usage(
+    transcript_path: Path, seen_ids: set[str], start_offset: int = 0
+) -> tuple[list[dict[str, object]], int]:
+    """New assistant-usage dicts from a transcript, read incrementally.
 
-    Entries with an empty msg_id (cannot dedup safely) and malformed JSON lines
-    are skipped; a missing/unreadable transcript yields []. The dedup is what
-    makes re-firing hooks and the Stop-time sweep over the main transcript safe
-    to call repeatedly without double-counting.
+    Reads only the bytes after ``start_offset`` (transcripts are append-only
+    JSONL) so a repeatedly-firing Stop/SubagentStop hook does not re-parse the
+    whole multi-MB file each turn. Returns ``(usages, new_offset)`` where
+    ``new_offset`` advances only past the last COMPLETE line — a partial line
+    from a concurrent append is left for the next call. ``msg_id`` dedup against
+    ``seen_ids`` is kept as a safety net (e.g. if the file is rotated and the
+    offset resets). Entries with an empty msg_id or malformed JSON are skipped;
+    a missing/unreadable transcript returns ``([], start_offset)``.
     """
     path = Path(transcript_path)
-    if not path.is_file():
-        return []
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
-        return []
+        if not path.is_file():
+            return [], start_offset
+        size = path.stat().st_size
+    except OSError:
+        return [], start_offset
+    # A stored offset past EOF means the file was truncated/rotated — restart.
+    offset = start_offset if 0 <= start_offset <= size else 0
+    try:
+        with path.open("rb") as handle:
+            handle.seek(offset)
+            chunk = handle.read()
+    except OSError:
+        return [], start_offset
+
+    last_newline = chunk.rfind(b"\n")
+    if last_newline == -1:
+        # No complete line yet beyond the offset.
+        return [], offset
+    complete = chunk[: last_newline + 1]
+    new_offset = offset + len(complete)
+
     out: list[dict[str, object]] = []
-    for raw in lines:
+    for raw in complete.decode("utf-8", errors="replace").splitlines():
         raw = raw.strip()
         if not raw:
             continue
@@ -622,28 +644,39 @@ def _iter_new_usage(transcript_path: Path, seen_ids: set[str]) -> list[dict[str,
         if not mid or mid in seen_ids:
             continue
         out.append(usage)
-    return out
+    return out, new_offset
 
 
 def _token_meter_cache_path(branch_name: str) -> Path:
     return get_branch_dir(branch_name) / TOKEN_METER_CACHE_NAME
 
 
-def _load_seen_ids(branch_name: str) -> set[str]:
+def _load_meter_cache(branch_name: str) -> tuple[dict[str, int], set[str]]:
+    """Return (per-transcript byte offsets, seen msg_ids) from the meter cache."""
     data = _read_json_file(_token_meter_cache_path(branch_name))
+    offsets: dict[str, int] = {}
+    seen: set[str] = set()
     if isinstance(data, dict):
-        ids = data.get("seen_ids")
-        if isinstance(ids, list):
-            return {str(x) for x in ids if isinstance(x, str)}
-    return set()
+        raw_offsets = data.get("offsets")
+        if isinstance(raw_offsets, dict):
+            for key, value in raw_offsets.items():
+                if isinstance(key, str) and isinstance(value, int) and value >= 0:
+                    offsets[key] = value
+        raw_seen = data.get("seen_ids")
+        if isinstance(raw_seen, list):
+            seen = {str(x) for x in raw_seen if isinstance(x, str)}
+    return offsets, seen
 
 
-def _save_seen_ids(branch_name: str, seen_ids: set[str]) -> None:
-    # Bound the cache so a long run can't grow it without limit.
+def _save_meter_cache(
+    branch_name: str, offsets: dict[str, int], seen_ids: set[str]
+) -> None:
+    # Offsets are the primary dedup; seen_ids is a bounded safety net (a long
+    # run never re-reads old lines, so a lexicographic trim cannot double-count).
     trimmed = sorted(seen_ids)[-_SEEN_ID_CACHE_LIMIT:]
     _write_json_file(
         _token_meter_cache_path(branch_name),
-        {"seen_ids": trimmed, "updated_at": _utc_timestamp()},
+        {"offsets": offsets, "seen_ids": trimmed, "updated_at": _utc_timestamp()},
     )
 
 
@@ -676,7 +709,10 @@ def record_token_event(
     (subtask/phase) falls back to step_state and agent to the phase mapping
     when callers don't pass them explicitly. Returns the totals just recorded.
     """
-    branch_name = branch or get_branch_name()
+    # Sanitize an explicit branch the same way MAP does elsewhere — the value
+    # becomes a path segment via get_branch_dir, so an unsanitized argument
+    # (e.g. "../../tmp") would escape the .map tree.
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     if not transcript_path:
         return {"status": "error", "reason": "transcript_path required"}
 
@@ -685,10 +721,20 @@ def record_token_event(
     phase = phase or cur_phase or ""
     agent = agent or _PHASE_TO_AGENT.get(phase, "orchestrator")
 
-    seen = _load_seen_ids(branch_name)
-    new_usages = _iter_new_usage(Path(transcript_path), seen)
+    transcript_key = str(transcript_path)
+    offsets, seen = _load_meter_cache(branch_name)
+    start_offset = offsets.get(transcript_key, 0)
+    new_usages, new_offset = _iter_new_usage(
+        Path(transcript_path), seen, start_offset
+    )
     totals: dict[str, int] = {field: 0 for field in _TOKEN_FIELDS}
+
     if not new_usages:
+        # Still persist an advanced offset so non-usage lines (user turns) are
+        # not re-scanned next call.
+        if new_offset != start_offset:
+            offsets[transcript_key] = new_offset
+            _save_meter_cache(branch_name, offsets, seen)
         return {
             "status": "success",
             "recorded": 0,
@@ -720,7 +766,8 @@ def record_token_event(
     except OSError as exc:
         return {"status": "error", "reason": str(exc)}
 
-    _save_seen_ids(branch_name, seen)
+    offsets[transcript_key] = new_offset
+    _save_meter_cache(branch_name, offsets, seen)
     _rebuild_token_accounting(branch_name)
     return {
         "status": "success",
@@ -743,7 +790,7 @@ def _rebuild_token_accounting(branch: Optional[str] = None) -> dict[str, object]
     ``cache_hit_ratio`` (cache_read / (input + cache_read)) and
     ``est_cost_usd``. Returns the written payload.
     """
-    branch_name = branch or get_branch_name()
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
     by_subtask: dict[str, dict[str, float]] = {}
     by_agent: dict[str, dict[str, float]] = {}
@@ -816,7 +863,7 @@ def _rebuild_token_accounting(branch: Optional[str] = None) -> dict[str, object]
 
 def token_report(branch: Optional[str] = None) -> str:
     """Render a per-subtask token table (input/output/cache/cost) as text."""
-    branch_name = branch or get_branch_name()
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     payload = _rebuild_token_accounting(branch_name)
     aggregate = cast(dict[str, float], payload["aggregate"])
     by_subtask = cast(dict[str, dict[str, float]], payload["by_subtask"])

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -38,7 +38,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Mapping, Optional, cast
+from typing import Callable, Iterable, Mapping, Optional, cast
 
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
@@ -483,6 +483,379 @@ def record_token_budget_decision(
         return {"status": "error", "path": str(artifact_path), "reason": str(exc)}
 
 
+# ---------------------------------------------------------------------------
+# Per-subtask token accounting (input / output / cache).
+#
+# Distinct from record_token_budget_decision above (which logs prompt-PATH
+# budget decisions). This block reads the Claude Code transcript's per-turn
+# ``usage`` block and attributes input/output/cache tokens to the active
+# subtask/phase/agent so a run produces token_accounting.json with cost and
+# cache-hit-ratio rollups. Self-contained on stdlib (no mapify_cli import) so
+# the shipped .map/scripts/ copy works in generated projects where the
+# mapify_cli package is absent.
+# ---------------------------------------------------------------------------
+
+TOKEN_LOG_NAME = "token_log.jsonl"
+TOKEN_ACCOUNTING_NAME = "token_accounting.json"
+TOKEN_METER_CACHE_NAME = ".token-meter-cache.json"
+_SEEN_ID_CACHE_LIMIT = 5000
+
+_TOKEN_FIELDS = ("input", "output", "cache_creation", "cache_read")
+
+# Price per 1M tokens (USD). Update as provider pricing changes; an unknown
+# model falls back to the default entry so cost stays an estimate, never a
+# crash. cache_creation is the ~1.25x write multiplier and cache_read the
+# ~0.1x hit multiplier of the input price.
+MODEL_TOKEN_PRICES: dict[str, dict[str, float]] = {
+    "claude-opus-4-7": {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+    "claude-opus-4-6": {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+    "claude-sonnet-4-6": {"input": 3.0, "output": 15.0, "cache_creation": 3.75, "cache_read": 0.3},
+    "claude-sonnet-4-5": {"input": 3.0, "output": 15.0, "cache_creation": 3.75, "cache_read": 0.3},
+    "claude-haiku-4-5": {"input": 1.0, "output": 5.0, "cache_creation": 1.25, "cache_read": 0.1},
+}
+_DEFAULT_PRICE_MODEL = "claude-opus-4-7"
+
+# step_state phase -> MAP agent name. Claude Code does not put subagent_type on
+# the hook stdin, so attribution falls back to the active phase.
+_PHASE_TO_AGENT = {
+    "DECOMPOSE": "task-decomposer",
+    "RESEARCH": "research-agent",
+    "ACTOR": "actor",
+    "MONITOR": "monitor",
+    "PREDICT": "predictor",
+}
+
+
+def _model_price(model: str) -> dict[str, float]:
+    """Resolve a price row for a model id, tolerating real-world id shapes.
+
+    Transcript model ids carry a date suffix on some models but not others
+    (e.g. ``claude-haiku-4-5-20251001`` vs ``claude-opus-4-7``). Match in
+    order: exact key, then the id with a trailing ``-YYYYMMDD`` stripped, then
+    a known key that prefixes the id; finally the default. Without this a
+    date-suffixed haiku id would silently fall back to Opus pricing (~15x the
+    real cost).
+    """
+    if model in MODEL_TOKEN_PRICES:
+        return MODEL_TOKEN_PRICES[model]
+    stripped = re.sub(r"-\d{8}$", "", model)
+    if stripped in MODEL_TOKEN_PRICES:
+        return MODEL_TOKEN_PRICES[stripped]
+    for known in MODEL_TOKEN_PRICES:
+        if model.startswith(known):
+            return MODEL_TOKEN_PRICES[known]
+    return MODEL_TOKEN_PRICES[_DEFAULT_PRICE_MODEL]
+
+
+def _token_cost(usage: Mapping[str, int], model: str) -> float:
+    """Best-effort USD cost for one usage record under the model's price."""
+    price = _model_price(model)
+    total = 0.0
+    for field in _TOKEN_FIELDS:
+        total += usage.get(field, 0) / 1_000_000 * price.get(field, 0.0)
+    return round(total, 6)
+
+
+def _extract_turn_usage(entry: object) -> Optional[dict[str, object]]:
+    """Pull one assistant turn's full usage from a transcript JSONL entry.
+
+    Returns a flat dict (input/output/cache_creation/cache_read as ints, plus
+    ``model`` and a stable ``msg_id`` for dedup), or None when the entry is not
+    an assistant message carrying a ``usage`` block.
+    """
+    if not isinstance(entry, dict):
+        return None
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return None
+    if message.get("role") != "assistant" and entry.get("type") != "assistant":
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    def _int(key: str) -> int:
+        try:
+            return int(usage.get(key, 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    msg_id = message.get("id") or entry.get("uuid") or ""
+    return {
+        "input": _int("input_tokens"),
+        "output": _int("output_tokens"),
+        "cache_creation": _int("cache_creation_input_tokens"),
+        "cache_read": _int("cache_read_input_tokens"),
+        "model": str(message.get("model") or ""),
+        "msg_id": str(msg_id),
+    }
+
+
+def _iter_new_usage(transcript_path: Path, seen_ids: set[str]) -> list[dict[str, object]]:
+    """Usage dicts for assistant turns whose msg_id is not already in seen_ids.
+
+    Entries with an empty msg_id (cannot dedup safely) and malformed JSON lines
+    are skipped; a missing/unreadable transcript yields []. The dedup is what
+    makes re-firing hooks and the Stop-time sweep over the main transcript safe
+    to call repeatedly without double-counting.
+    """
+    path = Path(transcript_path)
+    if not path.is_file():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    out: list[dict[str, object]] = []
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        usage = _extract_turn_usage(entry)
+        if usage is None:
+            continue
+        mid = str(usage["msg_id"])
+        if not mid or mid in seen_ids:
+            continue
+        out.append(usage)
+    return out
+
+
+def _token_meter_cache_path(branch_name: str) -> Path:
+    return get_branch_dir(branch_name) / TOKEN_METER_CACHE_NAME
+
+
+def _load_seen_ids(branch_name: str) -> set[str]:
+    data = _read_json_file(_token_meter_cache_path(branch_name))
+    if isinstance(data, dict):
+        ids = data.get("seen_ids")
+        if isinstance(ids, list):
+            return {str(x) for x in ids if isinstance(x, str)}
+    return set()
+
+
+def _save_seen_ids(branch_name: str, seen_ids: set[str]) -> None:
+    # Bound the cache so a long run can't grow it without limit.
+    trimmed = sorted(seen_ids)[-_SEEN_ID_CACHE_LIMIT:]
+    _write_json_file(
+        _token_meter_cache_path(branch_name),
+        {"seen_ids": trimmed, "updated_at": _utc_timestamp()},
+    )
+
+
+def _current_token_attribution(branch_name: str) -> tuple[Optional[str], str]:
+    """Return (current_subtask_id, current_step_phase) from step_state."""
+    data = _read_json_file(get_branch_dir(branch_name) / "step_state.json")
+    if not isinstance(data, dict):
+        return (None, "")
+    sid = data.get("current_subtask_id")
+    phase = data.get("current_step_phase")
+    return (
+        sid if isinstance(sid, str) else None,
+        phase if isinstance(phase, str) else "",
+    )
+
+
+def record_token_event(
+    branch: Optional[str] = None,
+    *,
+    transcript_path: str = "",
+    agent: str = "",
+    phase: str = "",
+    subtask_id: str = "",
+) -> dict[str, object]:
+    """Attribute new transcript token usage to the active subtask and log it.
+
+    Parses assistant ``usage`` blocks from ``transcript_path`` that the
+    per-branch dedup cache hasn't seen, appends one attributed row per turn to
+    ``token_log.jsonl``, then rebuilds ``token_accounting.json``. Attribution
+    (subtask/phase) falls back to step_state and agent to the phase mapping
+    when callers don't pass them explicitly. Returns the totals just recorded.
+    """
+    branch_name = branch or get_branch_name()
+    if not transcript_path:
+        return {"status": "error", "reason": "transcript_path required"}
+
+    cur_subtask, cur_phase = _current_token_attribution(branch_name)
+    subtask_id = subtask_id or cur_subtask or "unattributed"
+    phase = phase or cur_phase or ""
+    agent = agent or _PHASE_TO_AGENT.get(phase, "orchestrator")
+
+    seen = _load_seen_ids(branch_name)
+    new_usages = _iter_new_usage(Path(transcript_path), seen)
+    totals: dict[str, int] = {field: 0 for field in _TOKEN_FIELDS}
+    if not new_usages:
+        return {
+            "status": "success",
+            "recorded": 0,
+            "subtask_id": subtask_id,
+            "phase": phase,
+            "agent": agent,
+            **totals,
+        }
+
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = _utc_timestamp()
+    try:
+        with log_path.open("a", encoding="utf-8") as handle:
+            for usage in new_usages:
+                row = {
+                    "ts": timestamp,
+                    "subtask_id": subtask_id,
+                    "phase": phase,
+                    "agent": agent,
+                    "model": str(usage["model"]),
+                    "msg_id": str(usage["msg_id"]),
+                    **{field: int(usage[field]) for field in _TOKEN_FIELDS},  # type: ignore[arg-type]
+                }
+                handle.write(json.dumps(row) + "\n")
+                for field in _TOKEN_FIELDS:
+                    totals[field] += int(usage[field])  # type: ignore[arg-type]
+                seen.add(str(usage["msg_id"]))
+    except OSError as exc:
+        return {"status": "error", "reason": str(exc)}
+
+    _save_seen_ids(branch_name, seen)
+    _rebuild_token_accounting(branch_name)
+    return {
+        "status": "success",
+        "recorded": len(new_usages),
+        "subtask_id": subtask_id,
+        "phase": phase,
+        "agent": agent,
+        **totals,
+    }
+
+
+def _empty_token_bucket() -> dict[str, float]:
+    return {field: 0 for field in _TOKEN_FIELDS}
+
+
+def _rebuild_token_accounting(branch: Optional[str] = None) -> dict[str, object]:
+    """Roll token_log.jsonl up into token_accounting.json.
+
+    Groups by subtask, agent, and phase, plus an aggregate carrying
+    ``cache_hit_ratio`` (cache_read / (input + cache_read)) and
+    ``est_cost_usd``. Returns the written payload.
+    """
+    branch_name = branch or get_branch_name()
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    by_subtask: dict[str, dict[str, float]] = {}
+    by_agent: dict[str, dict[str, float]] = {}
+    by_phase: dict[str, dict[str, float]] = {}
+    aggregate: dict[str, float] = _empty_token_bucket()
+    total_cost = 0.0
+    event_count = 0
+
+    if log_path.is_file():
+        try:
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            lines = []
+        for raw in lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            event_count += 1
+            model = str(row.get("model") or "")
+            usage: dict[str, int] = {}
+            for field in _TOKEN_FIELDS:
+                try:
+                    usage[field] = int(row.get(field, 0) or 0)
+                except (TypeError, ValueError):
+                    usage[field] = 0
+            row_cost = _token_cost(usage, model)
+            total_cost += row_cost
+            for dim_key, dim in (
+                (str(row.get("subtask_id") or "unattributed"), by_subtask),
+                (str(row.get("agent") or "unknown"), by_agent),
+                (str(row.get("phase") or "unknown"), by_phase),
+            ):
+                bucket = dim.setdefault(
+                    dim_key, {**_empty_token_bucket(), "est_cost_usd": 0.0}
+                )
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(
+                    bucket.get("est_cost_usd", 0.0) + row_cost, 6
+                )
+            for field in _TOKEN_FIELDS:
+                aggregate[field] += usage[field]
+
+    cache_read = aggregate["cache_read"]
+    cacheable = aggregate["input"] + cache_read
+    aggregate["cache_hit_ratio"] = (
+        round(cache_read / cacheable, 4) if cacheable else 0.0
+    )
+    aggregate["est_cost_usd"] = round(total_cost, 4)
+
+    payload: dict[str, object] = {
+        "schema_version": "1.0",
+        "branch": branch_name,
+        "updated_at": _utc_timestamp(),
+        "event_count": event_count,
+        "aggregate": aggregate,
+        "by_subtask": by_subtask,
+        "by_agent": by_agent,
+        "by_phase": by_phase,
+    }
+    _write_json_file(get_branch_dir(branch_name) / TOKEN_ACCOUNTING_NAME, payload)
+    return payload
+
+
+def token_report(branch: Optional[str] = None) -> str:
+    """Render a per-subtask token table (input/output/cache/cost) as text."""
+    branch_name = branch or get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload["aggregate"])
+    by_subtask = cast(dict[str, dict[str, float]], payload["by_subtask"])
+
+    header = (
+        f"{'subtask':<18}{'input':>13}{'output':>12}"
+        f"{'cache_rd':>13}{'cache_cr':>12}{'$cost':>10}"
+    )
+    rows = [
+        f"Token accounting — {branch_name} "
+        f"({payload['event_count']} assistant turns)",
+        "",
+        header,
+        "-" * len(header),
+    ]
+
+    def _fmt(label: str, bucket: Mapping[str, float]) -> str:
+        return (
+            f"{label:<18}"
+            f"{int(bucket.get('input', 0)):>13,}"
+            f"{int(bucket.get('output', 0)):>12,}"
+            f"{int(bucket.get('cache_read', 0)):>13,}"
+            f"{int(bucket.get('cache_creation', 0)):>12,}"
+            f"{bucket.get('est_cost_usd', 0.0):>10.2f}"
+        )
+
+    for sid in sorted(by_subtask):
+        rows.append(_fmt(sid, by_subtask[sid]))
+    rows.append("-" * len(header))
+    rows.append(_fmt("TOTAL", aggregate))
+    rows.append("")
+    ratio = float(aggregate.get("cache_hit_ratio", 0.0)) * 100
+    rows.append(
+        f"cache hit ratio: {ratio:.1f}%   "
+        f"est cost: ${float(aggregate.get('est_cost_usd', 0.0)):.2f}"
+    )
+    return "\n".join(rows) + "\n"
+
+
 def _prior_stage_file_entry(
     key: str,
     label: str,
@@ -638,7 +1011,8 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
         f"- Status: {report.get('status') or 'unknown'}",
         f"- Consumed required inputs: {consumed}/{required}",
     ]
-    for item in report.get("required_artifacts", []):
+    required_artifacts = report.get("required_artifacts", [])
+    for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
         status = "consumed" if item.get("consumed") else "missing"
@@ -1978,7 +2352,6 @@ def _extract_acceptance_tags(text: object) -> set[str]:
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
-    branch_name: str,
     extra_artifacts: Optional[Mapping[str, str]] = None,
 ) -> dict[str, str]:
     """Collect review/verification artifact text that can prove acceptance tags."""
@@ -2056,7 +2429,7 @@ def build_acceptance_coverage_report(
         if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
     }
     evidence_texts = _collect_acceptance_evidence_texts(
-        branch_dir, branch_name, extra_artifacts=extra_artifacts
+        branch_dir, extra_artifacts=extra_artifacts
     )
     evidence_tags_by_source = {
         source: _extract_acceptance_tags(text)
@@ -2073,7 +2446,11 @@ def build_acceptance_coverage_report(
             if isinstance(owner_subtask, dict)
             else []
         )
-        criterion_texts = [item for item in criteria if isinstance(item, str)]
+        criterion_texts = (
+            [item for item in criteria if isinstance(item, str)]
+            if isinstance(criteria, list)
+            else []
+        )
         validation_criteria_cited = any(
             f"[{requirement}]" in item for item in criterion_texts
         )
@@ -2201,6 +2578,8 @@ def _as_dict(value: object) -> dict[str, object]:
 
 def _as_int(value: object) -> int:
     """Best-effort integer coercion for counters loaded from JSON artifacts."""
+    if not isinstance(value, (int, float, str)):
+        return 0
     try:
         return int(value or 0)
     except (TypeError, ValueError):
@@ -2429,7 +2808,9 @@ def write_run_health_report(
     }
 
 
-def _load_run_health_schema_validator() -> tuple[object, object] | tuple[None, None]:
+def _load_run_health_schema_validator() -> tuple[
+    object, Optional[Callable[[object, object], tuple[bool, list[str]]]]
+]:
     """Return optional package schema validator for generated-project installs."""
     try:
         import importlib as _importlib
@@ -7259,6 +7640,35 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
         if report.get("status") == "error":
             sys.exit(1)
+
+    elif func_name == "record_token_event":
+        # CLI: record_token_event <branch> --transcript <path>
+        #        [--agent A] [--phase P] [--subtask ST-NNN]
+        # Advisory token meter: exit 0 always so the SubagentStop/Stop hooks
+        # never block the turn. Dedups by msg_id via the per-branch cache.
+        def _opt_value(flag: str) -> str:
+            if flag in sys.argv:
+                pos = sys.argv.index(flag)
+                if pos + 1 < len(sys.argv):
+                    return sys.argv[pos + 1]
+            return ""
+
+        tok_branch = (
+            sys.argv[2] if len(sys.argv) >= 3 and not sys.argv[2].startswith("--") else ""
+        )
+        report = record_token_event(
+            tok_branch or None,
+            transcript_path=_opt_value("--transcript"),
+            agent=_opt_value("--agent"),
+            phase=_opt_value("--phase"),
+            subtask_id=_opt_value("--subtask"),
+        )
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "token_report":
+        # CLI: token_report [branch]
+        tok_branch = sys.argv[2] if len(sys.argv) >= 3 else None
+        print(token_report(tok_branch))
 
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:
         # CLI: detect_already_done <branch> <subtask_id> [--since-ref REF]

--- a/src/mapify_cli/templates/settings.json
+++ b/src/mapify_cli/templates/settings.json
@@ -133,6 +133,19 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "description": "MAP Token Meter - attribute sub-agent token usage to the active subtask",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/map-token-meter.py",
+            "timeout": 5,
+            "description": "Reads the finished sub-agent transcript and records input/output/cache tokens to .map/<branch>/token_log.jsonl + token_accounting.json"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "description": "Lightweight quality gates - only critical issues",
@@ -142,6 +155,17 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/end-of-turn.sh",
             "timeout": 30,
             "description": "Auto-fixes silently, only reports secrets/syntax errors"
+          }
+        ]
+      },
+      {
+        "description": "MAP Token Meter - sweep main-session token usage at turn end",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/map-token-meter.py",
+            "timeout": 5,
+            "description": "Records main-session input/output/cache tokens (dedup by msg_id) into the branch token accounting artifacts"
           }
         ]
       }

--- a/src/mapify_cli/templates/skills/map-tokenreport/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-tokenreport/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: map-tokenreport
+description: |
+  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
+effort: low
+disable-model-invocation: true
+argument-hint: "[branch]"
+---
+# /map-tokenreport - Token Accounting Report
+
+Purpose: surface how many tokens (and how much money) the current branch's MAP
+run spent, attributed to the subtask, phase, and agent that spent them.
+Read-only reporting — this skill does not plan, implement, or run quality
+gates.
+
+The numbers come from the `map-token-meter` hook (wired on `SubagentStop` and
+`Stop`), which reads each Claude Code transcript's per-turn `usage` block and
+appends attributed rows to `.map/<branch>/token_log.jsonl`, rolled up into
+`.map/<branch>/token_accounting.json`. This skill just renders that rollup.
+
+## What it shows
+
+- **input / output** tokens, **cache_read** (cheap cache hits) and
+  **cache_creation** (cache writes) — tracked separately because they bill at
+  very different rates.
+- **est_cost_usd** — priced per model via `MODEL_TOKEN_PRICES` in
+  `map_step_runner.py` (estimate, not a billing source of truth).
+- **cache_hit_ratio** = `cache_read / (input + cache_read)` — how well prompt
+  caching is paying off.
+- Breakdowns by subtask, by agent (actor / monitor / research-agent /
+  orchestrator / ...), and by phase.
+
+## Steps
+
+### Step 1: Resolve the branch
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
+```
+
+If the user passed an explicit branch argument, use it instead of the detected
+one.
+
+### Step 2: Render the report
+
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH"
+```
+
+`token_report` re-reads `token_log.jsonl`, rebuilds `token_accounting.json`,
+and prints a per-subtask table plus a TOTAL line with the cache-hit ratio and
+estimated cost. It is idempotent and read-only against your code.
+
+### Step 3: Optional — inspect the raw rollup
+
+For the per-agent / per-phase split (the table only shows per-subtask), read
+the JSON directly:
+
+```bash
+jq '{aggregate, by_agent, by_phase}' ".map/${BRANCH}/token_accounting.json"
+```
+
+### Step 4: Summarize
+
+Report the totals (input / output / cache), the cache-hit ratio, and the
+estimated cost. Call out the most expensive subtask or agent, and a low
+cache-hit ratio if present (it usually means prompt-cache churn worth
+investigating). Then STOP — do not change code from this skill.
+
+## Examples
+
+Report token usage for the current branch:
+
+```text
+/map-tokenreport
+```
+
+Report for a specific branch:
+
+```text
+/map-tokenreport feat/add-multiply
+```
+
+Typical output:
+
+```text
+Token accounting — feat-add-multiply (93 assistant turns)
+
+subtask              input      output     cache_rd    cache_cr     $cost
+-------------------------------------------------------------------------
+ST-001                 183     150,879   14,085,841     792,780     47.31
+-------------------------------------------------------------------------
+TOTAL                  183     150,879   14,085,841     792,780     47.31
+
+cache hit ratio: 100.0%   est cost: $47.31
+```
+
+## Troubleshooting
+
+- **`token_accounting.json` does not exist / report is empty.** The
+  `map-token-meter` hook has not fired for this branch yet. It records on
+  `SubagentStop` and `Stop`, so a brand-new branch with no completed turns has
+  nothing to show. Confirm the hook is wired in `.claude/settings.json`
+  (`SubagentStop` and `Stop` entries) and that `.map/<branch>/token_log.jsonl`
+  exists.
+- **Everything is attributed to `orchestrator` / `unattributed`.** Those turns
+  ran outside a MAP subtask (e.g. direct edits, or before `step_state.json` had
+  a `current_subtask_id`). Per-subtask attribution appears once a
+  `/map-efficient` run sets the active subtask.
+- **Cost looks high relative to raw input.** That is expected when most input
+  is cached: `cache_creation` is the dominant cost on cache-heavy runs. Compare
+  `cache_creation` vs `cache_read` and the cache-hit ratio to see where the
+  spend goes.
+- **Unknown model in cost estimate.** `MODEL_TOKEN_PRICES` falls back to the
+  default model price for unrecognized model ids; update that table in
+  `map_step_runner.py` when a new model ships.

--- a/src/mapify_cli/templates/skills/skill-rules.json
+++ b/src/mapify_cli/templates/skills/skill-rules.json
@@ -277,6 +277,28 @@
           "(test.first|tdd|spec.driven).*(workflow|develop)"
         ]
       }
+    },
+    "map-tokenreport": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Render per-subtask/agent token accounting (tokens, cache, cost, cache-hit ratio) for the current branch.",
+      "promptTriggers": {
+        "keywords": [
+          "map-tokenreport",
+          "token report",
+          "token usage",
+          "token accounting",
+          "run cost",
+          "cache hit ratio"
+        ],
+        "intentPatterns": [
+          "map-tokenreport",
+          "(token|run).*(report|usage|accounting|cost|spent)",
+          "cache.hit.ratio"
+        ]
+      }
     }
   }
 }

--- a/tests/hooks/test_hook_inventory_smoke.py
+++ b/tests/hooks/test_hook_inventory_smoke.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -20,6 +21,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).parents[2]
 HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+SHIPPED_SCRIPTS = REPO_ROOT / "src" / "mapify_cli" / "templates" / "map" / "scripts"
 
 
 @dataclass(frozen=True)
@@ -90,11 +92,13 @@ def _json(stdout: str) -> dict[str, object]:
 
 
 def _assert_noop(run: HookRun, _project: Path) -> None:
+    del _project
     assert run.returncode == 0
     assert run.stdout == "{}" or run.stdout == ""
 
 
 def _assert_deny(run: HookRun, _project: Path) -> None:
+    del _project
     assert run.returncode == 0
     payload = _json(run.stdout)
     output = payload.get("hookSpecificOutput", {})
@@ -104,6 +108,7 @@ def _assert_deny(run: HookRun, _project: Path) -> None:
 
 def _assert_contains(*needles: str) -> Callable[[HookRun, Path], None]:
     def _inner(run: HookRun, _project: Path) -> None:
+        del _project
         assert run.returncode == 0
         for needle in needles:
             assert needle in run.stdout
@@ -129,7 +134,18 @@ def _assert_transcript_saved(run: HookRun, project: Path) -> None:
     assert (project / ".map" / "default" / "last-transcript.txt").is_file()
 
 
+def _assert_token_accounting(run: HookRun, project: Path) -> None:
+    assert run.returncode == 0
+    assert run.stdout == "{}"
+    accounting = project / ".map" / "default" / "token_accounting.json"
+    assert accounting.is_file(), "token meter must write token_accounting.json"
+    payload = json.loads(accounting.read_text())
+    assert payload["aggregate"]["input"] == 1000
+    assert "ST-001" in payload["by_subtask"]
+
+
 def _assert_end_turn_blocks_syntax(run: HookRun, _project: Path) -> None:
+    del _project
     assert run.returncode == 2
     assert "Python syntax error" in run.stderr
 
@@ -147,6 +163,12 @@ def hook_project(tmp_path: Path) -> Path:
     project = tmp_path / "project"
     branch = project / ".map" / "default"
     branch.mkdir(parents=True)
+    # Generated-project shape: ship the standalone runner + its map_utils
+    # sibling so hooks that shell out to .map/scripts/ behave as in the field.
+    scripts = project / ".map" / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy(SHIPPED_SCRIPTS / "map_step_runner.py", scripts / "map_step_runner.py")
+    shutil.copy(SHIPPED_SCRIPTS / "map_utils.py", scripts / "map_utils.py")
     (project / ".claude").mkdir()
     (project / ".claude" / "ralph-loop-config.json").write_text(
         json.dumps(
@@ -225,6 +247,8 @@ def hook_project(tmp_path: Path) -> Path:
                 "type": "assistant",
                 "message": {
                     "role": "assistant",
+                    "id": "msg_seed_1",
+                    "model": "claude-opus-4-7",
                     "usage": {"input_tokens": 1000, "output_tokens": 1000},
                     "content": [{"type": "text", "text": "working"}],
                 },
@@ -273,6 +297,11 @@ HOOK_CASES: dict[str, list[HookCase]] = {
     "end-of-turn.sh": [
         HookCase("non-git-noop", {}, _assert_noop, cwd_factory=lambda project: project),
         HookCase("syntax-block", {}, _assert_end_turn_blocks_syntax, cwd_factory=_make_dirty_git_repo),
+    ],
+    "map-token-meter.py": [
+        HookCase("subagentstop-records", {"agent_transcript_path": "__PROJECT__/transcript.jsonl", "agent_type": "actor"}, _assert_token_accounting),
+        HookCase("stop-records-main", {"transcript_path": "__PROJECT__/transcript.jsonl"}, _assert_token_accounting),
+        HookCase("skip-missing-transcript", {"session_id": "s1"}, _assert_noop),
     ],
 }
 

--- a/tests/integration/test_e2e_claude_sdk.py
+++ b/tests/integration/test_e2e_claude_sdk.py
@@ -210,7 +210,8 @@ def _run_map_plan_for_e2e(test_project: Path) -> str:
     """Run /map-plan with one contract-level retry for live model variance."""
     map_dir = _get_map_dir(test_project)
     prompt = MAP_PLAN_E2E_PROMPT
-    for attempt in range(2):
+    output = ""
+    for _ in range(2):
         output = _run_claude(prompt, cwd=str(test_project), timeout=3600, max_turns=80)
         if (map_dir / "blueprint.json").exists():
             return output
@@ -436,7 +437,7 @@ def _run_map_efficient_for_e2e(
     map_dir = _get_map_dir(test_project)
     last_max_turns_error: RuntimeError | None = None
     outputs: list[str] = []
-    for attempt in range(2):
+    for _ in range(2):
         try:
             outputs.append(_run_claude(prompt, cwd=str(test_project), timeout=3600, max_turns=180))
         except RuntimeError as exc:
@@ -875,6 +876,106 @@ class TestMapEfficientE2E:
         assert result.returncode == 0, (
             f"multiply() produced wrong results:\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_efficient_records_token_accounting(self, test_project):
+        """Live proof that the map-token-meter hooks fire in a real `claude -p`
+        run and produce a correct token_accounting.json rollup.
+
+        `mapify init` installs the hook + settings into the temp project; the
+        Stop hook fires on the main session and meters real `usage`. We assert
+        real tokens were recorded, the cost/cache rollup is present, and the
+        per-dimension buckets sum back to the aggregate (rollup correctness).
+
+        Note: this fast e2e prompt executes the change directly (Bash/Edit),
+        so it does not spawn Task sub-agents — the SubagentStop ->
+        agent_transcript_path attribution path is covered separately by
+        tests/test_map_token_meter.py against a real sub-agent transcript. If a
+        run DID spawn sub-agents, we additionally assert their tokens were
+        captured.
+        """
+        _ensure_map_plan_for_e2e(test_project)
+        _run_map_efficient_for_e2e(test_project)
+
+        map_dir = _get_map_dir(test_project)
+        accounting_path = map_dir / "token_accounting.json"
+        assert accounting_path.is_file(), (
+            "token_accounting.json was not produced by the token-meter hooks. "
+            f"Found in {map_dir}: {[f.name for f in map_dir.iterdir()]}"
+        )
+        assert (map_dir / "token_log.jsonl").is_file(), "append-only token_log.jsonl missing"
+
+        payload = json.loads(accounting_path.read_text(encoding="utf-8"))
+        aggregate = payload.get("aggregate", {})
+        by_agent = payload.get("by_agent", {})
+        by_subtask = payload.get("by_subtask", {})
+
+        # Real tokens were metered and rolled up with cost + cache fields.
+        assert payload.get("event_count", 0) > 0, f"no token events recorded: {payload}"
+        assert aggregate.get("output", 0) > 0, f"no output tokens recorded: {aggregate}"
+        assert (aggregate.get("input", 0) + aggregate.get("cache_read", 0)) > 0, (
+            f"no input/cache tokens recorded: {aggregate}"
+        )
+        assert "cache_hit_ratio" in aggregate, f"rollup missing cache_hit_ratio: {aggregate}"
+        assert aggregate.get("est_cost_usd", 0) > 0, f"no est_cost_usd computed: {aggregate}"
+        assert by_agent, f"no per-agent attribution: {payload}"
+        assert by_subtask, f"no per-subtask attribution: {payload}"
+
+        # Rollup correctness on real data: per-agent buckets must sum back to
+        # the aggregate for every token field (proves the grouping is sound).
+        for field in ("input", "output", "cache_creation", "cache_read"):
+            summed = sum(bucket.get(field, 0) for bucket in by_agent.values())
+            assert summed == aggregate.get(field, 0), (
+                f"by_agent {field} sum ({summed}) != aggregate ({aggregate.get(field)})"
+            )
+
+        # If the run happened to spawn Task sub-agents, their tokens must be
+        # attributed to the sub-agent (not folded into the orchestrator).
+        subagent_names = {"actor", "monitor", "research-agent", "task-decomposer", "predictor"}
+        if subagent_names & set(by_agent):
+            assert any(
+                by_agent[name].get("output", 0) > 0 for name in subagent_names & set(by_agent)
+            ), f"sub-agent present but recorded zero output: {by_agent}"
+
+    def test_subagentstop_captures_subagent_tokens(self, test_project):
+        """Force a real Task sub-agent and prove the SubagentStop ->
+        agent_transcript_path metering attributes its tokens to a
+        non-orchestrator agent.
+
+        The standard fast e2e executes directly (0 Task calls), so it never
+        exercises the live SubagentStop delivery. This test forces one
+        delegation so the sub-agent capture path is verified end-to-end with a
+        real `claude -p` run (no MAP plan needed — we only need a sub-agent to
+        spawn so the hook fires on its transcript).
+        """
+        prompt = (
+            "You MUST delegate via the Task tool. Launch exactly one subagent "
+            "using the Task tool with subagent_type 'general-purpose' and a "
+            "prompt asking it to read app.py and reply with a one-sentence "
+            "summary of what it does. Do NOT read the file yourself — delegate "
+            "through the Task tool, wait for the result, then print the summary."
+        )
+        _run_claude(prompt, cwd=str(test_project), timeout=600, max_turns=30)
+
+        map_dir = _get_map_dir(test_project)
+        accounting_path = map_dir / "token_accounting.json"
+        assert accounting_path.is_file(), (
+            f"token_accounting.json missing in {map_dir}: "
+            f"{[f.name for f in map_dir.iterdir()] if map_dir.is_dir() else 'no map dir'}"
+        )
+        payload = json.loads(accounting_path.read_text(encoding="utf-8"))
+        by_agent = payload.get("by_agent", {})
+        non_orchestrator = set(by_agent) - {"orchestrator"}
+        assert non_orchestrator, (
+            "SubagentStop did not capture any sub-agent tokens. by_agent="
+            f"{by_agent}. Either the run did not spawn a Task sub-agent, or the "
+            "agent_transcript_path metering is not firing on SubagentStop."
+        )
+        captured_output = sum(
+            by_agent[name].get("output", 0) for name in non_orchestrator
+        )
+        assert captured_output > 0, (
+            f"sub-agent(s) {sorted(non_orchestrator)} captured but zero output tokens"
         )
 
 

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import types
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -57,7 +58,7 @@ def branch_workspace(tmp_path, monkeypatch):
     return workspace
 
 
-def _valid_run_health_payload() -> dict[str, object]:
+def _valid_run_health_payload() -> dict[str, Any]:
     artifact_entry = {
         "kind": "state",
         "path": ".map/test-branch/step_state.json",
@@ -3384,7 +3385,7 @@ class TestBlueprintContractCrossRepoDetection:
             }],
         }
 
-    def test_warns_on_cross_repo_path(self, branch_workspace, monkeypatch, tmp_path):
+    def test_warns_on_cross_repo_path(self, branch_workspace, monkeypatch):
         repo = branch_workspace.parents[1]
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
         # Create a real file in current repo so we don't trigger drift warning.
@@ -6038,3 +6039,173 @@ class TestBuildReviewHandoffWithOrdering:
         result = map_step_runner.build_review_handoff()
 
         assert result["status"] == "success"
+
+
+class TestTokenAccounting:
+    """record_token_event attributes a transcript's per-turn usage to the
+    active subtask and rolls it up (cache-hit ratio + est cost) into
+    token_accounting.json. Dedup by msg_id keeps re-fired hooks honest.
+    """
+
+    TRANSCRIPT = (
+        '{"type":"assistant","uuid":"u1","message":{"role":"assistant","id":"msg_1",'
+        '"model":"claude-opus-4-7","usage":{"input_tokens":1000,"output_tokens":200,'
+        '"cache_creation_input_tokens":500,"cache_read_input_tokens":8000}}}\n'
+        '{"type":"user","message":{"role":"user","content":"hi"}}\n'
+        '{"type":"assistant","uuid":"u2","message":{"role":"assistant","id":"msg_2",'
+        '"model":"claude-opus-4-7","usage":{"input_tokens":300,"output_tokens":50,'
+        '"cache_creation_input_tokens":0,"cache_read_input_tokens":9000}}}\n'
+    )
+
+    def _state(self, branch_dir: Path, subtask: str = "ST-003", phase: str = "ACTOR") -> None:
+        (branch_dir / "step_state.json").write_text(
+            json.dumps({"current_subtask_id": subtask, "current_step_phase": phase})
+        )
+
+    def test_records_and_attributes_usage(self, branch_workspace):
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)
+        self._state(branch_workspace)
+
+        result = map_step_runner.record_token_event(
+            "test-branch", transcript_path=str(transcript)
+        )
+
+        assert result["status"] == "success"
+        assert result["recorded"] == 2
+        assert result["subtask_id"] == "ST-003"
+        assert result["agent"] == "actor"  # phase ACTOR -> actor
+        assert result["input"] == 1300
+        assert result["output"] == 250
+        assert result["cache_read"] == 17000
+        assert (branch_workspace / "token_log.jsonl").exists()
+
+        acct = json.loads((branch_workspace / "token_accounting.json").read_text())
+        assert acct["aggregate"]["input"] == 1300
+        assert acct["aggregate"]["cache_hit_ratio"] == round(17000 / 18300, 4)
+        assert acct["aggregate"]["est_cost_usd"] > 0
+        assert "ST-003" in acct["by_subtask"]
+        assert "actor" in acct["by_agent"]
+        assert "ACTOR" in acct["by_phase"]
+
+    def test_dedup_on_second_call(self, branch_workspace):
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)
+        self._state(branch_workspace)
+
+        map_step_runner.record_token_event("test-branch", transcript_path=str(transcript))
+        again = map_step_runner.record_token_event(
+            "test-branch", transcript_path=str(transcript)
+        )
+
+        assert again["recorded"] == 0
+        assert again["input"] == 0
+        log_rows = [
+            line
+            for line in (branch_workspace / "token_log.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(log_rows) == 2, "dedup must not append the same turns twice"
+
+    def test_missing_transcript_path_is_error(self, branch_workspace):
+        del branch_workspace
+        result = map_step_runner.record_token_event("test-branch", transcript_path="")
+        assert result["status"] == "error"
+
+    def test_unreadable_transcript_records_nothing(self, branch_workspace):
+        self._state(branch_workspace)
+        result = map_step_runner.record_token_event(
+            "test-branch",
+            transcript_path=str(branch_workspace.parents[1] / "absent.jsonl"),
+        )
+        assert result["status"] == "success"
+        assert result["recorded"] == 0
+
+    def test_explicit_attribution_overrides_state(self, branch_workspace):
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)
+        self._state(branch_workspace, subtask="ST-001", phase="ACTOR")
+
+        result = map_step_runner.record_token_event(
+            "test-branch",
+            transcript_path=str(transcript),
+            agent="monitor",
+            phase="MONITOR",
+            subtask_id="ST-009",
+        )
+        assert result["agent"] == "monitor"
+        assert result["subtask_id"] == "ST-009"
+        assert result["phase"] == "MONITOR"
+
+    def test_extract_turn_usage_only_assistant_with_usage(self):
+        assert (
+            map_step_runner._extract_turn_usage(
+                {"type": "user", "message": {"role": "user"}}
+            )
+            is None
+        )
+        assert map_step_runner._extract_turn_usage({"no": "message"}) is None
+        usage = map_step_runner._extract_turn_usage(
+            json.loads(
+                '{"type":"assistant","uuid":"x","message":{"role":"assistant",'
+                '"id":"m","model":"claude-opus-4-7",'
+                '"usage":{"input_tokens":5,"output_tokens":1}}}'
+            )
+        )
+        assert usage is not None
+        assert usage["input"] == 5
+        assert usage["msg_id"] == "m"
+
+    def test_token_cost_uses_model_price(self):
+        usage = {"input": 1_000_000, "output": 0, "cache_creation": 0, "cache_read": 0}
+        assert map_step_runner._token_cost(usage, "claude-opus-4-7") == 15.0
+
+    def test_unknown_model_falls_back_to_default_price(self):
+        usage = {"input": 1_000_000, "output": 0, "cache_creation": 0, "cache_read": 0}
+        assert map_step_runner._token_cost(usage, "some-future-model") == 15.0
+
+    def test_date_suffixed_model_id_resolves_to_real_price(self):
+        # Real transcripts carry date-suffixed ids (e.g. a haiku sub-agent);
+        # must price as haiku ($1/Mtok), NOT fall back to opus ($15/Mtok).
+        usage = {"input": 1_000_000, "output": 0, "cache_creation": 0, "cache_read": 0}
+        assert map_step_runner._token_cost(usage, "claude-haiku-4-5-20251001") == 1.0
+        assert map_step_runner._model_price("claude-haiku-4-5-20251001")["input"] == 1.0
+
+    def test_token_report_renders_table(self, branch_workspace):
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)
+        self._state(branch_workspace)
+        map_step_runner.record_token_event("test-branch", transcript_path=str(transcript))
+
+        report = map_step_runner.token_report("test-branch")
+        assert "ST-003" in report
+        assert "TOTAL" in report
+        assert "cache hit ratio" in report
+
+    def test_cli_record_and_report_exit_zero(self, branch_workspace):
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)
+        self._state(branch_workspace)
+        runner = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "mapify_cli" / "templates" / "map" / "scripts" / "map_step_runner.py"
+        )
+        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+        record = subprocess.run(
+            [sys.executable, str(runner), "record_token_event", "test-branch",
+             "--transcript", str(transcript)],
+            capture_output=True, text=True, cwd=str(repo), env=env,
+        )
+        assert record.returncode == 0, record.stderr
+        assert json.loads(record.stdout)["recorded"] == 2
+        report = subprocess.run(
+            [sys.executable, str(runner), "token_report", "test-branch"],
+            capture_output=True, text=True, cwd=str(repo), env=env,
+        )
+        assert report.returncode == 0, report.stderr
+        assert "cache hit ratio" in report.stdout

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -6109,6 +6109,67 @@ class TestTokenAccounting:
         ]
         assert len(log_rows) == 2, "dedup must not append the same turns twice"
 
+    def test_incremental_offset_captures_only_new_turns(self, branch_workspace):
+        """Appended turns are metered incrementally via the byte offset — old
+        turns are not re-read (no O(n) re-parse) and not double-counted."""
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)  # 2 turns
+        self._state(branch_workspace)
+
+        first = map_step_runner.record_token_event(
+            "test-branch", transcript_path=str(transcript)
+        )
+        assert first["recorded"] == 2
+
+        with transcript.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "uuid": "u3",
+                        "message": {
+                            "role": "assistant",
+                            "id": "msg_3",
+                            "model": "claude-opus-4-7",
+                            "usage": {"input_tokens": 10, "output_tokens": 5},
+                        },
+                    }
+                )
+                + "\n"
+            )
+
+        second = map_step_runner.record_token_event(
+            "test-branch", transcript_path=str(transcript)
+        )
+        assert second["recorded"] == 1, "only the appended turn should be recorded"
+        assert second["output"] == 5
+        log_rows = [
+            line
+            for line in (branch_workspace / "token_log.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(log_rows) == 3
+
+    def test_explicit_branch_is_sanitized_against_path_traversal(
+        self, branch_workspace
+    ):
+        """A malicious explicit branch must not escape the .map tree — it is
+        sanitized the same way MAP sanitizes branch names elsewhere."""
+        repo = branch_workspace.parents[1]
+        transcript = repo / "tr.jsonl"
+        transcript.write_text(self.TRANSCRIPT)
+
+        result = map_step_runner.record_token_event(
+            "../../pwned", transcript_path=str(transcript)
+        )
+        assert result["status"] == "success"
+        # Nothing was written outside the project's .map tree.
+        assert not (repo.parent / "pwned").exists()
+        assert not (repo / ".map" / ".." / ".." / "pwned").exists()
+        # The traversal collapsed to the safe 'default' branch dir under .map.
+        assert (repo / ".map" / "default" / "token_accounting.json").is_file()
+
     def test_missing_transcript_path_is_error(self, branch_workspace):
         del branch_workspace
         result = map_step_runner.record_token_event("test-branch", transcript_path="")

--- a/tests/test_map_token_meter.py
+++ b/tests/test_map_token_meter.py
@@ -1,0 +1,138 @@
+"""Tests for the map-token-meter SubagentStop/Stop hook.
+
+The hook is a thin shell over ``map_step_runner.py record_token_event``: it
+reads the transcript_path Claude Code hands it and asks the runner to attribute
+that transcript's token usage to the active subtask. We test both the silent
+no-op paths (CLAUDE_PROJECT_DIR rules) and a realistic positive path that
+proves the side-effect artifacts get written (per the repo rule that a hook
+returning ``{}`` only proves the silent path).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "map-token-meter.py"
+SHIPPED_SCRIPTS = REPO_ROOT / "src" / "mapify_cli" / "templates" / "map" / "scripts"
+SHIPPED_RUNNER = SHIPPED_SCRIPTS / "map_step_runner.py"
+
+TRANSCRIPT = (
+    '{"type":"assistant","uuid":"u1","message":{"role":"assistant","id":"msg_1",'
+    '"model":"claude-opus-4-7","usage":{"input_tokens":1000,"output_tokens":200,'
+    '"cache_creation_input_tokens":500,"cache_read_input_tokens":8000}}}\n'
+    '{"type":"assistant","uuid":"u2","message":{"role":"assistant","id":"msg_2",'
+    '"model":"claude-opus-4-7","usage":{"input_tokens":300,"output_tokens":50,'
+    '"cache_creation_input_tokens":0,"cache_read_input_tokens":9000}}}\n'
+)
+
+
+def _run_hook(stdin_text: str, project_dir: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": str(project_dir), "PYTHONDONTWRITEBYTECODE": "1"}
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        cwd=str(project_dir),
+        env=env,
+    )
+
+
+def test_malformed_stdin_is_silent(tmp_path):
+    result = _run_hook("not json", tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "{}"
+
+
+def test_missing_transcript_path_is_silent(tmp_path):
+    result = _run_hook(json.dumps({"session_id": "s1"}), tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "{}"
+    assert not (tmp_path / ".map").exists(), "no-op must not create accounting artifacts"
+
+
+def _init_git_branch(root: Path, branch: str) -> None:
+    subprocess.run(["git", "init"], cwd=root, capture_output=True, check=False)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=root, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, capture_output=True)
+    (root / ".seed").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=root, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", branch], cwd=root, capture_output=True)
+
+
+def _setup_project(tmp_path: Path, branch: str) -> Path:
+    """Lay out a generated-project shape: .map/scripts/ runner (+ its map_utils
+    sibling) + branch state + a git branch. Returns the branch artifact dir."""
+    scripts_dir = tmp_path / ".map" / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(SHIPPED_RUNNER, scripts_dir / "map_step_runner.py")
+    shutil.copy(SHIPPED_SCRIPTS / "map_utils.py", scripts_dir / "map_utils.py")
+    branch_dir = tmp_path / ".map" / branch
+    branch_dir.mkdir(parents=True)
+    (branch_dir / "step_state.json").write_text(
+        json.dumps({"current_subtask_id": "ST-005", "current_step_phase": "MONITOR"})
+    )
+    _init_git_branch(tmp_path, branch)
+    return branch_dir
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_subagentstop_meters_agent_transcript(tmp_path):
+    """On SubagentStop the hook must read agent_transcript_path (the sub-agent's
+    own transcript) and attribute to agent_type — NOT re-sweep the parent
+    transcript_path. We point the two paths at different files and prove only
+    the agent transcript's tokens are recorded under the agent_type."""
+    branch = "feat-meter"
+    branch_dir = _setup_project(tmp_path, branch)
+    agent_transcript = tmp_path / "agent.jsonl"
+    agent_transcript.write_text(TRANSCRIPT)  # input 1300 total
+    # Decoy parent transcript the hook must IGNORE on SubagentStop.
+    parent_transcript = tmp_path / "parent.jsonl"
+    parent_transcript.write_text(
+        '{"type":"assistant","uuid":"p1","message":{"role":"assistant","id":"msg_parent",'
+        '"model":"claude-opus-4-7","usage":{"input_tokens":99999,"output_tokens":1}}}\n'
+    )
+
+    result = _run_hook(
+        json.dumps(
+            {
+                "agent_transcript_path": str(agent_transcript),
+                "transcript_path": str(parent_transcript),
+                "agent_type": "monitor",
+            }
+        ),
+        tmp_path,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "{}"
+
+    payload = json.loads((branch_dir / "token_accounting.json").read_text())
+    assert payload["aggregate"]["input"] == 1300, "must meter the agent transcript only"
+    assert "monitor" in payload["by_agent"], "must attribute to agent_type"
+    assert "msg_parent" not in (branch_dir / "token_log.jsonl").read_text()
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_stop_meters_main_transcript_as_orchestrator(tmp_path):
+    """On Stop (no agent_transcript_path) the hook sweeps the main transcript
+    and labels those driving turns as the orchestrator."""
+    branch = "feat-meter"
+    branch_dir = _setup_project(tmp_path, branch)
+    transcript = tmp_path / "main.jsonl"
+    transcript.write_text(TRANSCRIPT)
+
+    result = _run_hook(json.dumps({"transcript_path": str(transcript)}), tmp_path)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "{}"
+
+    payload = json.loads((branch_dir / "token_accounting.json").read_text())
+    assert payload["aggregate"]["input"] == 1300
+    assert "ST-005" in payload["by_subtask"]
+    assert "orchestrator" in payload["by_agent"]


### PR DESCRIPTION
## Summary
- Meters real token usage per subtask/phase/agent for a MAP run. A new `map-token-meter` hook fires on **SubagentStop** (reads the sub-agent's `agent_transcript_path`) and **Stop** (main session), parses each transcript's `usage` block, and appends attributed rows to `.map/<branch>/token_log.jsonl`, rolled up into `token_accounting.json`.
- Tracks `input` / `output` / `cache_read` / `cache_creation` separately (they bill very differently), plus `est_cost_usd` (priced per model in `MODEL_TOKEN_PRICES`, tolerant of date-suffixed ids like `claude-haiku-4-5-20251001`) and `cache_hit_ratio`.
- Parse/record/rollup logic is **self-contained in `map_step_runner.py`** (stdlib only) so it runs in generated projects where the `mapify_cli` package is not importable; the hook shells out to it.
- Adds the **`/map-tokenreport`** skill to render the rollup for the current (or given) branch. Read-only.

## Verification (real, not synthetic)
- Validated the parser against **real Claude Code transcripts** (real `usage` schema, date-suffixed model ids) — this caught two bugs before merge: SubagentStop must read `agent_transcript_path` (not `transcript_path`), and model pricing must normalize date suffixes.
- **Live e2e** via the existing harness (`claude -p`): hooks fire in a real run and produce `token_accounting.json` with correct rollup; a dedicated test forces a real Task sub-agent and asserts `SubagentStop` attributes its tokens to a non-orchestrator agent (proved end-to-end).
- `mapify init` smoke: skill + hook + runner ship into a generated project; generated `skill-rules.json` classifies it `skillClass=task`.

## Test plan
- [x] `pytest` — 1619 passed (unit + hook-inventory + token accounting)
- [x] `pytest -m slow tests/integration/test_e2e_claude_sdk.py::TestMapEfficientE2E::test_efficient_records_token_accounting` + `::test_subagentstop_captures_subagent_tokens` — both pass live
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] `pyright` on changed files — 0/0/0
- [x] `test_skills.py` / `test_template_sync.py` — green; templates in parity

Usage: `/map-tokenreport` (current branch) or `/map-tokenreport <branch>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)