### PR TITLE
MAP cross-workflow safety guards (blast-radius, recommendation gate, actor mismatch)

### DIFF
--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -299,9 +299,18 @@ Before invoking Monitor, validate Actor's response via
 `detect_truncated_agent_output --agent actor`. If `truncated: true`, log via
 `log_agent_failure` and re-invoke ONCE using the prompt from
 `build_json_retry_prompt --agent actor --errors '<reasons>'`; if still
-malformed, stop with CLARIFICATION_NEEDED. Cross-check declared `files_changed`
-against `git diff --name-only` — undeclared writes = truncated. Full recipe in
-[efficient-reference.md](efficient-reference.md).
+malformed, stop with CLARIFICATION_NEEDED.
+
+**Files-changed mismatch check (MANDATORY):** Run
+`detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" --declared "<Actor's files_changed, comma-joined>"`.
+If `status_mismatch == true`, surface `recovery_instruction` and re-invoke Actor to finish `declared_not_written` files; do NOT record the subtask until clear. Full recipe: [efficient-reference.md](efficient-reference.md).
+
+### Symbol blast-radius gate (MANDATORY — pre-dispatch)
+
+Run `detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"`. If
+`recommended_gate == "validate_callers"`, append `external_callers` to the Monitor
+`<documents>` context and require Monitor to validate each external caller's contract.
+Full recipe: [efficient-reference.md](efficient-reference.md).
 
 ### Phase: MONITOR (2.4) - Required
 
@@ -358,29 +367,17 @@ Return JSON with valid, summary, issues, files_changed, tests_run, and escalatio
   python3 .map/scripts/map_orchestrator.py record_subtask_result "$SUBTASK_ID" valid \
     --files "$FILES_CSV" --summary "$ONE_LINE" --commit-sha "$SHA"
   ```
-  `record_subtask_result` is the canonical write path — the result lands in
-  `subtask_results` and `last_subtask_commit_sha` for downstream context.
-  Pass `--commit-sha` whenever you just made a per-subtask commit (see
-  rule above); when omitted, the orchestrator auto-detects via
-  `git log -1 --format=%H` but the explicit value is preferred so the
-  audit trail is unambiguous.
+  `record_subtask_result` is the canonical write path. Pass `--commit-sha`
+  (preferred); omitting it triggers auto-detect via `git log -1 --format=%H`.
 - **Auto-validate mutation boundary:** `validate_step 2.4` itself now runs
   `validate_mutation_boundary` for the current subtask and rejects on
   `status="violation"` (only when `MAP_STRICT_SCOPE=1`) or `status="error"`.
   No manual dispatch needed.
 - **Refresh blueprint affected_files after each clean close (RECOMMENDED):**
-  After commit + record_subtask_result, sync the blueprint's
-  `affected_files` for the just-closed subtask to the actual diff. This
-  keeps the next subtask's mutation-boundary check honest — without
-  refresh, decomposer-time guesses drift further from reality every
-  subtask and Monitor warnings degrade into background noise.
-
-  ```bash
-  python3 .map/scripts/map_step_runner.py refresh_blueprint_affected_files \
-    "$BRANCH" "$SUBTASK_ID"
-  ```
-  Idempotent and read-only against blueprint structure outside the
-  named subtask. Use `--dry-run` to preview the diff before writing.
+  After commit + record_subtask_result, run
+  `refresh_blueprint_affected_files "$BRANCH" "$SUBTASK_ID"` to sync the
+  blueprint to actual diff — keeps mutation-boundary checks honest.
+  Full recipe: [efficient-reference.md](efficient-reference.md).
 - If `valid=false`, write `code-review-N.md`, run `python3 .map/scripts/map_orchestrator.py monitor_failed --feedback "<feedback>"`, inspect `retry_isolation`, and invoke Predictor only when stuck/high-risk escalation rules apply.
 - If `retry_isolation=clean_retry_required`, run `python3 .map/scripts/map_step_runner.py validate_retry_quarantine` before the next Actor call. The next Actor prompt must use CLEAN_RETRY mode from `.map/<branch>/retry_quarantine.json` and must not reuse the rejected approach unless the quarantine artifact preserves it.
 - Treat test failures after Monitor approval as Monitor failure. **Cross-subtask regression gate (MANDATORY):** before the test gate, run `detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID"`; if `recommended_gate == "full_suite"` you MUST run the FULL suite (never a `-k` subset) before commit / `record_subtask_result` — per-subtask Monitor is blind to regressions on prior subtasks' code. Recipe: [efficient-reference.md](efficient-reference.md).

--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -90,8 +90,52 @@ If `truncated: true`:
    and re-invoke Actor ONCE using the prompt from
    `build_json_retry_prompt --agent actor --errors '<reasons>'`.
 2. If still malformed, stop with CLARIFICATION_NEEDED.
-3. Cross-check `files_changed` against `git diff --name-only`. Files
-   declared but not in the diff = Actor said it changed them but didn't.
+
+**Files-changed mismatch check (MANDATORY):** After the JSON envelope is
+confirmed intact, run:
+
+```bash
+FILES_DECLARED=$(echo "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
+MISMATCH=$(detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" \
+  --declared "$FILES_DECLARED")
+echo "$MISMATCH"
+STATUS_MISMATCH=$(echo "$MISMATCH" | jq -r '.status_mismatch')
+```
+
+- `status_mismatch == true` — Actor declared files it did not write (mid-edit
+  truncation). Read `recovery_instruction` from the JSON and re-invoke the
+  Actor to finish the `declared_not_written` files. Do NOT record the subtask
+  until the mismatch clears.
+- `status_mismatch == false` — no mismatch; proceed to Monitor.
+
+## Symbol blast-radius gate
+
+Per-subtask Monitor validates only the files the current subtask touched — it
+is structurally blind to callers of a changed symbol that live in OTHER files
+(other skills, workflows, or utilities). The canonical miss: a shared helper is
+renamed or its signature changes, and every caller outside `affected_files`
+breaks silently.
+
+Before dispatching Monitor, run the blast-radius detector:
+
+```bash
+BLAST=$(python3 .map/scripts/map_step_runner.py \
+  detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID")
+echo "$BLAST"   # inspect changed_symbols / external_callers / reason
+GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
+```
+
+- `recommended_gate == "validate_callers"` — the subtask changed a
+  module-level symbol referenced OUTSIDE its `affected_files`. You MUST:
+  1. Append the `external_callers` list to the Monitor `<documents>` context.
+  2. Require Monitor to validate the contract of EACH external caller (not
+     just the current subtask's files).
+  3. Do NOT accept a Monitor pass that ignores the external callers — this is
+     the guard that catches a shared-symbol refactor breaking another workflow.
+- `recommended_gate == "none"` — no external callers affected; proceed to
+  Monitor dispatch without modification.
+
+It is read-only and exits 0 always; callers branch on `recommended_gate`.
 
 ## Cross-subtask regression gate
 

--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -132,7 +132,7 @@ GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
      just the current subtask's files).
   3. Do NOT accept a Monitor pass that ignores the external callers — this is
      the guard that catches a shared-symbol refactor breaking another workflow.
-- `recommended_gate == "none"` — no external callers affected; proceed to
+- `recommended_gate == "scoped"` — no external callers affected; proceed to
   Monitor dispatch without modification.
 
 It is read-only and exits 0 always; callers branch on `recommended_gate`.

--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -301,12 +301,19 @@ Reviewer prompts reference `review-bundle.json`, `review-bundle.md`, the raw dif
 
 ### Step A.2b: Truncated-response gate (MANDATORY — post-fan-out, pre-verification)
 
-After each reviewer (monitor, predictor, evaluator) returns, validate its output
-via `detect_truncated_agent_output --agent <role>`. On truncation:
-log via `log_agent_failure --agent <role> --phase post-invoke --failure-label truncated --reasons '<reasons>'`
+After each reviewer returns, validate its output via
+`detect_truncated_agent_output --agent <kind>` using the role-specific kind
+shown below. On truncation: log via
+`log_agent_failure --agent <role> --phase post-invoke --failure-label truncated --reasons '<reasons>'`
 and re-invoke that reviewer ONCE using the prompt from
 `build_json_retry_prompt --agent <role> --errors '<reasons>'`; if still
 malformed, stop with CLARIFICATION_NEEDED.
+
+Role → `--agent` kind for the truncation check:
+- monitor reviewer → `--agent review-monitor` (enforces the full review schema:
+  evidence/valid/summary/verdict/issues/passed_checks/failed_checks)
+- predictor reviewer → `--agent predictor`
+- evaluator reviewer → `--agent evaluator`
 
 ### Step A.3: Verification gate (MANDATORY before any presentation)
 

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -1071,20 +1071,21 @@ def validate_step(
                 "envelope_error": envelope_error,
             }
 
-    # Recommendation-omitted warning: closing 2.4 without --recommendation
-    # leaves the verdict-consistency footgun open (Monitor valid=true +
-    # recommendation=revise would silently pass). Surface a soft warning
-    # so the operator knows to pipe Monitor's recommendation through.
-    recommendation_omitted_warning: Optional[str] = None
+    # Recommendation-required gate: closing 2.4 without --recommendation
+    # makes the verdict-consistency enforcement impossible. Hard-fail so
+    # the operator is forced to pipe Monitor's recommendation through.
     if step_id == "2.4" and not recommendation:
-        recommendation_omitted_warning = (
-            "validate_step 2.4 closed without --recommendation. The "
-            "verdict-consistency gate cannot enforce 'valid=true + "
-            "recommendation=revise/block/needs_investigation = fail' "
-            "unless you pass Monitor's recommendation. Recommended: "
-            "`python3 .map/scripts/map_orchestrator.py validate_step 2.4 "
-            "--recommendation \"$MONITOR_RECOMMENDATION\"`."
-        )
+        return {
+            "valid": False,
+            "message": (
+                "validate_step 2.4 requires --recommendation (Monitor's "
+                "verdict). Without it the verdict-consistency gate cannot "
+                "enforce 'valid=true + recommendation in {revise,block,"
+                "needs_investigation} = fail'. Re-run: validate_step 2.4 "
+                "--recommendation \"$MONITOR_RECOMMENDATION\"."
+            ),
+            "recommendation_required": True,
+        }
 
     # Monitor recommendation enforcement: when closing 2.4 (MONITOR) and
     # the caller passed a recommendation, refuse to close on revise /
@@ -1256,8 +1257,6 @@ def validate_step(
         response["skipped_for_deps"] = skipped_for_deps
     if next_step_signal == "BLOCKED_ON_DEPS":
         response["blocked_subtasks"] = blocked_remaining
-    if recommendation_omitted_warning:
-        response["warning"] = recommendation_omitted_warning
     return response
 
 
@@ -3430,6 +3429,8 @@ def main():
                 monitor_envelope=monitor_envelope_text,
             )
             print(json.dumps(result, indent=2))
+            if not result.get("valid", False):
+                sys.exit(1)
 
         elif args.command == "initialize":
             task = args.task_or_step or "MAP workflow task"

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -997,13 +997,14 @@ def validate_step(
     Args:
         step_id: Step identifier to validate
         branch: Git branch name (sanitized)
-        recommendation: For step_id="2.4" (Monitor close), optional
-            Monitor verdict field. When set to ``revise``, ``block``, or
-            ``needs_investigation``, validate_step refuses to close the
-            phase and returns valid=false — so the recommendation
-            contract (skill rule: "valid=true + recommendation∈{revise,
-            block, needs_investigation} = fail") is enforced
-            orchestrator-side, not just by-convention.
+        recommendation: For step_id="2.4" (Monitor close), REQUIRED
+            Monitor verdict field — omitting it returns valid=false
+            (recommendation_required) rather than closing the phase. When
+            set to ``revise``, ``block``, or ``needs_investigation``,
+            validate_step refuses to close the phase and returns valid=false
+            — so the recommendation contract (skill rule: "valid=true +
+            recommendation∈{revise, block, needs_investigation} = fail") is
+            enforced orchestrator-side, not just by-convention.
 
     Returns:
         Dict with valid: bool, message: str

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -7431,6 +7431,99 @@ def detect_cross_subtask_regression_risk(
 
 
 # ---------------------------------------------------------------------------
+# Actor files-changed mismatch detector
+# ---------------------------------------------------------------------------
+
+
+def detect_actor_files_changed_mismatch(
+    branch: str, subtask_id: str, declared_files: list[str]
+) -> dict:
+    """Flag when an Actor declared files in its envelope that it never wrote.
+
+    The canonical failure mode: the Actor response is truncated mid-edit
+    (model context overflow, timeout). The files_changed envelope lists the
+    intended targets, but the actual git diff is shorter — some files were
+    never written. The Monitor's mutation-boundary check sees *actual* files
+    only and cannot detect the omission; this detector closes that gap.
+
+    Distinct from related detectors:
+    - ``validate_mutation_boundary`` catches *wrote-but-NOT-declared* (scope
+      creep — the opposite direction).
+    - ``detect_truncated_agent_output`` checks JSON-envelope key completeness,
+      not file-system writes.
+    - THIS function checks *declared-but-not-written* only.  The load-bearing
+      field is ``declared_not_written``.
+
+    Returns::
+
+        {
+          "status": "ok" | "unknown",
+          "subtask_id": str,
+          "declared": [str],               # sorted; stripped declared_files
+          "actual": [str],                 # sorted; files from git diff
+          "declared_not_written": [str],   # sorted; declared minus actual
+          "status_mismatch": bool,         # True when declared_not_written non-empty
+          "recovery_instruction": str,     # non-empty only when status_mismatch
+          "reason": str,                   # non-empty only on status=="unknown"
+        }
+
+    Fail-safe: any git failure → ``status="unknown"`` + ``status_mismatch=True``
+    (never silently ``False``): the Actor gate must not pass blindly on a git
+    error.
+    """
+    branch_name = _sanitize_branch(branch)
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+    actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+    if actual_set is None:
+        # Intent: fail safe to mismatch so the gate cannot pass blindly.
+        declared_sorted = sorted(d.strip() for d in (declared_files or []) if d.strip())
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "declared": declared_sorted,
+            "actual": [],
+            "declared_not_written": declared_sorted,
+            "status_mismatch": True,
+            "recovery_instruction": (
+                "git diff unavailable (fail-safe — actual changes were NOT "
+                f"consulted): treating all declared files as unwritten: {declared_sorted}. "
+                "Re-invoke the Actor to finish any truncated edits and re-run this "
+                "check once git is available; do NOT record the subtask until "
+                "git diff --name-only covers every declared file."
+            ),
+            "reason": (
+                "could not compute the actual diff (git unavailable) — "
+                "assuming mismatch as a fail-safe."
+            ),
+        }
+
+    declared = [d.strip() for d in (declared_files or []) if d.strip()]
+    declared_not_written = sorted(d for d in declared if d not in actual_set)
+    status_mismatch = bool(declared_not_written)
+
+    recovery_instruction = ""
+    if status_mismatch:
+        recovery_instruction = (
+            f"Actor declared files it did not write: {declared_not_written}. "
+            "Its previous response was likely truncated mid-edit — re-invoke "
+            "the Actor to finish those files; do NOT record the subtask until "
+            "git diff --name-only covers every declared file."
+        )
+
+    return {
+        "status": "ok",
+        "subtask_id": subtask_id,
+        "declared": sorted(declared),
+        "actual": sorted(actual_set),
+        "declared_not_written": declared_not_written,
+        "status_mismatch": status_mismatch,
+        "recovery_instruction": recovery_instruction,
+        "reason": "",
+    }
+
+
+# ---------------------------------------------------------------------------
 # Symbol blast-radius detector
 # ---------------------------------------------------------------------------
 
@@ -8727,6 +8820,20 @@ if __name__ == "__main__":
         # can decide full-suite vs scoped without `set -e` tripping on an
         # advisory signal.
         report = detect_symbol_blast_radius(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "detect_actor_files_changed_mismatch" and len(sys.argv) >= 4:
+        # CLI: detect_actor_files_changed_mismatch <branch> <subtask_id> [--declared f1,f2,...]
+        # Read-only. Exit 0 always (callers branch on `status_mismatch` field)
+        # so a shell pipeline can decide whether to block recording without
+        # `set -e` tripping on an advisory signal.
+        declared_arg: list[str] = []
+        if "--declared" in sys.argv:
+            declared_idx = sys.argv.index("--declared")
+            if declared_idx + 1 < len(sys.argv):
+                raw_declared = sys.argv[declared_idx + 1]
+                declared_arg = [f for f in raw_declared.split(",") if f.strip()]
+        report = detect_actor_files_changed_mismatch(sys.argv[2], sys.argv[3], declared_arg)
         print(json.dumps(report, indent=2))
 
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -7429,6 +7429,364 @@ def detect_cross_subtask_regression_risk(
     }
 
 
+# ---------------------------------------------------------------------------
+# Symbol blast-radius detector
+# ---------------------------------------------------------------------------
+
+_SYMBOL_DEF_RE = re.compile(
+    r"^(?:async\s+)?def\s+(\w+)"      # function / async function
+    r"|^class\s+(\w+)"                 # class
+    r"|^([A-Z][A-Z0-9_]{2,})\s*[:=]", # UPPER_CONST (len >= 3 via {2,})
+)
+
+# Directories/globs searched by _grep_external_callers
+_GREP_SEARCH_PATHS = [".claude/skills", "src", ".map/scripts"]
+
+# Maximum distinct symbols we'll send to git-grep before short-circuiting
+_SYMBOL_GREP_CAP = 40
+
+# Sentinel returned by _grep_external_callers on git/subprocess failure.
+# Distinct from the legitimate "no matches" empty list — callers must treat
+# any entry with note=="grep_error" as an unknown/fail-safe signal rather
+# than evidence that no external callers exist.
+_GREP_ERROR_SENTINEL = [{"symbol": "*", "file": "", "line": 0, "note": "grep_error"}]
+
+
+def _extract_changed_module_symbols(diff_text: str) -> set[str]:
+    """Return module-level symbol names introduced in *added* diff lines.
+
+    Only lines that start with ``+`` (but not ``+++``) are considered.
+    Only column-0 definitions are recognised (no leading whitespace after the
+    ``+`` prefix) — this excludes nested/indented definitions.  Dunder names
+    and names shorter than 3 characters are excluded.
+    """
+    symbols: set[str] = set()
+    for raw_line in diff_text.splitlines():
+        if not raw_line.startswith("+") or raw_line.startswith("+++"):
+            continue
+        # Strip the leading '+' to get the actual source line
+        line = raw_line[1:]
+        # Module-level: no leading whitespace
+        if line and line[0] in (" ", "\t"):
+            continue
+        m = _SYMBOL_DEF_RE.match(line)
+        if not m:
+            continue
+        # Exactly one of the three groups is non-None
+        name = m.group(1) or m.group(2) or m.group(3)
+        if name is None:
+            continue
+        if name.startswith("__") or len(name) < 3:
+            continue
+        symbols.add(name)
+    return symbols
+
+
+def _grep_external_callers(
+    symbols: set[str], affected_files: list[str], project_dir: Path
+) -> list[dict]:
+    """Search for references to *symbols* in the project outside *affected_files*.
+
+    Uses a single batched ``git grep`` call with a whole-word alternation regex.
+    Returns a list of ``{"symbol": str, "file": str, "line": int}`` dicts, sorted
+    deterministically and deduped.
+
+    Symbol cap: when ``len(symbols) > _SYMBOL_GREP_CAP`` the search is skipped
+    and a single marker entry is returned so the caller still recommends
+    ``validate_callers`` (too many symbols → thorough gate is the safe default).
+
+    Returns an empty list on git-grep failure (non-zero exit code other than 1)
+    so callers can degrade gracefully without crashing.
+    """
+    if not symbols:
+        return []
+
+    # Cap: too many symbols → conservatively flag for caller validation
+    if len(symbols) > _SYMBOL_GREP_CAP:
+        return [{"symbol": "*", "file": "", "line": 0, "note": "skipped_too_many_symbols"}]
+
+    affected_set = set(affected_files)
+
+    # Build alternation pattern; sort for determinism
+    alternation = "|".join(re.escape(s) for s in sorted(symbols))
+    pattern = f"({alternation})"
+
+    try:
+        result = subprocess.run(
+            ["git", "grep", "-n", "-E", "-w", pattern, "--"] + _GREP_SEARCH_PATHS,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return list(_GREP_ERROR_SENTINEL)
+
+    # git grep exits with 1 when no matches (not an error); >1 is a real error
+    if result.returncode not in (0, 1):
+        return list(_GREP_ERROR_SENTINEL)
+
+    seen: set[tuple[str, str, int]] = set()
+    callers: list[dict] = []
+
+    for raw in result.stdout.splitlines():
+        # Format: path:lineno:content
+        parts = raw.split(":", 2)
+        if len(parts) < 3:
+            continue
+        file_path, lineno_str, content = parts[0], parts[1], parts[2]
+
+        # Exclude matches inside the subtask's own affected files
+        if file_path in affected_set:
+            continue
+
+        try:
+            lineno = int(lineno_str)
+        except ValueError:
+            continue
+
+        # Determine which symbol(s) matched this line
+        for sym in sorted(symbols):
+            if re.search(rf"\b{re.escape(sym)}\b", content):
+                key = (sym, file_path, lineno)
+                if key in seen:
+                    continue
+                seen.add(key)
+                callers.append({"symbol": sym, "file": file_path, "line": lineno})
+
+    callers.sort(key=lambda d: (d["file"], d["line"], d["symbol"]))
+    return callers
+
+
+def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
+    """Flag when a subtask changed a module-level symbol referenced outside its scope.
+
+    This is an *advisory* detector — it does not block; it informs the Monitor
+    gate of external callers that need explicit validation.  The canonical failure
+    mode it prevents: a shared helper (e.g. ``chunked_review_pipeline.py``)
+    is re-derived in one subtask and silently breaks callers in other subtasks
+    that are never re-tested in the scoped gate.
+
+    Returns::
+
+        {
+          "status": "ok" | "unknown",
+          "subtask_id": str,
+          "changed_symbols": [str],         # sorted; module-level additions
+          "external_callers": [...],         # {symbol, file, line} outside affected_files
+          "recommended_gate": "validate_callers" | "scoped",
+          "reason": str,
+        }
+
+    Fail-safe: any git failure → ``status="unknown"`` +
+    ``recommended_gate="validate_callers"`` (never silently ``"scoped"``).
+    """
+    branch_name = _sanitize_branch(branch)
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+    # ------------------------------------------------------------------
+    # 1. Resolve blueprint + affected_files
+    # ------------------------------------------------------------------
+    blueprint = load_blueprint(branch_name, project_dir)
+    subtask: Optional[dict] = None
+    if blueprint is not None:
+        subtask = get_subtask_from_blueprint(blueprint, subtask_id)
+    affected_files: list[str] = []
+    if subtask is not None:
+        raw_af = subtask.get("affected_files") or []
+        if isinstance(raw_af, list):
+            affected_files = [str(f) for f in raw_af if f]
+
+    # ------------------------------------------------------------------
+    # 2. Compute changed files for this subtask
+    # ------------------------------------------------------------------
+    changed = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+    if changed is None:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "Could not compute the current subtask diff (git unavailable) "
+                "— defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # 3. Filter to runtime Python files
+    # ------------------------------------------------------------------
+    runtime_changed = [
+        p for p in changed if p.endswith(".py") and not _is_test_path(p)
+    ]
+    if not runtime_changed:
+        return {
+            "status": "ok",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "scoped",
+            "reason": "No runtime .py symbols changed — scoped gate is sufficient.",
+        }
+
+    # ------------------------------------------------------------------
+    # 4. Get diff text for runtime files
+    # ------------------------------------------------------------------
+    base_ref: Optional[str] = None
+    state_file = project_dir / ".map" / branch_name / "step_state.json"
+    if state_file.exists():
+        try:
+            state_data = json.loads(state_file.read_text(encoding="utf-8"))
+            last_sha = state_data.get("last_subtask_commit_sha")
+            if isinstance(last_sha, str) and last_sha:
+                base_ref = last_sha
+        except (json.JSONDecodeError, OSError):
+            pass
+    if not base_ref:
+        try:
+            head_probe = subprocess.run(
+                ["git", "rev-parse", "--verify", "HEAD"],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if head_probe.returncode == 0:
+                base_ref = "HEAD"
+        except (OSError, subprocess.TimeoutExpired):
+            return {
+                "status": "unknown",
+                "subtask_id": subtask_id,
+                "changed_symbols": [],
+                "external_callers": [],
+                "recommended_gate": "validate_callers",
+                "reason": (
+                    "git rev-parse failed or timed out — "
+                    "defaulting to validate_callers as a fail-safe."
+                ),
+            }
+
+    if not base_ref:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "Could not resolve a git base ref for the diff — "
+                "defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", base_ref, "--"] + runtime_changed,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "git diff timed out or failed — "
+                "defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    if diff_result.returncode != 0:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                f"git diff returned non-zero exit code {diff_result.returncode} "
+                "— defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    diff_text = diff_result.stdout
+
+    # ------------------------------------------------------------------
+    # 5. Extract changed module-level symbols
+    # ------------------------------------------------------------------
+    changed_symbols = _extract_changed_module_symbols(diff_text)
+    if not changed_symbols:
+        return {
+            "status": "ok",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "scoped",
+            "reason": (
+                "Runtime .py files changed but no module-level symbol additions "
+                "detected — scoped gate is sufficient."
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # 6. Find external callers
+    # ------------------------------------------------------------------
+    external_callers = _grep_external_callers(changed_symbols, affected_files, project_dir)
+
+    # Detect grep-error sentinel: git/subprocess failure inside _grep_external_callers.
+    # An empty list is a legitimate "no matches" result; the sentinel is the fail-safe.
+    grep_errored = any(c.get("note") == "grep_error" for c in external_callers)
+    if grep_errored:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": sorted(changed_symbols),
+            "external_callers": external_callers,
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "git grep failed — defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    recommended_gate = "validate_callers" if external_callers else "scoped"
+
+    if external_callers and external_callers[0].get("note") == "skipped_too_many_symbols":
+        reason = (
+            f"Too many changed symbols ({len(changed_symbols)} > {_SYMBOL_GREP_CAP}) "
+            "— grep skipped; validate_callers applied conservatively."
+        )
+    elif external_callers:
+        caller_summary = ", ".join(
+            f"{c['symbol']} in {c['file']}:{c['line']}"
+            for c in external_callers[:5]
+        )
+        extra = f" (+{len(external_callers) - 5} more)" if len(external_callers) > 5 else ""
+        reason = (
+            f"Changed symbol(s) {sorted(changed_symbols)!r} are referenced "
+            f"outside affected_files: {caller_summary}{extra}. "
+            "All external callers must be explicitly validated."
+        )
+    else:
+        reason = (
+            f"Changed symbol(s) {sorted(changed_symbols)!r} have no external "
+            "callers outside affected_files — scoped gate is sufficient."
+        )
+
+    return {
+        "status": "ok",
+        "subtask_id": subtask_id,
+        "changed_symbols": sorted(changed_symbols),
+        "external_callers": external_callers,
+        "recommended_gate": recommended_gate,
+        "reason": reason,
+    }
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -8618,6 +8618,15 @@ if __name__ == "__main__":
         report = detect_cross_subtask_regression_risk(sys.argv[2], sys.argv[3])
         print(json.dumps(report, indent=2))
 
+    elif func_name == "detect_symbol_blast_radius" and len(sys.argv) >= 4:
+        # CLI: detect_symbol_blast_radius <branch> <subtask_id>
+        # Read-only. Exit 0 always (callers branch on the `recommended_gate`
+        # field, like detect_cross_subtask_regression_risk) so a shell pipeline
+        # can decide full-suite vs scoped without `set -e` tripping on an
+        # advisory signal.
+        report = detect_symbol_blast_radius(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:
         # CLI: detect_already_done <branch> <subtask_id> [--since-ref REF]
         branch_arg = sys.argv[2]

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -4409,7 +4409,7 @@ AGENT_OUTPUT_SCHEMAS: dict[str, AgentOutputSchema] = {
                     "line_range": "<string>",
                     "suggestion": "<string>",
                     "was_present_before_pr": "<boolean — required; True => pre-existing tech debt>",
-                    "reach_evidence": "<string — required for severity>=MEDIUM: grep:<pattern>:<line> | test_fail:<name> | linter:<tool>:<line>>",
+                    "reach_evidence": "<string — required when severity >= MEDIUM: grep:<pattern>:<line> | test_fail:<name> | linter:<tool>:<line>>",
                     "sibling_comparison": "<object — required when mode=sibling-aware: {sibling_path, equivalent_lines, divergences}>",
                 }
             ],
@@ -4497,6 +4497,8 @@ AGENT_OUTPUT_SCHEMAS: dict[str, AgentOutputSchema] = {
         "required_keys": (
             "files_changed",
             "tests_run",
+            "validation_notes",
+            "blocker",
         ),
         "skeleton": {
             "files_changed": ["<string — path of each file written>"],
@@ -5672,6 +5674,12 @@ def detect_truncated_agent_output(
     if expected_keys is None:
         if agent_kind == "monitor":
             expected_keys = list(_MONITOR_REQUIRED_KEYS)
+        elif agent_kind == "review-monitor":
+            # Full review-monitor schema (evidence/valid/summary/verdict/issues/
+            # passed_checks/failed_checks). Distinct from "monitor" which uses the
+            # minimal map-efficient common core so it doesn't reject valid efficient
+            # Monitor responses that never emit evidence/verdict/passed_checks/failed_checks.
+            expected_keys = list(AGENT_OUTPUT_SCHEMAS["monitor"]["required_keys"])
         elif agent_kind == "actor":
             expected_keys = list(_ACTOR_REQUIRED_KEYS)
         elif agent_kind in AGENT_OUTPUT_SCHEMAS:
@@ -7673,8 +7681,12 @@ def _grep_external_callers(
     and a single marker entry is returned so the caller still recommends
     ``validate_callers`` (too many symbols → thorough gate is the safe default).
 
-    Returns an empty list on git-grep failure (non-zero exit code other than 1)
-    so callers can degrade gracefully without crashing.
+    Returns ``_GREP_ERROR_SENTINEL`` (a one-entry list with ``note="grep_error"``)
+    on ``OSError``, ``subprocess.TimeoutExpired``, or a git-grep exit code not in
+    ``(0, 1)``.  Callers must detect the sentinel (``entry["note"] == "grep_error"``)
+    and fail-safe to ``validate_callers`` rather than treating it as evidence that
+    no external callers exist.  Do NOT revert this to an empty-list return — an
+    empty list means "grep ran and found nothing", which is a different signal.
     """
     if not symbols:
         return []
@@ -9105,18 +9117,12 @@ if __name__ == "__main__":
                 raw_errors = sys.argv[err_idx + 1]
                 try:
                     parsed_errors = json.loads(raw_errors)
-                except json.JSONDecodeError as exc:
-                    print(
-                        json.dumps({"status": "error", "message": f"--errors must be a JSON array: {exc}"}),
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)
-                if not isinstance(parsed_errors, list):
-                    print(
-                        json.dumps({"status": "error", "message": "--errors must be a JSON array, got non-list"}),
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)
+                    if not isinstance(parsed_errors, list):
+                        # JSON parsed to a scalar (e.g. a JSON string) — coerce to list
+                        parsed_errors = [raw_errors]
+                except json.JSONDecodeError:
+                    # Plain (non-JSON) string — coerce to single-element list
+                    parsed_errors = [raw_errors]
                 retry_errors = [str(e) for e in parsed_errors]
         retry_result = build_json_retry_prompt(retry_agent, retry_errors)
         print(json.dumps(retry_result, indent=2))
@@ -9253,18 +9259,12 @@ if __name__ == "__main__":
         if raw_reasons is not None:
             try:
                 parsed_reasons = json.loads(raw_reasons)
-            except json.JSONDecodeError as exc:
-                print(
-                    json.dumps({"status": "error", "message": f"--reasons must be a JSON array: {exc}"}),
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            if not isinstance(parsed_reasons, list):
-                print(
-                    json.dumps({"status": "error", "message": "--reasons must be a JSON array, got non-list"}),
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+                if not isinstance(parsed_reasons, list):
+                    # JSON parsed to a scalar (e.g. a JSON string) — coerce to list
+                    parsed_reasons = [raw_reasons]
+            except json.JSONDecodeError:
+                # Plain (non-JSON) string — coerce to single-element list
+                parsed_reasons = [raw_reasons]
             laf_reasons = [str(r) for r in parsed_reasons]
         laf_result = log_agent_failure(
             laf_agent,

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -27,6 +27,7 @@ TESTING:
     update_step_state('ST-001', 'actor', 'ACTOR_CALLED')"
 """
 
+import ast
 import fnmatch
 import hashlib
 import json
@@ -7433,12 +7434,6 @@ def detect_cross_subtask_regression_risk(
 # Symbol blast-radius detector
 # ---------------------------------------------------------------------------
 
-_SYMBOL_DEF_RE = re.compile(
-    r"^(?:async\s+)?def\s+(\w+)"      # function / async function
-    r"|^class\s+(\w+)"                 # class
-    r"|^([A-Z][A-Z0-9_]{2,})\s*[:=]", # UPPER_CONST (len >= 3 via {2,})
-)
-
 # Directories/globs searched by _grep_external_callers
 _GREP_SEARCH_PATHS = [".claude/skills", "src", ".map/scripts"]
 
@@ -7452,33 +7447,123 @@ _SYMBOL_GREP_CAP = 40
 _GREP_ERROR_SENTINEL = [{"symbol": "*", "file": "", "line": 0, "note": "grep_error"}]
 
 
-def _extract_changed_module_symbols(diff_text: str) -> set[str]:
-    """Return module-level symbol names introduced in *added* diff lines.
+def _changed_line_numbers_by_file(diff_text: str) -> dict[str, set[int]]:
+    """Parse a unified diff and return new-file line numbers of added lines per path.
 
-    Only lines that start with ``+`` (but not ``+++``) are considered.
-    Only column-0 definitions are recognised (no leading whitespace after the
-    ``+`` prefix) — this excludes nested/indented definitions.  Dunder names
-    and names shorter than 3 characters are excluded.
+    Only ``+``-prefixed lines (not ``+++`` headers) are recorded.  Context and
+    ``-`` lines advance or preserve the new-file line counter respectively.
+
+    Returns ``{relative_path: set_of_added_new_file_line_numbers}``.
     """
+    result: dict[str, set[int]] = {}
+    current_file: Optional[str] = None
+    new_line: int = 0
+
+    hunk_header_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+    for raw in diff_text.splitlines():
+        # New file header: "+++ b/<path>"  (ignore /dev/null)
+        if raw.startswith("+++ "):
+            path = raw[4:]
+            if path.startswith("b/"):
+                path = path[2:]
+            current_file = None if path == "/dev/null" else path
+            new_line = 0
+            continue
+
+        if current_file is None:
+            continue
+
+        # Hunk header: "@@ -a,b +c,d @@"
+        hm = hunk_header_re.match(raw)
+        if hm:
+            new_line = int(hm.group(1))
+            continue
+
+        if raw.startswith("+++") or raw.startswith("---"):
+            # diff header lines — skip without touching counter
+            continue
+
+        if raw.startswith("+"):
+            # Added line — record current new_line position then advance
+            result.setdefault(current_file, set()).add(new_line)
+            new_line += 1
+        elif raw.startswith("-"):
+            # Removed line — does NOT advance new-file counter
+            pass
+        else:
+            # Context line (space-prefixed or bare) — advance new-file counter
+            new_line += 1
+
+    return result
+
+
+def _enclosing_changed_symbols(
+    abs_path: Path, changed_lines: set[int]
+) -> Optional[set[str]]:
+    """Return top-level symbol names whose span covers any line in *changed_lines*.
+
+    Recognises ``FunctionDef``, ``AsyncFunctionDef``, ``ClassDef``, ``Assign``
+    with ``Name`` targets, and ``AnnAssign`` with a ``Name`` target.
+
+    Excludes dunder names (start AND end with ``__``) and names shorter than 3
+    characters.  Leading-underscore names such as ``_MONITOR_REQUIRED_KEYS`` are
+    intentionally kept.
+
+    Returns ``None`` on ``SyntaxError`` or ``OSError`` (caller must treat this as
+    a fail-safe / unknown signal).
+    """
+    try:
+        source = abs_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(abs_path))
+    except (SyntaxError, OSError):
+        return None
+
     symbols: set[str] = set()
-    for raw_line in diff_text.splitlines():
-        if not raw_line.startswith("+") or raw_line.startswith("+++"):
-            continue
-        # Strip the leading '+' to get the actual source line
-        line = raw_line[1:]
-        # Module-level: no leading whitespace
-        if line and line[0] in (" ", "\t"):
-            continue
-        m = _SYMBOL_DEF_RE.match(line)
-        if not m:
-            continue
-        # Exactly one of the three groups is non-None
-        name = m.group(1) or m.group(2) or m.group(3)
-        if name is None:
-            continue
-        if name.startswith("__") or len(name) < 3:
-            continue
-        symbols.add(name)
+
+    for node in ast.iter_child_nodes(tree):
+        name: Optional[str] = None
+        start: int = 0
+        end: int = 0
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            name = node.name
+            # Span starts at earliest decorator line (if any), otherwise def/class line
+            decorator_lines = [d.lineno for d in node.decorator_list]
+            start = min([node.lineno] + decorator_lines)
+            end = node.end_lineno or node.lineno
+
+            if name and not (name.startswith("__") and name.endswith("__")) and len(name) >= 3:
+                if any(start <= ln <= end for ln in changed_lines):
+                    symbols.add(name)
+
+        elif isinstance(node, ast.Assign):
+            end = node.end_lineno or node.lineno
+            start = node.lineno
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    tname = target.id
+                    if (
+                        tname
+                        and not (tname.startswith("__") and tname.endswith("__"))
+                        and len(tname) >= 3
+                        and any(start <= ln <= end for ln in changed_lines)
+                    ):
+                        symbols.add(tname)
+
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                tname = node.target.id
+                start = node.lineno
+                end = node.end_lineno or node.lineno
+                if (
+                    tname
+                    and not (tname.startswith("__") and tname.endswith("__"))
+                    and len(tname) >= 3
+                    and any(start <= ln <= end for ln in changed_lines)
+                ):
+                    symbols.add(tname)
+
     return symbols
 
 
@@ -7717,9 +7802,26 @@ def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
     diff_text = diff_result.stdout
 
     # ------------------------------------------------------------------
-    # 5. Extract changed module-level symbols
+    # 5. Extract changed module-level symbols via AST enclosing-symbol mapping
     # ------------------------------------------------------------------
-    changed_symbols = _extract_changed_module_symbols(diff_text)
+    lines_by_file = _changed_line_numbers_by_file(diff_text)
+    changed_symbols: set[str] = set()
+    for path in runtime_changed:
+        enc = _enclosing_changed_symbols(project_dir / path, lines_by_file.get(path, set()))
+        if enc is None:
+            # AST parse or read error — fail safe
+            return {
+                "status": "unknown",
+                "subtask_id": subtask_id,
+                "changed_symbols": [],
+                "external_callers": [],
+                "recommended_gate": "validate_callers",
+                "reason": (
+                    f"Could not parse {path} — defaulting to validate_callers as a fail-safe."
+                ),
+            }
+        changed_symbols |= enc
+
     if not changed_symbols:
         return {
             "status": "ok",
@@ -7728,8 +7830,8 @@ def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
             "external_callers": [],
             "recommended_gate": "scoped",
             "reason": (
-                "Runtime .py files changed but no module-level symbol additions "
-                "detected — scoped gate is sufficient."
+                "Runtime .py files changed but no module-level symbols affected "
+                "— scoped gate is sufficient."
             ),
         }
 

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -1071,20 +1071,21 @@ def validate_step(
                 "envelope_error": envelope_error,
             }
 
-    # Recommendation-omitted warning: closing 2.4 without --recommendation
-    # leaves the verdict-consistency footgun open (Monitor valid=true +
-    # recommendation=revise would silently pass). Surface a soft warning
-    # so the operator knows to pipe Monitor's recommendation through.
-    recommendation_omitted_warning: Optional[str] = None
+    # Recommendation-required gate: closing 2.4 without --recommendation
+    # makes the verdict-consistency enforcement impossible. Hard-fail so
+    # the operator is forced to pipe Monitor's recommendation through.
     if step_id == "2.4" and not recommendation:
-        recommendation_omitted_warning = (
-            "validate_step 2.4 closed without --recommendation. The "
-            "verdict-consistency gate cannot enforce 'valid=true + "
-            "recommendation=revise/block/needs_investigation = fail' "
-            "unless you pass Monitor's recommendation. Recommended: "
-            "`python3 .map/scripts/map_orchestrator.py validate_step 2.4 "
-            "--recommendation \"$MONITOR_RECOMMENDATION\"`."
-        )
+        return {
+            "valid": False,
+            "message": (
+                "validate_step 2.4 requires --recommendation (Monitor's "
+                "verdict). Without it the verdict-consistency gate cannot "
+                "enforce 'valid=true + recommendation in {revise,block,"
+                "needs_investigation} = fail'. Re-run: validate_step 2.4 "
+                "--recommendation \"$MONITOR_RECOMMENDATION\"."
+            ),
+            "recommendation_required": True,
+        }
 
     # Monitor recommendation enforcement: when closing 2.4 (MONITOR) and
     # the caller passed a recommendation, refuse to close on revise /
@@ -1256,8 +1257,6 @@ def validate_step(
         response["skipped_for_deps"] = skipped_for_deps
     if next_step_signal == "BLOCKED_ON_DEPS":
         response["blocked_subtasks"] = blocked_remaining
-    if recommendation_omitted_warning:
-        response["warning"] = recommendation_omitted_warning
     return response
 
 
@@ -3430,6 +3429,8 @@ def main():
                 monitor_envelope=monitor_envelope_text,
             )
             print(json.dumps(result, indent=2))
+            if not result.get("valid", False):
+                sys.exit(1)
 
         elif args.command == "initialize":
             task = args.task_or_step or "MAP workflow task"

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -997,13 +997,14 @@ def validate_step(
     Args:
         step_id: Step identifier to validate
         branch: Git branch name (sanitized)
-        recommendation: For step_id="2.4" (Monitor close), optional
-            Monitor verdict field. When set to ``revise``, ``block``, or
-            ``needs_investigation``, validate_step refuses to close the
-            phase and returns valid=false — so the recommendation
-            contract (skill rule: "valid=true + recommendation∈{revise,
-            block, needs_investigation} = fail") is enforced
-            orchestrator-side, not just by-convention.
+        recommendation: For step_id="2.4" (Monitor close), REQUIRED
+            Monitor verdict field — omitting it returns valid=false
+            (recommendation_required) rather than closing the phase. When
+            set to ``revise``, ``block``, or ``needs_investigation``,
+            validate_step refuses to close the phase and returns valid=false
+            — so the recommendation contract (skill rule: "valid=true +
+            recommendation∈{revise, block, needs_investigation} = fail") is
+            enforced orchestrator-side, not just by-convention.
 
     Returns:
         Dict with valid: bool, message: str

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -27,6 +27,7 @@ TESTING:
     update_step_state('ST-001', 'actor', 'ACTOR_CALLED')"
 """
 
+import ast
 import fnmatch
 import hashlib
 import json
@@ -7429,6 +7430,558 @@ def detect_cross_subtask_regression_risk(
     }
 
 
+# ---------------------------------------------------------------------------
+# Actor files-changed mismatch detector
+# ---------------------------------------------------------------------------
+
+
+def detect_actor_files_changed_mismatch(
+    branch: str, subtask_id: str, declared_files: list[str]
+) -> dict:
+    """Flag when an Actor declared files in its envelope that it never wrote.
+
+    The canonical failure mode: the Actor response is truncated mid-edit
+    (model context overflow, timeout). The files_changed envelope lists the
+    intended targets, but the actual git diff is shorter — some files were
+    never written. The Monitor's mutation-boundary check sees *actual* files
+    only and cannot detect the omission; this detector closes that gap.
+
+    Distinct from related detectors:
+    - ``validate_mutation_boundary`` catches *wrote-but-NOT-declared* (scope
+      creep — the opposite direction).
+    - ``detect_truncated_agent_output`` checks JSON-envelope key completeness,
+      not file-system writes.
+    - THIS function checks *declared-but-not-written* only.  The load-bearing
+      field is ``declared_not_written``.
+
+    Returns::
+
+        {
+          "status": "ok" | "unknown",
+          "subtask_id": str,
+          "declared": [str],               # sorted; stripped declared_files
+          "actual": [str],                 # sorted; files from git diff
+          "declared_not_written": [str],   # sorted; declared minus actual
+          "status_mismatch": bool,         # True when declared_not_written non-empty
+          "recovery_instruction": str,     # non-empty only when status_mismatch
+          "reason": str,                   # non-empty only on status=="unknown"
+        }
+
+    Fail-safe: any git failure → ``status="unknown"`` + ``status_mismatch=True``
+    (never silently ``False``): the Actor gate must not pass blindly on a git
+    error.
+    """
+    branch_name = _sanitize_branch(branch)
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+    actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+    if actual_set is None:
+        # Intent: fail safe to mismatch so the gate cannot pass blindly.
+        declared_sorted = sorted(d.strip() for d in (declared_files or []) if d.strip())
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "declared": declared_sorted,
+            "actual": [],
+            "declared_not_written": declared_sorted,
+            "status_mismatch": True,
+            "recovery_instruction": (
+                "git diff unavailable (fail-safe — actual changes were NOT "
+                f"consulted): treating all declared files as unwritten: {declared_sorted}. "
+                "Re-invoke the Actor to finish any truncated edits and re-run this "
+                "check once git is available; do NOT record the subtask until "
+                "git diff --name-only covers every declared file."
+            ),
+            "reason": (
+                "could not compute the actual diff (git unavailable) — "
+                "assuming mismatch as a fail-safe."
+            ),
+        }
+
+    declared = [d.strip() for d in (declared_files or []) if d.strip()]
+    declared_not_written = sorted(d for d in declared if d not in actual_set)
+    status_mismatch = bool(declared_not_written)
+
+    recovery_instruction = ""
+    if status_mismatch:
+        recovery_instruction = (
+            f"Actor declared files it did not write: {declared_not_written}. "
+            "Its previous response was likely truncated mid-edit — re-invoke "
+            "the Actor to finish those files; do NOT record the subtask until "
+            "git diff --name-only covers every declared file."
+        )
+
+    return {
+        "status": "ok",
+        "subtask_id": subtask_id,
+        "declared": sorted(declared),
+        "actual": sorted(actual_set),
+        "declared_not_written": declared_not_written,
+        "status_mismatch": status_mismatch,
+        "recovery_instruction": recovery_instruction,
+        "reason": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Symbol blast-radius detector
+# ---------------------------------------------------------------------------
+
+# Directories/globs searched by _grep_external_callers
+_GREP_SEARCH_PATHS = [".claude/skills", "src", ".map/scripts"]
+
+# Maximum distinct symbols we'll send to git-grep before short-circuiting
+_SYMBOL_GREP_CAP = 40
+
+# Sentinel returned by _grep_external_callers on git/subprocess failure.
+# Distinct from the legitimate "no matches" empty list — callers must treat
+# any entry with note=="grep_error" as an unknown/fail-safe signal rather
+# than evidence that no external callers exist.
+_GREP_ERROR_SENTINEL = [{"symbol": "*", "file": "", "line": 0, "note": "grep_error"}]
+
+
+def _changed_line_numbers_by_file(diff_text: str) -> dict[str, set[int]]:
+    """Parse a unified diff and return new-file line numbers of added lines per path.
+
+    Only ``+``-prefixed lines (not ``+++`` headers) are recorded.  Context and
+    ``-`` lines advance or preserve the new-file line counter respectively.
+
+    Returns ``{relative_path: set_of_added_new_file_line_numbers}``.
+    """
+    result: dict[str, set[int]] = {}
+    current_file: Optional[str] = None
+    new_line: int = 0
+
+    hunk_header_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+    for raw in diff_text.splitlines():
+        # New file header: "+++ b/<path>"  (ignore /dev/null)
+        if raw.startswith("+++ "):
+            path = raw[4:]
+            if path.startswith("b/"):
+                path = path[2:]
+            current_file = None if path == "/dev/null" else path
+            new_line = 0
+            continue
+
+        if current_file is None:
+            continue
+
+        # Hunk header: "@@ -a,b +c,d @@"
+        hm = hunk_header_re.match(raw)
+        if hm:
+            new_line = int(hm.group(1))
+            continue
+
+        if raw.startswith("+++") or raw.startswith("---"):
+            # diff header lines — skip without touching counter
+            continue
+
+        if raw.startswith("+"):
+            # Added line — record current new_line position then advance
+            result.setdefault(current_file, set()).add(new_line)
+            new_line += 1
+        elif raw.startswith("-"):
+            # Removed line — does NOT advance new-file counter
+            pass
+        else:
+            # Context line (space-prefixed or bare) — advance new-file counter
+            new_line += 1
+
+    return result
+
+
+def _enclosing_changed_symbols(
+    abs_path: Path, changed_lines: set[int]
+) -> Optional[set[str]]:
+    """Return top-level symbol names whose span covers any line in *changed_lines*.
+
+    Recognises ``FunctionDef``, ``AsyncFunctionDef``, ``ClassDef``, ``Assign``
+    with ``Name`` targets, and ``AnnAssign`` with a ``Name`` target.
+
+    Excludes dunder names (start AND end with ``__``) and names shorter than 3
+    characters.  Leading-underscore names such as ``_MONITOR_REQUIRED_KEYS`` are
+    intentionally kept.
+
+    Returns ``None`` on ``SyntaxError`` or ``OSError`` (caller must treat this as
+    a fail-safe / unknown signal).
+    """
+    try:
+        source = abs_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(abs_path))
+    except (SyntaxError, OSError):
+        return None
+
+    symbols: set[str] = set()
+
+    for node in ast.iter_child_nodes(tree):
+        name: Optional[str] = None
+        start: int = 0
+        end: int = 0
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            name = node.name
+            # Span starts at earliest decorator line (if any), otherwise def/class line
+            decorator_lines = [d.lineno for d in node.decorator_list]
+            start = min([node.lineno] + decorator_lines)
+            end = node.end_lineno or node.lineno
+
+            if name and not (name.startswith("__") and name.endswith("__")) and len(name) >= 3:
+                if any(start <= ln <= end for ln in changed_lines):
+                    symbols.add(name)
+
+        elif isinstance(node, ast.Assign):
+            end = node.end_lineno or node.lineno
+            start = node.lineno
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    tname = target.id
+                    if (
+                        tname
+                        and not (tname.startswith("__") and tname.endswith("__"))
+                        and len(tname) >= 3
+                        and any(start <= ln <= end for ln in changed_lines)
+                    ):
+                        symbols.add(tname)
+
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                tname = node.target.id
+                start = node.lineno
+                end = node.end_lineno or node.lineno
+                if (
+                    tname
+                    and not (tname.startswith("__") and tname.endswith("__"))
+                    and len(tname) >= 3
+                    and any(start <= ln <= end for ln in changed_lines)
+                ):
+                    symbols.add(tname)
+
+    return symbols
+
+
+def _grep_external_callers(
+    symbols: set[str], affected_files: list[str], project_dir: Path
+) -> list[dict]:
+    """Search for references to *symbols* in the project outside *affected_files*.
+
+    Uses a single batched ``git grep`` call with a whole-word alternation regex.
+    Returns a list of ``{"symbol": str, "file": str, "line": int}`` dicts, sorted
+    deterministically and deduped.
+
+    Symbol cap: when ``len(symbols) > _SYMBOL_GREP_CAP`` the search is skipped
+    and a single marker entry is returned so the caller still recommends
+    ``validate_callers`` (too many symbols → thorough gate is the safe default).
+
+    Returns an empty list on git-grep failure (non-zero exit code other than 1)
+    so callers can degrade gracefully without crashing.
+    """
+    if not symbols:
+        return []
+
+    # Cap: too many symbols → conservatively flag for caller validation
+    if len(symbols) > _SYMBOL_GREP_CAP:
+        return [{"symbol": "*", "file": "", "line": 0, "note": "skipped_too_many_symbols"}]
+
+    affected_set = set(affected_files)
+
+    # Build alternation pattern; sort for determinism
+    alternation = "|".join(re.escape(s) for s in sorted(symbols))
+    pattern = f"({alternation})"
+
+    try:
+        result = subprocess.run(
+            ["git", "grep", "-n", "-E", "-w", pattern, "--"] + _GREP_SEARCH_PATHS,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return list(_GREP_ERROR_SENTINEL)
+
+    # git grep exits with 1 when no matches (not an error); >1 is a real error
+    if result.returncode not in (0, 1):
+        return list(_GREP_ERROR_SENTINEL)
+
+    seen: set[tuple[str, str, int]] = set()
+    callers: list[dict] = []
+
+    for raw in result.stdout.splitlines():
+        # Format: path:lineno:content
+        parts = raw.split(":", 2)
+        if len(parts) < 3:
+            continue
+        file_path, lineno_str, content = parts[0], parts[1], parts[2]
+
+        # Exclude matches inside the subtask's own affected files
+        if file_path in affected_set:
+            continue
+
+        try:
+            lineno = int(lineno_str)
+        except ValueError:
+            continue
+
+        # Determine which symbol(s) matched this line
+        for sym in sorted(symbols):
+            if re.search(rf"\b{re.escape(sym)}\b", content):
+                key = (sym, file_path, lineno)
+                if key in seen:
+                    continue
+                seen.add(key)
+                callers.append({"symbol": sym, "file": file_path, "line": lineno})
+
+    callers.sort(key=lambda d: (d["file"], d["line"], d["symbol"]))
+    return callers
+
+
+def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
+    """Flag when a subtask changed a module-level symbol referenced outside its scope.
+
+    This is an *advisory* detector — it does not block; it informs the Monitor
+    gate of external callers that need explicit validation.  The canonical failure
+    mode it prevents: a shared helper (e.g. ``chunked_review_pipeline.py``)
+    is re-derived in one subtask and silently breaks callers in other subtasks
+    that are never re-tested in the scoped gate.
+
+    Returns::
+
+        {
+          "status": "ok" | "unknown",
+          "subtask_id": str,
+          "changed_symbols": [str],         # sorted; module-level additions
+          "external_callers": [...],         # {symbol, file, line} outside affected_files
+          "recommended_gate": "validate_callers" | "scoped",
+          "reason": str,
+        }
+
+    Fail-safe: any git failure → ``status="unknown"`` +
+    ``recommended_gate="validate_callers"`` (never silently ``"scoped"``).
+    """
+    branch_name = _sanitize_branch(branch)
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+    # ------------------------------------------------------------------
+    # 1. Resolve blueprint + affected_files
+    # ------------------------------------------------------------------
+    blueprint = load_blueprint(branch_name, project_dir)
+    subtask: Optional[dict] = None
+    if blueprint is not None:
+        subtask = get_subtask_from_blueprint(blueprint, subtask_id)
+    affected_files: list[str] = []
+    if subtask is not None:
+        raw_af = subtask.get("affected_files") or []
+        if isinstance(raw_af, list):
+            affected_files = [str(f) for f in raw_af if f]
+
+    # ------------------------------------------------------------------
+    # 2. Compute changed files for this subtask
+    # ------------------------------------------------------------------
+    changed = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+    if changed is None:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "Could not compute the current subtask diff (git unavailable) "
+                "— defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # 3. Filter to runtime Python files
+    # ------------------------------------------------------------------
+    runtime_changed = [
+        p for p in changed if p.endswith(".py") and not _is_test_path(p)
+    ]
+    if not runtime_changed:
+        return {
+            "status": "ok",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "scoped",
+            "reason": "No runtime .py symbols changed — scoped gate is sufficient.",
+        }
+
+    # ------------------------------------------------------------------
+    # 4. Get diff text for runtime files
+    # ------------------------------------------------------------------
+    base_ref: Optional[str] = None
+    state_file = project_dir / ".map" / branch_name / "step_state.json"
+    if state_file.exists():
+        try:
+            state_data = json.loads(state_file.read_text(encoding="utf-8"))
+            last_sha = state_data.get("last_subtask_commit_sha")
+            if isinstance(last_sha, str) and last_sha:
+                base_ref = last_sha
+        except (json.JSONDecodeError, OSError):
+            pass
+    if not base_ref:
+        try:
+            head_probe = subprocess.run(
+                ["git", "rev-parse", "--verify", "HEAD"],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if head_probe.returncode == 0:
+                base_ref = "HEAD"
+        except (OSError, subprocess.TimeoutExpired):
+            return {
+                "status": "unknown",
+                "subtask_id": subtask_id,
+                "changed_symbols": [],
+                "external_callers": [],
+                "recommended_gate": "validate_callers",
+                "reason": (
+                    "git rev-parse failed or timed out — "
+                    "defaulting to validate_callers as a fail-safe."
+                ),
+            }
+
+    if not base_ref:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "Could not resolve a git base ref for the diff — "
+                "defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", base_ref, "--"] + runtime_changed,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "git diff timed out or failed — "
+                "defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    if diff_result.returncode != 0:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "validate_callers",
+            "reason": (
+                f"git diff returned non-zero exit code {diff_result.returncode} "
+                "— defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    diff_text = diff_result.stdout
+
+    # ------------------------------------------------------------------
+    # 5. Extract changed module-level symbols via AST enclosing-symbol mapping
+    # ------------------------------------------------------------------
+    lines_by_file = _changed_line_numbers_by_file(diff_text)
+    changed_symbols: set[str] = set()
+    for path in runtime_changed:
+        enc = _enclosing_changed_symbols(project_dir / path, lines_by_file.get(path, set()))
+        if enc is None:
+            # AST parse or read error — fail safe
+            return {
+                "status": "unknown",
+                "subtask_id": subtask_id,
+                "changed_symbols": [],
+                "external_callers": [],
+                "recommended_gate": "validate_callers",
+                "reason": (
+                    f"Could not parse {path} — defaulting to validate_callers as a fail-safe."
+                ),
+            }
+        changed_symbols |= enc
+
+    if not changed_symbols:
+        return {
+            "status": "ok",
+            "subtask_id": subtask_id,
+            "changed_symbols": [],
+            "external_callers": [],
+            "recommended_gate": "scoped",
+            "reason": (
+                "Runtime .py files changed but no module-level symbols affected "
+                "— scoped gate is sufficient."
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # 6. Find external callers
+    # ------------------------------------------------------------------
+    external_callers = _grep_external_callers(changed_symbols, affected_files, project_dir)
+
+    # Detect grep-error sentinel: git/subprocess failure inside _grep_external_callers.
+    # An empty list is a legitimate "no matches" result; the sentinel is the fail-safe.
+    grep_errored = any(c.get("note") == "grep_error" for c in external_callers)
+    if grep_errored:
+        return {
+            "status": "unknown",
+            "subtask_id": subtask_id,
+            "changed_symbols": sorted(changed_symbols),
+            "external_callers": external_callers,
+            "recommended_gate": "validate_callers",
+            "reason": (
+                "git grep failed — defaulting to validate_callers as a fail-safe."
+            ),
+        }
+
+    recommended_gate = "validate_callers" if external_callers else "scoped"
+
+    if external_callers and external_callers[0].get("note") == "skipped_too_many_symbols":
+        reason = (
+            f"Too many changed symbols ({len(changed_symbols)} > {_SYMBOL_GREP_CAP}) "
+            "— grep skipped; validate_callers applied conservatively."
+        )
+    elif external_callers:
+        caller_summary = ", ".join(
+            f"{c['symbol']} in {c['file']}:{c['line']}"
+            for c in external_callers[:5]
+        )
+        extra = f" (+{len(external_callers) - 5} more)" if len(external_callers) > 5 else ""
+        reason = (
+            f"Changed symbol(s) {sorted(changed_symbols)!r} are referenced "
+            f"outside affected_files: {caller_summary}{extra}. "
+            "All external callers must be explicitly validated."
+        )
+    else:
+        reason = (
+            f"Changed symbol(s) {sorted(changed_symbols)!r} have no external "
+            "callers outside affected_files — scoped gate is sufficient."
+        )
+
+    return {
+        "status": "ok",
+        "subtask_id": subtask_id,
+        "changed_symbols": sorted(changed_symbols),
+        "external_callers": external_callers,
+        "recommended_gate": recommended_gate,
+        "reason": reason,
+    }
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 
@@ -8258,6 +8811,29 @@ if __name__ == "__main__":
         # shell pipeline can decide full-suite vs scoped without `set -e`
         # tripping on an advisory signal.
         report = detect_cross_subtask_regression_risk(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "detect_symbol_blast_radius" and len(sys.argv) >= 4:
+        # CLI: detect_symbol_blast_radius <branch> <subtask_id>
+        # Read-only. Exit 0 always (callers branch on the `recommended_gate`
+        # field, like detect_cross_subtask_regression_risk) so a shell pipeline
+        # can decide full-suite vs scoped without `set -e` tripping on an
+        # advisory signal.
+        report = detect_symbol_blast_radius(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "detect_actor_files_changed_mismatch" and len(sys.argv) >= 4:
+        # CLI: detect_actor_files_changed_mismatch <branch> <subtask_id> [--declared f1,f2,...]
+        # Read-only. Exit 0 always (callers branch on `status_mismatch` field)
+        # so a shell pipeline can decide whether to block recording without
+        # `set -e` tripping on an advisory signal.
+        declared_arg: list[str] = []
+        if "--declared" in sys.argv:
+            declared_idx = sys.argv.index("--declared")
+            if declared_idx + 1 < len(sys.argv):
+                raw_declared = sys.argv[declared_idx + 1]
+                declared_arg = [f for f in raw_declared.split(",") if f.strip()]
+        report = detect_actor_files_changed_mismatch(sys.argv[2], sys.argv[3], declared_arg)
         print(json.dumps(report, indent=2))
 
     elif func_name == "detect_already_done" and len(sys.argv) >= 4:

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -4409,7 +4409,7 @@ AGENT_OUTPUT_SCHEMAS: dict[str, AgentOutputSchema] = {
                     "line_range": "<string>",
                     "suggestion": "<string>",
                     "was_present_before_pr": "<boolean — required; True => pre-existing tech debt>",
-                    "reach_evidence": "<string — required for severity>=MEDIUM: grep:<pattern>:<line> | test_fail:<name> | linter:<tool>:<line>>",
+                    "reach_evidence": "<string — required when severity >= MEDIUM: grep:<pattern>:<line> | test_fail:<name> | linter:<tool>:<line>>",
                     "sibling_comparison": "<object — required when mode=sibling-aware: {sibling_path, equivalent_lines, divergences}>",
                 }
             ],
@@ -4497,6 +4497,8 @@ AGENT_OUTPUT_SCHEMAS: dict[str, AgentOutputSchema] = {
         "required_keys": (
             "files_changed",
             "tests_run",
+            "validation_notes",
+            "blocker",
         ),
         "skeleton": {
             "files_changed": ["<string — path of each file written>"],
@@ -5672,6 +5674,12 @@ def detect_truncated_agent_output(
     if expected_keys is None:
         if agent_kind == "monitor":
             expected_keys = list(_MONITOR_REQUIRED_KEYS)
+        elif agent_kind == "review-monitor":
+            # Full review-monitor schema (evidence/valid/summary/verdict/issues/
+            # passed_checks/failed_checks). Distinct from "monitor" which uses the
+            # minimal map-efficient common core so it doesn't reject valid efficient
+            # Monitor responses that never emit evidence/verdict/passed_checks/failed_checks.
+            expected_keys = list(AGENT_OUTPUT_SCHEMAS["monitor"]["required_keys"])
         elif agent_kind == "actor":
             expected_keys = list(_ACTOR_REQUIRED_KEYS)
         elif agent_kind in AGENT_OUTPUT_SCHEMAS:
@@ -7673,8 +7681,12 @@ def _grep_external_callers(
     and a single marker entry is returned so the caller still recommends
     ``validate_callers`` (too many symbols → thorough gate is the safe default).
 
-    Returns an empty list on git-grep failure (non-zero exit code other than 1)
-    so callers can degrade gracefully without crashing.
+    Returns ``_GREP_ERROR_SENTINEL`` (a one-entry list with ``note="grep_error"``)
+    on ``OSError``, ``subprocess.TimeoutExpired``, or a git-grep exit code not in
+    ``(0, 1)``.  Callers must detect the sentinel (``entry["note"] == "grep_error"``)
+    and fail-safe to ``validate_callers`` rather than treating it as evidence that
+    no external callers exist.  Do NOT revert this to an empty-list return — an
+    empty list means "grep ran and found nothing", which is a different signal.
     """
     if not symbols:
         return []
@@ -9105,18 +9117,12 @@ if __name__ == "__main__":
                 raw_errors = sys.argv[err_idx + 1]
                 try:
                     parsed_errors = json.loads(raw_errors)
-                except json.JSONDecodeError as exc:
-                    print(
-                        json.dumps({"status": "error", "message": f"--errors must be a JSON array: {exc}"}),
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)
-                if not isinstance(parsed_errors, list):
-                    print(
-                        json.dumps({"status": "error", "message": "--errors must be a JSON array, got non-list"}),
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)
+                    if not isinstance(parsed_errors, list):
+                        # JSON parsed to a scalar (e.g. a JSON string) — coerce to list
+                        parsed_errors = [raw_errors]
+                except json.JSONDecodeError:
+                    # Plain (non-JSON) string — coerce to single-element list
+                    parsed_errors = [raw_errors]
                 retry_errors = [str(e) for e in parsed_errors]
         retry_result = build_json_retry_prompt(retry_agent, retry_errors)
         print(json.dumps(retry_result, indent=2))
@@ -9253,18 +9259,12 @@ if __name__ == "__main__":
         if raw_reasons is not None:
             try:
                 parsed_reasons = json.loads(raw_reasons)
-            except json.JSONDecodeError as exc:
-                print(
-                    json.dumps({"status": "error", "message": f"--reasons must be a JSON array: {exc}"}),
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            if not isinstance(parsed_reasons, list):
-                print(
-                    json.dumps({"status": "error", "message": "--reasons must be a JSON array, got non-list"}),
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+                if not isinstance(parsed_reasons, list):
+                    # JSON parsed to a scalar (e.g. a JSON string) — coerce to list
+                    parsed_reasons = [raw_reasons]
+            except json.JSONDecodeError:
+                # Plain (non-JSON) string — coerce to single-element list
+                parsed_reasons = [raw_reasons]
             laf_reasons = [str(r) for r in parsed_reasons]
         laf_result = log_agent_failure(
             laf_agent,

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -299,9 +299,18 @@ Before invoking Monitor, validate Actor's response via
 `detect_truncated_agent_output --agent actor`. If `truncated: true`, log via
 `log_agent_failure` and re-invoke ONCE using the prompt from
 `build_json_retry_prompt --agent actor --errors '<reasons>'`; if still
-malformed, stop with CLARIFICATION_NEEDED. Cross-check declared `files_changed`
-against `git diff --name-only` — undeclared writes = truncated. Full recipe in
-[efficient-reference.md](efficient-reference.md).
+malformed, stop with CLARIFICATION_NEEDED.
+
+**Files-changed mismatch check (MANDATORY):** Run
+`detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" --declared "<Actor's files_changed, comma-joined>"`.
+If `status_mismatch == true`, surface `recovery_instruction` and re-invoke Actor to finish `declared_not_written` files; do NOT record the subtask until clear. Full recipe: [efficient-reference.md](efficient-reference.md).
+
+### Symbol blast-radius gate (MANDATORY — pre-dispatch)
+
+Run `detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"`. If
+`recommended_gate == "validate_callers"`, append `external_callers` to the Monitor
+`<documents>` context and require Monitor to validate each external caller's contract.
+Full recipe: [efficient-reference.md](efficient-reference.md).
 
 ### Phase: MONITOR (2.4) - Required
 
@@ -358,29 +367,17 @@ Return JSON with valid, summary, issues, files_changed, tests_run, and escalatio
   python3 .map/scripts/map_orchestrator.py record_subtask_result "$SUBTASK_ID" valid \
     --files "$FILES_CSV" --summary "$ONE_LINE" --commit-sha "$SHA"
   ```
-  `record_subtask_result` is the canonical write path — the result lands in
-  `subtask_results` and `last_subtask_commit_sha` for downstream context.
-  Pass `--commit-sha` whenever you just made a per-subtask commit (see
-  rule above); when omitted, the orchestrator auto-detects via
-  `git log -1 --format=%H` but the explicit value is preferred so the
-  audit trail is unambiguous.
+  `record_subtask_result` is the canonical write path. Pass `--commit-sha`
+  (preferred); omitting it triggers auto-detect via `git log -1 --format=%H`.
 - **Auto-validate mutation boundary:** `validate_step 2.4` itself now runs
   `validate_mutation_boundary` for the current subtask and rejects on
   `status="violation"` (only when `MAP_STRICT_SCOPE=1`) or `status="error"`.
   No manual dispatch needed.
 - **Refresh blueprint affected_files after each clean close (RECOMMENDED):**
-  After commit + record_subtask_result, sync the blueprint's
-  `affected_files` for the just-closed subtask to the actual diff. This
-  keeps the next subtask's mutation-boundary check honest — without
-  refresh, decomposer-time guesses drift further from reality every
-  subtask and Monitor warnings degrade into background noise.
-
-  ```bash
-  python3 .map/scripts/map_step_runner.py refresh_blueprint_affected_files \
-    "$BRANCH" "$SUBTASK_ID"
-  ```
-  Idempotent and read-only against blueprint structure outside the
-  named subtask. Use `--dry-run` to preview the diff before writing.
+  After commit + record_subtask_result, run
+  `refresh_blueprint_affected_files "$BRANCH" "$SUBTASK_ID"` to sync the
+  blueprint to actual diff — keeps mutation-boundary checks honest.
+  Full recipe: [efficient-reference.md](efficient-reference.md).
 - If `valid=false`, write `code-review-N.md`, run `python3 .map/scripts/map_orchestrator.py monitor_failed --feedback "<feedback>"`, inspect `retry_isolation`, and invoke Predictor only when stuck/high-risk escalation rules apply.
 - If `retry_isolation=clean_retry_required`, run `python3 .map/scripts/map_step_runner.py validate_retry_quarantine` before the next Actor call. The next Actor prompt must use CLEAN_RETRY mode from `.map/<branch>/retry_quarantine.json` and must not reuse the rejected approach unless the quarantine artifact preserves it.
 - Treat test failures after Monitor approval as Monitor failure. **Cross-subtask regression gate (MANDATORY):** before the test gate, run `detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID"`; if `recommended_gate == "full_suite"` you MUST run the FULL suite (never a `-k` subset) before commit / `record_subtask_result` — per-subtask Monitor is blind to regressions on prior subtasks' code. Recipe: [efficient-reference.md](efficient-reference.md).

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -90,8 +90,52 @@ If `truncated: true`:
    and re-invoke Actor ONCE using the prompt from
    `build_json_retry_prompt --agent actor --errors '<reasons>'`.
 2. If still malformed, stop with CLARIFICATION_NEEDED.
-3. Cross-check `files_changed` against `git diff --name-only`. Files
-   declared but not in the diff = Actor said it changed them but didn't.
+
+**Files-changed mismatch check (MANDATORY):** After the JSON envelope is
+confirmed intact, run:
+
+```bash
+FILES_DECLARED=$(echo "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
+MISMATCH=$(detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" \
+  --declared "$FILES_DECLARED")
+echo "$MISMATCH"
+STATUS_MISMATCH=$(echo "$MISMATCH" | jq -r '.status_mismatch')
+```
+
+- `status_mismatch == true` — Actor declared files it did not write (mid-edit
+  truncation). Read `recovery_instruction` from the JSON and re-invoke the
+  Actor to finish the `declared_not_written` files. Do NOT record the subtask
+  until the mismatch clears.
+- `status_mismatch == false` — no mismatch; proceed to Monitor.
+
+## Symbol blast-radius gate
+
+Per-subtask Monitor validates only the files the current subtask touched — it
+is structurally blind to callers of a changed symbol that live in OTHER files
+(other skills, workflows, or utilities). The canonical miss: a shared helper is
+renamed or its signature changes, and every caller outside `affected_files`
+breaks silently.
+
+Before dispatching Monitor, run the blast-radius detector:
+
+```bash
+BLAST=$(python3 .map/scripts/map_step_runner.py \
+  detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID")
+echo "$BLAST"   # inspect changed_symbols / external_callers / reason
+GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
+```
+
+- `recommended_gate == "validate_callers"` — the subtask changed a
+  module-level symbol referenced OUTSIDE its `affected_files`. You MUST:
+  1. Append the `external_callers` list to the Monitor `<documents>` context.
+  2. Require Monitor to validate the contract of EACH external caller (not
+     just the current subtask's files).
+  3. Do NOT accept a Monitor pass that ignores the external callers — this is
+     the guard that catches a shared-symbol refactor breaking another workflow.
+- `recommended_gate == "none"` — no external callers affected; proceed to
+  Monitor dispatch without modification.
+
+It is read-only and exits 0 always; callers branch on `recommended_gate`.
 
 ## Cross-subtask regression gate
 

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -132,7 +132,7 @@ GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
      just the current subtask's files).
   3. Do NOT accept a Monitor pass that ignores the external callers — this is
      the guard that catches a shared-symbol refactor breaking another workflow.
-- `recommended_gate == "none"` — no external callers affected; proceed to
+- `recommended_gate == "scoped"` — no external callers affected; proceed to
   Monitor dispatch without modification.
 
 It is read-only and exits 0 always; callers branch on `recommended_gate`.

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -301,12 +301,19 @@ Reviewer prompts reference `review-bundle.json`, `review-bundle.md`, the raw dif
 
 ### Step A.2b: Truncated-response gate (MANDATORY — post-fan-out, pre-verification)
 
-After each reviewer (monitor, predictor, evaluator) returns, validate its output
-via `detect_truncated_agent_output --agent <role>`. On truncation:
-log via `log_agent_failure --agent <role> --phase post-invoke --failure-label truncated --reasons '<reasons>'`
+After each reviewer returns, validate its output via
+`detect_truncated_agent_output --agent <kind>` using the role-specific kind
+shown below. On truncation: log via
+`log_agent_failure --agent <role> --phase post-invoke --failure-label truncated --reasons '<reasons>'`
 and re-invoke that reviewer ONCE using the prompt from
 `build_json_retry_prompt --agent <role> --errors '<reasons>'`; if still
 malformed, stop with CLARIFICATION_NEEDED.
+
+Role → `--agent` kind for the truncation check:
+- monitor reviewer → `--agent review-monitor` (enforces the full review schema:
+  evidence/valid/summary/verdict/issues/passed_checks/failed_checks)
+- predictor reviewer → `--agent predictor`
+- evaluator reviewer → `--agent evaluator`
 
 ### Step A.3: Verification gate (MANDATORY before any presentation)
 

--- a/tests/integration/test_e2e_artifact_contracts.py
+++ b/tests/integration/test_e2e_artifact_contracts.py
@@ -470,7 +470,9 @@ class TestFullLifecycle:
             assert (
                 step["step_id"] == step_id
             ), f"Expected {step_id}, got {step['step_id']}"
-            map_orchestrator.validate_step(step_id, branch)
+            # ST-003: closing 2.4 now requires Monitor's recommendation.
+            rec = "proceed" if step_id == "2.4" else None
+            map_orchestrator.validate_step(step_id, branch, recommendation=rec)
 
         # 7. Should advance to next subtask
         step = map_orchestrator.get_next_step(branch)
@@ -482,7 +484,9 @@ class TestFullLifecycle:
         for step_id in ["2.2", "2.3", "2.4"]:
             step = map_orchestrator.get_next_step(branch)
             assert step["step_id"] == step_id
-            map_orchestrator.validate_step(step_id, branch)
+            # ST-003: closing 2.4 now requires Monitor's recommendation.
+            rec = "proceed" if step_id == "2.4" else None
+            map_orchestrator.validate_step(step_id, branch, recommendation=rec)
 
         # 9. All done
         step = map_orchestrator.get_next_step(branch)

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -2063,7 +2063,7 @@ class TestValidateStepInterSubtaskBoundary:
         plan_dir.mkdir(parents=True, exist_ok=True)
         state_file = plan_dir / "step_state.json"
         state.save(state_file)
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["valid"] is True
         assert result["next_step"] == "2.2", result
         assert result["subtask_advanced_from"] == "ST-001"
@@ -2088,7 +2088,7 @@ class TestValidateStepInterSubtaskBoundary:
         state.pending_steps = ["2.4"]
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["next_step"] == "COMPLETE"
 
 
@@ -2202,7 +2202,7 @@ class TestValidateStepTransactionalMonitor:
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
         # Jump straight to 2.4 — historically this returned Step mismatch.
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["valid"] is True, result
         reloaded = map_orchestrator.StepState.load(state_file)
         assert "2.3" in reloaded.completed_steps
@@ -2289,7 +2289,7 @@ class TestValidateStepAutoMutationBoundary:
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
         monkeypatch.setenv("MAP_STRICT_SCOPE", "1")
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["valid"] is False
         assert "Mutation-boundary violation" in result["message"]
 
@@ -2639,10 +2639,9 @@ class TestGetNextStepResearchSkipWarning:
 
 
 class TestValidateStepRecommendationOmittedWarning:
-    """Fix #6 (2026-05-26): closing 2.4 without --recommendation leaves
-    the verdict-consistency footgun open. The orchestrator now surfaces
-    a warning so the operator sees they should pass the recommendation
-    next time.
+    """ST-003: closing 2.4 without --recommendation is now a hard-fail so the
+    verdict-consistency gate cannot be bypassed. The orchestrator returns
+    valid=False with recommendation_required=True when recommendation is absent.
     """
 
     def _seed(self, branch_dir: str, tmp_path: Path) -> Path:
@@ -2658,16 +2657,18 @@ class TestValidateStepRecommendationOmittedWarning:
         state.save(sf)
         return sf
 
-    def test_warning_emitted_when_recommendation_omitted(
+    def test_hard_fail_when_recommendation_omitted(
         self, branch_dir, tmp_path
     ):
+        """ST-003: omitting --recommendation is now a hard-fail (valid=False),
+        not a soft warning. Enforces the verdict-consistency gate structurally."""
         self._seed(branch_dir, tmp_path)
         result = map_orchestrator.validate_step("2.4", branch_dir)
-        assert result["valid"] is True
-        assert "warning" in result, result
-        assert "--recommendation" in result["warning"]
+        assert result["valid"] is False, result
+        assert result.get("recommendation_required") is True, result
+        assert "--recommendation" in result["message"]
 
-    def test_no_warning_when_recommendation_passed(
+    def test_no_error_when_recommendation_passed(
         self, branch_dir, tmp_path
     ):
         self._seed(branch_dir, tmp_path)
@@ -2675,7 +2676,7 @@ class TestValidateStepRecommendationOmittedWarning:
             "2.4", branch_dir, recommendation="proceed"
         )
         assert result["valid"] is True
-        assert "warning" not in result, result
+        assert result.get("recommendation_required") is None
 
 
 class TestValidateStepRecommendationContract:
@@ -2732,14 +2733,15 @@ class TestValidateStepRecommendationContract:
         )
         assert result["valid"] is True
 
-    def test_missing_recommendation_is_backward_compat(
+    def test_missing_recommendation_is_now_hard_fail(
         self, branch_dir, tmp_path
     ):
-        # Legacy callers that don't pass recommendation get the old
-        # behavior: 2.4 closes on any valid=true path.
+        # ST-003: omitting recommendation is now a hard-fail, not backward-compat.
+        # Callers MUST pass --recommendation to close 2.4.
         self._seed_state(branch_dir, tmp_path)
         result = map_orchestrator.validate_step("2.4", branch_dir)
-        assert result["valid"] is True
+        assert result["valid"] is False
+        assert result.get("recommendation_required") is True
 
 
 class TestMarkSubtaskCompleteKind:
@@ -2813,6 +2815,7 @@ class TestCursorAdvancesPastMarkedSubtasks:
     """
 
     def test_uppercase_phase_marker_counts_as_done(self, branch_dir, tmp_path):
+        del branch_dir, tmp_path
         state = map_orchestrator.StepState()
         state.workflow_status = "IN_PROGRESS"
         state.subtask_sequence = ["ST-001", "ST-002"]
@@ -2826,6 +2829,7 @@ class TestCursorAdvancesPastMarkedSubtasks:
     def test_subtask_results_entry_alone_counts_as_done(
         self, branch_dir, tmp_path
     ):
+        del branch_dir, tmp_path
         # Even without a subtask_phases marker, any recorded entry should
         # let the cursor move past the id.
         state = map_orchestrator.StepState()
@@ -2861,7 +2865,7 @@ class TestCursorAdvancesPastMarkedSubtasks:
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
 
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["valid"] is True
         assert result["next_step"] == "COMPLETE", result
 
@@ -2940,7 +2944,7 @@ class TestDepsAwareRuntimeAdvance:
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
 
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
 
         assert result["valid"] is True
         assert result["subtask_advanced_from"] == "ST-001"
@@ -2977,7 +2981,7 @@ class TestDepsAwareRuntimeAdvance:
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
 
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
 
         assert result["valid"] is True
         assert result["next_step"] == "BLOCKED_ON_DEPS"
@@ -3005,7 +3009,7 @@ class TestDepsAwareRuntimeAdvance:
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
 
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["valid"] is True
         assert result["subtask_advanced_to"] == "ST-002"
 
@@ -3036,7 +3040,7 @@ class TestDepsAwareRuntimeAdvance:
         state_file = tmp_path / ".map" / branch_dir / "step_state.json"
         state.save(state_file)
 
-        result = map_orchestrator.validate_step("2.4", branch_dir)
+        result = map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
         assert result["valid"] is True
         # Now ST-002 is ready (ST-003 marked done) — advance lands on it.
         assert result["subtask_advanced_to"] == "ST-002"
@@ -3360,6 +3364,93 @@ class TestCwdIndependence:
         assert "ST-001" in flat and "ST-X" not in flat, (
             f"set_waves resolved blueprint relative to cwd (project_b) "
             f"instead of script project (project_a). got: {out}"
+        )
+
+
+class TestValidateStep24RequiredRecommendation:
+    """ST-003 / VC1-VC3: validate_step 2.4 requires --recommendation.
+    Without it the verdict-consistency gate cannot enforce that Monitor's
+    revise/block/needs_investigation is honoured.
+    """
+
+    def _seed(self, branch_dir: str, tmp_path: Path) -> None:
+        state = map_orchestrator.StepState()
+        state.workflow_status = "IN_PROGRESS"
+        state.subtask_sequence = ["ST-001"]
+        state.subtask_index = 0
+        state.current_subtask_id = "ST-001"
+        state.current_step_id = "2.4"
+        state.current_step_phase = "MONITOR"
+        state.completed_steps = ["2.2", "2.3"]
+        state.pending_steps = ["2.4"]
+        sf = tmp_path / ".map" / branch_dir / "step_state.json"
+        sf.parent.mkdir(parents=True, exist_ok=True)
+        state.save(sf)
+
+    # VC1 -------------------------------------------------------------------
+    def test_vc1_validate_step_24_requires_recommendation(
+        self, branch_dir: str, tmp_path: Path
+    ) -> None:
+        """VC1: omitting recommendation → valid=False + recommendation_required=True."""
+        self._seed(branch_dir, tmp_path)
+        result = map_orchestrator.validate_step("2.4", branch_dir)
+        assert result["valid"] is False, result
+        assert result.get("recommendation_required") is True, result
+        assert "--recommendation" in result["message"]
+
+    # VC3 -------------------------------------------------------------------
+    def test_vc3_validate_step_24_proceed_closes(
+        self, branch_dir: str, tmp_path: Path
+    ) -> None:
+        """VC3: recommendation='proceed' → valid=True (step closes cleanly)."""
+        self._seed(branch_dir, tmp_path)
+        result = map_orchestrator.validate_step(
+            "2.4", branch_dir, recommendation="proceed"
+        )
+        assert result["valid"] is True, result
+        assert result.get("recommendation_required") is None
+
+    def test_vc3_validate_step_24_revise_rejects(
+        self, branch_dir: str, tmp_path: Path
+    ) -> None:
+        """VC3: recommendation='revise' → valid=False (Monitor verdict enforced)."""
+        self._seed(branch_dir, tmp_path)
+        result = map_orchestrator.validate_step(
+            "2.4", branch_dir, recommendation="revise"
+        )
+        assert result["valid"] is False, result
+        assert result.get("recommendation") == "revise"
+
+    def test_vc3_validate_step_24_idempotent_noop(
+        self, branch_dir: str, tmp_path: Path
+    ) -> None:
+        """VC3: already-completed 2.4 re-validated with recommendation=None → valid=True (no-op path)."""
+        self._seed(branch_dir, tmp_path)
+        # First close it properly.
+        map_orchestrator.validate_step("2.4", branch_dir, recommendation="proceed")
+        # Now re-validate without recommendation — idempotent path must succeed.
+        result = map_orchestrator.validate_step("2.4", branch_dir)
+        assert result["valid"] is True, result
+        assert result.get("idempotent") is True, result
+
+    # VC2 -------------------------------------------------------------------
+    def test_vc2_validate_step_24_cli_nonzero_without_recommendation(
+        self, branch_dir: str, tmp_path: Path
+    ) -> None:
+        """VC2: CLI subprocess validate_step 2.4 without --recommendation → returncode != 0."""
+        self._seed(branch_dir, tmp_path)
+        script = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "mapify_cli" / "templates" / "map" / "scripts" / "map_orchestrator.py"
+        )
+        result = subprocess.run(
+            [sys.executable, str(script), "validate_step", "2.4",
+             "--branch", branch_dir],
+            capture_output=True, text=True, cwd=str(tmp_path),
+        )
+        assert result.returncode != 0, (
+            f"Expected non-zero exit when --recommendation omitted; "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
         )
 
 

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3192,12 +3192,94 @@ class TestDetectTruncatedAgentOutput:
         assert "trailing or leading text around JSON object" in report["reasons"]
 
     def test_actor_kind_required_keys(self):
+        # FIX 2: actor required_keys now includes all four envelope fields.
         text = json.dumps({"files_changed": ["a.py"]})
         report = map_step_runner.detect_truncated_agent_output(
             text, agent_kind="actor"
         )
         assert report["truncated"] is True
         assert any("missing required key: tests_run" in r for r in report["reasons"])
+        assert any("missing required key: validation_notes" in r for r in report["reasons"])
+        assert any("missing required key: blocker" in r for r in report["reasons"])
+
+    def test_actor_full_output_not_truncated(self):
+        """FIX 2: full actor envelope with all four required keys is not truncated."""
+        text = json.dumps({
+            "files_changed": ["a.py"],
+            "tests_run": ["pytest: 5 passed"],
+            "validation_notes": "satisfies VC1 and VC2",
+            "blocker": None,
+        })
+        report = map_step_runner.detect_truncated_agent_output(
+            text, agent_kind="actor"
+        )
+        assert report["truncated"] is False, report
+
+    def test_review_monitor_full_output_not_truncated(self):
+        """FIX 4: review-monitor with the full review schema is not truncated."""
+        text = json.dumps({
+            "evidence": [],
+            "valid": True,
+            "summary": "all good",
+            "verdict": "approved",
+            "issues": [],
+            "passed_checks": ["all checks pass"],
+            "failed_checks": [],
+        })
+        report = map_step_runner.detect_truncated_agent_output(
+            text, agent_kind="review-monitor"
+        )
+        assert report["truncated"] is False, report
+
+    def test_review_monitor_missing_verdict_is_truncated(self):
+        """FIX 4: review-monitor output missing a full-schema key (verdict) is truncated."""
+        text = json.dumps({
+            "evidence": [],
+            "valid": True,
+            "summary": "ok",
+            "issues": [],
+            "passed_checks": [],
+            "failed_checks": [],
+            # "verdict" intentionally omitted
+        })
+        report = map_step_runner.detect_truncated_agent_output(
+            text, agent_kind="review-monitor"
+        )
+        assert report["truncated"] is True
+        assert any("missing required key: verdict" in r for r in report["reasons"])
+
+    def test_review_monitor_missing_passed_checks_is_truncated(self):
+        """FIX 4: review-monitor output missing passed_checks is truncated."""
+        text = json.dumps({
+            "evidence": [],
+            "valid": True,
+            "summary": "ok",
+            "verdict": "approved",
+            "issues": [],
+            # "passed_checks" intentionally omitted
+            "failed_checks": [],
+        })
+        report = map_step_runner.detect_truncated_agent_output(
+            text, agent_kind="review-monitor"
+        )
+        assert report["truncated"] is True
+        assert any("missing required key: passed_checks" in r for r in report["reasons"])
+
+    def test_monitor_still_accepts_efficient_output(self):
+        """FIX 4: --agent monitor still accepts map-efficient Monitor output
+        (no evidence/verdict/passed_checks/failed_checks) — regression guard."""
+        text = json.dumps({
+            "valid": True,
+            "summary": "ST-001 satisfies all criteria",
+            "issues": [],
+            "files_changed": ["a.py"],
+            "tests_run": ["pytest: 10 passed"],
+            "escalation_required": False,
+        })
+        report = map_step_runner.detect_truncated_agent_output(
+            text, agent_kind="monitor"
+        )
+        assert report["truncated"] is False, report
 
     def test_empty_response_is_truncated(self):
         report = map_step_runner.detect_truncated_agent_output("")

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -6922,3 +6922,531 @@ class TestAgentFailureTelemetry:
         assert len(lines) == 2
         assert json.loads(lines[0])["failure_label"] == "format_violation"
         assert json.loads(lines[1])["failure_label"] == "truncated"
+
+
+# ---------------------------------------------------------------------------
+# ST-006: Tests for the three new guards
+# ---------------------------------------------------------------------------
+
+
+class TestChangedLineNumbersByFile:
+    """VC1: _changed_line_numbers_by_file parses unified diff into
+    {relative_path: set[new_file_line_number]} for added (+) lines only.
+    Header lines (+++ / ---) are NOT recorded as content.
+    """
+
+    def test_vc1_parses_added_line_numbers_single_hunk(self) -> None:
+        """Single hunk with @@ -10,3 +10,4 @@: one added line at new-file line 12."""
+        diff = (
+            "diff --git a/f.py b/f.py\n"
+            "--- a/f.py\n"
+            "+++ b/f.py\n"
+            "@@ -10,3 +10,4 @@\n"
+            " context_line\n"   # line 10 — context, new_line → 11
+            " context_line2\n"  # line 11 — context, new_line → 12
+            "+added_line\n"     # added at new_file line 12
+            " context_line3\n"  # context, new_line → 13
+        )
+        result = map_step_runner._changed_line_numbers_by_file(diff)
+        assert "f.py" in result
+        assert 12 in result["f.py"]
+        # Only the one added line is recorded.
+        assert result["f.py"] == {12}
+
+    def test_vc1_parses_added_line_numbers_multi_hunk(self) -> None:
+        """Two hunks in the same file → lines from both collected under one key."""
+        diff = (
+            "diff --git a/src/foo.py b/src/foo.py\n"
+            "--- a/src/foo.py\n"
+            "+++ b/src/foo.py\n"
+            "@@ -1,2 +1,3 @@\n"
+            " a\n"      # line 1, new_line → 2
+            "+b\n"      # added at new-file line 2
+            " c\n"      # context
+            "@@ -20,1 +21,2 @@\n"
+            " x\n"      # line 21, new_line → 22
+            "+y\n"      # added at new-file line 22
+        )
+        result = map_step_runner._changed_line_numbers_by_file(diff)
+        assert "src/foo.py" in result
+        assert 2 in result["src/foo.py"]
+        assert 22 in result["src/foo.py"]
+
+    def test_vc1_headers_not_recorded_as_content(self) -> None:
+        """'+++ b/f.py' header lines must not appear as added line numbers."""
+        diff = (
+            "diff --git a/f.py b/f.py\n"
+            "--- a/f.py\n"
+            "+++ b/f.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            " existing\n"
+            "+added\n"
+        )
+        result = map_step_runner._changed_line_numbers_by_file(diff)
+        # Only "f.py" key — no "b/f.py" header bleed-through.
+        assert list(result.keys()) == ["f.py"]
+        # 1 added line — the "+added" line at position 2.
+        assert len(result["f.py"]) == 1
+
+    def test_vc1_dev_null_source_ignored(self) -> None:
+        """New-file diffs with '--- /dev/null' must still record added lines."""
+        diff = (
+            "diff --git a/new.py b/new.py\n"
+            "--- /dev/null\n"
+            "+++ b/new.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+line_one\n"
+            "+line_two\n"
+        )
+        result = map_step_runner._changed_line_numbers_by_file(diff)
+        assert "new.py" in result
+        assert result["new.py"] == {1, 2}
+
+    def test_vc1_empty_diff_returns_empty(self) -> None:
+        assert map_step_runner._changed_line_numbers_by_file("") == {}
+
+
+class TestEnclosingChangedSymbols:
+    """VC1: _enclosing_changed_symbols maps changed line numbers to the
+    enclosing top-level symbol name.
+
+    Rules:
+    - FunctionDef, AsyncFunctionDef, ClassDef → name kept if len>=3, not dunder.
+    - Assign / AnnAssign with Name target: same filter.
+    - Leading underscore names (_PRIVATE) are KEPT.
+    - Dunder names (__all__) and short names (ab) are EXCLUDED.
+    - Nested functions → maps to the enclosing top-level symbol, NOT the nested name.
+    - SyntaxError or missing file → returns None.
+    """
+
+    # Shared source fixture written to a temp file.
+    _SOURCE = """\
+_PRIVATE_CONST = (1, 2)
+
+def shared_fn(x):
+    # body line 4
+    return x + 1
+
+class Foo:
+    def method(self):
+        def _inner():
+            pass
+        return _inner()
+
+__all__ = ["shared_fn"]
+
+ab = 1
+"""
+
+    def _write_source(self, tmp_path: Path) -> Path:
+        p = tmp_path / "module.py"
+        p.write_text(self._SOURCE, encoding="utf-8")
+        return p
+
+    def test_vc1_body_change_maps_to_enclosing_function(self, tmp_path: Path) -> None:
+        """Line inside shared_fn's body → {'shared_fn'}."""
+        src = self._write_source(tmp_path)
+        # Line 4 is "    # body line 4" inside shared_fn.
+        result = map_step_runner._enclosing_changed_symbols(src, {4})
+        assert result is not None
+        assert "shared_fn" in result
+
+    def test_vc1_underscore_const_detected(self, tmp_path: Path) -> None:
+        """Leading-underscore names like _PRIVATE_CONST must be kept."""
+        src = self._write_source(tmp_path)
+        # Line 1 is "_PRIVATE_CONST = (1, 2)".
+        result = map_step_runner._enclosing_changed_symbols(src, {1})
+        assert result is not None
+        assert "_PRIVATE_CONST" in result
+
+    def test_vc1_dunder_and_short_excluded(self, tmp_path: Path) -> None:
+        """__all__ (dunder) and ab (2-char) must NOT appear in result."""
+        src = self._write_source(tmp_path)
+        # __all__ is on line 13; ab is on line 15.
+        result = map_step_runner._enclosing_changed_symbols(src, {13, 15})
+        assert result is not None
+        assert "__all__" not in result
+        assert "ab" not in result
+
+    def test_vc1_nested_not_surfaced(self, tmp_path: Path) -> None:
+        """A line inside a nested function maps to the top-level enclosing symbol."""
+        src = self._write_source(tmp_path)
+        # Line 10 is "            pass" inside _inner() inside Foo.method().
+        # Top-level enclosing node is class Foo.
+        result = map_step_runner._enclosing_changed_symbols(src, {10})
+        assert result is not None
+        assert "Foo" in result
+        assert "_inner" not in result
+
+    def test_vc3_syntax_error_returns_none(self, tmp_path: Path) -> None:
+        """SyntaxError in source → None (fail-safe / unknown signal)."""
+        bad = tmp_path / "bad.py"
+        bad.write_text("def broken(\n", encoding="utf-8")
+        result = map_step_runner._enclosing_changed_symbols(bad, {1})
+        assert result is None
+
+    def test_vc3_missing_file_returns_none(self, tmp_path: Path) -> None:
+        """Non-existent file → None (OSError caught)."""
+        missing = tmp_path / "no_such_file.py"
+        result = map_step_runner._enclosing_changed_symbols(missing, {1})
+        assert result is None
+
+
+class TestDetectSymbolBlastRadius:
+    """VC2-VC4: detect_symbol_blast_radius end-to-end with a real temp git repo.
+
+    Mirrors TestDetectCrossSubtaskRegressionRisk fixture pattern.
+    """
+
+    def _init_git(self, root: Path) -> None:
+        subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "t@t.com"], cwd=root, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "t"], cwd=root, capture_output=True, check=True
+        )
+        (root / ".seed").write_text("seed\n")
+        subprocess.run(["git", "add", "."], cwd=root, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=root, capture_output=True, check=True
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=root, capture_output=True, text=True,
+        )
+        assert head.returncode == 0, "test setup: initial commit produced no resolvable HEAD"
+
+    def _write_state(self, branch_dir: Path, last_sha: str = "") -> None:
+        state: dict[str, object] = {"subtask_results": {}}
+        if last_sha:
+            state["last_subtask_commit_sha"] = last_sha
+        (branch_dir / "step_state.json").write_text(json.dumps(state))
+
+    def _write_blueprint(self, branch_dir: Path, affected_files: list[str]) -> None:
+        bp = {"subtasks": [{"id": "ST-001", "affected_files": affected_files}]}
+        (branch_dir / "blueprint.json").write_text(json.dumps(bp))
+
+    def test_vc2_external_caller_yields_validate_callers(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC2: symbol changed in runner.py; .claude/skills/foo/SKILL.md references it
+        externally → recommended_gate=='validate_callers'."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_blueprint(branch_workspace, ["runner.py"])
+
+        # Write base version of runner.py and commit it (establishes HEAD).
+        (repo / "runner.py").write_text(
+            "def shared_fn(x):\n    return x\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"], cwd=repo, capture_output=True, check=True
+        )
+
+        # Plant an external caller in .claude/skills/ (one of _GREP_SEARCH_PATHS).
+        skill_dir = repo / ".claude" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "Uses shared_fn to do the thing.\n", encoding="utf-8"
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add skill"], cwd=repo, capture_output=True, check=True
+        )
+
+        # Record the SHA of the last subtask so the diff covers the body change.
+        last_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo, capture_output=True, text=True,
+        ).stdout.strip()
+        self._write_state(branch_workspace, last_sha=last_sha)
+
+        # Now body-change shared_fn (staged/uncommitted).
+        (repo / "runner.py").write_text(
+            "def shared_fn(x):\n    return x + 1  # changed\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_symbol_blast_radius("test-branch", "ST-001")
+
+        assert "shared_fn" in report["changed_symbols"], report
+        external_files = [c["file"] for c in report["external_callers"]]
+        assert any(".claude/skills" in f for f in external_files), report
+        assert report["recommended_gate"] == "validate_callers", report
+
+    def test_vc2_no_external_caller_scoped(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC2: symbol referenced ONLY within affected_files → recommended_gate=='scoped'."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_blueprint(branch_workspace, ["runner.py"])
+
+        (repo / "runner.py").write_text(
+            "def internal_fn(x):\n    return x\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+        base = subprocess.run(
+            ["git", "commit", "-m", "base"], cwd=repo, capture_output=True, text=True
+        )
+        assert base.returncode == 0
+
+        last_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo, capture_output=True, text=True,
+        ).stdout.strip()
+        self._write_state(branch_workspace, last_sha=last_sha)
+
+        # Body-change internal_fn — no external callers anywhere.
+        (repo / "runner.py").write_text(
+            "def internal_fn(x):\n    return x * 2  # changed\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_symbol_blast_radius("test-branch", "ST-001")
+
+        assert report["status"] == "ok", report
+        assert report["recommended_gate"] == "scoped", report
+
+    def test_vc3_stale_base_ref_fails_safe(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC3: last_subtask_commit_sha='0'*40 (nonexistent) → status=='unknown',
+        recommended_gate=='validate_callers' (fail-safe, never silently 'scoped')."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_blueprint(branch_workspace, ["runner.py"])
+        self._write_state(branch_workspace, last_sha="0" * 40)
+
+        (repo / "runner.py").write_text("def any_fn(x):\n    return x\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_symbol_blast_radius("test-branch", "ST-001")
+
+        assert report["status"] == "unknown", report
+        assert report["recommended_gate"] == "validate_callers", report
+
+    def test_vc4_pr145_motivating_case(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC4 / PR #145 regression: runner.py has _MONITOR_REQUIRED_KEYS and
+        detect_truncated(); a skill references both. Changing both symbols
+        must produce changed_symbols containing both and recommended_gate=='validate_callers'.
+
+        This is the exact failure mode PR #145 was designed to prevent:
+        re-deriving a shared helper in one subtask breaks callers that are
+        never re-tested in the scoped gate.
+        """
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_blueprint(branch_workspace, ["runner.py"])
+
+        base_source = (
+            "_MONITOR_REQUIRED_KEYS = ('severity', 'justification')\n"
+            "\n"
+            "def detect_truncated(output):\n"
+            "    return any(k not in output for k in _MONITOR_REQUIRED_KEYS)\n"
+        )
+        (repo / "runner.py").write_text(base_source, encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"], cwd=repo, capture_output=True, check=True
+        )
+
+        # Plant skill that references BOTH symbols.
+        skill_dir = repo / ".claude" / "skills" / "monitor"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "Calls detect_truncated using _MONITOR_REQUIRED_KEYS.\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add skill"], cwd=repo, capture_output=True, check=True
+        )
+
+        last_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo, capture_output=True, text=True,
+        ).stdout.strip()
+        self._write_state(branch_workspace, last_sha=last_sha)
+
+        # Mutate BOTH symbols.
+        changed_source = (
+            "_MONITOR_REQUIRED_KEYS = ('severity', 'justification', 'sibling_comparison')\n"
+            "\n"
+            "def detect_truncated(output):\n"
+            "    # body changed\n"
+            "    return any(k not in output for k in _MONITOR_REQUIRED_KEYS)\n"
+        )
+        (repo / "runner.py").write_text(changed_source, encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_symbol_blast_radius("test-branch", "ST-001")
+
+        assert "_MONITOR_REQUIRED_KEYS" in report["changed_symbols"], report
+        assert "detect_truncated" in report["changed_symbols"], report
+        assert report["recommended_gate"] == "validate_callers", report
+
+    def test_vc_cli_exits_zero(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLI is advisory: exit 0 always; result is parseable JSON."""
+        del monkeypatch
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_blueprint(branch_workspace, ["runner.py"])
+        self._write_state(branch_workspace)
+        runner = SCRIPTS_PATH / "map_step_runner.py"
+        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1", "CLAUDE_PROJECT_DIR": str(repo)}
+        result = subprocess.run(
+            [sys.executable, str(runner), "detect_symbol_blast_radius", "test-branch", "ST-001"],
+            capture_output=True, text=True, cwd=str(repo), env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        parsed = json.loads(result.stdout)
+        assert "recommended_gate" in parsed
+
+
+class TestDetectActorFilesChangedMismatch:
+    """VC1-VC3: detect_actor_files_changed_mismatch catches declared-but-not-written files.
+
+    Mirrors TestDetectCrossSubtaskRegressionRisk fixture pattern.
+    """
+
+    def _init_git(self, root: Path) -> None:
+        subprocess.run(["git", "init"], cwd=root, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "t@t.com"], cwd=root, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "t"], cwd=root, capture_output=True, check=True
+        )
+        (root / ".seed").write_text("seed\n")
+        subprocess.run(["git", "add", "."], cwd=root, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=root, capture_output=True, check=True
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=root, capture_output=True, text=True,
+        )
+        assert head.returncode == 0, "test setup: initial commit produced no resolvable HEAD"
+
+    def _write_state(self, branch_dir: Path) -> None:
+        (branch_dir / "step_state.json").write_text(
+            json.dumps({"subtask_results": {}})
+        )
+
+    def test_vc1_declared_not_written_listed(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC1: declare a.py + b.py; only a.py actually changed → declared_not_written==['b.py']."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        # Only write a.py (b.py is declared but never written).
+        (repo / "a.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-001", ["a.py", "b.py"]
+        )
+
+        assert report["declared_not_written"] == ["b.py"], report
+        assert report["status_mismatch"] is True, report
+
+    def test_vc2_mismatch_sets_recovery(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC2: mismatch → status_mismatch=True + non-empty recovery_instruction."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        (repo / "a.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-001", ["a.py", "b.py"]
+        )
+
+        assert report["status_mismatch"] is True, report
+        assert report["recovery_instruction"] != "", report
+
+    def test_vc2_clean_no_recovery(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC2: declared files all written → status_mismatch=False, recovery_instruction=''."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        (repo / "a.py").write_text("x = 1\n")
+        (repo / "b.py").write_text("y = 2\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-001", ["a.py", "b.py"]
+        )
+
+        assert report["status_mismatch"] is False, report
+        assert report["recovery_instruction"] == "", report
+
+    def test_vc3_git_error_failsafe(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC3: stale/nonexistent SHA → status=='unknown', status_mismatch=True,
+        declared_not_written == declared (fail-safe, all files assumed unwritten)."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        # Plant a stale SHA so git diff fails.
+        (branch_workspace / "step_state.json").write_text(
+            json.dumps({"subtask_results": {}, "last_subtask_commit_sha": "0" * 40})
+        )
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-001", ["a.py", "b.py"]
+        )
+
+        assert report["status"] == "unknown", report
+        assert report["status_mismatch"] is True, report
+        assert report["declared_not_written"] == ["a.py", "b.py"], report
+
+    def test_vc3_cli_exits_zero(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """VC3: CLI with --declared a.py,b.py → exit 0, JSON parseable."""
+        del monkeypatch
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+        runner = SCRIPTS_PATH / "map_step_runner.py"
+        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1", "CLAUDE_PROJECT_DIR": str(repo)}
+        result = subprocess.run(
+            [
+                sys.executable, str(runner),
+                "detect_actor_files_changed_mismatch",
+                "test-branch", "ST-001",
+                "--declared", "a.py,b.py",
+            ],
+            capture_output=True, text=True, cwd=str(repo), env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        parsed = json.loads(result.stdout)
+        assert "status_mismatch" in parsed


### PR DESCRIPTION
## Summary

Adds three deterministic cross-workflow safety guards to the MAP framework so a runtime refactor of a **shared symbol** can no longer silently break another workflow. Motivation: in #145 a re-derivation of `_MONITOR_REQUIRED_KEYS` broke the map-efficient Monitor truncation gate, and every in-workflow Monitor + the final-verifier missed it — only external Copilot review caught it. Per-subtask Monitor validates the subtask's own contract in isolation and is structurally blind to cross-workflow runtime interactions.

Built and verified via `/map-efficient` itself (dogfooding) with full sub-agent delegation.

- **Blast-radius gate (`detect_symbol_blast_radius`)**: maps a subtask's changed lines to their **enclosing top-level symbol via AST** (`_changed_line_numbers_by_file` + `_enclosing_changed_symbols` — catches body changes to existing functions AND leading-underscore module constants), then greps for references **outside** the subtask's declared `affected_files` across skills/src/scripts. Returns `recommended_gate=validate_callers` when a changed symbol is referenced elsewhere. Fails safe to `validate_callers` on any git/grep/AST error.
- **Recommendation gate**: `validate_step 2.4` now **hard-requires** `--recommendation` (omitted → `valid=False`) and the CLI exits non-zero on invalid — closing the documented footgun where `valid=true + recommendation=revise` could slip through.
- **Actor files-changed mismatch (`detect_actor_files_changed_mismatch`)**: flags files the Actor declared in `files_changed` but never wrote (mid-edit truncation), with a recovery instruction.
- Both detector gates are wired into `map-efficient` SKILL.md (MANDATORY: blast-radius pre-dispatch, files-mismatch in the Actor gate) with full recipes in `efficient-reference.md`.

The new gate provably catches the #145 class — see the regression test `test_vc4_pr145_motivating_case` (body change + underscore-const reassignment referenced from a skill → `validate_callers`).

> Note: this branch stacks on #145, so its base is `analysis/harness-sensitivity-eval` to keep the diff focused on the guards. Retarget to `main` after #145 merges.

## Test plan

- [x] `make check` — ruff + mypy + pytest: 1696 passed, 4 skipped
- [x] `pyright src/ tests/` — 0 errors / 0 warnings / 0 informations
- [x] `diff -q` both runner-copy pairs + both map-efficient skill-file pairs — byte-identical
- [x] `pytest tests/test_template_sync.py` — 49 passed
- [x] `uv run mapify init <tmp> --no-git --mcp none` smoke — ships both guard fns, AST helpers, the recommendation requirement, and both skill-gate CLIs
- [x] Independent final-verifier: PASS (confirmed the blast-radius gate catches the #145 motivating case, not a tautology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)