### PR TITLE
fix(workflow-gate): scope RESEARCH block to current subtask's affected_files (#164)

### DIFF
--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -12,9 +12,18 @@ ENFORCEMENT:
   - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
   - Fail-open: missing or unreadable step_state.json → allow
   - Always allows: .map/ artifacts, non-editing tools
+  - RESEARCH blocks only the CURRENT subtask's declared affected_files;
+    docs-only surfaces and files orthogonal to that subtask are allowed so
+    out-of-band hotfixes don't have to be smuggled through Bash (#164).
 
 CONSTRAINTS (from step_state.json):
   - scope_glob: restrict edits to matching file patterns
+
+KNOWN LIMITATION (#164): this gate intercepts Edit/Write/MultiEdit only.
+File writes performed via Bash (``cat >``, ``tee``, ``sed -i``) are NOT
+gated. Closing that bypass requires parsing shell write-targets and is
+deferred to avoid false positives that would block legitimate Bash in the
+many repos this hook ships into.
 
 Exit code 0 always (fail-open on errors).
 """
@@ -229,6 +238,114 @@ def _current_phase_is_research(branch: str) -> bool:
     return isinstance(phase, str) and phase.upper() == "RESEARCH"
 
 
+def _load_blueprint_subtasks(branch: str) -> Optional[list]:
+    """Read blueprint.json subtasks for *branch* (stdlib-only, fail-soft).
+
+    Mirrors map_step_runner.load_blueprint's nested-payload handling: a
+    blueprint may be stored either flat (``{"subtasks": [...]}``) or wrapped
+    (``{"blueprint": {"subtasks": [...]}}``). Returns the subtasks list, or
+    None when the file is absent/unreadable/misshaped — callers treat None
+    as "cannot scope" and keep the strict block.
+    """
+    bp_file = PROJECT_DIR / ".map" / branch / "blueprint.json"
+    if not bp_file.exists():
+        return None
+    try:
+        with open(bp_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    body = (
+        payload["blueprint"]
+        if isinstance(payload.get("blueprint"), dict)
+        else payload
+    )
+    subtasks = body.get("subtasks")
+    return subtasks if isinstance(subtasks, list) else None
+
+
+def _to_repo_relative(file_path: str) -> Optional[str]:
+    """Normalize *file_path* to a repo-relative string, or None.
+
+    Returns None when the path is empty, unresolvable, or resolves outside
+    PROJECT_DIR (an out-of-repo path is never part of a repo-relative
+    affected_files list).
+    """
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    candidate = Path(file_path)
+    try:
+        resolved = (
+            candidate.resolve(strict=False)
+            if candidate.is_absolute()
+            else (PROJECT_DIR / candidate).resolve(strict=False)
+        )
+        return str(resolved.relative_to(PROJECT_DIR))
+    except (ValueError, OSError):
+        return None
+
+
+def _current_subtask_affected_files(branch: str) -> Optional[set[str]]:
+    """Return the CURRENT subtask's declared affected_files (normalized).
+
+    Resolves ``current_subtask_id`` from step_state.json, looks the subtask
+    up in blueprint.json, and returns its ``affected_files`` normalized to
+    repo-relative paths. Returns None (the "cannot scope" signal) when the
+    subtask id, blueprint, subtask entry, or a non-empty affected_files list
+    is unavailable — so the caller keeps the strict RESEARCH block rather
+    than widening it on incomplete information.
+    """
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
+    if not step_file.exists():
+        return None
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    subtask_id = state.get("current_subtask_id")
+    if not isinstance(subtask_id, str) or not subtask_id:
+        return None
+    subtasks = _load_blueprint_subtasks(branch)
+    if not subtasks:
+        return None
+    affected_raw = None
+    for subtask in subtasks:
+        if isinstance(subtask, dict) and subtask.get("id") == subtask_id:
+            affected_raw = subtask.get("affected_files")
+            break
+    if not isinstance(affected_raw, list) or not affected_raw:
+        return None
+    normalized: set[str] = set()
+    for entry in affected_raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        rel = _to_repo_relative(entry)
+        normalized.add(rel if rel is not None else entry)
+    return normalized or None
+
+
+def is_orthogonal_to_current_subtask(branch: str, file_path: str) -> bool:
+    """Return True iff *file_path* is provably OUTSIDE the current subtask's
+    affected_files — an orthogonal edit RESEARCH does not protect.
+
+    Conservative by construction: returns False ("keep blocking") whenever
+    the current subtask's mutation surface cannot be determined, or the
+    target resolves outside the repo. The RESEARCH block is lifted only on
+    positive evidence that the file belongs to no part of the current
+    subtask's declared work.
+    """
+    affected = _current_subtask_affected_files(branch)
+    if not affected:
+        return False
+    rel = _to_repo_relative(file_path)
+    if rel is None:
+        return False
+    return rel not in affected
+
+
 def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
     """Check step_state.json: is current phase one where Edit is allowed?
 
@@ -274,7 +391,11 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
             f"  1. echo '<findings>' | python3 .map/scripts/map_step_runner.py \\\n"
             f"       save_research <branch> {subtask}  # default kind=actor\n"
             f"  2. python3 .map/scripts/map_orchestrator.py validate_step 2.2\n"
-            "  3. Then Edit/Write opens (ACTOR phase)."
+            "  3. Then Edit/Write opens (ACTOR phase).\n"
+            "\n"
+            f"Note: this block is scoped to {subtask}'s affected_files. Edits to\n"
+            "files OUTSIDE that surface (orthogonal hotfixes, repo-root config,\n"
+            "an unrelated failing test) are allowed during RESEARCH."
         )
     if current_phase == "MONITOR":
         return False, (
@@ -388,17 +509,40 @@ def main() -> None:
         # Phase check (step_state.json)
         allowed, error = is_editing_phase(branch)
         if not allowed:
-            # Docs-only exception: when EVERY target path is a docs
-            # surface (README, runbook, CHANGELOG, anything matching the
+            research = _current_phase_is_research(branch)
+            # RESEARCH exception #1 (docs-only): when EVERY target path is a
+            # docs surface (README, runbook, CHANGELOG, anything matching the
             # configured DOCS_ONLY_* allowlist) AND the current phase is
             # RESEARCH, allow the edit — BUT still run scope_glob /
             # constraints so the exception doesn't silently widen scope.
             # The exception lifts the phase block; it does not bypass
             # mutation-boundary constraints.
             if (
-                target_paths
+                research
+                and target_paths
                 and all(is_docs_only_path(p) for p in target_paths)
-                and _current_phase_is_research(branch)
+            ):
+                constraint_error = check_constraints(branch, target_paths)
+                if constraint_error:
+                    deny(constraint_error)
+                allow()
+            # RESEARCH exception #2 (orthogonal hotfix): the RESEARCH gate
+            # exists to force research-before-code for the CURRENT subtask's
+            # files. Edits to files OUTSIDE that subtask's declared
+            # affected_files (a repo-root config, an unrelated failing test, an
+            # out-of-band hotfix the operator asked for) are not what RESEARCH
+            # protects — blocking them only pushed those edits into Bash
+            # heredocs (#164). Allow them when EVERY target is provably
+            # orthogonal, still subject to scope_glob / constraints so the
+            # relief cannot silently widen scope. A single in-scope target in
+            # the batch (mixed edit) falls through to the block.
+            if (
+                research
+                and target_paths
+                and all(
+                    is_orthogonal_to_current_subtask(branch, p)
+                    for p in target_paths
+                )
             ):
                 constraint_error = check_constraints(branch, target_paths)
                 if constraint_error:

--- a/.codex/hooks/workflow-gate.py
+++ b/.codex/hooks/workflow-gate.py
@@ -12,9 +12,18 @@ ENFORCEMENT:
   - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
   - Fail-open: missing or unreadable step_state.json → allow
   - Always allows: .map/ artifacts, non-editing tools
+  - RESEARCH blocks only the CURRENT subtask's declared affected_files;
+    docs-only surfaces and files orthogonal to that subtask are allowed so
+    out-of-band hotfixes don't have to be smuggled through Bash (#164).
 
 CONSTRAINTS (from step_state.json):
   - scope_glob: restrict edits to matching file patterns
+
+KNOWN LIMITATION (#164): this gate intercepts Edit/Write/MultiEdit only.
+File writes performed via Bash (``cat >``, ``tee``, ``sed -i``) are NOT
+gated. Closing that bypass requires parsing shell write-targets and is
+deferred to avoid false positives that would block legitimate Bash in the
+many repos this hook ships into.
 
 Exit code 0 always (fail-open on errors).
 """
@@ -229,6 +238,114 @@ def _current_phase_is_research(branch: str) -> bool:
     return isinstance(phase, str) and phase.upper() == "RESEARCH"
 
 
+def _load_blueprint_subtasks(branch: str) -> Optional[list]:
+    """Read blueprint.json subtasks for *branch* (stdlib-only, fail-soft).
+
+    Mirrors map_step_runner.load_blueprint's nested-payload handling: a
+    blueprint may be stored either flat (``{"subtasks": [...]}``) or wrapped
+    (``{"blueprint": {"subtasks": [...]}}``). Returns the subtasks list, or
+    None when the file is absent/unreadable/misshaped — callers treat None
+    as "cannot scope" and keep the strict block.
+    """
+    bp_file = PROJECT_DIR / ".map" / branch / "blueprint.json"
+    if not bp_file.exists():
+        return None
+    try:
+        with open(bp_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    body = (
+        payload["blueprint"]
+        if isinstance(payload.get("blueprint"), dict)
+        else payload
+    )
+    subtasks = body.get("subtasks")
+    return subtasks if isinstance(subtasks, list) else None
+
+
+def _to_repo_relative(file_path: str) -> Optional[str]:
+    """Normalize *file_path* to a repo-relative string, or None.
+
+    Returns None when the path is empty, unresolvable, or resolves outside
+    PROJECT_DIR (an out-of-repo path is never part of a repo-relative
+    affected_files list).
+    """
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    candidate = Path(file_path)
+    try:
+        resolved = (
+            candidate.resolve(strict=False)
+            if candidate.is_absolute()
+            else (PROJECT_DIR / candidate).resolve(strict=False)
+        )
+        return str(resolved.relative_to(PROJECT_DIR))
+    except (ValueError, OSError):
+        return None
+
+
+def _current_subtask_affected_files(branch: str) -> Optional[set[str]]:
+    """Return the CURRENT subtask's declared affected_files (normalized).
+
+    Resolves ``current_subtask_id`` from step_state.json, looks the subtask
+    up in blueprint.json, and returns its ``affected_files`` normalized to
+    repo-relative paths. Returns None (the "cannot scope" signal) when the
+    subtask id, blueprint, subtask entry, or a non-empty affected_files list
+    is unavailable — so the caller keeps the strict RESEARCH block rather
+    than widening it on incomplete information.
+    """
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
+    if not step_file.exists():
+        return None
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    subtask_id = state.get("current_subtask_id")
+    if not isinstance(subtask_id, str) or not subtask_id:
+        return None
+    subtasks = _load_blueprint_subtasks(branch)
+    if not subtasks:
+        return None
+    affected_raw = None
+    for subtask in subtasks:
+        if isinstance(subtask, dict) and subtask.get("id") == subtask_id:
+            affected_raw = subtask.get("affected_files")
+            break
+    if not isinstance(affected_raw, list) or not affected_raw:
+        return None
+    normalized: set[str] = set()
+    for entry in affected_raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        rel = _to_repo_relative(entry)
+        normalized.add(rel if rel is not None else entry)
+    return normalized or None
+
+
+def is_orthogonal_to_current_subtask(branch: str, file_path: str) -> bool:
+    """Return True iff *file_path* is provably OUTSIDE the current subtask's
+    affected_files — an orthogonal edit RESEARCH does not protect.
+
+    Conservative by construction: returns False ("keep blocking") whenever
+    the current subtask's mutation surface cannot be determined, or the
+    target resolves outside the repo. The RESEARCH block is lifted only on
+    positive evidence that the file belongs to no part of the current
+    subtask's declared work.
+    """
+    affected = _current_subtask_affected_files(branch)
+    if not affected:
+        return False
+    rel = _to_repo_relative(file_path)
+    if rel is None:
+        return False
+    return rel not in affected
+
+
 def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
     """Check step_state.json: is current phase one where Edit is allowed?
 
@@ -274,7 +391,11 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
             f"  1. echo '<findings>' | python3 .map/scripts/map_step_runner.py \\\n"
             f"       save_research <branch> {subtask}  # default kind=actor\n"
             f"  2. python3 .map/scripts/map_orchestrator.py validate_step 2.2\n"
-            "  3. Then Edit/Write opens (ACTOR phase)."
+            "  3. Then Edit/Write opens (ACTOR phase).\n"
+            "\n"
+            f"Note: this block is scoped to {subtask}'s affected_files. Edits to\n"
+            "files OUTSIDE that surface (orthogonal hotfixes, repo-root config,\n"
+            "an unrelated failing test) are allowed during RESEARCH."
         )
     if current_phase == "MONITOR":
         return False, (
@@ -388,17 +509,40 @@ def main() -> None:
         # Phase check (step_state.json)
         allowed, error = is_editing_phase(branch)
         if not allowed:
-            # Docs-only exception: when EVERY target path is a docs
-            # surface (README, runbook, CHANGELOG, anything matching the
+            research = _current_phase_is_research(branch)
+            # RESEARCH exception #1 (docs-only): when EVERY target path is a
+            # docs surface (README, runbook, CHANGELOG, anything matching the
             # configured DOCS_ONLY_* allowlist) AND the current phase is
             # RESEARCH, allow the edit — BUT still run scope_glob /
             # constraints so the exception doesn't silently widen scope.
             # The exception lifts the phase block; it does not bypass
             # mutation-boundary constraints.
             if (
-                target_paths
+                research
+                and target_paths
                 and all(is_docs_only_path(p) for p in target_paths)
-                and _current_phase_is_research(branch)
+            ):
+                constraint_error = check_constraints(branch, target_paths)
+                if constraint_error:
+                    deny(constraint_error)
+                allow()
+            # RESEARCH exception #2 (orthogonal hotfix): the RESEARCH gate
+            # exists to force research-before-code for the CURRENT subtask's
+            # files. Edits to files OUTSIDE that subtask's declared
+            # affected_files (a repo-root config, an unrelated failing test, an
+            # out-of-band hotfix the operator asked for) are not what RESEARCH
+            # protects — blocking them only pushed those edits into Bash
+            # heredocs (#164). Allow them when EVERY target is provably
+            # orthogonal, still subject to scope_glob / constraints so the
+            # relief cannot silently widen scope. A single in-scope target in
+            # the batch (mixed edit) falls through to the block.
+            if (
+                research
+                and target_paths
+                and all(
+                    is_orthogonal_to_current_subtask(branch, p)
+                    for p in target_paths
+                )
             ):
                 constraint_error = check_constraints(branch, target_paths)
                 if constraint_error:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   importable; the meter is advisory and never blocks a turn.
 
 ### Fixed
+- **`workflow-gate` RESEARCH block scoped to the current subtask's
+  `affected_files` (#164)**: during the RESEARCH phase the gate used to block
+  *every* `Edit`/`Write`/`MultiEdit` (except docs-only surfaces), so orthogonal
+  out-of-band fixes — a repo-root config, an unrelated failing test, a hotfix
+  the operator explicitly asked for — had to be smuggled through `Bash`
+  heredocs, losing read-before-write safety and minimal-diff review. The gate
+  now lifts the RESEARCH block for any target that is *provably outside* the
+  current subtask's declared `affected_files` (resolved from `blueprint.json`),
+  while files inside that surface stay blocked so research-before-code is still
+  enforced where it matters. The relief is conservative — it falls back to the
+  strict block whenever the mutation surface can't be determined (no blueprint,
+  unknown subtask, empty `affected_files`, or an out-of-repo target) — and it
+  still honours `scope_glob`/constraints, so it can't silently widen scope. The
+  `Bash` write bypass noted in the issue is documented as a known limitation
+  and deferred (closing it needs shell write-target parsing that risks
+  false-positives across host repos).
 - **Structural create-vs-modify replaces magic-prose matching in
   `validate_blueprint_contract` (#167)**: the `affected_files`-drift check used
   to decide "this subtask creates a new file" by string-matching prose phrases

--- a/src/mapify_cli/templates/codex/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/codex/hooks/workflow-gate.py
@@ -12,9 +12,18 @@ ENFORCEMENT:
   - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
   - Fail-open: missing or unreadable step_state.json → allow
   - Always allows: .map/ artifacts, non-editing tools
+  - RESEARCH blocks only the CURRENT subtask's declared affected_files;
+    docs-only surfaces and files orthogonal to that subtask are allowed so
+    out-of-band hotfixes don't have to be smuggled through Bash (#164).
 
 CONSTRAINTS (from step_state.json):
   - scope_glob: restrict edits to matching file patterns
+
+KNOWN LIMITATION (#164): this gate intercepts Edit/Write/MultiEdit only.
+File writes performed via Bash (``cat >``, ``tee``, ``sed -i``) are NOT
+gated. Closing that bypass requires parsing shell write-targets and is
+deferred to avoid false positives that would block legitimate Bash in the
+many repos this hook ships into.
 
 Exit code 0 always (fail-open on errors).
 """
@@ -229,6 +238,114 @@ def _current_phase_is_research(branch: str) -> bool:
     return isinstance(phase, str) and phase.upper() == "RESEARCH"
 
 
+def _load_blueprint_subtasks(branch: str) -> Optional[list]:
+    """Read blueprint.json subtasks for *branch* (stdlib-only, fail-soft).
+
+    Mirrors map_step_runner.load_blueprint's nested-payload handling: a
+    blueprint may be stored either flat (``{"subtasks": [...]}``) or wrapped
+    (``{"blueprint": {"subtasks": [...]}}``). Returns the subtasks list, or
+    None when the file is absent/unreadable/misshaped — callers treat None
+    as "cannot scope" and keep the strict block.
+    """
+    bp_file = PROJECT_DIR / ".map" / branch / "blueprint.json"
+    if not bp_file.exists():
+        return None
+    try:
+        with open(bp_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    body = (
+        payload["blueprint"]
+        if isinstance(payload.get("blueprint"), dict)
+        else payload
+    )
+    subtasks = body.get("subtasks")
+    return subtasks if isinstance(subtasks, list) else None
+
+
+def _to_repo_relative(file_path: str) -> Optional[str]:
+    """Normalize *file_path* to a repo-relative string, or None.
+
+    Returns None when the path is empty, unresolvable, or resolves outside
+    PROJECT_DIR (an out-of-repo path is never part of a repo-relative
+    affected_files list).
+    """
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    candidate = Path(file_path)
+    try:
+        resolved = (
+            candidate.resolve(strict=False)
+            if candidate.is_absolute()
+            else (PROJECT_DIR / candidate).resolve(strict=False)
+        )
+        return str(resolved.relative_to(PROJECT_DIR))
+    except (ValueError, OSError):
+        return None
+
+
+def _current_subtask_affected_files(branch: str) -> Optional[set[str]]:
+    """Return the CURRENT subtask's declared affected_files (normalized).
+
+    Resolves ``current_subtask_id`` from step_state.json, looks the subtask
+    up in blueprint.json, and returns its ``affected_files`` normalized to
+    repo-relative paths. Returns None (the "cannot scope" signal) when the
+    subtask id, blueprint, subtask entry, or a non-empty affected_files list
+    is unavailable — so the caller keeps the strict RESEARCH block rather
+    than widening it on incomplete information.
+    """
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
+    if not step_file.exists():
+        return None
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    subtask_id = state.get("current_subtask_id")
+    if not isinstance(subtask_id, str) or not subtask_id:
+        return None
+    subtasks = _load_blueprint_subtasks(branch)
+    if not subtasks:
+        return None
+    affected_raw = None
+    for subtask in subtasks:
+        if isinstance(subtask, dict) and subtask.get("id") == subtask_id:
+            affected_raw = subtask.get("affected_files")
+            break
+    if not isinstance(affected_raw, list) or not affected_raw:
+        return None
+    normalized: set[str] = set()
+    for entry in affected_raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        rel = _to_repo_relative(entry)
+        normalized.add(rel if rel is not None else entry)
+    return normalized or None
+
+
+def is_orthogonal_to_current_subtask(branch: str, file_path: str) -> bool:
+    """Return True iff *file_path* is provably OUTSIDE the current subtask's
+    affected_files — an orthogonal edit RESEARCH does not protect.
+
+    Conservative by construction: returns False ("keep blocking") whenever
+    the current subtask's mutation surface cannot be determined, or the
+    target resolves outside the repo. The RESEARCH block is lifted only on
+    positive evidence that the file belongs to no part of the current
+    subtask's declared work.
+    """
+    affected = _current_subtask_affected_files(branch)
+    if not affected:
+        return False
+    rel = _to_repo_relative(file_path)
+    if rel is None:
+        return False
+    return rel not in affected
+
+
 def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
     """Check step_state.json: is current phase one where Edit is allowed?
 
@@ -274,7 +391,11 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
             f"  1. echo '<findings>' | python3 .map/scripts/map_step_runner.py \\\n"
             f"       save_research <branch> {subtask}  # default kind=actor\n"
             f"  2. python3 .map/scripts/map_orchestrator.py validate_step 2.2\n"
-            "  3. Then Edit/Write opens (ACTOR phase)."
+            "  3. Then Edit/Write opens (ACTOR phase).\n"
+            "\n"
+            f"Note: this block is scoped to {subtask}'s affected_files. Edits to\n"
+            "files OUTSIDE that surface (orthogonal hotfixes, repo-root config,\n"
+            "an unrelated failing test) are allowed during RESEARCH."
         )
     if current_phase == "MONITOR":
         return False, (
@@ -388,17 +509,40 @@ def main() -> None:
         # Phase check (step_state.json)
         allowed, error = is_editing_phase(branch)
         if not allowed:
-            # Docs-only exception: when EVERY target path is a docs
-            # surface (README, runbook, CHANGELOG, anything matching the
+            research = _current_phase_is_research(branch)
+            # RESEARCH exception #1 (docs-only): when EVERY target path is a
+            # docs surface (README, runbook, CHANGELOG, anything matching the
             # configured DOCS_ONLY_* allowlist) AND the current phase is
             # RESEARCH, allow the edit — BUT still run scope_glob /
             # constraints so the exception doesn't silently widen scope.
             # The exception lifts the phase block; it does not bypass
             # mutation-boundary constraints.
             if (
-                target_paths
+                research
+                and target_paths
                 and all(is_docs_only_path(p) for p in target_paths)
-                and _current_phase_is_research(branch)
+            ):
+                constraint_error = check_constraints(branch, target_paths)
+                if constraint_error:
+                    deny(constraint_error)
+                allow()
+            # RESEARCH exception #2 (orthogonal hotfix): the RESEARCH gate
+            # exists to force research-before-code for the CURRENT subtask's
+            # files. Edits to files OUTSIDE that subtask's declared
+            # affected_files (a repo-root config, an unrelated failing test, an
+            # out-of-band hotfix the operator asked for) are not what RESEARCH
+            # protects — blocking them only pushed those edits into Bash
+            # heredocs (#164). Allow them when EVERY target is provably
+            # orthogonal, still subject to scope_glob / constraints so the
+            # relief cannot silently widen scope. A single in-scope target in
+            # the batch (mixed edit) falls through to the block.
+            if (
+                research
+                and target_paths
+                and all(
+                    is_orthogonal_to_current_subtask(branch, p)
+                    for p in target_paths
+                )
             ):
                 constraint_error = check_constraints(branch, target_paths)
                 if constraint_error:

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -12,9 +12,18 @@ ENFORCEMENT:
   - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
   - Fail-open: missing or unreadable step_state.json → allow
   - Always allows: .map/ artifacts, non-editing tools
+  - RESEARCH blocks only the CURRENT subtask's declared affected_files;
+    docs-only surfaces and files orthogonal to that subtask are allowed so
+    out-of-band hotfixes don't have to be smuggled through Bash (#164).
 
 CONSTRAINTS (from step_state.json):
   - scope_glob: restrict edits to matching file patterns
+
+KNOWN LIMITATION (#164): this gate intercepts Edit/Write/MultiEdit only.
+File writes performed via Bash (``cat >``, ``tee``, ``sed -i``) are NOT
+gated. Closing that bypass requires parsing shell write-targets and is
+deferred to avoid false positives that would block legitimate Bash in the
+many repos this hook ships into.
 
 Exit code 0 always (fail-open on errors).
 """
@@ -229,6 +238,114 @@ def _current_phase_is_research(branch: str) -> bool:
     return isinstance(phase, str) and phase.upper() == "RESEARCH"
 
 
+def _load_blueprint_subtasks(branch: str) -> Optional[list]:
+    """Read blueprint.json subtasks for *branch* (stdlib-only, fail-soft).
+
+    Mirrors map_step_runner.load_blueprint's nested-payload handling: a
+    blueprint may be stored either flat (``{"subtasks": [...]}``) or wrapped
+    (``{"blueprint": {"subtasks": [...]}}``). Returns the subtasks list, or
+    None when the file is absent/unreadable/misshaped — callers treat None
+    as "cannot scope" and keep the strict block.
+    """
+    bp_file = PROJECT_DIR / ".map" / branch / "blueprint.json"
+    if not bp_file.exists():
+        return None
+    try:
+        with open(bp_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    body = (
+        payload["blueprint"]
+        if isinstance(payload.get("blueprint"), dict)
+        else payload
+    )
+    subtasks = body.get("subtasks")
+    return subtasks if isinstance(subtasks, list) else None
+
+
+def _to_repo_relative(file_path: str) -> Optional[str]:
+    """Normalize *file_path* to a repo-relative string, or None.
+
+    Returns None when the path is empty, unresolvable, or resolves outside
+    PROJECT_DIR (an out-of-repo path is never part of a repo-relative
+    affected_files list).
+    """
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    candidate = Path(file_path)
+    try:
+        resolved = (
+            candidate.resolve(strict=False)
+            if candidate.is_absolute()
+            else (PROJECT_DIR / candidate).resolve(strict=False)
+        )
+        return str(resolved.relative_to(PROJECT_DIR))
+    except (ValueError, OSError):
+        return None
+
+
+def _current_subtask_affected_files(branch: str) -> Optional[set[str]]:
+    """Return the CURRENT subtask's declared affected_files (normalized).
+
+    Resolves ``current_subtask_id`` from step_state.json, looks the subtask
+    up in blueprint.json, and returns its ``affected_files`` normalized to
+    repo-relative paths. Returns None (the "cannot scope" signal) when the
+    subtask id, blueprint, subtask entry, or a non-empty affected_files list
+    is unavailable — so the caller keeps the strict RESEARCH block rather
+    than widening it on incomplete information.
+    """
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
+    if not step_file.exists():
+        return None
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    subtask_id = state.get("current_subtask_id")
+    if not isinstance(subtask_id, str) or not subtask_id:
+        return None
+    subtasks = _load_blueprint_subtasks(branch)
+    if not subtasks:
+        return None
+    affected_raw = None
+    for subtask in subtasks:
+        if isinstance(subtask, dict) and subtask.get("id") == subtask_id:
+            affected_raw = subtask.get("affected_files")
+            break
+    if not isinstance(affected_raw, list) or not affected_raw:
+        return None
+    normalized: set[str] = set()
+    for entry in affected_raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        rel = _to_repo_relative(entry)
+        normalized.add(rel if rel is not None else entry)
+    return normalized or None
+
+
+def is_orthogonal_to_current_subtask(branch: str, file_path: str) -> bool:
+    """Return True iff *file_path* is provably OUTSIDE the current subtask's
+    affected_files — an orthogonal edit RESEARCH does not protect.
+
+    Conservative by construction: returns False ("keep blocking") whenever
+    the current subtask's mutation surface cannot be determined, or the
+    target resolves outside the repo. The RESEARCH block is lifted only on
+    positive evidence that the file belongs to no part of the current
+    subtask's declared work.
+    """
+    affected = _current_subtask_affected_files(branch)
+    if not affected:
+        return False
+    rel = _to_repo_relative(file_path)
+    if rel is None:
+        return False
+    return rel not in affected
+
+
 def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
     """Check step_state.json: is current phase one where Edit is allowed?
 
@@ -274,7 +391,11 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
             f"  1. echo '<findings>' | python3 .map/scripts/map_step_runner.py \\\n"
             f"       save_research <branch> {subtask}  # default kind=actor\n"
             f"  2. python3 .map/scripts/map_orchestrator.py validate_step 2.2\n"
-            "  3. Then Edit/Write opens (ACTOR phase)."
+            "  3. Then Edit/Write opens (ACTOR phase).\n"
+            "\n"
+            f"Note: this block is scoped to {subtask}'s affected_files. Edits to\n"
+            "files OUTSIDE that surface (orthogonal hotfixes, repo-root config,\n"
+            "an unrelated failing test) are allowed during RESEARCH."
         )
     if current_phase == "MONITOR":
         return False, (
@@ -388,17 +509,40 @@ def main() -> None:
         # Phase check (step_state.json)
         allowed, error = is_editing_phase(branch)
         if not allowed:
-            # Docs-only exception: when EVERY target path is a docs
-            # surface (README, runbook, CHANGELOG, anything matching the
+            research = _current_phase_is_research(branch)
+            # RESEARCH exception #1 (docs-only): when EVERY target path is a
+            # docs surface (README, runbook, CHANGELOG, anything matching the
             # configured DOCS_ONLY_* allowlist) AND the current phase is
             # RESEARCH, allow the edit — BUT still run scope_glob /
             # constraints so the exception doesn't silently widen scope.
             # The exception lifts the phase block; it does not bypass
             # mutation-boundary constraints.
             if (
-                target_paths
+                research
+                and target_paths
                 and all(is_docs_only_path(p) for p in target_paths)
-                and _current_phase_is_research(branch)
+            ):
+                constraint_error = check_constraints(branch, target_paths)
+                if constraint_error:
+                    deny(constraint_error)
+                allow()
+            # RESEARCH exception #2 (orthogonal hotfix): the RESEARCH gate
+            # exists to force research-before-code for the CURRENT subtask's
+            # files. Edits to files OUTSIDE that subtask's declared
+            # affected_files (a repo-root config, an unrelated failing test, an
+            # out-of-band hotfix the operator asked for) are not what RESEARCH
+            # protects — blocking them only pushed those edits into Bash
+            # heredocs (#164). Allow them when EVERY target is provably
+            # orthogonal, still subject to scope_glob / constraints so the
+            # relief cannot silently widen scope. A single in-scope target in
+            # the batch (mixed edit) falls through to the block.
+            if (
+                research
+                and target_paths
+                and all(
+                    is_orthogonal_to_current_subtask(branch, p)
+                    for p in target_paths
+                )
             ):
                 constraint_error = check_constraints(branch, target_paths)
                 if constraint_error:

--- a/src/mapify_cli/templates_src/codex/hooks/workflow-gate.py.jinja
+++ b/src/mapify_cli/templates_src/codex/hooks/workflow-gate.py.jinja
@@ -12,9 +12,18 @@ ENFORCEMENT:
   - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
   - Fail-open: missing or unreadable step_state.json → allow
   - Always allows: .map/ artifacts, non-editing tools
+  - RESEARCH blocks only the CURRENT subtask's declared affected_files;
+    docs-only surfaces and files orthogonal to that subtask are allowed so
+    out-of-band hotfixes don't have to be smuggled through Bash (#164).
 
 CONSTRAINTS (from step_state.json):
   - scope_glob: restrict edits to matching file patterns
+
+KNOWN LIMITATION (#164): this gate intercepts Edit/Write/MultiEdit only.
+File writes performed via Bash (``cat >``, ``tee``, ``sed -i``) are NOT
+gated. Closing that bypass requires parsing shell write-targets and is
+deferred to avoid false positives that would block legitimate Bash in the
+many repos this hook ships into.
 
 Exit code 0 always (fail-open on errors).
 """
@@ -229,6 +238,114 @@ def _current_phase_is_research(branch: str) -> bool:
     return isinstance(phase, str) and phase.upper() == "RESEARCH"
 
 
+def _load_blueprint_subtasks(branch: str) -> Optional[list]:
+    """Read blueprint.json subtasks for *branch* (stdlib-only, fail-soft).
+
+    Mirrors map_step_runner.load_blueprint's nested-payload handling: a
+    blueprint may be stored either flat (``{"subtasks": [...]}``) or wrapped
+    (``{"blueprint": {"subtasks": [...]}}``). Returns the subtasks list, or
+    None when the file is absent/unreadable/misshaped — callers treat None
+    as "cannot scope" and keep the strict block.
+    """
+    bp_file = PROJECT_DIR / ".map" / branch / "blueprint.json"
+    if not bp_file.exists():
+        return None
+    try:
+        with open(bp_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    body = (
+        payload["blueprint"]
+        if isinstance(payload.get("blueprint"), dict)
+        else payload
+    )
+    subtasks = body.get("subtasks")
+    return subtasks if isinstance(subtasks, list) else None
+
+
+def _to_repo_relative(file_path: str) -> Optional[str]:
+    """Normalize *file_path* to a repo-relative string, or None.
+
+    Returns None when the path is empty, unresolvable, or resolves outside
+    PROJECT_DIR (an out-of-repo path is never part of a repo-relative
+    affected_files list).
+    """
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    candidate = Path(file_path)
+    try:
+        resolved = (
+            candidate.resolve(strict=False)
+            if candidate.is_absolute()
+            else (PROJECT_DIR / candidate).resolve(strict=False)
+        )
+        return str(resolved.relative_to(PROJECT_DIR))
+    except (ValueError, OSError):
+        return None
+
+
+def _current_subtask_affected_files(branch: str) -> Optional[set[str]]:
+    """Return the CURRENT subtask's declared affected_files (normalized).
+
+    Resolves ``current_subtask_id`` from step_state.json, looks the subtask
+    up in blueprint.json, and returns its ``affected_files`` normalized to
+    repo-relative paths. Returns None (the "cannot scope" signal) when the
+    subtask id, blueprint, subtask entry, or a non-empty affected_files list
+    is unavailable — so the caller keeps the strict RESEARCH block rather
+    than widening it on incomplete information.
+    """
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
+    if not step_file.exists():
+        return None
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    subtask_id = state.get("current_subtask_id")
+    if not isinstance(subtask_id, str) or not subtask_id:
+        return None
+    subtasks = _load_blueprint_subtasks(branch)
+    if not subtasks:
+        return None
+    affected_raw = None
+    for subtask in subtasks:
+        if isinstance(subtask, dict) and subtask.get("id") == subtask_id:
+            affected_raw = subtask.get("affected_files")
+            break
+    if not isinstance(affected_raw, list) or not affected_raw:
+        return None
+    normalized: set[str] = set()
+    for entry in affected_raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        rel = _to_repo_relative(entry)
+        normalized.add(rel if rel is not None else entry)
+    return normalized or None
+
+
+def is_orthogonal_to_current_subtask(branch: str, file_path: str) -> bool:
+    """Return True iff *file_path* is provably OUTSIDE the current subtask's
+    affected_files — an orthogonal edit RESEARCH does not protect.
+
+    Conservative by construction: returns False ("keep blocking") whenever
+    the current subtask's mutation surface cannot be determined, or the
+    target resolves outside the repo. The RESEARCH block is lifted only on
+    positive evidence that the file belongs to no part of the current
+    subtask's declared work.
+    """
+    affected = _current_subtask_affected_files(branch)
+    if not affected:
+        return False
+    rel = _to_repo_relative(file_path)
+    if rel is None:
+        return False
+    return rel not in affected
+
+
 def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
     """Check step_state.json: is current phase one where Edit is allowed?
 
@@ -274,7 +391,11 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
             f"  1. echo '<findings>' | python3 .map/scripts/map_step_runner.py \\\n"
             f"       save_research <branch> {subtask}  # default kind=actor\n"
             f"  2. python3 .map/scripts/map_orchestrator.py validate_step 2.2\n"
-            "  3. Then Edit/Write opens (ACTOR phase)."
+            "  3. Then Edit/Write opens (ACTOR phase).\n"
+            "\n"
+            f"Note: this block is scoped to {subtask}'s affected_files. Edits to\n"
+            "files OUTSIDE that surface (orthogonal hotfixes, repo-root config,\n"
+            "an unrelated failing test) are allowed during RESEARCH."
         )
     if current_phase == "MONITOR":
         return False, (
@@ -388,17 +509,40 @@ def main() -> None:
         # Phase check (step_state.json)
         allowed, error = is_editing_phase(branch)
         if not allowed:
-            # Docs-only exception: when EVERY target path is a docs
-            # surface (README, runbook, CHANGELOG, anything matching the
+            research = _current_phase_is_research(branch)
+            # RESEARCH exception #1 (docs-only): when EVERY target path is a
+            # docs surface (README, runbook, CHANGELOG, anything matching the
             # configured DOCS_ONLY_* allowlist) AND the current phase is
             # RESEARCH, allow the edit — BUT still run scope_glob /
             # constraints so the exception doesn't silently widen scope.
             # The exception lifts the phase block; it does not bypass
             # mutation-boundary constraints.
             if (
-                target_paths
+                research
+                and target_paths
                 and all(is_docs_only_path(p) for p in target_paths)
-                and _current_phase_is_research(branch)
+            ):
+                constraint_error = check_constraints(branch, target_paths)
+                if constraint_error:
+                    deny(constraint_error)
+                allow()
+            # RESEARCH exception #2 (orthogonal hotfix): the RESEARCH gate
+            # exists to force research-before-code for the CURRENT subtask's
+            # files. Edits to files OUTSIDE that subtask's declared
+            # affected_files (a repo-root config, an unrelated failing test, an
+            # out-of-band hotfix the operator asked for) are not what RESEARCH
+            # protects — blocking them only pushed those edits into Bash
+            # heredocs (#164). Allow them when EVERY target is provably
+            # orthogonal, still subject to scope_glob / constraints so the
+            # relief cannot silently widen scope. A single in-scope target in
+            # the batch (mixed edit) falls through to the block.
+            if (
+                research
+                and target_paths
+                and all(
+                    is_orthogonal_to_current_subtask(branch, p)
+                    for p in target_paths
+                )
             ):
                 constraint_error = check_constraints(branch, target_paths)
                 if constraint_error:

--- a/src/mapify_cli/templates_src/hooks/workflow-gate.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/workflow-gate.py.jinja
@@ -12,9 +12,18 @@ ENFORCEMENT:
   - Edit blocked during all other phases (DECOMPOSE, MONITOR, PREDICTOR, etc.)
   - Fail-open: missing or unreadable step_state.json → allow
   - Always allows: .map/ artifacts, non-editing tools
+  - RESEARCH blocks only the CURRENT subtask's declared affected_files;
+    docs-only surfaces and files orthogonal to that subtask are allowed so
+    out-of-band hotfixes don't have to be smuggled through Bash (#164).
 
 CONSTRAINTS (from step_state.json):
   - scope_glob: restrict edits to matching file patterns
+
+KNOWN LIMITATION (#164): this gate intercepts Edit/Write/MultiEdit only.
+File writes performed via Bash (``cat >``, ``tee``, ``sed -i``) are NOT
+gated. Closing that bypass requires parsing shell write-targets and is
+deferred to avoid false positives that would block legitimate Bash in the
+many repos this hook ships into.
 
 Exit code 0 always (fail-open on errors).
 """
@@ -229,6 +238,114 @@ def _current_phase_is_research(branch: str) -> bool:
     return isinstance(phase, str) and phase.upper() == "RESEARCH"
 
 
+def _load_blueprint_subtasks(branch: str) -> Optional[list]:
+    """Read blueprint.json subtasks for *branch* (stdlib-only, fail-soft).
+
+    Mirrors map_step_runner.load_blueprint's nested-payload handling: a
+    blueprint may be stored either flat (``{"subtasks": [...]}``) or wrapped
+    (``{"blueprint": {"subtasks": [...]}}``). Returns the subtasks list, or
+    None when the file is absent/unreadable/misshaped — callers treat None
+    as "cannot scope" and keep the strict block.
+    """
+    bp_file = PROJECT_DIR / ".map" / branch / "blueprint.json"
+    if not bp_file.exists():
+        return None
+    try:
+        with open(bp_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    body = (
+        payload["blueprint"]
+        if isinstance(payload.get("blueprint"), dict)
+        else payload
+    )
+    subtasks = body.get("subtasks")
+    return subtasks if isinstance(subtasks, list) else None
+
+
+def _to_repo_relative(file_path: str) -> Optional[str]:
+    """Normalize *file_path* to a repo-relative string, or None.
+
+    Returns None when the path is empty, unresolvable, or resolves outside
+    PROJECT_DIR (an out-of-repo path is never part of a repo-relative
+    affected_files list).
+    """
+    if not isinstance(file_path, str) or not file_path.strip():
+        return None
+    candidate = Path(file_path)
+    try:
+        resolved = (
+            candidate.resolve(strict=False)
+            if candidate.is_absolute()
+            else (PROJECT_DIR / candidate).resolve(strict=False)
+        )
+        return str(resolved.relative_to(PROJECT_DIR))
+    except (ValueError, OSError):
+        return None
+
+
+def _current_subtask_affected_files(branch: str) -> Optional[set[str]]:
+    """Return the CURRENT subtask's declared affected_files (normalized).
+
+    Resolves ``current_subtask_id`` from step_state.json, looks the subtask
+    up in blueprint.json, and returns its ``affected_files`` normalized to
+    repo-relative paths. Returns None (the "cannot scope" signal) when the
+    subtask id, blueprint, subtask entry, or a non-empty affected_files list
+    is unavailable — so the caller keeps the strict RESEARCH block rather
+    than widening it on incomplete information.
+    """
+    step_file = PROJECT_DIR / ".map" / branch / "step_state.json"
+    if not step_file.exists():
+        return None
+    try:
+        with open(step_file, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    subtask_id = state.get("current_subtask_id")
+    if not isinstance(subtask_id, str) or not subtask_id:
+        return None
+    subtasks = _load_blueprint_subtasks(branch)
+    if not subtasks:
+        return None
+    affected_raw = None
+    for subtask in subtasks:
+        if isinstance(subtask, dict) and subtask.get("id") == subtask_id:
+            affected_raw = subtask.get("affected_files")
+            break
+    if not isinstance(affected_raw, list) or not affected_raw:
+        return None
+    normalized: set[str] = set()
+    for entry in affected_raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        rel = _to_repo_relative(entry)
+        normalized.add(rel if rel is not None else entry)
+    return normalized or None
+
+
+def is_orthogonal_to_current_subtask(branch: str, file_path: str) -> bool:
+    """Return True iff *file_path* is provably OUTSIDE the current subtask's
+    affected_files — an orthogonal edit RESEARCH does not protect.
+
+    Conservative by construction: returns False ("keep blocking") whenever
+    the current subtask's mutation surface cannot be determined, or the
+    target resolves outside the repo. The RESEARCH block is lifted only on
+    positive evidence that the file belongs to no part of the current
+    subtask's declared work.
+    """
+    affected = _current_subtask_affected_files(branch)
+    if not affected:
+        return False
+    rel = _to_repo_relative(file_path)
+    if rel is None:
+        return False
+    return rel not in affected
+
+
 def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
     """Check step_state.json: is current phase one where Edit is allowed?
 
@@ -274,7 +391,11 @@ def is_editing_phase(branch: str) -> tuple[bool, Optional[str]]:
             f"  1. echo '<findings>' | python3 .map/scripts/map_step_runner.py \\\n"
             f"       save_research <branch> {subtask}  # default kind=actor\n"
             f"  2. python3 .map/scripts/map_orchestrator.py validate_step 2.2\n"
-            "  3. Then Edit/Write opens (ACTOR phase)."
+            "  3. Then Edit/Write opens (ACTOR phase).\n"
+            "\n"
+            f"Note: this block is scoped to {subtask}'s affected_files. Edits to\n"
+            "files OUTSIDE that surface (orthogonal hotfixes, repo-root config,\n"
+            "an unrelated failing test) are allowed during RESEARCH."
         )
     if current_phase == "MONITOR":
         return False, (
@@ -388,17 +509,40 @@ def main() -> None:
         # Phase check (step_state.json)
         allowed, error = is_editing_phase(branch)
         if not allowed:
-            # Docs-only exception: when EVERY target path is a docs
-            # surface (README, runbook, CHANGELOG, anything matching the
+            research = _current_phase_is_research(branch)
+            # RESEARCH exception #1 (docs-only): when EVERY target path is a
+            # docs surface (README, runbook, CHANGELOG, anything matching the
             # configured DOCS_ONLY_* allowlist) AND the current phase is
             # RESEARCH, allow the edit — BUT still run scope_glob /
             # constraints so the exception doesn't silently widen scope.
             # The exception lifts the phase block; it does not bypass
             # mutation-boundary constraints.
             if (
-                target_paths
+                research
+                and target_paths
                 and all(is_docs_only_path(p) for p in target_paths)
-                and _current_phase_is_research(branch)
+            ):
+                constraint_error = check_constraints(branch, target_paths)
+                if constraint_error:
+                    deny(constraint_error)
+                allow()
+            # RESEARCH exception #2 (orthogonal hotfix): the RESEARCH gate
+            # exists to force research-before-code for the CURRENT subtask's
+            # files. Edits to files OUTSIDE that subtask's declared
+            # affected_files (a repo-root config, an unrelated failing test, an
+            # out-of-band hotfix the operator asked for) are not what RESEARCH
+            # protects — blocking them only pushed those edits into Bash
+            # heredocs (#164). Allow them when EVERY target is provably
+            # orthogonal, still subject to scope_glob / constraints so the
+            # relief cannot silently widen scope. A single in-scope target in
+            # the batch (mixed edit) falls through to the block.
+            if (
+                research
+                and target_paths
+                and all(
+                    is_orthogonal_to_current_subtask(branch, p)
+                    for p in target_paths
+                )
             ):
                 constraint_error = check_constraints(branch, target_paths)
                 if constraint_error:

--- a/tests/test_workflow_gate.py
+++ b/tests/test_workflow_gate.py
@@ -156,6 +156,25 @@ class TestWorkflowGate:
         }
         (map_dir / "step_state.json").write_text(json.dumps(state))
 
+    def _setup_blueprint(
+        self,
+        tmp_path: Path,
+        branch: str,
+        subtasks: list[dict],
+        nested: bool = False,
+    ) -> None:
+        """Create blueprint.json with the given subtasks.
+
+        ``nested=True`` wraps the body in a ``{"blueprint": {...}}`` envelope to
+        exercise the same nested-payload handling map_step_runner.load_blueprint
+        performs.
+        """
+        map_dir = tmp_path / ".map" / branch
+        map_dir.mkdir(parents=True, exist_ok=True)
+        body = {"subtasks": subtasks}
+        payload = {"blueprint": body} if nested else body
+        (map_dir / "blueprint.json").write_text(json.dumps(payload))
+
     # --- Non-editing tools ---
 
     def test_allows_non_editing_tools(self, tmp_path: Path) -> None:
@@ -451,6 +470,198 @@ class TestWorkflowGate:
         assert "RESEARCH" in reason
         assert "save_research" in reason, reason
         assert "validate_step 2.2" in reason, reason
+
+    # --- RESEARCH scoped to current subtask's affected_files (#164) ---
+
+    def test_research_allows_orthogonal_edit_outside_affected_files(
+        self, tmp_path: Path
+    ) -> None:
+        """#164: RESEARCH blocks only the CURRENT subtask's affected_files.
+
+        An edit to a file orthogonal to ST-001's declared surface (an
+        out-of-band hotfix, repo-root config, an unrelated failing test) must
+        be allowed via Edit/Write — operators were forced to smuggle these
+        through Bash heredocs.
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        self._setup_blueprint(
+            tmp_path,
+            "master",
+            [{"id": "ST-001", "affected_files": ["src/app.py"]}],
+        )
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(tmp_path / "src" / "other.py")},
+            },
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
+
+    def test_research_blocks_edit_inside_affected_files(
+        self, tmp_path: Path
+    ) -> None:
+        """Counter-test: a file IN the current subtask's affected_files is still
+        blocked during RESEARCH — research-before-code is the protected
+        contract for exactly those files. The message names the scoping.
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        self._setup_blueprint(
+            tmp_path,
+            "master",
+            [{"id": "ST-001", "affected_files": ["src/app.py"]}],
+        )
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(tmp_path / "src" / "app.py")},
+            },
+            tmp_path,
+        )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "RESEARCH" in reason
+        assert "affected_files" in reason, reason
+
+    def test_research_mixed_affected_and_orthogonal_blocks(
+        self, tmp_path: Path
+    ) -> None:
+        """A batch touching BOTH an affected file and an orthogonal file is
+        blocked — a single in-scope target defeats the orthogonal relief, so
+        code can't sneak in alongside an orthogonal path.
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        self._setup_blueprint(
+            tmp_path,
+            "master",
+            [{"id": "ST-001", "affected_files": ["src/app.py"]}],
+        )
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "MultiEdit",
+                "tool_input": {
+                    "file_path": str(tmp_path / "src" / "app.py"),
+                    "edits": [
+                        {"file_path": str(tmp_path / "src" / "other.py")},
+                        {"file_path": str(tmp_path / "src" / "app.py")},
+                    ],
+                },
+            },
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_research_no_blueprint_blocks_code_edit(self, tmp_path: Path) -> None:
+        """Conservative fallback: with a current_subtask_id but no blueprint to
+        derive affected_files, the mutation surface is unknown — keep the
+        strict block rather than widening it on incomplete information.
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(tmp_path / "src" / "other.py")},
+            },
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_research_empty_affected_files_blocks(self, tmp_path: Path) -> None:
+        """A subtask whose affected_files is empty cannot be scoped — fall back
+        to the strict block (cannot prove the target orthogonal).
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        self._setup_blueprint(
+            tmp_path, "master", [{"id": "ST-001", "affected_files": []}]
+        )
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(tmp_path / "src" / "other.py")},
+            },
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_research_orthogonal_still_respects_scope_glob(
+        self, tmp_path: Path
+    ) -> None:
+        """The orthogonal relief lifts the phase block but does NOT bypass
+        scope_glob: an orthogonal file outside an explicit scope_glob is still
+        denied by the constraint check.
+        """
+        map_dir = tmp_path / ".map" / "master"
+        map_dir.mkdir(parents=True, exist_ok=True)
+        (map_dir / "step_state.json").write_text(
+            json.dumps(
+                {
+                    "current_step_phase": "RESEARCH",
+                    "current_subtask_id": "ST-001",
+                    "subtask_phases": {},
+                    "constraints": {"scope_glob": "src/*"},
+                }
+            )
+        )
+        self._setup_blueprint(
+            tmp_path,
+            "master",
+            [{"id": "ST-001", "affected_files": ["src/app.py"]}],
+        )
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(tmp_path / "tests" / "foo.py")},
+            },
+            tmp_path,
+        )
+        assert code == 0
+        reason = self._assert_denied(stdout)
+        assert "scope_glob" in reason
+
+    def test_research_orthogonal_out_of_repo_blocks(self, tmp_path: Path) -> None:
+        """An out-of-repo path is not a repo-relative affected_files member, but
+        the relief is conservative and does NOT open arbitrary out-of-repo
+        writes during RESEARCH — it stays blocked.
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        self._setup_blueprint(
+            tmp_path,
+            "master",
+            [{"id": "ST-001", "affected_files": ["src/app.py"]}],
+        )
+        code, stdout, _ = self.run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "/etc/hosts"}},
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_denied(stdout)
+
+    def test_research_orthogonal_handles_nested_blueprint(
+        self, tmp_path: Path
+    ) -> None:
+        """The blueprint reader handles the wrapped {"blueprint": {...}} envelope
+        identically to the flat form when scoping orthogonal edits.
+        """
+        self._setup_step_state(tmp_path, "master", "RESEARCH", subtask_id="ST-001")
+        self._setup_blueprint(
+            tmp_path,
+            "master",
+            [{"id": "ST-001", "affected_files": ["src/app.py"]}],
+            nested=True,
+        )
+        code, stdout, _ = self.run_hook(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(tmp_path / "src" / "other.py")},
+            },
+            tmp_path,
+        )
+        assert code == 0
+        self._assert_allowed(stdout)
 
     def test_monitor_strict_mode_blocks_edit(self, tmp_path: Path) -> None:
         """MAP_MONITOR_HOTFIX=0 restores strict read-only MONITOR. The deny


### PR DESCRIPTION
## Summary

Fixes #164. During the **RESEARCH** phase, `workflow-gate.py` blocked *every*
`Edit`/`Write`/`MultiEdit` (except docs-only surfaces), even for files entirely
**orthogonal** to the current subtask — a repo-root config, an unrelated failing
test, an out-of-band hotfix the operator explicitly asked for. The only escape
was writing via `Bash` heredocs, which defeats read-before-write safety,
minimal-diff review, and the gate itself.

This PR scopes the RESEARCH block to **the current subtask's declared
`affected_files`** (the issue's preferred option 1):

- Edits to files **provably outside** the current subtask's `affected_files`
  (resolved from `blueprint.json` by `current_subtask_id`) are now **allowed**
  during RESEARCH.
- Edits to files **inside** that surface stay **blocked** — research-before-code
  is still enforced exactly where it matters.

### Safety / conservatism

The relief lifts the *phase* block only; it never widens scope:

- **Fail-safe to strict block** when the mutation surface can't be determined:
  no `blueprint.json`, unknown subtask, empty `affected_files`, or an
  out-of-repo target → keep blocking (relax only on positive evidence).
- **`scope_glob`/constraints still enforced** — an orthogonal file outside an
  explicit `scope_glob` is still denied by the constraint check.
- **Mixed batches block**: a single in-scope target in a `MultiEdit` defeats the
  orthogonal relief, so code can't sneak in alongside an orthogonal path.

### Deferred (documented in-code)

The `Bash` write bypass (`cat >`, `tee`, `sed -i`) called out in the issue is
left as a **known limitation** with an in-file note. Closing it needs shell
write-target parsing that risks false-positives across the many host repos this
hook ships into; option 1 removes the actual friction that drove people to Bash
in the first place.

## Changes

- Single-source `templates_src/hooks/workflow-gate.py.jinja` **and**
  `templates_src/codex/hooks/workflow-gate.py.jinja` updated, then
  `make render-templates` propagated to all 4 generated trees (byte-identical;
  verified by `make check-render`).
- New helpers: `_load_blueprint_subtasks`, `_to_repo_relative`,
  `_current_subtask_affected_files`, `is_orthogonal_to_current_subtask`
  (stdlib-only, fail-soft — the hook runs in host repos).
- **8 new tests** in `tests/test_workflow_gate.py`: orthogonal-allow,
  in-scope-block (+message names the scoping), mixed-batch-block,
  no-blueprint/empty-`affected_files` fallbacks, `scope_glob`-still-enforced,
  out-of-repo block, nested-blueprint envelope. Negative-proof verified
  (disabling the relief turns the allow-tests red, block-tests stay green).
- `CHANGELOG.md` entry.

## Test plan

- `make check` → lint (ruff + mypy + pyright + lint-hooks) + **2305 passed**,
  3 skipped + `check-render` (generated trees match source). ✅
- `pytest tests/test_workflow_gate.py` → **47 passed** (39 existing + 8 new). ✅

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)