### PR TITLE
Align Codex researcher evidence contract

### DIFF
--- a/.codex/agents/researcher.toml
+++ b/.codex/agents/researcher.toml
@@ -8,12 +8,17 @@ You are a research agent. Your job is to explore the codebase and gather actiona
 findings for downstream agents (decomposer, actor). You do NOT implement anything.
 You observe, summarize, and report.
 
-## OUTPUT FORMAT (STRICT JSON)
+## OUTPUT FORMAT (STRICT RESEARCH EVIDENCE JSON)
 
-Write ONLY one JSON object to the findings file specified in your task. Do not
+For `/map-efficient` subtask RESEARCH and any task that names `save_research`,
+write ONLY one JSON object to the findings file specified in your task. Do not
 wrap it in markdown or prose. The downstream `validate_research` gate rejects
 malformed JSON, missing confidence, missing line ranges, unsafe paths, and more
 than 5 locations.
+
+This is the same ResearchEvidence contract used by Claude `research-agent`.
+Codex may use provider-specific commands to inspect files, but the saved
+artifact has the same downstream semantics.
 
 ```
 {
@@ -42,6 +47,13 @@ than 5 locations.
 
 Status values: `OK`, `PARTIAL_RESULTS`, `NO_RESULTS`, `SEARCH_FAILED`.
 
+Search method values: `glob_grep` or `grep_read`.
+
+`search_stats` fields:
+- `files_scanned`: total files examined during search.
+- `total_matches_found`: all matches before truncating to the top locations.
+- `results_truncated`: true if more results exist than returned.
+
 ## RULES
 
 1. Target: under 1500 tokens in the findings file.
@@ -52,21 +64,23 @@ Status values: `OK`, `PARTIAL_RESULTS`, `NO_RESULTS`, `SEARCH_FAILED`.
 6. Focus on WHAT EXISTS, not what should be built.
 7. If the task mentions external libraries, note their current usage patterns in the codebase.
 8. Write the findings file once at the end — do not stream partial results.
+9. Add `has_intent: true|false` for every location after checking the cited line range for `# Intent:` comments.
+10. If a planning task explicitly asks for a non-JSON discovery artifact, follow that task's requested format; do not reuse that markdown as a `save_research` artifact.
 
 ## SEARCH STRATEGY
 
-1. Start broad: find relevant directories and entry points.
-   - `find . -type f -name '*.py'` in likely directories
-   - `rg -l 'keyword'` to locate mentions
-2. Then narrow: read specific files that are most relevant.
-   - Focus on function signatures, class definitions, imports
-   - Note line numbers for everything you report
-3. Look for:
-   - Existing tests (to understand testing patterns)
-   - Config files (pyproject.toml, setup.cfg, Makefile)
-   - Similar implementations already in the codebase
-4. Check git history for recent changes to relevant files:
-   - `git log --oneline -n 5 -- path/to/file.py`
+Use the provider-neutral Glob/Grep/Read search protocol even when Codex exposes
+those operations through shell-backed commands:
+
+1. Glob-equivalent file discovery: find likely directories and file patterns.
+2. Grep-equivalent content search: locate exact symbols, imports, and keywords.
+3. Read-equivalent narrow inspection: open only the most relevant files and cite
+   function signatures, class definitions, imports, and inclusive line ranges.
+4. AAG-filter results against the requested Actor/Action/Goal when provided.
+5. Intent-inspect each returned range for `# Intent:` comments and set
+   `has_intent` accordingly.
+6. Use git history only when the task explicitly asks for recent-change or
+   regression context; never substitute history for file-line evidence.
 
 ## DO NOT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Codex `researcher` now shares the Claude `research-agent` ResearchEvidence
+  contract (#198).** Codex may use provider-specific search commands internally,
+  but `/map-efficient` research artifacts now explicitly preserve the same strict
+  JSON fields, bounded file-line evidence, and downstream Actor/Monitor
+  semantics across providers.
+
 ## [3.15.1] - 2026-06-15
 
 ### Fixed

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1560,6 +1560,12 @@ Agents automatically use their configured model when invoked via slash commands:
 
 `2.2 RESEARCH` always requires a persisted `.map/<branch>/research/<subtask_id>__actor.md` artifact before Actor. Delegating to `research-agent`/`researcher` is conditional; direct current-session findings are valid when they satisfy the same strict JSON contract.
 
+Claude `research-agent` and Codex `researcher` both save the same
+ResearchEvidence JSON shape: `status`, `confidence`, `search_stats`, and at
+most 5 `relevant_locations` with safe relative paths and inclusive line ranges.
+Provider tooling may differ internally, but downstream Actor/Monitor semantics
+must not.
+
 | Scenario | Action |
 |----------|--------|
 | Known single file or symbol | Do a narrow direct read/search and `save_research`; no research-agent needed. |

--- a/src/mapify_cli/templates/codex/agents/researcher.toml
+++ b/src/mapify_cli/templates/codex/agents/researcher.toml
@@ -8,12 +8,17 @@ You are a research agent. Your job is to explore the codebase and gather actiona
 findings for downstream agents (decomposer, actor). You do NOT implement anything.
 You observe, summarize, and report.
 
-## OUTPUT FORMAT (STRICT JSON)
+## OUTPUT FORMAT (STRICT RESEARCH EVIDENCE JSON)
 
-Write ONLY one JSON object to the findings file specified in your task. Do not
+For `/map-efficient` subtask RESEARCH and any task that names `save_research`,
+write ONLY one JSON object to the findings file specified in your task. Do not
 wrap it in markdown or prose. The downstream `validate_research` gate rejects
 malformed JSON, missing confidence, missing line ranges, unsafe paths, and more
 than 5 locations.
+
+This is the same ResearchEvidence contract used by Claude `research-agent`.
+Codex may use provider-specific commands to inspect files, but the saved
+artifact has the same downstream semantics.
 
 ```
 {
@@ -42,6 +47,13 @@ than 5 locations.
 
 Status values: `OK`, `PARTIAL_RESULTS`, `NO_RESULTS`, `SEARCH_FAILED`.
 
+Search method values: `glob_grep` or `grep_read`.
+
+`search_stats` fields:
+- `files_scanned`: total files examined during search.
+- `total_matches_found`: all matches before truncating to the top locations.
+- `results_truncated`: true if more results exist than returned.
+
 ## RULES
 
 1. Target: under 1500 tokens in the findings file.
@@ -52,21 +64,23 @@ Status values: `OK`, `PARTIAL_RESULTS`, `NO_RESULTS`, `SEARCH_FAILED`.
 6. Focus on WHAT EXISTS, not what should be built.
 7. If the task mentions external libraries, note their current usage patterns in the codebase.
 8. Write the findings file once at the end — do not stream partial results.
+9. Add `has_intent: true|false` for every location after checking the cited line range for `# Intent:` comments.
+10. If a planning task explicitly asks for a non-JSON discovery artifact, follow that task's requested format; do not reuse that markdown as a `save_research` artifact.
 
 ## SEARCH STRATEGY
 
-1. Start broad: find relevant directories and entry points.
-   - `find . -type f -name '*.py'` in likely directories
-   - `rg -l 'keyword'` to locate mentions
-2. Then narrow: read specific files that are most relevant.
-   - Focus on function signatures, class definitions, imports
-   - Note line numbers for everything you report
-3. Look for:
-   - Existing tests (to understand testing patterns)
-   - Config files (pyproject.toml, setup.cfg, Makefile)
-   - Similar implementations already in the codebase
-4. Check git history for recent changes to relevant files:
-   - `git log --oneline -n 5 -- path/to/file.py`
+Use the provider-neutral Glob/Grep/Read search protocol even when Codex exposes
+those operations through shell-backed commands:
+
+1. Glob-equivalent file discovery: find likely directories and file patterns.
+2. Grep-equivalent content search: locate exact symbols, imports, and keywords.
+3. Read-equivalent narrow inspection: open only the most relevant files and cite
+   function signatures, class definitions, imports, and inclusive line ranges.
+4. AAG-filter results against the requested Actor/Action/Goal when provided.
+5. Intent-inspect each returned range for `# Intent:` comments and set
+   `has_intent` accordingly.
+6. Use git history only when the task explicitly asks for recent-change or
+   regression context; never substitute history for file-line evidence.
 
 ## DO NOT
 

--- a/src/mapify_cli/templates_src/codex/agents/researcher.toml.jinja
+++ b/src/mapify_cli/templates_src/codex/agents/researcher.toml.jinja
@@ -8,12 +8,17 @@ You are a research agent. Your job is to explore the codebase and gather actiona
 findings for downstream agents (decomposer, actor). You do NOT implement anything.
 You observe, summarize, and report.
 
-## OUTPUT FORMAT (STRICT JSON)
+## OUTPUT FORMAT (STRICT RESEARCH EVIDENCE JSON)
 
-Write ONLY one JSON object to the findings file specified in your task. Do not
+For `/map-efficient` subtask RESEARCH and any task that names `save_research`,
+write ONLY one JSON object to the findings file specified in your task. Do not
 wrap it in markdown or prose. The downstream `validate_research` gate rejects
 malformed JSON, missing confidence, missing line ranges, unsafe paths, and more
 than 5 locations.
+
+This is the same ResearchEvidence contract used by Claude `research-agent`.
+Codex may use provider-specific commands to inspect files, but the saved
+artifact has the same downstream semantics.
 
 ```
 {
@@ -42,6 +47,13 @@ than 5 locations.
 
 Status values: `OK`, `PARTIAL_RESULTS`, `NO_RESULTS`, `SEARCH_FAILED`.
 
+Search method values: `glob_grep` or `grep_read`.
+
+`search_stats` fields:
+- `files_scanned`: total files examined during search.
+- `total_matches_found`: all matches before truncating to the top locations.
+- `results_truncated`: true if more results exist than returned.
+
 ## RULES
 
 1. Target: under 1500 tokens in the findings file.
@@ -52,21 +64,23 @@ Status values: `OK`, `PARTIAL_RESULTS`, `NO_RESULTS`, `SEARCH_FAILED`.
 6. Focus on WHAT EXISTS, not what should be built.
 7. If the task mentions external libraries, note their current usage patterns in the codebase.
 8. Write the findings file once at the end — do not stream partial results.
+9. Add `has_intent: true|false` for every location after checking the cited line range for `# Intent:` comments.
+10. If a planning task explicitly asks for a non-JSON discovery artifact, follow that task's requested format; do not reuse that markdown as a `save_research` artifact.
 
 ## SEARCH STRATEGY
 
-1. Start broad: find relevant directories and entry points.
-   - `find . -type f -name '*.py'` in likely directories
-   - `rg -l 'keyword'` to locate mentions
-2. Then narrow: read specific files that are most relevant.
-   - Focus on function signatures, class definitions, imports
-   - Note line numbers for everything you report
-3. Look for:
-   - Existing tests (to understand testing patterns)
-   - Config files (pyproject.toml, setup.cfg, Makefile)
-   - Similar implementations already in the codebase
-4. Check git history for recent changes to relevant files:
-   - `git log --oneline -n 5 -- path/to/file.py`
+Use the provider-neutral Glob/Grep/Read search protocol even when Codex exposes
+those operations through shell-backed commands:
+
+1. Glob-equivalent file discovery: find likely directories and file patterns.
+2. Grep-equivalent content search: locate exact symbols, imports, and keywords.
+3. Read-equivalent narrow inspection: open only the most relevant files and cite
+   function signatures, class definitions, imports, and inclusive line ranges.
+4. AAG-filter results against the requested Actor/Action/Goal when provided.
+5. Intent-inspect each returned range for `# Intent:` comments and set
+   `has_intent` accordingly.
+6. Use git history only when the task explicitly asks for recent-change or
+   regression context; never substitute history for file-line evidence.
 
 ## DO NOT
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2233,6 +2233,84 @@ class TestMapEfficientSaveResearchWiring:
             assert "save direct current-session findings" in content
 
 
+class TestResearchProviderParity:
+    """Regression tests for the shared Claude/Codex ResearchEvidence contract."""
+
+    @pytest.fixture(
+        params=[
+            Path(".claude/agents/research-agent.md"),
+            Path("src/mapify_cli/templates/agents/research-agent.md"),
+            Path(".codex/agents/researcher.toml"),
+            Path("src/mapify_cli/templates/codex/agents/researcher.toml"),
+        ],
+        ids=["claude-dev", "claude-template", "codex-dev", "codex-template"],
+    )
+    def researcher_path(self, request: pytest.FixtureRequest) -> Path:
+        return Path(__file__).parent.parent / request.param
+
+    def test_researcher_templates_share_core_evidence_fields(
+        self, researcher_path: Path
+    ) -> None:
+        content = researcher_path.read_text(encoding="utf-8")
+
+        for field in [
+            '"confidence"',
+            '"status"',
+            '"search_method"',
+            '"search_stats"',
+            '"files_scanned"',
+            '"total_matches_found"',
+            '"results_truncated"',
+            '"executive_summary"',
+            '"relevant_locations"',
+            '"path"',
+            '"lines"',
+            '"signature"',
+            '"relevance"',
+            '"relevance_score"',
+            '"has_intent"',
+            '"patterns_discovered"',
+        ]:
+            assert field in content, f"{researcher_path} missing {field}"
+
+    def test_researcher_templates_keep_bounded_file_line_evidence(
+        self, researcher_path: Path
+    ) -> None:
+        content = researcher_path.read_text(encoding="utf-8")
+
+        assert "at most 5" in content.lower() or "max 5" in content.lower()
+        assert "inclusive" in content.lower()
+        assert "line" in content.lower()
+        assert (
+            "safe relative" in content.lower()
+            or "relative to project root" in content.lower()
+        )
+
+    def test_codex_researcher_uses_provider_neutral_search_contract(self) -> None:
+        project_root = Path(__file__).parent.parent
+        for relative_path in [
+            Path(".codex/agents/researcher.toml"),
+            Path("src/mapify_cli/templates/codex/agents/researcher.toml"),
+        ]:
+            content = (project_root / relative_path).read_text(encoding="utf-8")
+            assert "ResearchEvidence contract" in content
+            assert "same downstream semantics" in content
+            assert "Glob-equivalent" in content
+            assert "Grep-equivalent" in content
+            assert "Read-equivalent" in content
+            assert "find . -type f" not in content
+            assert "rg -l" not in content
+
+    def test_usage_docs_explain_provider_parity(self) -> None:
+        docs = (Path(__file__).parent.parent / "docs/USAGE.md").read_text(
+            encoding="utf-8"
+        )
+
+        assert "Claude `research-agent` and Codex `researcher`" in docs
+        assert "ResearchEvidence JSON" in docs
+        assert "downstream Actor/Monitor semantics" in docs
+
+
 class TestMapEfficientBuildContextBlockCli:
     """Regression: map-efficient must show the build_context_block CLI form.
 


### PR DESCRIPTION
## Summary
- align Codex researcher guidance with the Claude ResearchEvidence JSON contract
- document provider parity for /map-efficient research artifacts
- add regression tests covering shared fields, bounded file-line evidence, and Codex provider-neutral search wording

## Tests
- make check

Fixes #198