### PR TITLE
fix(blueprint-contract): structural creates_files replaces magic-prose drift matching (#167)

### DIFF
--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -195,6 +195,9 @@ Return **ONLY** valid JSON in this exact structure:
         "affected_files": [
           "path/to/file1.py",
           "path/to/file2.jsx"
+        ],
+        "creates_files": [
+          "path/to/file1.py"
         ]
       }
     ]
@@ -321,6 +324,7 @@ Return **ONLY** valid JSON in this exact structure:
     - The repository has no automated test harness, and adding one is out-of-scope for this subtask.
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
+**subtasks[].creates_files**: OPTIONAL subset of `affected_files` that this subtask CREATES from scratch (paths not yet on disk). List each such path in BOTH `affected_files` and `creates_files`. This is the prose-free, structural signal `validate_blueprint_contract` uses to mark those paths expected-absent — do NOT rely on description wording ("creates new", "introduces") to silence the affected_files-drift warning. Omit the field (or use `[]`) when the subtask only modifies existing files.
 
 ### Integration & Runtime Bootstrapping Subtasks
 
@@ -655,11 +659,11 @@ When invoked with `mode: "re_decomposition"` from the orchestrator, you receive 
 - [ ] All affected_files are precise paths
 - [ ] No vague references ("backend", "frontend", "code")
 - [ ] Paths match actual project structure
-- [ ] Paths verified to exist on disk (grep/glob) OR explicitly marked as new-file creation in the subtask description — `validate_blueprint_contract` warns "affected_files drift" when every declared path is missing under CLAUDE_PROJECT_DIR
+- [ ] Paths verified to exist on disk (grep/glob) OR, for files this subtask creates from scratch, listed in `creates_files` (a subset of `affected_files`) — `validate_blueprint_contract` warns "affected_files drift" when every MODIFY-target path is missing under CLAUDE_PROJECT_DIR. Use the structural `creates_files` field, not description prose, to mark new files.
 
 **Symbol Grounding (MANDATORY)**:
 - [ ] Every class / function / method name referenced in `aag_contract` or `validation_criteria` has been grep-verified against actual source code (`rg 'class FooBar'` or `rg 'def baz_method'`). Do NOT name symbols from memory or from a similar-looking project. Recurring decomposer failure mode: hallucinating `SourceCraftPublisher.publish_inline` when the real entry point is `publish_findings`, sending Actor on a wild-goose chase before the bug is caught.
-- [ ] If the subtask creates a NEW symbol, mark it explicitly in the description ("introduces new class `X`") so reviewers don't expect to find it in the current tree.
+- [ ] If the subtask creates a NEW file, list it in `creates_files` (and `affected_files`). If it creates a NEW symbol inside an existing file, note it in the description ("introduces new class `X`") so reviewers don't expect to find it in the current tree.
 - [ ] When extending an existing class, name the class AND verify the file path where it currently lives — the decomposer's working assumption ("the obvious name") is wrong often enough that grep before write is cheaper than Actor rework.
 
 **Tool-Call Budget Estimate (MANDATORY)**:

--- a/.codex/agents/decomposer.toml
+++ b/.codex/agents/decomposer.toml
@@ -156,6 +156,9 @@ Return **ONLY** valid JSON in this exact structure:
         "affected_files": [
           "path/to/file1.py",
           "path/to/file2.jsx"
+        ],
+        "creates_files": [
+          "path/to/file1.py"
         ]
       }
     ]
@@ -282,6 +285,7 @@ Return **ONLY** valid JSON in this exact structure:
     - The repository has no automated test harness, and adding one is out-of-scope for this subtask.
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
+**subtasks[].creates_files**: OPTIONAL subset of `affected_files` this subtask CREATES from scratch (paths not yet on disk); list each such path in BOTH arrays. This is the prose-free signal `validate_blueprint_contract` uses to mark them expected-absent — do NOT rely on description wording to silence the affected_files-drift warning. Omit (or `[]`) when the subtask only modifies existing files.
 
 ### Integration & Runtime Bootstrapping Subtasks
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -2141,6 +2141,43 @@ def validate_blueprint_contract(
                     "reviewable concern (or add split_rationale to ack the size)"
                 )
 
+        # Structural create-vs-modify (issue #167): `creates_files` is the
+        # prose-free, canonical list of which affected_files this subtask
+        # creates from scratch. It MUST be a subset of affected_files — a
+        # created file is part of the mutation surface the scoped gates allow
+        # the Actor to write. When the field is ABSENT the subtask is legacy
+        # and the drift check below falls back to the deprecated
+        # description-phrase heuristic; when PRESENT (even empty) the prose
+        # heuristic is ignored and `creates_files` is authoritative.
+        raw_creates_files = subtask.get("creates_files")
+        creates_files_declared = raw_creates_files is not None
+        creates_files_list: list[str] = []
+        if creates_files_declared:
+            if not isinstance(raw_creates_files, list) or not all(
+                isinstance(p, str) for p in raw_creates_files
+            ):
+                errors.append(
+                    f"{label}: creates_files must be an array of path strings"
+                )
+                creates_files_declared = False
+            else:
+                creates_files_list = [p for p in raw_creates_files if p.strip()]
+                affected_set = (
+                    {p for p in affected_files if isinstance(p, str)}
+                    if isinstance(affected_files, list)
+                    else set()
+                )
+                orphan_creates = [
+                    p for p in creates_files_list if p not in affected_set
+                ]
+                if orphan_creates:
+                    errors.append(
+                        f"{label}: creates_files entries {orphan_creates!r} are not "
+                        "listed in affected_files — a created file is part of the "
+                        "mutation surface; add it to affected_files "
+                        "(normalize_blueprint unions these automatically)"
+                    )
+
         # affected_files drift check: warn when EVERY declared path is
         # missing from disk (decomposer hallucinated names that don't
         # exist anywhere — the canonical friction was ST-016 pointing at
@@ -2185,37 +2222,50 @@ def validate_blueprint_contract(
                         "intent in the subtask description and acknowledge that "
                         "MAP cannot verify the change."
                     )
-                # Drift detection: warn ONLY when every declared path is
-                # both (a) missing on disk AND (b) not a cross-repo path
-                # AND (c) not flagged as a new-file creation by the
-                # subtask description. Without these guards the drift
-                # warning fired for legitimate cases (new file, sibling
-                # repo) and degraded into noise.
+                # Drift detection: warn ONLY for the affected_files this
+                # subtask is expected to MODIFY (not create) that are both
+                # (a) missing on disk AND (b) not cross-repo paths. The
+                # create-vs-modify split comes structurally from
+                # `creates_files` (issue #167): created paths are
+                # expected-absent and never count as drift. For legacy
+                # blueprints that predate `creates_files`, fall back to the
+                # deprecated description-phrase heuristic (whole-subtask
+                # opt-out) so their behavior is unchanged.
                 cross_repo_set = set(cross_repo_paths)
                 local_files = [p for p in string_files if p not in cross_repo_set]
-                description_text = subtask.get("description") or ""
-                description_str = (
-                    description_text
-                    if isinstance(description_text, str)
-                    else ""
-                ).lower()
-                creates_new = bool(
-                    re.search(r"\b(creates? new|new file|introduces?|adds? new)\b", description_str)
-                )
+                if creates_files_declared:
+                    create_set = set(creates_files_list)
+                else:
+                    description_text = subtask.get("description") or ""
+                    description_str = (
+                        description_text
+                        if isinstance(description_text, str)
+                        else ""
+                    ).lower()
+                    creates_new = bool(
+                        re.search(
+                            r"\b(creates? new|new file|introduces?|adds? new)\b",
+                            description_str,
+                        )
+                    )
+                    create_set = set(local_files) if creates_new else set()
                 if local_files:
-                    missing_local = [
-                        p for p in local_files
+                    expected_present = [
+                        p for p in local_files if p not in create_set
+                    ]
+                    missing_present = [
+                        p for p in expected_present
                         if not (project_root_check / p).exists()
                     ]
-                    if missing_local == local_files and not creates_new:
+                    if expected_present and missing_present == expected_present:
                         warnings.append(
                             f"{label}: affected_files drift — none of "
-                            f"{local_files!r} exist under {project_root_check}; "
+                            f"{expected_present!r} exist under {project_root_check}; "
                             "verify the decomposer didn't hallucinate file names. "
-                            "If this subtask CREATES the files from scratch, mark "
-                            "that in the subtask description (phrases: "
-                            "'creates new', 'new file', 'introduces', 'adds new') "
-                            "to silence this warning."
+                            "If this subtask CREATES these files from scratch, list "
+                            "them in the subtask's `creates_files` array (structural "
+                            "— preferred over description phrases) so they are "
+                            "treated as expected-absent."
                         )
 
     coverage_map = payload.get("coverage_map") or blueprint_body.get("coverage_map")
@@ -2386,6 +2436,12 @@ def normalize_blueprint(
          whose owner subtask's ``validation_criteria`` does not already cite
          ``[req]``, append a traceability criterion that does. This is the
          auto-fix the validator's ``[AC-N]`` / ``[SC-N]`` lineage check expects.
+      3. **creates_files ⊆ affected_files** — for every subtask whose
+         ``creates_files`` (the structural create-vs-modify signal, issue #167)
+         names a path missing from ``affected_files``, backfill that path into
+         ``affected_files`` so a created file stays inside the mutation surface
+         the scoped gates allow and ``validate_blueprint_contract`` does not
+         hard-stop on the subset rule.
 
     Normalization is conservative: it never invents ``coverage_map`` ownership,
     never rewrites dependency edges, and never touches a soft constraint that
@@ -2482,7 +2538,35 @@ def normalize_blueprint(
             )
             injected_tags.append(f"{owner}:{tag}")
 
-    changed = order_changed or bool(injected_tags)
+    # --- 3. Union creates_files into affected_files ----------------------
+    # A created file is part of the mutation surface; the decomposer
+    # occasionally lists a new path in `creates_files` but forgets to add it
+    # to `affected_files`. Backfill deterministically so the subset rule in
+    # validate_blueprint_contract does not hard-stop the self-serve loop.
+    unioned_creates: list[str] = []
+    for subtask in new_order:
+        if not isinstance(subtask, dict):
+            continue
+        raw_creates = subtask.get("creates_files")
+        if not isinstance(raw_creates, list):
+            continue
+        create_paths = [
+            p for p in raw_creates if isinstance(p, str) and p.strip()
+        ]
+        if not create_paths:
+            continue
+        affected = subtask.get("affected_files")
+        if not isinstance(affected, list):
+            affected = []
+            subtask["affected_files"] = affected
+        affected_strs = {p for p in affected if isinstance(p, str)}
+        for path_str in create_paths:
+            if path_str not in affected_strs:
+                affected.append(path_str)
+                affected_strs.add(path_str)
+                unioned_creates.append(f"{subtask.get('id')}:{path_str}")
+
+    changed = order_changed or bool(injected_tags) or bool(unioned_creates)
 
     if order_changed:
         blueprint_body["subtasks"] = new_order
@@ -2496,6 +2580,7 @@ def normalize_blueprint(
         "reordered": order_changed,
         "subtask_order": [s.get("id") for s in new_order if isinstance(s, dict)],
         "injected_coverage_tags": injected_tags,
+        "unioned_creates_files": unioned_creates,
         "notes": notes,
         "path": str(path),
         "written": bool(changed and write),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   importable; the meter is advisory and never blocks a turn.
 
 ### Fixed
+- **Structural create-vs-modify replaces magic-prose matching in
+  `validate_blueprint_contract` (#167)**: the `affected_files`-drift check used
+  to decide "this subtask creates a new file" by string-matching prose phrases
+  (`creates new` / `new file` / `introduces` / `adds new`) in the free-text
+  subtask `description` — brittle, and it forced authors to pollute descriptions
+  with boilerplate written for the parser. Subtasks now carry an optional
+  structural `creates_files: [...]` field (the subset of `affected_files` created
+  from scratch). The validator marks those paths *expected-absent* and only
+  warns drift for missing **modify-targets**; the deprecated prose heuristic
+  survives solely as a fallback for blueprints that predate the field. A
+  `creates_files` path not listed in `affected_files` is a hard error (a created
+  file is part of the mutation surface the scoped gates allow), and
+  `normalize_blueprint` self-heals it by unioning such paths into
+  `affected_files` so the `decompose → normalize → validate` loop stays
+  self-serve. The `task-decomposer` schema, field docs, and planning checklist
+  now point to `creates_files` instead of description prose.
 - **False-progress on every committed subtask (#162)**: `validate_step 2.4`
   (which auto-runs `validate_mutation_boundary`) compared the *working tree*
   against the contract's `affected_files`. In the documented per-subtask close

--- a/src/mapify_cli/schemas.py
+++ b/src/mapify_cli/schemas.py
@@ -381,6 +381,16 @@ BLUEPRINT_SCHEMA = {
                         "description": "Files expected to be created or modified",
                         "items": {"type": "string"},
                     },
+                    "creates_files": {
+                        "type": "array",
+                        "description": (
+                            "Optional subset of affected_files this subtask creates "
+                            "from scratch (expected-absent on disk); the prose-free "
+                            "create-vs-modify signal used by "
+                            "validate_blueprint_contract instead of description phrases"
+                        ),
+                        "items": {"type": "string"},
+                    },
                     "acceptance_criteria": {
                         "type": "array",
                         "description": "Criteria that must be met for the subtask to be considered complete",

--- a/src/mapify_cli/templates/agents/task-decomposer.md
+++ b/src/mapify_cli/templates/agents/task-decomposer.md
@@ -195,6 +195,9 @@ Return **ONLY** valid JSON in this exact structure:
         "affected_files": [
           "path/to/file1.py",
           "path/to/file2.jsx"
+        ],
+        "creates_files": [
+          "path/to/file1.py"
         ]
       }
     ]
@@ -321,6 +324,7 @@ Return **ONLY** valid JSON in this exact structure:
     - The repository has no automated test harness, and adding one is out-of-scope for this subtask.
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
+**subtasks[].creates_files**: OPTIONAL subset of `affected_files` that this subtask CREATES from scratch (paths not yet on disk). List each such path in BOTH `affected_files` and `creates_files`. This is the prose-free, structural signal `validate_blueprint_contract` uses to mark those paths expected-absent — do NOT rely on description wording ("creates new", "introduces") to silence the affected_files-drift warning. Omit the field (or use `[]`) when the subtask only modifies existing files.
 
 ### Integration & Runtime Bootstrapping Subtasks
 
@@ -655,11 +659,11 @@ When invoked with `mode: "re_decomposition"` from the orchestrator, you receive 
 - [ ] All affected_files are precise paths
 - [ ] No vague references ("backend", "frontend", "code")
 - [ ] Paths match actual project structure
-- [ ] Paths verified to exist on disk (grep/glob) OR explicitly marked as new-file creation in the subtask description — `validate_blueprint_contract` warns "affected_files drift" when every declared path is missing under CLAUDE_PROJECT_DIR
+- [ ] Paths verified to exist on disk (grep/glob) OR, for files this subtask creates from scratch, listed in `creates_files` (a subset of `affected_files`) — `validate_blueprint_contract` warns "affected_files drift" when every MODIFY-target path is missing under CLAUDE_PROJECT_DIR. Use the structural `creates_files` field, not description prose, to mark new files.
 
 **Symbol Grounding (MANDATORY)**:
 - [ ] Every class / function / method name referenced in `aag_contract` or `validation_criteria` has been grep-verified against actual source code (`rg 'class FooBar'` or `rg 'def baz_method'`). Do NOT name symbols from memory or from a similar-looking project. Recurring decomposer failure mode: hallucinating `SourceCraftPublisher.publish_inline` when the real entry point is `publish_findings`, sending Actor on a wild-goose chase before the bug is caught.
-- [ ] If the subtask creates a NEW symbol, mark it explicitly in the description ("introduces new class `X`") so reviewers don't expect to find it in the current tree.
+- [ ] If the subtask creates a NEW file, list it in `creates_files` (and `affected_files`). If it creates a NEW symbol inside an existing file, note it in the description ("introduces new class `X`") so reviewers don't expect to find it in the current tree.
 - [ ] When extending an existing class, name the class AND verify the file path where it currently lives — the decomposer's working assumption ("the obvious name") is wrong often enough that grep before write is cheaper than Actor rework.
 
 **Tool-Call Budget Estimate (MANDATORY)**:

--- a/src/mapify_cli/templates/codex/agents/decomposer.toml
+++ b/src/mapify_cli/templates/codex/agents/decomposer.toml
@@ -156,6 +156,9 @@ Return **ONLY** valid JSON in this exact structure:
         "affected_files": [
           "path/to/file1.py",
           "path/to/file2.jsx"
+        ],
+        "creates_files": [
+          "path/to/file1.py"
         ]
       }
     ]
@@ -282,6 +285,7 @@ Return **ONLY** valid JSON in this exact structure:
     - The repository has no automated test harness, and adding one is out-of-scope for this subtask.
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
+**subtasks[].creates_files**: OPTIONAL subset of `affected_files` this subtask CREATES from scratch (paths not yet on disk); list each such path in BOTH arrays. This is the prose-free signal `validate_blueprint_contract` uses to mark them expected-absent — do NOT rely on description wording to silence the affected_files-drift warning. Omit (or `[]`) when the subtask only modifies existing files.
 
 ### Integration & Runtime Bootstrapping Subtasks
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -2141,6 +2141,43 @@ def validate_blueprint_contract(
                     "reviewable concern (or add split_rationale to ack the size)"
                 )
 
+        # Structural create-vs-modify (issue #167): `creates_files` is the
+        # prose-free, canonical list of which affected_files this subtask
+        # creates from scratch. It MUST be a subset of affected_files — a
+        # created file is part of the mutation surface the scoped gates allow
+        # the Actor to write. When the field is ABSENT the subtask is legacy
+        # and the drift check below falls back to the deprecated
+        # description-phrase heuristic; when PRESENT (even empty) the prose
+        # heuristic is ignored and `creates_files` is authoritative.
+        raw_creates_files = subtask.get("creates_files")
+        creates_files_declared = raw_creates_files is not None
+        creates_files_list: list[str] = []
+        if creates_files_declared:
+            if not isinstance(raw_creates_files, list) or not all(
+                isinstance(p, str) for p in raw_creates_files
+            ):
+                errors.append(
+                    f"{label}: creates_files must be an array of path strings"
+                )
+                creates_files_declared = False
+            else:
+                creates_files_list = [p for p in raw_creates_files if p.strip()]
+                affected_set = (
+                    {p for p in affected_files if isinstance(p, str)}
+                    if isinstance(affected_files, list)
+                    else set()
+                )
+                orphan_creates = [
+                    p for p in creates_files_list if p not in affected_set
+                ]
+                if orphan_creates:
+                    errors.append(
+                        f"{label}: creates_files entries {orphan_creates!r} are not "
+                        "listed in affected_files — a created file is part of the "
+                        "mutation surface; add it to affected_files "
+                        "(normalize_blueprint unions these automatically)"
+                    )
+
         # affected_files drift check: warn when EVERY declared path is
         # missing from disk (decomposer hallucinated names that don't
         # exist anywhere — the canonical friction was ST-016 pointing at
@@ -2185,37 +2222,50 @@ def validate_blueprint_contract(
                         "intent in the subtask description and acknowledge that "
                         "MAP cannot verify the change."
                     )
-                # Drift detection: warn ONLY when every declared path is
-                # both (a) missing on disk AND (b) not a cross-repo path
-                # AND (c) not flagged as a new-file creation by the
-                # subtask description. Without these guards the drift
-                # warning fired for legitimate cases (new file, sibling
-                # repo) and degraded into noise.
+                # Drift detection: warn ONLY for the affected_files this
+                # subtask is expected to MODIFY (not create) that are both
+                # (a) missing on disk AND (b) not cross-repo paths. The
+                # create-vs-modify split comes structurally from
+                # `creates_files` (issue #167): created paths are
+                # expected-absent and never count as drift. For legacy
+                # blueprints that predate `creates_files`, fall back to the
+                # deprecated description-phrase heuristic (whole-subtask
+                # opt-out) so their behavior is unchanged.
                 cross_repo_set = set(cross_repo_paths)
                 local_files = [p for p in string_files if p not in cross_repo_set]
-                description_text = subtask.get("description") or ""
-                description_str = (
-                    description_text
-                    if isinstance(description_text, str)
-                    else ""
-                ).lower()
-                creates_new = bool(
-                    re.search(r"\b(creates? new|new file|introduces?|adds? new)\b", description_str)
-                )
+                if creates_files_declared:
+                    create_set = set(creates_files_list)
+                else:
+                    description_text = subtask.get("description") or ""
+                    description_str = (
+                        description_text
+                        if isinstance(description_text, str)
+                        else ""
+                    ).lower()
+                    creates_new = bool(
+                        re.search(
+                            r"\b(creates? new|new file|introduces?|adds? new)\b",
+                            description_str,
+                        )
+                    )
+                    create_set = set(local_files) if creates_new else set()
                 if local_files:
-                    missing_local = [
-                        p for p in local_files
+                    expected_present = [
+                        p for p in local_files if p not in create_set
+                    ]
+                    missing_present = [
+                        p for p in expected_present
                         if not (project_root_check / p).exists()
                     ]
-                    if missing_local == local_files and not creates_new:
+                    if expected_present and missing_present == expected_present:
                         warnings.append(
                             f"{label}: affected_files drift — none of "
-                            f"{local_files!r} exist under {project_root_check}; "
+                            f"{expected_present!r} exist under {project_root_check}; "
                             "verify the decomposer didn't hallucinate file names. "
-                            "If this subtask CREATES the files from scratch, mark "
-                            "that in the subtask description (phrases: "
-                            "'creates new', 'new file', 'introduces', 'adds new') "
-                            "to silence this warning."
+                            "If this subtask CREATES these files from scratch, list "
+                            "them in the subtask's `creates_files` array (structural "
+                            "— preferred over description phrases) so they are "
+                            "treated as expected-absent."
                         )
 
     coverage_map = payload.get("coverage_map") or blueprint_body.get("coverage_map")
@@ -2386,6 +2436,12 @@ def normalize_blueprint(
          whose owner subtask's ``validation_criteria`` does not already cite
          ``[req]``, append a traceability criterion that does. This is the
          auto-fix the validator's ``[AC-N]`` / ``[SC-N]`` lineage check expects.
+      3. **creates_files ⊆ affected_files** — for every subtask whose
+         ``creates_files`` (the structural create-vs-modify signal, issue #167)
+         names a path missing from ``affected_files``, backfill that path into
+         ``affected_files`` so a created file stays inside the mutation surface
+         the scoped gates allow and ``validate_blueprint_contract`` does not
+         hard-stop on the subset rule.
 
     Normalization is conservative: it never invents ``coverage_map`` ownership,
     never rewrites dependency edges, and never touches a soft constraint that
@@ -2482,7 +2538,35 @@ def normalize_blueprint(
             )
             injected_tags.append(f"{owner}:{tag}")
 
-    changed = order_changed or bool(injected_tags)
+    # --- 3. Union creates_files into affected_files ----------------------
+    # A created file is part of the mutation surface; the decomposer
+    # occasionally lists a new path in `creates_files` but forgets to add it
+    # to `affected_files`. Backfill deterministically so the subset rule in
+    # validate_blueprint_contract does not hard-stop the self-serve loop.
+    unioned_creates: list[str] = []
+    for subtask in new_order:
+        if not isinstance(subtask, dict):
+            continue
+        raw_creates = subtask.get("creates_files")
+        if not isinstance(raw_creates, list):
+            continue
+        create_paths = [
+            p for p in raw_creates if isinstance(p, str) and p.strip()
+        ]
+        if not create_paths:
+            continue
+        affected = subtask.get("affected_files")
+        if not isinstance(affected, list):
+            affected = []
+            subtask["affected_files"] = affected
+        affected_strs = {p for p in affected if isinstance(p, str)}
+        for path_str in create_paths:
+            if path_str not in affected_strs:
+                affected.append(path_str)
+                affected_strs.add(path_str)
+                unioned_creates.append(f"{subtask.get('id')}:{path_str}")
+
+    changed = order_changed or bool(injected_tags) or bool(unioned_creates)
 
     if order_changed:
         blueprint_body["subtasks"] = new_order
@@ -2496,6 +2580,7 @@ def normalize_blueprint(
         "reordered": order_changed,
         "subtask_order": [s.get("id") for s in new_order if isinstance(s, dict)],
         "injected_coverage_tags": injected_tags,
+        "unioned_creates_files": unioned_creates,
         "notes": notes,
         "path": str(path),
         "written": bool(changed and write),

--- a/src/mapify_cli/templates_src/agents/task-decomposer.md.jinja
+++ b/src/mapify_cli/templates_src/agents/task-decomposer.md.jinja
@@ -195,6 +195,9 @@ Return **ONLY** valid JSON in this exact structure:
         "affected_files": [
           "path/to/file1.py",
           "path/to/file2.jsx"
+        ],
+        "creates_files": [
+          "path/to/file1.py"
         ]
       }
     ]
@@ -321,6 +324,7 @@ Return **ONLY** valid JSON in this exact structure:
     - The repository has no automated test harness, and adding one is out-of-scope for this subtask.
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
+**subtasks[].creates_files**: OPTIONAL subset of `affected_files` that this subtask CREATES from scratch (paths not yet on disk). List each such path in BOTH `affected_files` and `creates_files`. This is the prose-free, structural signal `validate_blueprint_contract` uses to mark those paths expected-absent — do NOT rely on description wording ("creates new", "introduces") to silence the affected_files-drift warning. Omit the field (or use `[]`) when the subtask only modifies existing files.
 
 ### Integration & Runtime Bootstrapping Subtasks
 
@@ -655,11 +659,11 @@ When invoked with `mode: "re_decomposition"` from the orchestrator, you receive 
 - [ ] All affected_files are precise paths
 - [ ] No vague references ("backend", "frontend", "code")
 - [ ] Paths match actual project structure
-- [ ] Paths verified to exist on disk (grep/glob) OR explicitly marked as new-file creation in the subtask description — `validate_blueprint_contract` warns "affected_files drift" when every declared path is missing under CLAUDE_PROJECT_DIR
+- [ ] Paths verified to exist on disk (grep/glob) OR, for files this subtask creates from scratch, listed in `creates_files` (a subset of `affected_files`) — `validate_blueprint_contract` warns "affected_files drift" when every MODIFY-target path is missing under CLAUDE_PROJECT_DIR. Use the structural `creates_files` field, not description prose, to mark new files.
 
 **Symbol Grounding (MANDATORY)**:
 - [ ] Every class / function / method name referenced in `aag_contract` or `validation_criteria` has been grep-verified against actual source code (`rg 'class FooBar'` or `rg 'def baz_method'`). Do NOT name symbols from memory or from a similar-looking project. Recurring decomposer failure mode: hallucinating `SourceCraftPublisher.publish_inline` when the real entry point is `publish_findings`, sending Actor on a wild-goose chase before the bug is caught.
-- [ ] If the subtask creates a NEW symbol, mark it explicitly in the description ("introduces new class `X`") so reviewers don't expect to find it in the current tree.
+- [ ] If the subtask creates a NEW file, list it in `creates_files` (and `affected_files`). If it creates a NEW symbol inside an existing file, note it in the description ("introduces new class `X`") so reviewers don't expect to find it in the current tree.
 - [ ] When extending an existing class, name the class AND verify the file path where it currently lives — the decomposer's working assumption ("the obvious name") is wrong often enough that grep before write is cheaper than Actor rework.
 
 **Tool-Call Budget Estimate (MANDATORY)**:

--- a/src/mapify_cli/templates_src/codex/agents/decomposer.toml.jinja
+++ b/src/mapify_cli/templates_src/codex/agents/decomposer.toml.jinja
@@ -156,6 +156,9 @@ Return **ONLY** valid JSON in this exact structure:
         "affected_files": [
           "path/to/file1.py",
           "path/to/file2.jsx"
+        ],
+        "creates_files": [
+          "path/to/file1.py"
         ]
       }
     ]
@@ -282,6 +285,7 @@ Return **ONLY** valid JSON in this exact structure:
     - The repository has no automated test harness, and adding one is out-of-scope for this subtask.
     - In that case: either add a FOUNDATION subtask to introduce a minimal test harness, or document the gap explicitly in risks/assumptions.
 **subtasks[].affected_files**: Precise file paths (NOT "backend", "frontend"); use [] if paths unknown
+**subtasks[].creates_files**: OPTIONAL subset of `affected_files` this subtask CREATES from scratch (paths not yet on disk); list each such path in BOTH arrays. This is the prose-free signal `validate_blueprint_contract` uses to mark them expected-absent — do NOT rely on description wording to silence the affected_files-drift warning. Omit (or `[]`) when the subtask only modifies existing files.
 
 ### Integration & Runtime Bootstrapping Subtasks
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -2141,6 +2141,43 @@ def validate_blueprint_contract(
                     "reviewable concern (or add split_rationale to ack the size)"
                 )
 
+        # Structural create-vs-modify (issue #167): `creates_files` is the
+        # prose-free, canonical list of which affected_files this subtask
+        # creates from scratch. It MUST be a subset of affected_files — a
+        # created file is part of the mutation surface the scoped gates allow
+        # the Actor to write. When the field is ABSENT the subtask is legacy
+        # and the drift check below falls back to the deprecated
+        # description-phrase heuristic; when PRESENT (even empty) the prose
+        # heuristic is ignored and `creates_files` is authoritative.
+        raw_creates_files = subtask.get("creates_files")
+        creates_files_declared = raw_creates_files is not None
+        creates_files_list: list[str] = []
+        if creates_files_declared:
+            if not isinstance(raw_creates_files, list) or not all(
+                isinstance(p, str) for p in raw_creates_files
+            ):
+                errors.append(
+                    f"{label}: creates_files must be an array of path strings"
+                )
+                creates_files_declared = False
+            else:
+                creates_files_list = [p for p in raw_creates_files if p.strip()]
+                affected_set = (
+                    {p for p in affected_files if isinstance(p, str)}
+                    if isinstance(affected_files, list)
+                    else set()
+                )
+                orphan_creates = [
+                    p for p in creates_files_list if p not in affected_set
+                ]
+                if orphan_creates:
+                    errors.append(
+                        f"{label}: creates_files entries {orphan_creates!r} are not "
+                        "listed in affected_files — a created file is part of the "
+                        "mutation surface; add it to affected_files "
+                        "(normalize_blueprint unions these automatically)"
+                    )
+
         # affected_files drift check: warn when EVERY declared path is
         # missing from disk (decomposer hallucinated names that don't
         # exist anywhere — the canonical friction was ST-016 pointing at
@@ -2185,37 +2222,50 @@ def validate_blueprint_contract(
                         "intent in the subtask description and acknowledge that "
                         "MAP cannot verify the change."
                     )
-                # Drift detection: warn ONLY when every declared path is
-                # both (a) missing on disk AND (b) not a cross-repo path
-                # AND (c) not flagged as a new-file creation by the
-                # subtask description. Without these guards the drift
-                # warning fired for legitimate cases (new file, sibling
-                # repo) and degraded into noise.
+                # Drift detection: warn ONLY for the affected_files this
+                # subtask is expected to MODIFY (not create) that are both
+                # (a) missing on disk AND (b) not cross-repo paths. The
+                # create-vs-modify split comes structurally from
+                # `creates_files` (issue #167): created paths are
+                # expected-absent and never count as drift. For legacy
+                # blueprints that predate `creates_files`, fall back to the
+                # deprecated description-phrase heuristic (whole-subtask
+                # opt-out) so their behavior is unchanged.
                 cross_repo_set = set(cross_repo_paths)
                 local_files = [p for p in string_files if p not in cross_repo_set]
-                description_text = subtask.get("description") or ""
-                description_str = (
-                    description_text
-                    if isinstance(description_text, str)
-                    else ""
-                ).lower()
-                creates_new = bool(
-                    re.search(r"\b(creates? new|new file|introduces?|adds? new)\b", description_str)
-                )
+                if creates_files_declared:
+                    create_set = set(creates_files_list)
+                else:
+                    description_text = subtask.get("description") or ""
+                    description_str = (
+                        description_text
+                        if isinstance(description_text, str)
+                        else ""
+                    ).lower()
+                    creates_new = bool(
+                        re.search(
+                            r"\b(creates? new|new file|introduces?|adds? new)\b",
+                            description_str,
+                        )
+                    )
+                    create_set = set(local_files) if creates_new else set()
                 if local_files:
-                    missing_local = [
-                        p for p in local_files
+                    expected_present = [
+                        p for p in local_files if p not in create_set
+                    ]
+                    missing_present = [
+                        p for p in expected_present
                         if not (project_root_check / p).exists()
                     ]
-                    if missing_local == local_files and not creates_new:
+                    if expected_present and missing_present == expected_present:
                         warnings.append(
                             f"{label}: affected_files drift — none of "
-                            f"{local_files!r} exist under {project_root_check}; "
+                            f"{expected_present!r} exist under {project_root_check}; "
                             "verify the decomposer didn't hallucinate file names. "
-                            "If this subtask CREATES the files from scratch, mark "
-                            "that in the subtask description (phrases: "
-                            "'creates new', 'new file', 'introduces', 'adds new') "
-                            "to silence this warning."
+                            "If this subtask CREATES these files from scratch, list "
+                            "them in the subtask's `creates_files` array (structural "
+                            "— preferred over description phrases) so they are "
+                            "treated as expected-absent."
                         )
 
     coverage_map = payload.get("coverage_map") or blueprint_body.get("coverage_map")
@@ -2386,6 +2436,12 @@ def normalize_blueprint(
          whose owner subtask's ``validation_criteria`` does not already cite
          ``[req]``, append a traceability criterion that does. This is the
          auto-fix the validator's ``[AC-N]`` / ``[SC-N]`` lineage check expects.
+      3. **creates_files ⊆ affected_files** — for every subtask whose
+         ``creates_files`` (the structural create-vs-modify signal, issue #167)
+         names a path missing from ``affected_files``, backfill that path into
+         ``affected_files`` so a created file stays inside the mutation surface
+         the scoped gates allow and ``validate_blueprint_contract`` does not
+         hard-stop on the subset rule.
 
     Normalization is conservative: it never invents ``coverage_map`` ownership,
     never rewrites dependency edges, and never touches a soft constraint that
@@ -2482,7 +2538,35 @@ def normalize_blueprint(
             )
             injected_tags.append(f"{owner}:{tag}")
 
-    changed = order_changed or bool(injected_tags)
+    # --- 3. Union creates_files into affected_files ----------------------
+    # A created file is part of the mutation surface; the decomposer
+    # occasionally lists a new path in `creates_files` but forgets to add it
+    # to `affected_files`. Backfill deterministically so the subset rule in
+    # validate_blueprint_contract does not hard-stop the self-serve loop.
+    unioned_creates: list[str] = []
+    for subtask in new_order:
+        if not isinstance(subtask, dict):
+            continue
+        raw_creates = subtask.get("creates_files")
+        if not isinstance(raw_creates, list):
+            continue
+        create_paths = [
+            p for p in raw_creates if isinstance(p, str) and p.strip()
+        ]
+        if not create_paths:
+            continue
+        affected = subtask.get("affected_files")
+        if not isinstance(affected, list):
+            affected = []
+            subtask["affected_files"] = affected
+        affected_strs = {p for p in affected if isinstance(p, str)}
+        for path_str in create_paths:
+            if path_str not in affected_strs:
+                affected.append(path_str)
+                affected_strs.add(path_str)
+                unioned_creates.append(f"{subtask.get('id')}:{path_str}")
+
+    changed = order_changed or bool(injected_tags) or bool(unioned_creates)
 
     if order_changed:
         blueprint_body["subtasks"] = new_order
@@ -2496,6 +2580,7 @@ def normalize_blueprint(
         "reordered": order_changed,
         "subtask_order": [s.get("id") for s in new_order if isinstance(s, dict)],
         "injected_coverage_tags": injected_tags,
+        "unioned_creates_files": unioned_creates,
         "notes": notes,
         "path": str(path),
         "written": bool(changed and write),

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -752,7 +752,61 @@ def test_normalize_blueprint_is_idempotent(branch_workspace):
     assert second["changed"] is False
     assert second["reordered"] is False
     assert second["injected_coverage_tags"] == []
+    assert second["unioned_creates_files"] == []
     assert second["written"] is False
+
+
+def test_normalize_blueprint_unions_creates_files_into_affected(branch_workspace):
+    """Repair #3 (issue #167): a `creates_files` path missing from
+    `affected_files` is backfilled so the subset rule does not hard-stop the
+    self-serve decompose->normalize->validate loop."""
+    blueprint = {
+        "summary": "Scaffold a new analyzer module",
+        **_blueprint_constraint_fields(),
+        "subtasks": [
+            {
+                "id": "ST-001",
+                "title": "Scaffold the analyzer module",
+                "aag_contract": "Analyzer -> run() -> report",
+                "dependencies": [],
+                "affected_files": ["src/analyzer.py"],
+                # tests/test_analyzer.py is a created file but the decomposer
+                # forgot to also list it in affected_files.
+                "creates_files": ["src/analyzer.py", "tests/test_analyzer.py"],
+                "expected_diff_size": "small",
+                "concern_type": "runtime",
+                "one_logical_step": True,
+                "validation_criteria": ["VC1 [AC-1]: analyzer returns a report"],
+            }
+        ],
+        "coverage_map": {"AC-1": "ST-001"},
+    }
+    blueprint_path = branch_workspace / "blueprint.json"
+    blueprint_path.write_text(json.dumps(blueprint))
+
+    # Before normalize: validator hard-stops on the subset rule.
+    before = map_step_runner.validate_blueprint_contract()
+    assert before["valid"] is False
+    assert any(
+        "creates_files" in str(e) and "affected_files" in str(e)
+        for e in before["errors"]
+    ), before["errors"]
+
+    norm = map_step_runner.normalize_blueprint()
+    assert norm["status"] == "ok"
+    assert norm["changed"] is True
+    assert norm["unioned_creates_files"] == ["ST-001:tests/test_analyzer.py"]
+    assert norm["written"] is True
+
+    # After normalize: validator passes; the created file is now in the
+    # mutation surface on disk.
+    after = map_step_runner.validate_blueprint_contract()
+    assert after["valid"] is True, after["errors"]
+
+    written = json.loads(blueprint_path.read_text())
+    affected = written["subtasks"][0]["affected_files"]
+    assert "tests/test_analyzer.py" in affected
+    assert "src/analyzer.py" in affected
 
 
 def test_normalize_blueprint_preserves_order_for_independent_subtasks(branch_workspace):
@@ -3789,6 +3843,98 @@ class TestBlueprintContractAffectedFilesDrift:
         result = map_step_runner.validate_blueprint_contract(str(path))
         assert result["valid"] is True
         assert any("affected_files drift" in w for w in result["warnings"]), result["warnings"]
+
+    def test_drift_suppressed_when_creates_files_lists_all_paths(
+        self, branch_workspace, monkeypatch
+    ):
+        """Structural opt-out (issue #167): when every missing path is declared
+        in `creates_files`, the subtask creates them all — no drift warning and
+        no description prose required."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        files = ["src/new_module.py", "tests/test_new_module.py"]
+        bp = self._bp(files)
+        bp["subtasks"][0]["creates_files"] = list(files)
+        path = branch_workspace / "blueprint.json"
+        path.write_text(json.dumps(bp))
+        result = map_step_runner.validate_blueprint_contract(str(path))
+        assert result["valid"] is True, result["errors"]
+        assert not any(
+            "affected_files drift" in w for w in result["warnings"]
+        ), result["warnings"]
+
+    def test_drift_fires_for_missing_modify_target_with_partial_creates_files(
+        self, branch_workspace, monkeypatch
+    ):
+        """`creates_files` names only the new file; the other affected path is a
+        modify-target that is missing on disk → drift fires and names the
+        missing modify-target, not the created file."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        bp = self._bp(["src/new_module.py", "src/missing_modify.py"])
+        bp["subtasks"][0]["creates_files"] = ["src/new_module.py"]
+        path = branch_workspace / "blueprint.json"
+        path.write_text(json.dumps(bp))
+        result = map_step_runner.validate_blueprint_contract(str(path))
+        assert result["valid"] is True, result["errors"]
+        drift = [w for w in result["warnings"] if "affected_files drift" in w]
+        assert drift, result["warnings"]
+        assert "src/missing_modify.py" in drift[0]
+        assert "src/new_module.py" not in drift[0]
+
+    def test_structural_creates_files_overrides_description_prose(
+        self, branch_workspace, monkeypatch
+    ):
+        """When `creates_files` is present (even empty) it is authoritative and
+        the deprecated description-phrase heuristic is ignored: empty
+        creates_files + 'introduces new module' prose + a missing path still
+        fires drift (the path is NOT declared as a create)."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        bp = self._bp(["src/hallucinated.py"])
+        bp["subtasks"][0]["creates_files"] = []
+        bp["subtasks"][0]["description"] = "Introduces new module from scratch."
+        path = branch_workspace / "blueprint.json"
+        path.write_text(json.dumps(bp))
+        result = map_step_runner.validate_blueprint_contract(str(path))
+        assert result["valid"] is True, result["errors"]
+        assert any(
+            "affected_files drift" in w for w in result["warnings"]
+        ), result["warnings"]
+
+    def test_creates_files_must_be_subset_of_affected_files(
+        self, branch_workspace, monkeypatch
+    ):
+        """A `creates_files` path not in `affected_files` is a structural error —
+        a created file must be inside the declared mutation surface."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        bp = self._bp(["src/new_module.py"])
+        bp["subtasks"][0]["creates_files"] = ["src/orphan_not_declared.py"]
+        path = branch_workspace / "blueprint.json"
+        path.write_text(json.dumps(bp))
+        result = map_step_runner.validate_blueprint_contract(str(path))
+        assert result["valid"] is False
+        assert any(
+            "creates_files" in str(e) and "affected_files" in str(e)
+            for e in result["errors"]
+        ), result["errors"]
+
+    def test_creates_files_must_be_an_array(
+        self, branch_workspace, monkeypatch
+    ):
+        """`creates_files` must be an array of path strings, not a bare string."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        bp = self._bp(["src/new_module.py"])
+        bp["subtasks"][0]["creates_files"] = "src/new_module.py"
+        path = branch_workspace / "blueprint.json"
+        path.write_text(json.dumps(bp))
+        result = map_step_runner.validate_blueprint_contract(str(path))
+        assert result["valid"] is False
+        assert any(
+            "creates_files must be an array" in str(e) for e in result["errors"]
+        ), result["errors"]
 
 
 class TestBlueprintContractSoftConstraintForwardDisclosure:


### PR DESCRIPTION
## Summary

Closes #167.

`validate_blueprint_contract` decided whether a subtask *creates* vs *modifies* a file by **string-matching magic prose phrases** (`creates new` / `new file` / `introduces` / `adds new`) in the free-text subtask `description`. This is brittle — it coupled a structural property to natural-language wording, produced false-positive `affected_files drift` warnings on legitimate new-file subtasks, and forced authors to inject boilerplate (`"Creates new file(s). "`) written for the parser, not the reader.

This replaces the prose heuristic with a **structural** signal.

## What changed

- **New optional field `subtasks[].creates_files: [...]`** — the subset of `affected_files` a subtask creates from scratch (expected-absent on disk). `affected_files` stays `list[str]`, so every other consumer (workflow-gate scoping, `validate_mutation_boundary`, file-conflict checker) is untouched.
- **Validator (`validate_blueprint_contract`)** now derives create-vs-modify from `creates_files`: created paths are marked expected-absent and the drift warning fires **only for missing modify-targets**. When `creates_files` is **present** (even empty) it is authoritative and the prose heuristic is ignored; when **absent** (legacy blueprints) the deprecated prose fallback preserves the old behavior unchanged.
- **Subset rule:** a `creates_files` path not listed in `affected_files` is a hard error — a created file is part of the mutation surface the scoped gates must allow the Actor to write.
- **`normalize_blueprint` repair #3:** self-heals that subset rule by unioning `creates_files` paths into `affected_files`, keeping the `decompose → normalize → validate` loop self-serve (idempotent).
- **Schema + prompts:** `schemas.py` `BLUEPRINT_SCHEMA` gains `creates_files` (optional); the `task-decomposer` prompt (both Claude `agents/task-decomposer.md` and Codex `agents/decomposer.toml`) — JSON schema, field docs, and planning checklist — now point to `creates_files` instead of description prose.

All edits made in `templates_src/**/*.jinja`, propagated via `make render-templates` (render-gate parity green).

## Tests

Added to `tests/test_map_step_runner.py`:
- drift suppressed when `creates_files` lists all paths;
- partial `creates_files` still flags missing **modify-targets** (and names them, not the created file);
- present-but-empty `creates_files` overrides `introduces new module` prose;
- subset + array-type validation errors;
- `normalize_blueprint` union repair (hard-stop before → valid after, path backfilled into `affected_files`).

Existing legacy prose-fallback drift tests stay green.

## Verification

- `make check` → 2297 passed, 3 skipped; render parity (`check-render`) green.
- `make lint` → ruff clean, mypy clean, pyright **0 errors / 0 warnings / 0 informations**, hook-lint conform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)