### PR TITLE
feat(cli): make `mapify upgrade` self-upgrade the CLI to the latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`mapify upgrade` now self-upgrades the CLI to the latest release.**
+  Previously `mapify upgrade` refreshed the *current project's* shipped MAP
+  files (and, on Codex projects, only printed a re-init hint). It now upgrades
+  the installed `mapify-cli` package itself: it auto-detects the install method
+  and runs `uv tool upgrade mapify-cli` (uv tool installs) or
+  `python -m pip install --upgrade mapify-cli` (pip installs). The command is
+  now provider-agnostic and writes no project files. When already on the latest
+  release it does nothing; when run from a source checkout / editable install,
+  self-upgrade is disabled. To refresh a project's shipped MAP files with the
+  new templates after upgrading, run `mapify init . --force`.
+
 ## [3.11.0] - 2026-06-12
 
 ### Added

--- a/docs/CLI_COMMAND_REFERENCE.md
+++ b/docs/CLI_COMMAND_REFERENCE.md
@@ -152,21 +152,28 @@ mapify check --debug
 
 ### `mapify upgrade`
 
-**Refresh MAP Framework files in the current project**
+**Upgrade the `mapify` CLI itself to the latest released version**
 
 ```bash
 mapify upgrade
 ```
 
-Refreshes shipped MAP files in the current project:
-- `.claude/agents/`
-- `.claude/commands/README.md` custom-command guidance
-- `.claude/skills/`
-- `.claude/references/`
-- `.claude/hooks/`
-- `.claude/settings.json`, `.claude/workflow-rules.json`, `.claude/ralph-loop-config.json`
+Self-upgrades the installed `mapify-cli` package (the tool) — it does **not**
+touch the files inside a project and is provider-agnostic:
 
-Preserves project-specific MCP selections in `.mcp.json` and `.claude/mcp_config.json`.
+- Auto-detects the install method and runs `uv tool upgrade mapify-cli`
+  (uv tool installs) or `python -m pip install --upgrade mapify-cli`
+  (pip installs).
+- When already on the latest release, it does nothing.
+- When running from a source checkout / editable install, self-upgrade is
+  disabled (update that clone with `git pull`).
+
+To refresh a project's shipped MAP files with the new templates after
+upgrading, run:
+
+```bash
+mapify init . --force
+```
 
 ---
 

--- a/docs/CLI_REFERENCE.json
+++ b/docs/CLI_REFERENCE.json
@@ -171,13 +171,13 @@
           ]
         },
         "upgrade": {
-          "description": "Refresh MAP Framework files in the current project",
+          "description": "Upgrade the mapify CLI itself to the latest released version",
           "usage": "mapify upgrade",
           "parameters": {},
           "examples": [
             {
               "command": "mapify upgrade",
-              "description": "Refresh shipped MAP files in the current project"
+              "description": "Self-upgrade mapify-cli to the latest release (uv tool / pip), then run 'mapify init . --force' to refresh project files"
             }
           ]
         }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -386,15 +386,26 @@ pip install -r requirements-semantic.txt
 
 ## Updating MAP Framework
 
-To update to the latest version:
+Upgrade the `mapify` CLI itself to the latest release:
 
 ```bash
-# Reinstall mapify with latest version
-uv tool upgrade mapify-cli
+# Self-upgrade the mapify CLI (auto-detects uv tool vs pip install)
+mapify upgrade
 
-# Update agents in existing project
+# Then refresh an existing project's shipped MAP files with the new templates
 mapify init . --force
 ```
+
+`mapify upgrade` detects how the tool was installed and runs the right command
+for you. The equivalent manual commands are:
+
+```bash
+uv tool upgrade mapify-cli                    # if installed via `uv tool`
+python -m pip install --upgrade mapify-cli    # if installed via pip
+```
+
+> Running `mapify upgrade` from a source checkout / editable install disables
+> self-upgrade — update that clone with `git pull` instead.
 
 ## Troubleshooting
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -242,12 +242,21 @@ All diagnostic commands auto-detect the active provider:
 ```bash
 mapify check    # Shows codex-specific tool checks
 mapify doctor   # Validates .codex/ structure
-mapify upgrade  # Guides re-init for codex projects
+```
+
+### Updating
+
+`mapify upgrade` self-upgrades the `mapify` CLI itself to the latest release
+(provider-agnostic — it writes no project files):
+
+```bash
+mapify upgrade        # uv tool upgrade / pip install --upgrade, auto-detected
+mapify init . --force # then refresh this project's shipped MAP files
 ```
 
 ### Provider coexistence
 
-Both `.claude/` and `.codex/` can exist in the same project. When both are present, `mapify check`/`doctor`/`upgrade` operate in codex mode. The default provider (without `--provider` flag) remains Claude Code.
+Both `.claude/` and `.codex/` can exist in the same project. When both are present, `mapify check`/`doctor` operate in codex mode. The default provider (without `--provider` flag) remains Claude Code.
 
 ## Navigation
 

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -70,12 +70,12 @@ from mapify_cli.delivery import (
     create_evaluator_content as create_evaluator_content,
     create_reflector_content as create_reflector_content,
     create_documentation_reviewer_content as create_documentation_reviewer_content,
-    create_agent_files,
-    create_reference_files,
-    create_command_files,
-    create_skill_files,
-    create_hook_files,
-    create_config_files,
+    create_agent_files as create_agent_files,
+    create_reference_files as create_reference_files,
+    create_command_files as create_command_files,
+    create_skill_files as create_skill_files,
+    create_hook_files as create_hook_files,
+    create_config_files as create_config_files,
     create_commands_dir as create_commands_dir,
 )
 from mapify_cli.config import (
@@ -1259,32 +1259,62 @@ def doctor(debug: bool = typer.Option(False, "--debug", help="Enable debug loggi
             console.print(f"  • {path_name}")
 
 
+def _mapify_install_kind() -> str:
+    """Classify how this mapify CLI is installed.
+
+    Returns one of:
+      - ``"uv-tool"``: installed via ``uv tool install`` (self-upgradeable with uv)
+      - ``"pip"``:     installed into a regular/virtualenv site-packages (pip -U)
+      - ``"source"``:  running from a source checkout / editable install
+        (self-upgrade disabled — the user owns the tree)
+    """
+    pkg = str(Path(__file__).resolve()).replace("\\", "/")
+    if "/uv/tools/" in pkg:
+        return "uv-tool"
+    if "/site-packages/" in pkg or "/dist-packages/" in pkg:
+        return "pip"
+    return "source"
+
+
+def _self_upgrade_command(kind: str) -> Optional[List[str]]:
+    """Return the argv that upgrades mapify-cli for ``kind``, or None if unknown."""
+    if kind == "uv-tool":
+        uv = shutil.which("uv")
+        return [uv, "tool", "upgrade", "mapify-cli"] if uv else None
+    if kind == "pip":
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "mapify-cli"]
+    return None
+
+
+def _run_self_upgrade(cmd: List[str]) -> int:
+    """Run the self-upgrade command, streaming its output. Returns the exit code.
+
+    Returns ``127`` when the executable is not found. Isolated into its own
+    function so tests can stub the subprocess invocation without patching the
+    module-level ``subprocess`` used by many other commands.
+    """
+    try:
+        return subprocess.run(cmd, check=False).returncode
+    except FileNotFoundError:
+        return 127
+
+
 @app.command()
 def upgrade():
-    """Upgrade MAP agents to the latest version."""
+    """Upgrade the mapify CLI itself to the latest released version.
+
+    This refreshes the installed ``mapify-cli`` package (the tool), not the
+    files inside a project. After upgrading, run ``mapify init . --force`` to
+    refresh a project's shipped MAP files with the new templates.
+    """
     show_banner()
-    project_path = Path.cwd()
 
-    if not is_map_initialized(project_path):
-        console.print(
-            "[yellow]MAP Framework not initialized in this directory.[/yellow]"
-        )
-        console.print("Run: [cyan]mapify init .[/cyan]")
-        raise typer.Exit(0)
-
-    if _detect_provider(project_path) == "codex":
-        console.print(
-            "[yellow]Codex projects: re-run "
-            "[cyan]mapify init . --provider codex --force[/cyan] to refresh.[/yellow]"
-        )
-        raise typer.Exit(0)
-
-    console.print("[cyan]Checking for updates...[/cyan]")
+    console.print("[cyan]Checking for the latest release...[/cyan]")
     latest_release = get_latest_release("azalio", "map-framework")
-    latest_version = None
+    latest_version: Optional[str] = None
 
     if latest_release and latest_release.get("tag_name"):
-        latest_version = latest_release["tag_name"].lstrip("v")
+        latest_version = str(latest_release["tag_name"]).lstrip("v")
         if parse_version(latest_version) > parse_version(__version__):
             console.print(
                 f"[yellow]New version available:[/yellow] {latest_version} "
@@ -1294,97 +1324,61 @@ def upgrade():
                 console.print(f"Release: [cyan]{latest_release['html_url']}[/cyan]")
         else:
             console.print(
-                f"[green]You are on the latest installed version ({__version__}).[/green]"
+                f"[green]Already on the latest release ({__version__}).[/green]"
             )
+            console.print("[dim]Nothing to upgrade.[/dim]")
+            raise typer.Exit(0)
     else:
         console.print(
-            "[dim]Could not fetch release metadata; refreshing local templates anyway.[/dim]"
+            "[dim]Could not fetch release metadata; attempting upgrade anyway.[/dim]"
         )
 
-    tracker = StepTracker("Upgrade MAP Framework Files")
+    kind = _mapify_install_kind()
 
-    # Track drift across all file types
-    from mapify_cli.delivery.managed_file_copier import DriftReport
+    if kind == "source":
+        source_root = Path(__file__).resolve().parents[2]
+        console.print(
+            "[yellow]Running from a source checkout — self-upgrade is disabled.[/yellow]"
+        )
+        console.print(f"[dim]Source: {source_root}[/dim]")
+        console.print(
+            "[dim]Update with [cyan]git pull[/cyan] "
+            "(then re-install the tool if needed).[/dim]"
+        )
+        raise typer.Exit(0)
 
-    drift_report = DriftReport()
-
-    existing_project_mcp = read_project_mcp_json(project_path / ".mcp.json")
-    existing_server_names = []
-    if existing_project_mcp:
-        existing_server_names = list(existing_project_mcp.get("mcpServers", {}).keys())
-
-    tracker.add("agents", "Refresh agent templates")
-    tracker.start("agents")
-    agent_count = create_agent_files(project_path, existing_server_names, drift_report)
-    tracker.complete("agents", f"{agent_count} files")
-
-    tracker.add("commands", "Refresh slash commands")
-    tracker.start("commands")
-    command_count = create_command_files(project_path, drift_report)
-    tracker.complete("commands", f"{command_count} files")
-
-    tracker.add("skills", "Refresh skills")
-    tracker.start("skills")
-    skill_count = create_skill_files(project_path)
-    tracker.complete("skills", f"{skill_count} folders")
-
-    tracker.add("references", "Refresh reference files")
-    tracker.start("references")
-    ref_count = create_reference_files(project_path, drift_report)
-    tracker.complete("references", f"{ref_count} files")
-
-    tracker.add("hooks", "Refresh shared hooks")
-    tracker.start("hooks")
-    hook_count = create_hook_files(project_path, drift_report)
-    tracker.complete("hooks", f"{hook_count} files")
-
-    tracker.add("configs", "Refresh config files")
-    tracker.start("configs")
-    config_count = create_config_files(project_path, drift_report)
-    tracker.complete("configs", f"{config_count} files")
-
-    tracker.add("permissions", "Merge local approvals")
-    tracker.start("permissions")
-    create_or_merge_project_settings_local(project_path)
-    tracker.complete("permissions", "settings.local.json updated")
-
-    if (project_path / ".claude" / "mcp_config.json").exists() or (
-        project_path / ".mcp.json"
-    ).exists():
-        tracker.add("mcp", "Preserve MCP config")
-        tracker.complete("mcp", "left unchanged")
+    cmd = _self_upgrade_command(kind)
+    if cmd is None:
+        console.print(
+            "[red]Could not determine how to upgrade mapify automatically.[/red]"
+        )
+        console.print(
+            "Upgrade manually: [cyan]uv tool upgrade mapify-cli[/cyan] "
+            "or [cyan]pip install --upgrade mapify-cli[/cyan]"
+        )
+        raise typer.Exit(1)
 
     console.print()
-    console.print(tracker.render())
+    console.print(f"[cyan]Upgrading mapify-cli...[/cyan] [dim]({' '.join(cmd)})[/dim]")
+    exit_code = _run_self_upgrade(cmd)
 
-    # Show drift warnings if any files were modified by the user
-    if drift_report.has_drift:
+    if exit_code != 0:
         console.print()
         console.print(
-            f"[yellow]⚠ {len(drift_report.drifted_files)} file(s) had local modifications:[/yellow]"
+            f"[red]Upgrade command failed (exit {exit_code}).[/red] Run it manually:"
         )
-        for r in drift_report.drifted_files:
-            try:
-                rel = r.dest.relative_to(project_path)
-            except ValueError:
-                rel = r.dest
-            backup_note = ""
-            if r.backed_up and r.backup_path:
-                try:
-                    backup_rel = r.backup_path.relative_to(project_path)
-                except ValueError:
-                    backup_rel = r.backup_path
-                backup_note = f" → backup: [cyan]{backup_rel}[/cyan]"
-            console.print(f"  [yellow]•[/yellow] {rel}{backup_note}")
-        console.print(
-            "[dim]Your changes were backed up to .bak files. "
-            "Review and re-apply any customizations if needed.[/dim]"
-        )
+        console.print(f"  [cyan]{' '.join(cmd)}[/cyan]")
+        raise typer.Exit(1)
 
+    target = latest_version or "the latest release"
     console.print()
-    console.print("[bold green]Upgrade complete.[/bold green]")
     console.print(
-        "[dim]Note: upgrade refreshes shipped MAP files but does not overwrite project-specific MCP selections.[/dim]"
+        f"[bold green]mapify upgraded[/bold green] (was {__version__}, now {target})."
+    )
+    console.print("[dim]Confirm with [cyan]mapify --version[/cyan].[/dim]")
+    console.print(
+        "[dim]To refresh this project's MAP files with the new templates, run "
+        "[cyan]mapify init . --force[/cyan].[/dim]"
     )
 
 

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 # Add src directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+import mapify_cli
 from mapify_cli.delivery import create_map_tools
 from mapify_cli import (
     app,
@@ -703,17 +704,19 @@ class TestDoctorCommand:
 class TestUpgradeCommand:
     """Test the upgrade command."""
 
+    @mock.patch("mapify_cli._run_self_upgrade", return_value=0)
+    @mock.patch(
+        "mapify_cli._self_upgrade_command",
+        return_value=["uv", "tool", "upgrade", "mapify-cli"],
+    )
+    @mock.patch("mapify_cli._mapify_install_kind", return_value="uv-tool")
     @mock.patch("mapify_cli.get_latest_release")
-    def test_upgrade_available(self, mock_get_latest, tmp_path):
-        """Test upgrade refreshes files and reports newer release."""
+    def test_upgrade_self_upgrades_when_newer(
+        self, mock_get_latest, _mock_kind, _mock_cmd, mock_run, tmp_path
+    ):
+        """A newer release self-upgrades the mapify CLI and writes no project files."""
+        del _mock_kind, _mock_cmd
         os.chdir(tmp_path)
-        init_result = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
-        assert init_result.exit_code == 0
-
-        actor_file = tmp_path / ".claude" / "agents" / "actor.md"
-        original_content = actor_file.read_text()
-        actor_file.write_text("stale content\n")
-
         mock_get_latest.return_value = {
             "tag_name": "v9.9.9",
             "html_url": "https://github.com/azalio/map-framework/releases/tag/v9.9.9",
@@ -721,43 +724,144 @@ class TestUpgradeCommand:
 
         result = runner.invoke(app, ["upgrade"])
 
-        assert result.exit_code == 0
-        assert "New version available" in result.stdout
-        assert "Upgrade complete" in result.stdout
-        # Compare content ignoring MAP-MANAGED metadata timestamps (which differ between init and upgrade)
-        import re
+        # Rich may hard-wrap output to terminal width; normalize whitespace
+        # before substring checks so wrapped lines still match.
+        normalized = " ".join(result.stdout.split())
+        assert result.exit_code == 0, result.stdout
+        assert "New version available" in normalized
+        assert "mapify upgraded" in normalized
+        # Directs users at the project-file refresh path
+        assert "mapify init . --force" in normalized
+        # Shelled out to the self-upgrade command exactly once
+        mock_run.assert_called_once_with(["uv", "tool", "upgrade", "mapify-cli"])
+        # upgrade no longer creates any project files
+        assert not (tmp_path / ".claude").exists()
 
-        def _strip_managed_meta(text):
-            return re.sub(r"<!-- MAP-MANAGED:.*?-->\n?", "", text)
-
-        assert _strip_managed_meta(actor_file.read_text()) == _strip_managed_meta(
-            original_content
-        )
-
+    @mock.patch("mapify_cli._run_self_upgrade")
     @mock.patch("mapify_cli.get_latest_release")
-    def test_upgrade_not_available(self, mock_get_latest, tmp_path):
-        """Test upgrade when already on latest version."""
+    def test_upgrade_already_latest_does_nothing(
+        self, mock_get_latest, mock_run, tmp_path
+    ):
+        """When already on the latest release, no upgrade command runs."""
         os.chdir(tmp_path)
-        init_result = runner.invoke(app, ["init", ".", "--no-git", "--mcp", "none"])
-        assert init_result.exit_code == 0
         mock_get_latest.return_value = {
-            "tag_name": "v3.5.0",
-            "html_url": "https://github.com/azalio/map-framework/releases/tag/v3.5.0",
+            "tag_name": "v0.0.1",
+            "html_url": "https://github.com/azalio/map-framework/releases/tag/v0.0.1",
         }
 
         result = runner.invoke(app, ["upgrade"])
 
         assert result.exit_code == 0
-        assert "latest installed version" in result.stdout
-        assert "Upgrade complete" in result.stdout
+        assert "Already on the latest release" in result.stdout
+        assert "Nothing to upgrade" in result.stdout
+        mock_run.assert_not_called()
 
-    def test_upgrade_not_initialized(self, tmp_path):
-        """Test upgrade in non-initialized directory."""
+    @mock.patch("mapify_cli._run_self_upgrade")
+    @mock.patch("mapify_cli._mapify_install_kind", return_value="source")
+    @mock.patch("mapify_cli.get_latest_release")
+    def test_upgrade_source_checkout_disabled(
+        self, mock_get_latest, _mock_kind, mock_run, tmp_path
+    ):
+        """A source checkout disables self-upgrade and runs no command."""
+        del _mock_kind
         os.chdir(tmp_path)
+        mock_get_latest.return_value = {"tag_name": "v9.9.9"}
+
         result = runner.invoke(app, ["upgrade"])
 
         assert result.exit_code == 0
-        assert "MAP Framework not initialized" in result.stdout
+        assert "self-upgrade is disabled" in result.stdout
+        mock_run.assert_not_called()
+
+    @mock.patch("mapify_cli._run_self_upgrade", return_value=1)
+    @mock.patch(
+        "mapify_cli._self_upgrade_command",
+        return_value=["uv", "tool", "upgrade", "mapify-cli"],
+    )
+    @mock.patch("mapify_cli._mapify_install_kind", return_value="uv-tool")
+    @mock.patch("mapify_cli.get_latest_release")
+    def test_upgrade_command_failure_exits_nonzero(
+        self, mock_get_latest, _mock_kind, _mock_cmd, _mock_run, tmp_path
+    ):
+        """A failing upgrade command surfaces a nonzero exit and a manual hint."""
+        del _mock_kind, _mock_cmd, _mock_run
+        os.chdir(tmp_path)
+        mock_get_latest.return_value = {"tag_name": "v9.9.9"}
+
+        result = runner.invoke(app, ["upgrade"])
+
+        assert result.exit_code == 1
+        assert "Upgrade command failed" in result.stdout
+
+    @mock.patch("mapify_cli.get_latest_release", return_value=None)
+    def test_upgrade_no_release_metadata_attempts_anyway(
+        self, _mock_get_latest, tmp_path
+    ):
+        """No release metadata: upgrade still proceeds past the version gate."""
+        del _mock_get_latest
+        os.chdir(tmp_path)
+        result = runner.invoke(app, ["upgrade"])
+
+        # In the pytest runtime mapify resolves to a source checkout, so the
+        # self-upgrade path short-circuits cleanly instead of shelling out.
+        normalized = " ".join(result.stdout.split())
+        assert result.exit_code == 0
+        assert "Could not fetch release metadata" in normalized
+
+
+class TestSelfUpgradeHelpers:
+    """Unit tests for install-kind detection and the upgrade-command builder."""
+
+    def test_install_kind_uv_tool(self, monkeypatch):
+        monkeypatch.setattr(
+            mapify_cli,
+            "__file__",
+            "/home/u/.local/share/uv/tools/mapify-cli/lib/"
+            "python3.11/site-packages/mapify_cli/__init__.py",
+        )
+        assert mapify_cli._mapify_install_kind() == "uv-tool"
+
+    def test_install_kind_pip(self, monkeypatch):
+        monkeypatch.setattr(
+            mapify_cli,
+            "__file__",
+            "/home/u/.venv/lib/python3.11/site-packages/mapify_cli/__init__.py",
+        )
+        assert mapify_cli._mapify_install_kind() == "pip"
+
+    def test_install_kind_source(self, monkeypatch):
+        monkeypatch.setattr(
+            mapify_cli,
+            "__file__",
+            "/home/u/gitroot/map-framework/src/mapify_cli/__init__.py",
+        )
+        assert mapify_cli._mapify_install_kind() == "source"
+
+    def test_self_upgrade_command_uv_tool(self, monkeypatch):
+        monkeypatch.setattr(mapify_cli.shutil, "which", lambda *_: "/usr/bin/uv")
+        assert mapify_cli._self_upgrade_command("uv-tool") == [
+            "/usr/bin/uv",
+            "tool",
+            "upgrade",
+            "mapify-cli",
+        ]
+
+    def test_self_upgrade_command_uv_tool_missing_uv(self, monkeypatch):
+        monkeypatch.setattr(mapify_cli.shutil, "which", lambda *_: None)
+        assert mapify_cli._self_upgrade_command("uv-tool") is None
+
+    def test_self_upgrade_command_pip(self):
+        assert mapify_cli._self_upgrade_command("pip") == [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "mapify-cli",
+        ]
+
+    def test_self_upgrade_command_source_is_none(self):
+        assert mapify_cli._self_upgrade_command("source") is None
 
 
 class TestAgentCreation:
@@ -1721,18 +1825,21 @@ class TestCodexProvider:
     # AC-21: upgrade on codex project must not create .claude/             #
     # ------------------------------------------------------------------ #
 
-    def test_ac21_upgrade_codex_project_no_claude(self, codex_project):
-        """AC-21: 'mapify upgrade' on codex project must not create .claude/."""
+    @mock.patch("mapify_cli.get_latest_release")
+    def test_ac21_upgrade_codex_project_no_claude(self, mock_get_latest, codex_project):
+        """AC-21: 'mapify upgrade' upgrades the CLI only and creates no project files.
+
+        upgrade is now provider-agnostic and never writes into the project, so a
+        codex project stays codex-only — no .claude/ is ever created.
+        """
+        mock_get_latest.return_value = {"tag_name": "v9.9.9"}
         local_runner = CliRunner()
         os.chdir(codex_project)
         result = local_runner.invoke(app, ["upgrade"])
         assert result.exit_code == 0, f"upgrade failed: {result.output}"
         assert not (
             codex_project / ".claude"
-        ).exists(), ".claude/ must NOT be created when upgrading a codex project"
-        assert (
-            "mapify init . --provider codex --force" in result.output
-        ), "upgrade must tell codex users to re-run init with --provider codex"
+        ).exists(), ".claude/ must NOT be created by upgrade on a codex project"
 
     def test_ac22_map_efficient_state_machine_markers(self, codex_project):
         """AC-22: $map-efficient documents the required state-machine commands."""


### PR DESCRIPTION
## Summary

`mapify upgrade` now **upgrades the `mapify` CLI itself** to the latest released version, instead of refreshing the current project's shipped MAP files.

Previously `mapify upgrade` refreshed `.claude/`/`.codex/` files in the project, and on Codex projects only printed a `mapify init . --provider codex --force` hint — which made it a confusing near no-op in mixed/dev trees (e.g. running it in the map-framework source repo detected `codex` and bailed without doing anything useful).

## What changed

**Runtime (`src/mapify_cli/__init__.py`)**
- `upgrade()` rewritten: fetches the latest GitHub release, compares to the installed version, and self-upgrades the `mapify-cli` package when newer.
- New helpers:
  - `_mapify_install_kind()` — classifies the install: `uv-tool` (path under `/uv/tools/`), `pip` (under `site-packages`), or `source` (checkout/editable).
  - `_self_upgrade_command(kind)` — builds `uv tool upgrade mapify-cli` or `python -m pip install --upgrade mapify-cli`.
  - `_run_self_upgrade(cmd)` — runs it, streams output, returns the exit code.
- Edge cases: already-latest → no-op; source checkout → self-upgrade disabled (hint: `git pull`); failed upgrade → nonzero exit + manual command.
- The command is now **provider-agnostic** and **writes no project files**. Project-file refresh moves to `mapify init . --force` (upgrade prints the hint).

**Tests (`tests/test_mapify_cli.py`)**
- Rewrote `TestUpgradeCommand` (self-upgrade-when-newer, already-latest no-op, source-disabled, failure→exit 1, no-metadata).
- Added `TestSelfUpgradeHelpers` (install-kind detection + command builder).
- Updated AC-21 codex test to the new provider-agnostic, no-file-write contract.

**Docs**
- CHANGELOG (Unreleased → Changed), `docs/USAGE.md`, `docs/INSTALL.md`, `docs/CLI_COMMAND_REFERENCE.md`, `docs/CLI_REFERENCE.json`.

## Verification
- `make check` (lint + test + check-render): **2413 passed, 3 skipped**; generated trees match `templates_src`.
- `ruff`: clean. `pyright`: **0 errors, 0 warnings, 0 informations**.
- Live `mapify upgrade` from the repo (source path): correctly hit the GitHub API → "Already on the latest release (3.11.0)".
- No template trees touched — `render-templates` not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)