### PR TITLE
fix(map-plan): compare plan goals in resume-detection, not branch name alone (#166)

### DIFF
--- a/.agents/skills/map-plan/SKILL.md
+++ b/.agents/skills/map-plan/SKILL.md
@@ -24,20 +24,24 @@ description: "ARCHITECT phase - decompose complex tasks into atomic subtasks wit
 
 ## Pre-flight: Resume Detection
 
-Before any step, detect which artifacts already exist:
+Before any step, detect which artifacts already exist AND whether the request matches the existing plan's goal:
 
 ```
 shell_command:
   cmd: |
     BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
     echo "BRANCH=$BRANCH"
-    echo "findings:  $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "spec:      $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "task_plan: $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "state:     $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+    python3 .map/scripts/map_step_runner.py check_plan_resume "$ARGUMENTS"
 ```
 
-**Resume rules:**
+This reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) AND a `verdict` comparing the prior plan's goal against the current request — so a branch that already hosts a *completed* plan for a different goal is not mistaken for "this plan is done" (a single branch can host several sequential plans over its lifetime).
+
+**Branch on `verdict`:**
+- `no_plan` → no prior artifacts; plan fresh from Step 0
+- `goal_mismatch` → the branch already holds a plan for a **different** goal. Do **NOT** print "plan complete" and do **NOT** overwrite the prior `spec`/`blueprint`/`task_plan`. Follow the `recommendation`: archive or rename the existing `.map/<branch>/` artifacts (or run `$map-plan` on a fresh branch) — confirm with the operator first — then plan the new goal
+- `resume` → the request matches the existing plan (or no request text was supplied to compare); apply the per-artifact resume rules below
+
+**Per-artifact resume rules (only when `verdict` is `resume`):**
 - `findings` EXISTS → skip Step 0 ONLY if the file has an `Already Implemented` section; if it predates that format, re-run Step 0 so the Step 0.5 gate has its evidence
 - `spec` EXISTS → skip Steps 1-2, read existing spec
 - `task_plan` EXISTS → skip Steps 4-6, read existing plan

--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -52,13 +52,16 @@ parallel_tool_policy: discovery_only
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
-echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "state:       $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+python3 .map/scripts/map_step_runner.py check_plan_resume "$ARGUMENTS"
 ```
 
-Resume rules:
+This reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) AND a `verdict` that compares the prior plan's goal against the current request — so a branch that already hosts a *completed* plan for a different goal is not mistaken for "this plan is done". Branch on `verdict`:
+
+- `no_plan` → no prior artifacts; plan fresh from Step 0.
+- `goal_mismatch` → the branch already holds a plan for a **different** goal (a single branch can host several sequential plans over its lifetime). Do **NOT** print "plan complete" and do **NOT** overwrite the prior `spec`/`blueprint`/`task_plan`. Follow the `recommendation`: archive or rename the existing `.map/<branch>/` artifacts (or run `/map-plan` on a fresh branch) — confirm with the operator first — then plan the new goal.
+- `resume` → the request matches the existing plan (or no request text was supplied to compare). Apply the per-artifact resume rules below.
+
+Per-artifact resume rules (only when `verdict` is `resume`):
 - Existing `findings`: reuse discovery only if the file has an `Already Implemented` section; if it predates that format, re-run discovery (see Step 0).
 - Existing `spec`: skip interview/spec writing.
 - Existing `task_plan`: skip decomposition and plan creation.
@@ -303,6 +306,7 @@ Runner functions you'll commonly need from `/map-plan`:
 | `normalize_blueprint [<path>] [--check]` | Deterministically repair decomposer drift before validation: topo-sort `subtasks[]` so deps precede dependents + inject missing `coverage_map` bracket-tags. `--check` reports without writing. |
 | `validate_blueprint_contract <path>` | Run schema + semantic checks on `blueprint.json`. |
 | `list_plans` | List per-branch plan artifacts under `.map/` to pick scope from a multi-roadmap workspace. |
+| `check_plan_resume "<request>" [--branch <b>]` | Resume preflight: reports existing artifacts + a `verdict` (`no_plan`/`resume`/`goal_mismatch`) comparing the prior plan's goal against the incoming request, so a branch hosting a *completed* plan for a different goal isn't falsely treated as "complete". |
 | `save_research <branch> <subtask_id>` | Persist research-agent findings for a subtask (stdin-fed). |
 
 ### Step 8: Output Checkpoint

--- a/.claude/skills/map-plan/plan-reference.md
+++ b/.claude/skills/map-plan/plan-reference.md
@@ -96,7 +96,7 @@ Remaining gap (planned):
 
 ## Troubleshooting
 
-- Existing `step_state.json`: planning already completed; print checkpoint and stop.
+- Existing `step_state.json`: planning already completed; print checkpoint and stop — but only when the Resume-Detection `verdict` is `resume`. The `.map/<branch>/` layout is single-plan-per-branch, so a branch can host several sequential plans over its lifetime; `check_plan_resume "$ARGUMENTS"` compares the prior plan's goal against the current request and returns `goal_mismatch` when they differ. On `goal_mismatch`, do NOT report "plan complete" and do NOT overwrite the prior `spec`/`blueprint`/`task_plan`; archive or rename the existing `.map/<branch>/` artifacts (or plan on a fresh branch) with operator confirmation, then plan the new goal.
 - `validate_blueprint_contract` fails: fix decomposer output before task plan creation.
 - Coverage key missing from validation criteria: add bracketed criteria such as `VC1 [AC-1]: ...`.
 - Hard constraint uncovered: add it to `coverage_map` and owning validation criteria.

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -44,6 +44,17 @@ from typing import Callable, Iterable, Mapping, Optional, TypedDict, cast
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
 
+# check_plan_resume() goal-comparison thresholds (issue #164/#166). The resume
+# preflight diverts a brand-new request to `goal_mismatch` (instead of falsely
+# reporting "plan complete" / silently clobbering the prior plan) ONLY on strong
+# evidence: both the existing goal and the incoming request must carry at least
+# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and their containment (shared
+# tokens / smaller significant-token set) must fall below
+# RESUME_GOAL_MISMATCH_CONTAINMENT. Conservative by design so a legitimate resume
+# with a shorter paraphrase is never falsely diverted.
+RESUME_GOAL_MISMATCH_CONTAINMENT = 0.25
+RESUME_MIN_TOKENS_FOR_MISMATCH = 2
+
 
 HUMAN_ARTIFACT_DEFAULTS = {
     "qa-001.md": "# QA 001\n\n",
@@ -7253,6 +7264,167 @@ def _dt_from_mtime(ts: float) -> str:
     return datetime.fromtimestamp(ts, timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _read_existing_plan_goal(spec_path: Path, task_plan_path: Path) -> str:
+    """Extract the existing plan's goal text from task_plan + spec for resume
+    comparison. Prefers the task plan's ``- Goal:`` line (falling back to the
+    whole ``## Overview``/``## Goal`` block), and folds in the task-plan and spec
+    H1 titles so short distinctive goals still yield significant tokens. Returns
+    a de-duplicated newline-joined string ("" when nothing is extractable)."""
+    parts: list[str] = []
+    if task_plan_path.exists():
+        try:
+            content = task_plan_path.read_text(encoding="utf-8")
+            block_match = re.search(GOAL_HEADING_RE, content, re.DOTALL)
+            if block_match:
+                block = block_match.group(1).strip()
+                goal_line = re.search(r"(?im)^[-*]?\s*Goal:\s*(.+)$", block)
+                parts.append(goal_line.group(1).strip() if goal_line else block)
+            title_match = re.search(
+                r"(?m)^#\s+(?:Task Plan:\s*)?(.+)$", content
+            )
+            if title_match:
+                parts.append(title_match.group(1).strip())
+        except OSError:
+            pass
+    if spec_path.exists():
+        try:
+            content = spec_path.read_text(encoding="utf-8")
+            spec_title = re.search(r"(?m)^#\s+(?:Spec:\s*)?(.+)$", content)
+            if spec_title:
+                parts.append(spec_title.group(1).strip())
+        except OSError:
+            pass
+    seen: set[str] = set()
+    unique: list[str] = []
+    for part in parts:
+        if part and part not in seen:
+            seen.add(part)
+            unique.append(part)
+    return "\n".join(unique).strip()
+
+
+def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
+    """Resume-detection preflight for /map-plan on the branch-keyed
+    ``.map/<branch>/`` layout (issue #166).
+
+    A single git branch can host more than one sequential planning effort over
+    its lifetime. Keying resume purely on "does ``step_state.json`` exist?"
+    falsely reports "plan complete" for a brand-new, unrelated request and, if
+    the operator proceeds anyway, silently clobbers the prior plan's
+    spec/blueprint/task_plan. This preflight compares the existing plan's goal
+    against the incoming request and returns one of three verdicts:
+
+    - ``no_plan``: no prior planning artifacts on the branch — plan fresh.
+    - ``resume``: artifacts exist AND the request matches the existing plan's
+      goal (or no request text / extractable goal was available to compare) —
+      apply the per-artifact resume rules (existing ``step_state`` => complete).
+    - ``goal_mismatch``: artifacts exist BUT the request describes a DIFFERENT
+      goal than the completed plan — do NOT report "plan complete"; archive or
+      rename the prior ``.map/<branch>/`` artifacts (or plan on a fresh branch)
+      before planning the new goal, with operator confirmation.
+
+    Goal comparison is a deterministic token-overlap heuristic (see
+    RESUME_GOAL_MISMATCH_CONTAINMENT) — intentionally conservative so a real
+    resume with a shorter paraphrase is never falsely diverted.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    branch_dir = project_dir / ".map" / branch_name
+    findings_path = branch_dir / f"findings_{branch_name}.md"
+    spec_path = branch_dir / f"spec_{branch_name}.md"
+    task_plan_path = branch_dir / f"task_plan_{branch_name}.md"
+    state_path = branch_dir / "step_state.json"
+
+    artifacts = {
+        "findings": findings_path.exists(),
+        "spec": spec_path.exists(),
+        "task_plan": task_plan_path.exists(),
+        "step_state": state_path.exists(),
+    }
+    has_plan = (
+        artifacts["spec"] or artifacts["task_plan"] or artifacts["step_state"]
+    )
+    request_text = (request or "").strip()
+
+    if not has_plan:
+        return {
+            "status": "ok",
+            "branch": branch_name,
+            "verdict": "no_plan",
+            "artifacts": artifacts,
+            "existing_goal": None,
+            "request": request_text,
+            "overlap": 0.0,
+            "containment": 0.0,
+            "shared_terms": [],
+            "recommendation": (
+                f"No prior planning artifacts on branch '{branch_name}'. "
+                "Proceed with a fresh plan from Step 0."
+            ),
+        }
+
+    existing_goal = _read_existing_plan_goal(spec_path, task_plan_path)
+    goal_tokens = _tokenize_learning_text(existing_goal)
+    request_tokens = _tokenize_learning_text(request_text)
+    shared = sorted(goal_tokens & request_tokens)
+    union = goal_tokens | request_tokens
+    overlap = round(len(shared) / len(union), 3) if union else 0.0
+    min_len = min(len(goal_tokens), len(request_tokens))
+    containment = round(len(shared) / min_len, 3) if min_len else 0.0
+
+    comparable = bool(
+        request_text
+        and goal_tokens
+        and request_tokens
+        and min_len >= RESUME_MIN_TOKENS_FOR_MISMATCH
+    )
+
+    if comparable and containment < RESUME_GOAL_MISMATCH_CONTAINMENT:
+        verdict = "goal_mismatch"
+        snippet = " ".join(existing_goal.split())
+        if len(snippet) > 160:
+            snippet = snippet[:157].rstrip() + "..."
+        recommendation = (
+            f"The existing plan on branch '{branch_name}' targets a DIFFERENT "
+            f"goal than the current request (goal-overlap {overlap}, "
+            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}). "
+            f'Existing goal: "{snippet}". Do NOT report "plan complete" / STOP. '
+            f"Archive or rename the prior .map/{branch_name}/ artifacts (or run "
+            "/map-plan on a fresh branch) so the completed plan is preserved, "
+            "then plan the new goal. Confirm the archival/overwrite with the "
+            "operator before writing."
+        )
+    else:
+        verdict = "resume"
+        if not request_text:
+            reason = "No request text supplied to compare against the existing plan"
+        elif not existing_goal:
+            reason = "Existing plan has no extractable goal to compare"
+        else:
+            reason = (
+                "Incoming request matches the existing plan goal "
+                f"(overlap {overlap}, containment {containment})"
+            )
+        recommendation = (
+            f"{reason}. Apply the per-artifact resume rules: existing "
+            "step_state => plan complete (print checkpoint and STOP); existing "
+            "spec/task_plan => skip those steps and reuse them."
+        )
+
+    return {
+        "status": "ok",
+        "branch": branch_name,
+        "verdict": verdict,
+        "artifacts": artifacts,
+        "existing_goal": existing_goal or None,
+        "request": request_text,
+        "overlap": overlap,
+        "containment": containment,
+        "shared_terms": shared,
+        "recommendation": recommendation,
+    }
+
+
 def record_scope_baseline(branch: str) -> dict:
     """Snapshot the current uncommitted / untracked file set as a baseline
     that validate_mutation_boundary will subtract from `actual` on future
@@ -9200,6 +9372,20 @@ if __name__ == "__main__":
 
     elif func_name == "list_plans":
         report = list_plans()
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "check_plan_resume":
+        # CLI: check_plan_resume "<incoming request>" [--branch <branch>]
+        # Advisory preflight (always exits 0) — the skill branches on `verdict`.
+        rest = list(sys.argv[2:])
+        cpr_branch: Optional[str] = None
+        if "--branch" in rest:
+            bidx = rest.index("--branch")
+            if bidx + 1 < len(rest):
+                cpr_branch = rest[bidx + 1]
+                del rest[bidx:bidx + 2]
+        cpr_request = rest[0] if rest else ""
+        report = check_plan_resume(cpr_request, branch=cpr_branch)
         print(json.dumps(report, indent=2))
 
     elif func_name == "subtask_boundary_compact_check" and len(sys.argv) >= 3:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   importable; the meter is advisory and never blocks a turn.
 
 ### Fixed
+- **`/map-plan` resume-detection compares plan goals instead of branch-keying
+  alone (#166)**: a single git branch can host more than one sequential
+  planning effort over its lifetime, but the Resume-Detection preflight keyed
+  "plan complete" purely on `test -f .map/<branch>/step_state.json`. A
+  brand-new, unrelated request on a branch that already held a *completed* plan
+  was therefore falsely off-ramped as "plan complete" (no plan produced), and
+  proceeding anyway silently clobbered the prior plan's `spec`/`blueprint`/
+  `task_plan`. New `check_plan_resume "<request>" [--branch <b>]` runner
+  function reports the existing artifacts AND a `verdict`
+  (`no_plan`/`resume`/`goal_mismatch`) by comparing the prior plan's goal
+  (from `task_plan`/`spec`) against the incoming request via a deterministic
+  token-overlap (containment) heuristic. On `goal_mismatch` the skill no longer
+  prints "plan complete" and does not overwrite the prior artifacts — it
+  recommends archiving/renaming `.map/<branch>/` (or planning on a fresh
+  branch) with operator confirmation, then planning the new goal. Comparison is
+  intentionally conservative — both sides must carry ≥2 significant tokens and
+  fall below the containment threshold, so a legitimate resume with a shorter
+  paraphrase (or a bare `/map-plan` with no request text) is never falsely
+  diverted. Both provider surfaces (Claude + Codex `map-plan` SKILL) and
+  `plan-reference.md` document the single-plan-per-branch layout and the
+  `goal_mismatch` off-ramp.
 - **`workflow-gate` RESEARCH block scoped to the current subtask's
   `affected_files` (#164)**: during the RESEARCH phase the gate used to block
   *every* `Edit`/`Write`/`MultiEdit` (except docs-only surfaces), so orthogonal

--- a/src/mapify_cli/templates/codex/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-plan/SKILL.md
@@ -24,20 +24,24 @@ description: "ARCHITECT phase - decompose complex tasks into atomic subtasks wit
 
 ## Pre-flight: Resume Detection
 
-Before any step, detect which artifacts already exist:
+Before any step, detect which artifacts already exist AND whether the request matches the existing plan's goal:
 
 ```
 shell_command:
   cmd: |
     BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
     echo "BRANCH=$BRANCH"
-    echo "findings:  $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "spec:      $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "task_plan: $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "state:     $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+    python3 .map/scripts/map_step_runner.py check_plan_resume "$ARGUMENTS"
 ```
 
-**Resume rules:**
+This reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) AND a `verdict` comparing the prior plan's goal against the current request — so a branch that already hosts a *completed* plan for a different goal is not mistaken for "this plan is done" (a single branch can host several sequential plans over its lifetime).
+
+**Branch on `verdict`:**
+- `no_plan` → no prior artifacts; plan fresh from Step 0
+- `goal_mismatch` → the branch already holds a plan for a **different** goal. Do **NOT** print "plan complete" and do **NOT** overwrite the prior `spec`/`blueprint`/`task_plan`. Follow the `recommendation`: archive or rename the existing `.map/<branch>/` artifacts (or run `$map-plan` on a fresh branch) — confirm with the operator first — then plan the new goal
+- `resume` → the request matches the existing plan (or no request text was supplied to compare); apply the per-artifact resume rules below
+
+**Per-artifact resume rules (only when `verdict` is `resume`):**
 - `findings` EXISTS → skip Step 0 ONLY if the file has an `Already Implemented` section; if it predates that format, re-run Step 0 so the Step 0.5 gate has its evidence
 - `spec` EXISTS → skip Steps 1-2, read existing spec
 - `task_plan` EXISTS → skip Steps 4-6, read existing plan

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -44,6 +44,17 @@ from typing import Callable, Iterable, Mapping, Optional, TypedDict, cast
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
 
+# check_plan_resume() goal-comparison thresholds (issue #164/#166). The resume
+# preflight diverts a brand-new request to `goal_mismatch` (instead of falsely
+# reporting "plan complete" / silently clobbering the prior plan) ONLY on strong
+# evidence: both the existing goal and the incoming request must carry at least
+# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and their containment (shared
+# tokens / smaller significant-token set) must fall below
+# RESUME_GOAL_MISMATCH_CONTAINMENT. Conservative by design so a legitimate resume
+# with a shorter paraphrase is never falsely diverted.
+RESUME_GOAL_MISMATCH_CONTAINMENT = 0.25
+RESUME_MIN_TOKENS_FOR_MISMATCH = 2
+
 
 HUMAN_ARTIFACT_DEFAULTS = {
     "qa-001.md": "# QA 001\n\n",
@@ -7253,6 +7264,167 @@ def _dt_from_mtime(ts: float) -> str:
     return datetime.fromtimestamp(ts, timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _read_existing_plan_goal(spec_path: Path, task_plan_path: Path) -> str:
+    """Extract the existing plan's goal text from task_plan + spec for resume
+    comparison. Prefers the task plan's ``- Goal:`` line (falling back to the
+    whole ``## Overview``/``## Goal`` block), and folds in the task-plan and spec
+    H1 titles so short distinctive goals still yield significant tokens. Returns
+    a de-duplicated newline-joined string ("" when nothing is extractable)."""
+    parts: list[str] = []
+    if task_plan_path.exists():
+        try:
+            content = task_plan_path.read_text(encoding="utf-8")
+            block_match = re.search(GOAL_HEADING_RE, content, re.DOTALL)
+            if block_match:
+                block = block_match.group(1).strip()
+                goal_line = re.search(r"(?im)^[-*]?\s*Goal:\s*(.+)$", block)
+                parts.append(goal_line.group(1).strip() if goal_line else block)
+            title_match = re.search(
+                r"(?m)^#\s+(?:Task Plan:\s*)?(.+)$", content
+            )
+            if title_match:
+                parts.append(title_match.group(1).strip())
+        except OSError:
+            pass
+    if spec_path.exists():
+        try:
+            content = spec_path.read_text(encoding="utf-8")
+            spec_title = re.search(r"(?m)^#\s+(?:Spec:\s*)?(.+)$", content)
+            if spec_title:
+                parts.append(spec_title.group(1).strip())
+        except OSError:
+            pass
+    seen: set[str] = set()
+    unique: list[str] = []
+    for part in parts:
+        if part and part not in seen:
+            seen.add(part)
+            unique.append(part)
+    return "\n".join(unique).strip()
+
+
+def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
+    """Resume-detection preflight for /map-plan on the branch-keyed
+    ``.map/<branch>/`` layout (issue #166).
+
+    A single git branch can host more than one sequential planning effort over
+    its lifetime. Keying resume purely on "does ``step_state.json`` exist?"
+    falsely reports "plan complete" for a brand-new, unrelated request and, if
+    the operator proceeds anyway, silently clobbers the prior plan's
+    spec/blueprint/task_plan. This preflight compares the existing plan's goal
+    against the incoming request and returns one of three verdicts:
+
+    - ``no_plan``: no prior planning artifacts on the branch — plan fresh.
+    - ``resume``: artifacts exist AND the request matches the existing plan's
+      goal (or no request text / extractable goal was available to compare) —
+      apply the per-artifact resume rules (existing ``step_state`` => complete).
+    - ``goal_mismatch``: artifacts exist BUT the request describes a DIFFERENT
+      goal than the completed plan — do NOT report "plan complete"; archive or
+      rename the prior ``.map/<branch>/`` artifacts (or plan on a fresh branch)
+      before planning the new goal, with operator confirmation.
+
+    Goal comparison is a deterministic token-overlap heuristic (see
+    RESUME_GOAL_MISMATCH_CONTAINMENT) — intentionally conservative so a real
+    resume with a shorter paraphrase is never falsely diverted.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    branch_dir = project_dir / ".map" / branch_name
+    findings_path = branch_dir / f"findings_{branch_name}.md"
+    spec_path = branch_dir / f"spec_{branch_name}.md"
+    task_plan_path = branch_dir / f"task_plan_{branch_name}.md"
+    state_path = branch_dir / "step_state.json"
+
+    artifacts = {
+        "findings": findings_path.exists(),
+        "spec": spec_path.exists(),
+        "task_plan": task_plan_path.exists(),
+        "step_state": state_path.exists(),
+    }
+    has_plan = (
+        artifacts["spec"] or artifacts["task_plan"] or artifacts["step_state"]
+    )
+    request_text = (request or "").strip()
+
+    if not has_plan:
+        return {
+            "status": "ok",
+            "branch": branch_name,
+            "verdict": "no_plan",
+            "artifacts": artifacts,
+            "existing_goal": None,
+            "request": request_text,
+            "overlap": 0.0,
+            "containment": 0.0,
+            "shared_terms": [],
+            "recommendation": (
+                f"No prior planning artifacts on branch '{branch_name}'. "
+                "Proceed with a fresh plan from Step 0."
+            ),
+        }
+
+    existing_goal = _read_existing_plan_goal(spec_path, task_plan_path)
+    goal_tokens = _tokenize_learning_text(existing_goal)
+    request_tokens = _tokenize_learning_text(request_text)
+    shared = sorted(goal_tokens & request_tokens)
+    union = goal_tokens | request_tokens
+    overlap = round(len(shared) / len(union), 3) if union else 0.0
+    min_len = min(len(goal_tokens), len(request_tokens))
+    containment = round(len(shared) / min_len, 3) if min_len else 0.0
+
+    comparable = bool(
+        request_text
+        and goal_tokens
+        and request_tokens
+        and min_len >= RESUME_MIN_TOKENS_FOR_MISMATCH
+    )
+
+    if comparable and containment < RESUME_GOAL_MISMATCH_CONTAINMENT:
+        verdict = "goal_mismatch"
+        snippet = " ".join(existing_goal.split())
+        if len(snippet) > 160:
+            snippet = snippet[:157].rstrip() + "..."
+        recommendation = (
+            f"The existing plan on branch '{branch_name}' targets a DIFFERENT "
+            f"goal than the current request (goal-overlap {overlap}, "
+            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}). "
+            f'Existing goal: "{snippet}". Do NOT report "plan complete" / STOP. '
+            f"Archive or rename the prior .map/{branch_name}/ artifacts (or run "
+            "/map-plan on a fresh branch) so the completed plan is preserved, "
+            "then plan the new goal. Confirm the archival/overwrite with the "
+            "operator before writing."
+        )
+    else:
+        verdict = "resume"
+        if not request_text:
+            reason = "No request text supplied to compare against the existing plan"
+        elif not existing_goal:
+            reason = "Existing plan has no extractable goal to compare"
+        else:
+            reason = (
+                "Incoming request matches the existing plan goal "
+                f"(overlap {overlap}, containment {containment})"
+            )
+        recommendation = (
+            f"{reason}. Apply the per-artifact resume rules: existing "
+            "step_state => plan complete (print checkpoint and STOP); existing "
+            "spec/task_plan => skip those steps and reuse them."
+        )
+
+    return {
+        "status": "ok",
+        "branch": branch_name,
+        "verdict": verdict,
+        "artifacts": artifacts,
+        "existing_goal": existing_goal or None,
+        "request": request_text,
+        "overlap": overlap,
+        "containment": containment,
+        "shared_terms": shared,
+        "recommendation": recommendation,
+    }
+
+
 def record_scope_baseline(branch: str) -> dict:
     """Snapshot the current uncommitted / untracked file set as a baseline
     that validate_mutation_boundary will subtract from `actual` on future
@@ -9200,6 +9372,20 @@ if __name__ == "__main__":
 
     elif func_name == "list_plans":
         report = list_plans()
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "check_plan_resume":
+        # CLI: check_plan_resume "<incoming request>" [--branch <branch>]
+        # Advisory preflight (always exits 0) — the skill branches on `verdict`.
+        rest = list(sys.argv[2:])
+        cpr_branch: Optional[str] = None
+        if "--branch" in rest:
+            bidx = rest.index("--branch")
+            if bidx + 1 < len(rest):
+                cpr_branch = rest[bidx + 1]
+                del rest[bidx:bidx + 2]
+        cpr_request = rest[0] if rest else ""
+        report = check_plan_resume(cpr_request, branch=cpr_branch)
         print(json.dumps(report, indent=2))
 
     elif func_name == "subtask_boundary_compact_check" and len(sys.argv) >= 3:

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -52,13 +52,16 @@ parallel_tool_policy: discovery_only
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
-echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "state:       $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+python3 .map/scripts/map_step_runner.py check_plan_resume "$ARGUMENTS"
 ```
 
-Resume rules:
+This reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) AND a `verdict` that compares the prior plan's goal against the current request — so a branch that already hosts a *completed* plan for a different goal is not mistaken for "this plan is done". Branch on `verdict`:
+
+- `no_plan` → no prior artifacts; plan fresh from Step 0.
+- `goal_mismatch` → the branch already holds a plan for a **different** goal (a single branch can host several sequential plans over its lifetime). Do **NOT** print "plan complete" and do **NOT** overwrite the prior `spec`/`blueprint`/`task_plan`. Follow the `recommendation`: archive or rename the existing `.map/<branch>/` artifacts (or run `/map-plan` on a fresh branch) — confirm with the operator first — then plan the new goal.
+- `resume` → the request matches the existing plan (or no request text was supplied to compare). Apply the per-artifact resume rules below.
+
+Per-artifact resume rules (only when `verdict` is `resume`):
 - Existing `findings`: reuse discovery only if the file has an `Already Implemented` section; if it predates that format, re-run discovery (see Step 0).
 - Existing `spec`: skip interview/spec writing.
 - Existing `task_plan`: skip decomposition and plan creation.
@@ -303,6 +306,7 @@ Runner functions you'll commonly need from `/map-plan`:
 | `normalize_blueprint [<path>] [--check]` | Deterministically repair decomposer drift before validation: topo-sort `subtasks[]` so deps precede dependents + inject missing `coverage_map` bracket-tags. `--check` reports without writing. |
 | `validate_blueprint_contract <path>` | Run schema + semantic checks on `blueprint.json`. |
 | `list_plans` | List per-branch plan artifacts under `.map/` to pick scope from a multi-roadmap workspace. |
+| `check_plan_resume "<request>" [--branch <b>]` | Resume preflight: reports existing artifacts + a `verdict` (`no_plan`/`resume`/`goal_mismatch`) comparing the prior plan's goal against the incoming request, so a branch hosting a *completed* plan for a different goal isn't falsely treated as "complete". |
 | `save_research <branch> <subtask_id>` | Persist research-agent findings for a subtask (stdin-fed). |
 
 ### Step 8: Output Checkpoint

--- a/src/mapify_cli/templates/skills/map-plan/plan-reference.md
+++ b/src/mapify_cli/templates/skills/map-plan/plan-reference.md
@@ -96,7 +96,7 @@ Remaining gap (planned):
 
 ## Troubleshooting
 
-- Existing `step_state.json`: planning already completed; print checkpoint and stop.
+- Existing `step_state.json`: planning already completed; print checkpoint and stop — but only when the Resume-Detection `verdict` is `resume`. The `.map/<branch>/` layout is single-plan-per-branch, so a branch can host several sequential plans over its lifetime; `check_plan_resume "$ARGUMENTS"` compares the prior plan's goal against the current request and returns `goal_mismatch` when they differ. On `goal_mismatch`, do NOT report "plan complete" and do NOT overwrite the prior `spec`/`blueprint`/`task_plan`; archive or rename the existing `.map/<branch>/` artifacts (or plan on a fresh branch) with operator confirmation, then plan the new goal.
 - `validate_blueprint_contract` fails: fix decomposer output before task plan creation.
 - Coverage key missing from validation criteria: add bracketed criteria such as `VC1 [AC-1]: ...`.
 - Hard constraint uncovered: add it to `coverage_map` and owning validation criteria.

--- a/src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja
@@ -24,20 +24,24 @@ description: "ARCHITECT phase - decompose complex tasks into atomic subtasks wit
 
 ## Pre-flight: Resume Detection
 
-Before any step, detect which artifacts already exist:
+Before any step, detect which artifacts already exist AND whether the request matches the existing plan's goal:
 
 ```
 shell_command:
   cmd: |
     BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
     echo "BRANCH=$BRANCH"
-    echo "findings:  $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "spec:      $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "task_plan: $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
-    echo "state:     $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+    python3 .map/scripts/map_step_runner.py check_plan_resume "$ARGUMENTS"
 ```
 
-**Resume rules:**
+This reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) AND a `verdict` comparing the prior plan's goal against the current request — so a branch that already hosts a *completed* plan for a different goal is not mistaken for "this plan is done" (a single branch can host several sequential plans over its lifetime).
+
+**Branch on `verdict`:**
+- `no_plan` → no prior artifacts; plan fresh from Step 0
+- `goal_mismatch` → the branch already holds a plan for a **different** goal. Do **NOT** print "plan complete" and do **NOT** overwrite the prior `spec`/`blueprint`/`task_plan`. Follow the `recommendation`: archive or rename the existing `.map/<branch>/` artifacts (or run `$map-plan` on a fresh branch) — confirm with the operator first — then plan the new goal
+- `resume` → the request matches the existing plan (or no request text was supplied to compare); apply the per-artifact resume rules below
+
+**Per-artifact resume rules (only when `verdict` is `resume`):**
 - `findings` EXISTS → skip Step 0 ONLY if the file has an `Already Implemented` section; if it predates that format, re-run Step 0 so the Step 0.5 gate has its evidence
 - `spec` EXISTS → skip Steps 1-2, read existing spec
 - `task_plan` EXISTS → skip Steps 4-6, read existing plan

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -44,6 +44,17 @@ from typing import Callable, Iterable, Mapping, Optional, TypedDict, cast
 # Keep in sync with workflow-context-injector.py GOAL_HEADING_RE
 GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
 
+# check_plan_resume() goal-comparison thresholds (issue #164/#166). The resume
+# preflight diverts a brand-new request to `goal_mismatch` (instead of falsely
+# reporting "plan complete" / silently clobbering the prior plan) ONLY on strong
+# evidence: both the existing goal and the incoming request must carry at least
+# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and their containment (shared
+# tokens / smaller significant-token set) must fall below
+# RESUME_GOAL_MISMATCH_CONTAINMENT. Conservative by design so a legitimate resume
+# with a shorter paraphrase is never falsely diverted.
+RESUME_GOAL_MISMATCH_CONTAINMENT = 0.25
+RESUME_MIN_TOKENS_FOR_MISMATCH = 2
+
 
 HUMAN_ARTIFACT_DEFAULTS = {
     "qa-001.md": "# QA 001\n\n",
@@ -7253,6 +7264,167 @@ def _dt_from_mtime(ts: float) -> str:
     return datetime.fromtimestamp(ts, timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _read_existing_plan_goal(spec_path: Path, task_plan_path: Path) -> str:
+    """Extract the existing plan's goal text from task_plan + spec for resume
+    comparison. Prefers the task plan's ``- Goal:`` line (falling back to the
+    whole ``## Overview``/``## Goal`` block), and folds in the task-plan and spec
+    H1 titles so short distinctive goals still yield significant tokens. Returns
+    a de-duplicated newline-joined string ("" when nothing is extractable)."""
+    parts: list[str] = []
+    if task_plan_path.exists():
+        try:
+            content = task_plan_path.read_text(encoding="utf-8")
+            block_match = re.search(GOAL_HEADING_RE, content, re.DOTALL)
+            if block_match:
+                block = block_match.group(1).strip()
+                goal_line = re.search(r"(?im)^[-*]?\s*Goal:\s*(.+)$", block)
+                parts.append(goal_line.group(1).strip() if goal_line else block)
+            title_match = re.search(
+                r"(?m)^#\s+(?:Task Plan:\s*)?(.+)$", content
+            )
+            if title_match:
+                parts.append(title_match.group(1).strip())
+        except OSError:
+            pass
+    if spec_path.exists():
+        try:
+            content = spec_path.read_text(encoding="utf-8")
+            spec_title = re.search(r"(?m)^#\s+(?:Spec:\s*)?(.+)$", content)
+            if spec_title:
+                parts.append(spec_title.group(1).strip())
+        except OSError:
+            pass
+    seen: set[str] = set()
+    unique: list[str] = []
+    for part in parts:
+        if part and part not in seen:
+            seen.add(part)
+            unique.append(part)
+    return "\n".join(unique).strip()
+
+
+def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
+    """Resume-detection preflight for /map-plan on the branch-keyed
+    ``.map/<branch>/`` layout (issue #166).
+
+    A single git branch can host more than one sequential planning effort over
+    its lifetime. Keying resume purely on "does ``step_state.json`` exist?"
+    falsely reports "plan complete" for a brand-new, unrelated request and, if
+    the operator proceeds anyway, silently clobbers the prior plan's
+    spec/blueprint/task_plan. This preflight compares the existing plan's goal
+    against the incoming request and returns one of three verdicts:
+
+    - ``no_plan``: no prior planning artifacts on the branch — plan fresh.
+    - ``resume``: artifacts exist AND the request matches the existing plan's
+      goal (or no request text / extractable goal was available to compare) —
+      apply the per-artifact resume rules (existing ``step_state`` => complete).
+    - ``goal_mismatch``: artifacts exist BUT the request describes a DIFFERENT
+      goal than the completed plan — do NOT report "plan complete"; archive or
+      rename the prior ``.map/<branch>/`` artifacts (or plan on a fresh branch)
+      before planning the new goal, with operator confirmation.
+
+    Goal comparison is a deterministic token-overlap heuristic (see
+    RESUME_GOAL_MISMATCH_CONTAINMENT) — intentionally conservative so a real
+    resume with a shorter paraphrase is never falsely diverted.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    branch_dir = project_dir / ".map" / branch_name
+    findings_path = branch_dir / f"findings_{branch_name}.md"
+    spec_path = branch_dir / f"spec_{branch_name}.md"
+    task_plan_path = branch_dir / f"task_plan_{branch_name}.md"
+    state_path = branch_dir / "step_state.json"
+
+    artifacts = {
+        "findings": findings_path.exists(),
+        "spec": spec_path.exists(),
+        "task_plan": task_plan_path.exists(),
+        "step_state": state_path.exists(),
+    }
+    has_plan = (
+        artifacts["spec"] or artifacts["task_plan"] or artifacts["step_state"]
+    )
+    request_text = (request or "").strip()
+
+    if not has_plan:
+        return {
+            "status": "ok",
+            "branch": branch_name,
+            "verdict": "no_plan",
+            "artifacts": artifacts,
+            "existing_goal": None,
+            "request": request_text,
+            "overlap": 0.0,
+            "containment": 0.0,
+            "shared_terms": [],
+            "recommendation": (
+                f"No prior planning artifacts on branch '{branch_name}'. "
+                "Proceed with a fresh plan from Step 0."
+            ),
+        }
+
+    existing_goal = _read_existing_plan_goal(spec_path, task_plan_path)
+    goal_tokens = _tokenize_learning_text(existing_goal)
+    request_tokens = _tokenize_learning_text(request_text)
+    shared = sorted(goal_tokens & request_tokens)
+    union = goal_tokens | request_tokens
+    overlap = round(len(shared) / len(union), 3) if union else 0.0
+    min_len = min(len(goal_tokens), len(request_tokens))
+    containment = round(len(shared) / min_len, 3) if min_len else 0.0
+
+    comparable = bool(
+        request_text
+        and goal_tokens
+        and request_tokens
+        and min_len >= RESUME_MIN_TOKENS_FOR_MISMATCH
+    )
+
+    if comparable and containment < RESUME_GOAL_MISMATCH_CONTAINMENT:
+        verdict = "goal_mismatch"
+        snippet = " ".join(existing_goal.split())
+        if len(snippet) > 160:
+            snippet = snippet[:157].rstrip() + "..."
+        recommendation = (
+            f"The existing plan on branch '{branch_name}' targets a DIFFERENT "
+            f"goal than the current request (goal-overlap {overlap}, "
+            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}). "
+            f'Existing goal: "{snippet}". Do NOT report "plan complete" / STOP. '
+            f"Archive or rename the prior .map/{branch_name}/ artifacts (or run "
+            "/map-plan on a fresh branch) so the completed plan is preserved, "
+            "then plan the new goal. Confirm the archival/overwrite with the "
+            "operator before writing."
+        )
+    else:
+        verdict = "resume"
+        if not request_text:
+            reason = "No request text supplied to compare against the existing plan"
+        elif not existing_goal:
+            reason = "Existing plan has no extractable goal to compare"
+        else:
+            reason = (
+                "Incoming request matches the existing plan goal "
+                f"(overlap {overlap}, containment {containment})"
+            )
+        recommendation = (
+            f"{reason}. Apply the per-artifact resume rules: existing "
+            "step_state => plan complete (print checkpoint and STOP); existing "
+            "spec/task_plan => skip those steps and reuse them."
+        )
+
+    return {
+        "status": "ok",
+        "branch": branch_name,
+        "verdict": verdict,
+        "artifacts": artifacts,
+        "existing_goal": existing_goal or None,
+        "request": request_text,
+        "overlap": overlap,
+        "containment": containment,
+        "shared_terms": shared,
+        "recommendation": recommendation,
+    }
+
+
 def record_scope_baseline(branch: str) -> dict:
     """Snapshot the current uncommitted / untracked file set as a baseline
     that validate_mutation_boundary will subtract from `actual` on future
@@ -9200,6 +9372,20 @@ if __name__ == "__main__":
 
     elif func_name == "list_plans":
         report = list_plans()
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "check_plan_resume":
+        # CLI: check_plan_resume "<incoming request>" [--branch <branch>]
+        # Advisory preflight (always exits 0) — the skill branches on `verdict`.
+        rest = list(sys.argv[2:])
+        cpr_branch: Optional[str] = None
+        if "--branch" in rest:
+            bidx = rest.index("--branch")
+            if bidx + 1 < len(rest):
+                cpr_branch = rest[bidx + 1]
+                del rest[bidx:bidx + 2]
+        cpr_request = rest[0] if rest else ""
+        report = check_plan_resume(cpr_request, branch=cpr_branch)
         print(json.dumps(report, indent=2))
 
     elif func_name == "subtask_boundary_compact_check" and len(sys.argv) >= 3:

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -52,13 +52,16 @@ parallel_tool_policy: discovery_only
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|g; s|-{2,}|-|g; s|^-||; s|-$||')
-echo "findings:    $(test -f .map/${BRANCH}/findings_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "spec:        $(test -f .map/${BRANCH}/spec_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "task_plan:   $(test -f .map/${BRANCH}/task_plan_${BRANCH}.md && echo EXISTS || echo MISSING)"
-echo "state:       $(test -f .map/${BRANCH}/step_state.json && echo EXISTS || echo MISSING)"
+python3 .map/scripts/map_step_runner.py check_plan_resume "$ARGUMENTS"
 ```
 
-Resume rules:
+This reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) AND a `verdict` that compares the prior plan's goal against the current request — so a branch that already hosts a *completed* plan for a different goal is not mistaken for "this plan is done". Branch on `verdict`:
+
+- `no_plan` → no prior artifacts; plan fresh from Step 0.
+- `goal_mismatch` → the branch already holds a plan for a **different** goal (a single branch can host several sequential plans over its lifetime). Do **NOT** print "plan complete" and do **NOT** overwrite the prior `spec`/`blueprint`/`task_plan`. Follow the `recommendation`: archive or rename the existing `.map/<branch>/` artifacts (or run `/map-plan` on a fresh branch) — confirm with the operator first — then plan the new goal.
+- `resume` → the request matches the existing plan (or no request text was supplied to compare). Apply the per-artifact resume rules below.
+
+Per-artifact resume rules (only when `verdict` is `resume`):
 - Existing `findings`: reuse discovery only if the file has an `Already Implemented` section; if it predates that format, re-run discovery (see Step 0).
 - Existing `spec`: skip interview/spec writing.
 - Existing `task_plan`: skip decomposition and plan creation.
@@ -303,6 +306,7 @@ Runner functions you'll commonly need from `/map-plan`:
 | `normalize_blueprint [<path>] [--check]` | Deterministically repair decomposer drift before validation: topo-sort `subtasks[]` so deps precede dependents + inject missing `coverage_map` bracket-tags. `--check` reports without writing. |
 | `validate_blueprint_contract <path>` | Run schema + semantic checks on `blueprint.json`. |
 | `list_plans` | List per-branch plan artifacts under `.map/` to pick scope from a multi-roadmap workspace. |
+| `check_plan_resume "<request>" [--branch <b>]` | Resume preflight: reports existing artifacts + a `verdict` (`no_plan`/`resume`/`goal_mismatch`) comparing the prior plan's goal against the incoming request, so a branch hosting a *completed* plan for a different goal isn't falsely treated as "complete". |
 | `save_research <branch> <subtask_id>` | Persist research-agent findings for a subtask (stdin-fed). |
 
 ### Step 8: Output Checkpoint

--- a/src/mapify_cli/templates_src/skills/map-plan/plan-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/plan-reference.md.jinja
@@ -96,7 +96,7 @@ Remaining gap (planned):
 
 ## Troubleshooting
 
-- Existing `step_state.json`: planning already completed; print checkpoint and stop.
+- Existing `step_state.json`: planning already completed; print checkpoint and stop — but only when the Resume-Detection `verdict` is `resume`. The `.map/<branch>/` layout is single-plan-per-branch, so a branch can host several sequential plans over its lifetime; `check_plan_resume "$ARGUMENTS"` compares the prior plan's goal against the current request and returns `goal_mismatch` when they differ. On `goal_mismatch`, do NOT report "plan complete" and do NOT overwrite the prior `spec`/`blueprint`/`task_plan`; archive or rename the existing `.map/<branch>/` artifacts (or plan on a fresh branch) with operator confirmation, then plan the new goal.
 - `validate_blueprint_contract` fails: fix decomposer output before task plan creation.
 - Coverage key missing from validation criteria: add bracketed criteria such as `VC1 [AC-1]: ...`.
 - Hard constraint uncovered: add it to `coverage_map` and owning validation criteria.

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -636,6 +636,129 @@ def test_record_plan_artifacts_is_partial_when_only_step_state_exists(branch_wor
     assert result["plan_status"] == "partial"
 
 
+def _write_completed_plan(branch_workspace, goal_title: str) -> None:
+    """Seed a branch with a completed plan whose goal is `goal_title`."""
+    branch = branch_workspace.name
+    (branch_workspace / f"spec_{branch}.md").write_text(
+        f"# Spec: {goal_title}\n\n## Acceptance Criteria\n- AC-1: ...\n",
+        encoding="utf-8",
+    )
+    (branch_workspace / f"task_plan_{branch}.md").write_text(
+        f"# Task Plan: {goal_title}\n\n## Overview\n- Goal: {goal_title}\n"
+        f"- Source spec: .map/{branch}/spec_{branch}.md\n",
+        encoding="utf-8",
+    )
+    (branch_workspace / "step_state.json").write_text(
+        '{"current_step_phase": "COMPLETE", "workflow_status": "complete"}\n',
+        encoding="utf-8",
+    )
+
+
+def test_check_plan_resume_no_plan_when_branch_empty(branch_workspace):
+    del branch_workspace
+    result = map_step_runner.check_plan_resume("implement token budget reporting")
+
+    assert result["status"] == "ok"
+    assert result["verdict"] == "no_plan"
+    assert result["existing_goal"] is None
+    assert result["artifacts"] == {
+        "findings": False,
+        "spec": False,
+        "task_plan": False,
+        "step_state": False,
+    }
+
+
+def test_check_plan_resume_resume_on_matching_goal(branch_workspace):
+    _write_completed_plan(
+        branch_workspace, "Implement token authentication middleware for the API"
+    )
+
+    result = map_step_runner.check_plan_resume(
+        "Implement token authentication middleware"
+    )
+
+    assert result["verdict"] == "resume"
+    assert result["artifacts"]["step_state"] is True
+    # High overlap on the distinctive goal terms.
+    assert result["containment"] >= map_step_runner.RESUME_GOAL_MISMATCH_CONTAINMENT
+    assert "authentication" in result["shared_terms"]
+
+
+def test_check_plan_resume_goal_mismatch_issue_166(branch_workspace):
+    # Repro of issue #166: a long-lived branch already hosts a COMPLETED plan
+    # for one goal; a brand-new, unrelated request must NOT be off-ramped as
+    # "plan complete" nor silently clobber the prior plan.
+    _write_completed_plan(branch_workspace, "Auditable Graph-Guided Incident Analysis")
+
+    result = map_step_runner.check_plan_resume(
+        "Add per-subtask token budget reporting to the statusline meter"
+    )
+
+    assert result["verdict"] == "goal_mismatch"
+    assert result["existing_goal"] is not None
+    assert result["containment"] < map_step_runner.RESUME_GOAL_MISMATCH_CONTAINMENT
+    assert "archive" in result["recommendation"].lower()
+    # The prior plan's goal is surfaced so the operator can decide.
+    assert "Analysis" in result["recommendation"]
+
+
+def test_check_plan_resume_empty_request_defaults_to_resume(branch_workspace):
+    # A bare `/map-plan` resume (no request text) must preserve the prior
+    # "step_state => complete" behavior — never divert to goal_mismatch.
+    _write_completed_plan(branch_workspace, "Auditable Graph-Guided Incident Analysis")
+
+    result = map_step_runner.check_plan_resume("")
+
+    assert result["verdict"] == "resume"
+    assert result["request"] == ""
+
+
+def test_check_plan_resume_one_word_request_does_not_divert(branch_workspace):
+    # Too little signal (one significant token) must never trigger a divert.
+    _write_completed_plan(branch_workspace, "Auditable Graph-Guided Incident Analysis")
+
+    result = map_step_runner.check_plan_resume("refactor")
+
+    assert result["verdict"] == "resume"
+
+
+def test_check_plan_resume_cli_smoke(tmp_path):
+    branch = "test-branch"
+    branch_dir = tmp_path / ".map" / branch
+    branch_dir.mkdir(parents=True)
+    (branch_dir / f"spec_{branch}.md").write_text(
+        "# Spec: Auditable Graph-Guided Incident Analysis\n", encoding="utf-8"
+    )
+    (branch_dir / f"task_plan_{branch}.md").write_text(
+        "# Task Plan: Auditable Graph-Guided Incident Analysis\n\n"
+        "## Overview\n- Goal: Auditable Graph-Guided Incident Analysis\n",
+        encoding="utf-8",
+    )
+    (branch_dir / "step_state.json").write_text(
+        '{"current_step_phase": "COMPLETE"}\n', encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS_PATH / "map_step_runner.py"),
+            "check_plan_resume",
+            "Add per-subtask token budget reporting to the statusline meter",
+            "--branch",
+            branch,
+        ],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["verdict"] == "goal_mismatch"
+    assert payload["branch"] == branch
+
+
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):
     blueprint = {
         "summary": "Deliver a user-visible fix",


### PR DESCRIPTION
## Summary

Fixes #166. `/map-plan`'s Resume-Detection preflight keyed "plan complete" purely on `test -f .map/<branch>/step_state.json`. Because a single git branch can host **more than one sequential planning effort** over its lifetime, a brand-new, unrelated request on a branch that already held a *completed* plan was:

- **falsely off-ramped** as "plan complete" → STOP (the user got no plan), or
- if the operator proceeded anyway, **silently clobbered** the prior plan's `spec`/`blueprint`/`task_plan`.

## What changed

- **New runner function `check_plan_resume "<request>" [--branch <b>]`** (`map_step_runner.py`): reports the existing artifacts (`findings`/`spec`/`task_plan`/`step_state`) **and** a `verdict`:
  - `no_plan` — no prior artifacts; plan fresh.
  - `resume` — request matches the existing plan's goal (or no request text supplied to compare) → apply the per-artifact resume rules.
  - `goal_mismatch` — request describes a **different** goal than the completed plan → do **not** report "plan complete", do **not** overwrite prior artifacts; recommend archiving/renaming `.map/<branch>/` (or planning on a fresh branch) with operator confirmation.
- Goal comparison is a **deterministic token-overlap (containment) heuristic** over the prior goal (extracted from `task_plan`/`spec`) vs the incoming request. It is intentionally **conservative**: it only diverts to `goal_mismatch` when both sides carry ≥2 significant tokens and containment is below the threshold — so a legitimate resume with a shorter paraphrase, or a bare `/map-plan` with no request text, is never falsely diverted.
- **Both provider surfaces** (Claude + Codex `map-plan` SKILL) call `check_plan_resume "$ARGUMENTS"` and branch on `verdict`; `plan-reference.md` documents the single-plan-per-branch layout and the `goal_mismatch` off-ramp.

## Tests

Added to `tests/test_map_step_runner.py`:
- `test_check_plan_resume_no_plan_when_branch_empty`
- `test_check_plan_resume_resume_on_matching_goal`
- `test_check_plan_resume_goal_mismatch_issue_166` (the #166 repro)
- `test_check_plan_resume_empty_request_defaults_to_resume`
- `test_check_plan_resume_one_word_request_does_not_divert`
- `test_check_plan_resume_cli_smoke` (subprocess CLI)

## Verification

- Edited only `templates_src/**/*.jinja`; ran `make render-templates`.
- `make check` green: 2311 passed, 3 skipped; `make check-render` ✅ (generated trees byte-match source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)