### PR TITLE
feat(map-efficient): emit learning-handoff so deferred /map-learn auto-loads

### DIFF
--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -480,16 +480,15 @@ Set final status from verifier and gates:
 
 ```bash
 RUN_HEALTH_STATUS="${RUN_HEALTH_STATUS:?set from final decision}"
-python3 .map/scripts/map_step_runner.py write_run_health_report \
-  map-efficient \
-  "$RUN_HEALTH_STATUS"
+python3 .map/scripts/map_step_runner.py write_run_health_report map-efficient "$RUN_HEALTH_STATUS"
+python3 .map/scripts/map_step_runner.py write_learning_handoff map-efficient "" "$RUN_HEALTH_STATUS" "Run /map-learn to preserve patterns, then /map-review" ""
 ```
 
-This writes `.map/<branch>/run_health_report.json`, updates `run_health`, and gives reviewers a machine-readable terminal snapshot.
+This writes `run_health_report.json` (machine-readable run snapshot) plus `learning-handoff.md`/`.json`, so a later zero-argument `/map-learn` auto-loads this run instead of reconstructing it from memory.
 
 ## Step 4: Summary
 
-Report completed subtasks, files changed, checks run, final status, remaining issues, and next command (`/map-review` or the owning fix workflow).
+Report completed subtasks, files changed, checks run, final status, remaining issues, and next command (`/map-review`, the owning fix workflow, or optional `/map-learn` to preserve patterns).
 
 ## Examples
 

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -480,16 +480,15 @@ Set final status from verifier and gates:
 
 ```bash
 RUN_HEALTH_STATUS="${RUN_HEALTH_STATUS:?set from final decision}"
-python3 .map/scripts/map_step_runner.py write_run_health_report \
-  map-efficient \
-  "$RUN_HEALTH_STATUS"
+python3 .map/scripts/map_step_runner.py write_run_health_report map-efficient "$RUN_HEALTH_STATUS"
+python3 .map/scripts/map_step_runner.py write_learning_handoff map-efficient "" "$RUN_HEALTH_STATUS" "Run /map-learn to preserve patterns, then /map-review" ""
 ```
 
-This writes `.map/<branch>/run_health_report.json`, updates `run_health`, and gives reviewers a machine-readable terminal snapshot.
+This writes `run_health_report.json` (machine-readable run snapshot) plus `learning-handoff.md`/`.json`, so a later zero-argument `/map-learn` auto-loads this run instead of reconstructing it from memory.
 
 ## Step 4: Summary
 
-Report completed subtasks, files changed, checks run, final status, remaining issues, and next command (`/map-review` or the owning fix workflow).
+Report completed subtasks, files changed, checks run, final status, remaining issues, and next command (`/map-review`, the owning fix workflow, or optional `/map-learn` to preserve patterns).
 
 ## Examples
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1172,7 +1172,7 @@ class TestRunHealthCloseoutWiring:
         ), f"{skill_name} must invoke write_run_health_report with $RUN_HEALTH_STATUS"
         assert not re.search(
             "write_run_health_report" + token_gap + re.escape(skill_name)
-            + token_gap + r"(?:complete|pending|blocked|won't_do|superseded)\b",
+            + token_gap + r"""["']?(?:complete|pending|blocked|won't_do|superseded)\b""",
             content,
         ), f"{skill_name} must not hardcode a literal status into write_run_health_report"
         assert "run_health_report.json" in content

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1161,14 +1161,20 @@ class TestRunHealthCloseoutWiring:
         content = skill_md.read_text(encoding="utf-8")
 
         assert "write_run_health_report" in content
-        expected_invocation = f'''write_run_health_report \\
-  {skill_name} \\
-  "$RUN_HEALTH_STATUS"'''
-        assert expected_invocation in content
-        hardcoded_complete = f"""write_run_health_report \\
-  {skill_name} \\
-  complete"""
-        assert hardcoded_complete not in content
+        # Accept both single-line and backslash-continued invocations (map-efficient
+        # is line-budget-gated and uses the compact single-line form), but still
+        # require the status variable rather than a hardcoded literal in either form.
+        token_gap = r"\s+\\?\s*"
+        assert re.search(
+            "write_run_health_report" + token_gap + re.escape(skill_name)
+            + token_gap + r'"\$RUN_HEALTH_STATUS"',
+            content,
+        ), f"{skill_name} must invoke write_run_health_report with $RUN_HEALTH_STATUS"
+        assert not re.search(
+            "write_run_health_report" + token_gap + re.escape(skill_name)
+            + token_gap + r"(?:complete|pending|blocked|won't_do|superseded)\b",
+            content,
+        ), f"{skill_name} must not hardcode a literal status into write_run_health_report"
         assert "run_health_report.json" in content
         assert "run_health" in content
         assert "RUN_HEALTH_STATUS" in content


### PR DESCRIPTION
## Problem

`/map-efficient` was the **only** learning-eligible workflow that never invoked `write_learning_handoff`. After a (often hours-long) `/map-efficient` run, `.map/<branch>/learning-handoff.md` did not exist, so a deferred zero-argument `/map-learn` found no artifact and silently fell back to reconstructing the workflow summary from in-context memory ("No handoff artifact — I'll use an inline summary…"). That inline reconstruction degrades as the original run context ages out of the window.

`map-check`, `map-debug`, and `map-review` already emit the handoff; only `map-efficient` had the gap.

## Change

- **`.claude/skills/map-efficient/SKILL.md`** — add the `write_learning_handoff` closeout call in Step 3.3, right after `write_run_health_report`. Empty `task_title` auto-resolves via `read_current_goal`. Updated the closeout prose and Step 4 next-command to surface `/map-learn`.
- **`src/mapify_cli/templates/skills/map-efficient/SKILL.md`** — synced byte-for-byte via `make sync-templates` (repo template-sync invariant).
- **`tests/test_skills.py`** — the `TestRunHealthCloseoutWiring` pinned test asserted the exact 3-line backslash form of `write_run_health_report`; made it format-agnostic (accepts single-line and backslash-continued forms) while still catching a hardcoded-status regression.

## Constraints handled

- **500-line active-body budget** (`test_skills` cap on `HIGH_TRAFFIC_COMPACT_SKILL_REFS`): the file was at exactly 500. Collapsed `write_run_health_report` to its single-line form to make room; final **499**.
- **Codex variant (`.agents/skills/map-efficient`) intentionally untouched** — `map-learn` is not part of the Codex skill surface, so emitting a handoff there (and referencing `$map-learn`) would create a dangling reference.
- **Guard test negative-proofed** — hardcoded the status, confirmed RED, restored, confirmed GREEN.

## Verification

- `make check` green: `ruff` ✓, `mypy` ✓, `pyright` 0/0/0 ✓, hook-lint ✓, **1787 passed, 4 skipped**.
- Ran the new CLI command directly — it parses and writes `learning-handoff.md`/`.json` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)