### PR TITLE
fix(release): ignore changelog-only commits in heuristic

### DIFF
--- a/.claude/skills/map-release/SKILL.md
+++ b/.claude/skills/map-release/SKILL.md
@@ -194,13 +194,15 @@ LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 if [[ -n "$LAST_TAG" ]]; then
   echo "Checking CHANGELOG completeness since $LAST_TAG..."
 
-  # Get commits since last tag (exclude merge commits)
-  COMMITS_SINCE=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | wc -l | tr -d ' ')
+  # Get user-visible commits since last tag. Exclude merge commits plus release-note
+  # maintenance commits, which otherwise make this heuristic chase its own fixes.
+  COMMITS_SINCE=$(git log ${LAST_TAG}..HEAD --no-merges --format="%s" | awk '!/^(docs\(changelog\)|chore\(release\):)/ { count++ } END { print count + 0 }')
 
   # Count CHANGELOG entries in [Unreleased] section
   CHANGELOG_ENTRIES=$(awk '/## \[Unreleased\]/,/## \[/' CHANGELOG.md | grep -cE "^- " || echo "0")
 
-  echo "Commits since $LAST_TAG: $COMMITS_SINCE"
+  echo "Counted commits since $LAST_TAG: $COMMITS_SINCE"
+  echo "(excluding docs(changelog) and chore(release) maintenance commits)"
   echo "CHANGELOG entries: $CHANGELOG_ENTRIES"
 
   # If significant gap, show commits for review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `map-release` skill, release guide, and release checklist use `make check`
   plus explicit `uv run --with build` / `uv run --with twine` package checks
   instead of the stale Black-specific gate that failed on generated files (#186).
+- **Release changelog completeness checks ignore release-note maintenance commits.**
+  The `map-release` heuristic no longer counts `docs(changelog)` or
+  `chore(release)` commits as user-visible changes that need their own
+  changelog bullet (#191).
 
 ## [3.12.1] - 2026-06-12
 

--- a/src/mapify_cli/templates/skills/map-release/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-release/SKILL.md
@@ -194,13 +194,15 @@ LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 if [[ -n "$LAST_TAG" ]]; then
   echo "Checking CHANGELOG completeness since $LAST_TAG..."
 
-  # Get commits since last tag (exclude merge commits)
-  COMMITS_SINCE=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | wc -l | tr -d ' ')
+  # Get user-visible commits since last tag. Exclude merge commits plus release-note
+  # maintenance commits, which otherwise make this heuristic chase its own fixes.
+  COMMITS_SINCE=$(git log ${LAST_TAG}..HEAD --no-merges --format="%s" | awk '!/^(docs\(changelog\)|chore\(release\):)/ { count++ } END { print count + 0 }')
 
   # Count CHANGELOG entries in [Unreleased] section
   CHANGELOG_ENTRIES=$(awk '/## \[Unreleased\]/,/## \[/' CHANGELOG.md | grep -cE "^- " || echo "0")
 
-  echo "Commits since $LAST_TAG: $COMMITS_SINCE"
+  echo "Counted commits since $LAST_TAG: $COMMITS_SINCE"
+  echo "(excluding docs(changelog) and chore(release) maintenance commits)"
   echo "CHANGELOG entries: $CHANGELOG_ENTRIES"
 
   # If significant gap, show commits for review

--- a/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
@@ -194,13 +194,15 @@ LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 if [[ -n "$LAST_TAG" ]]; then
   echo "Checking CHANGELOG completeness since $LAST_TAG..."
 
-  # Get commits since last tag (exclude merge commits)
-  COMMITS_SINCE=$(git log ${LAST_TAG}..HEAD --oneline --no-merges | wc -l | tr -d ' ')
+  # Get user-visible commits since last tag. Exclude merge commits plus release-note
+  # maintenance commits, which otherwise make this heuristic chase its own fixes.
+  COMMITS_SINCE=$(git log ${LAST_TAG}..HEAD --no-merges --format="%s" | awk '!/^(docs\(changelog\)|chore\(release\):)/ { count++ } END { print count + 0 }')
 
   # Count CHANGELOG entries in [Unreleased] section
   CHANGELOG_ENTRIES=$(awk '/## \[Unreleased\]/,/## \[/' CHANGELOG.md | grep -cE "^- " || echo "0")
 
-  echo "Commits since $LAST_TAG: $COMMITS_SINCE"
+  echo "Counted commits since $LAST_TAG: $COMMITS_SINCE"
+  echo "(excluding docs(changelog) and chore(release) maintenance commits)"
   echo "CHANGELOG entries: $CHANGELOG_ENTRIES"
 
   # If significant gap, show commits for review


### PR DESCRIPTION
## Summary
- Exclude `docs(changelog)` and `chore(release)` subjects from the release skill's CHANGELOG completeness count.
- Keep full commit review in the warning path while preventing the heuristic from chasing release-note maintenance commits.
- Add the release note for the fix.

Closes #191

## Validation
- `uv run pytest tests/test_template_render.py tests/test_skills.py -v`
- `make check-render`
- `git diff --check`