### PR TITLE
fix(release): align validation gate with make check

### DIFF
--- a/.claude/skills/map-release/SKILL.md
+++ b/.claude/skills/map-release/SKILL.md
@@ -87,18 +87,14 @@ Execute all validation gates in parallel where possible:
 #### Gate 1-4: Code Quality Checks
 
 ```bash
-# Run checks sequentially (all must succeed)
-pytest tests/ --cov=src/mapify_cli --cov-report=term-missing && \
-black src/ tests/ --check && \
-ruff check src/ tests/ && \
-mypy src/
+# Run the maintained project gate (all checks must succeed)
+make check
 ```
 
 **Expected Results:**
 - ✅ All tests pass (100% success rate)
-- ✅ No black formatting issues
-- ✅ No ruff linting errors
-- ✅ No mypy type checking errors
+- ✅ `ruff`, `mypy`, `pyright`, and hook linting pass
+- ✅ Rendered templates match `templates_src`
 
 **If any check fails:** ABORT release, fix issues first.
 
@@ -106,10 +102,10 @@ mypy src/
 
 ```bash
 # Build package
-python -m build
+uv run --with build python -m build
 
 # Verify package integrity
-twine check dist/*
+uv run --with twine twine check dist/*
 ```
 
 **Expected Results:**
@@ -1205,7 +1201,7 @@ You should:
 1. **Phase 1 - Pre-Release Validation:**
    ```bash
    # Run all 12 validation gates
-   pytest tests/ && black --check src/ && ruff check src/ && mypy src/ && ...
+   make check && uv run --with build python -m build && uv run --with twine twine check dist/* && ...
    # Verify CI passed on main
    gh run list --branch main --limit 1
    ```

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -35,14 +35,12 @@ assignees: ''
 
 ### 1.1 Code Quality Checks
 
-- [ ] Run full test suite: `pytest tests/ --cov=src/mapify_cli --cov-report=term-missing`
+- [ ] Run full maintained gate: `make check`
 - [ ] ⚠️ All tests pass (100% success rate) - CRITICAL
-- [ ] Run code formatters: `black src/ tests/ --check`
-- [ ] Run linters: `ruff check src/ tests/`
-- [ ] Run type checker: `mypy src/`
+- [ ] Linters, type checkers, hook linting, and render check pass
 - [ ] No linting or type errors
-- [ ] Build package locally: `python -m build`
-- [ ] Validate package: `twine check dist/*`
+- [ ] Build package locally: `uv run --with build python -m build`
+- [ ] Validate package: `uv run --with twine twine check dist/*`
 - [ ] Package builds without errors
 
 ### 1.2 Documentation Review

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,23 +50,19 @@ Before starting the release process, verify all requirements are met:
 ### 1. Code Quality Checks
 
 ```bash
-# Run full CI/CD test suite locally
-pytest tests/ --cov=src/mapify_cli --cov-report=term-missing
-
-# Run linters
-black src/ tests/ --check
-ruff check src/ tests/
-mypy src/
+# Run the maintained CI/CD gate locally
+make check
 
 # Verify package builds successfully
-python -m build
-twine check dist/*
+uv run --with build python -m build
+uv run --with twine twine check dist/*
 ```
 
 **Expected Results**:
 - ✅ All tests pass (100% success rate)
 - ✅ No linting errors
 - ✅ Type checking passes
+- ✅ Rendered templates are up to date
 - ✅ Package builds without errors
 - ✅ `twine check` reports no issues
 

--- a/src/mapify_cli/templates/skills/map-release/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-release/SKILL.md
@@ -87,18 +87,14 @@ Execute all validation gates in parallel where possible:
 #### Gate 1-4: Code Quality Checks
 
 ```bash
-# Run checks sequentially (all must succeed)
-pytest tests/ --cov=src/mapify_cli --cov-report=term-missing && \
-black src/ tests/ --check && \
-ruff check src/ tests/ && \
-mypy src/
+# Run the maintained project gate (all checks must succeed)
+make check
 ```
 
 **Expected Results:**
 - ✅ All tests pass (100% success rate)
-- ✅ No black formatting issues
-- ✅ No ruff linting errors
-- ✅ No mypy type checking errors
+- ✅ `ruff`, `mypy`, `pyright`, and hook linting pass
+- ✅ Rendered templates match `templates_src`
 
 **If any check fails:** ABORT release, fix issues first.
 
@@ -106,10 +102,10 @@ mypy src/
 
 ```bash
 # Build package
-python -m build
+uv run --with build python -m build
 
 # Verify package integrity
-twine check dist/*
+uv run --with twine twine check dist/*
 ```
 
 **Expected Results:**
@@ -1205,7 +1201,7 @@ You should:
 1. **Phase 1 - Pre-Release Validation:**
    ```bash
    # Run all 12 validation gates
-   pytest tests/ && black --check src/ && ruff check src/ && mypy src/ && ...
+   make check && uv run --with build python -m build && uv run --with twine twine check dist/* && ...
    # Verify CI passed on main
    gh run list --branch main --limit 1
    ```

--- a/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
@@ -87,18 +87,14 @@ Execute all validation gates in parallel where possible:
 #### Gate 1-4: Code Quality Checks
 
 ```bash
-# Run checks sequentially (all must succeed)
-pytest tests/ --cov=src/mapify_cli --cov-report=term-missing && \
-black src/ tests/ --check && \
-ruff check src/ tests/ && \
-mypy src/
+# Run the maintained project gate (all checks must succeed)
+make check
 ```
 
 **Expected Results:**
 - ✅ All tests pass (100% success rate)
-- ✅ No black formatting issues
-- ✅ No ruff linting errors
-- ✅ No mypy type checking errors
+- ✅ `ruff`, `mypy`, `pyright`, and hook linting pass
+- ✅ Rendered templates match `templates_src`
 
 **If any check fails:** ABORT release, fix issues first.
 
@@ -106,10 +102,10 @@ mypy src/
 
 ```bash
 # Build package
-python -m build
+uv run --with build python -m build
 
 # Verify package integrity
-twine check dist/*
+uv run --with twine twine check dist/*
 ```
 
 **Expected Results:**
@@ -1205,7 +1201,7 @@ You should:
 1. **Phase 1 - Pre-Release Validation:**
    ```bash
    # Run all 12 validation gates
-   pytest tests/ && black --check src/ && ruff check src/ && mypy src/ && ...
+   make check && uv run --with build python -m build && uv run --with twine twine check dist/* && ...
    # Verify CI passed on main
    gh run list --branch main --limit 1
    ```


### PR DESCRIPTION
## Summary
- Replace the stale `black src/ tests/ --check` release gate with the maintained `make check` validation path.
- Use `uv run --with build` and `uv run --with twine` for package validation commands.
- Sync the release skill template, rendered skill copy, release docs, and release issue checklist.

Closes #186

## Validation
- `uv run pytest tests/test_template_render.py tests/test_skills.py -v`
- `make check`
- `uv run --with build python -m build && uv run --with twine twine check dist/*`