### PR TITLE
Teach Actor to consume research before broad search

### DIFF
--- a/.agents/skills/map-efficient/SKILL.md
+++ b/.agents/skills/map-efficient/SKILL.md
@@ -175,6 +175,13 @@ python3 .map/scripts/map_step_runner.py validate_research "$BRANCH" "$SUBTASK_ID
 python3 .map/scripts/map_orchestrator.py validate_step "$STEP_ID"
 ```
 
+Actor must consume high-confidence research before re-exploring: if
+`confidence >= 0.7` and `relevant_locations` are present, first read 1-3 cited
+ranges that match the subtask. Any later repository-wide `rg`/`grep`/`find`/
+`git grep` needs a stated reason, such as low confidence, missing symbol, failed
+narrow read, changed hypothesis, or stale research. Low-confidence or
+location-free research may broaden sooner, but the gap must be named.
+
 ### TEST_WRITER And TEST_FAIL_GATE
 
 Only run these in TDD mode. Write failing tests first, run them, and proceed to
@@ -202,6 +209,11 @@ Before Monitor, run the required pre-dispatch gates from
 python3 .map/scripts/map_step_runner.py detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" --declared "$FILES_CSV"
 python3 .map/scripts/map_step_runner.py detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"
 ```
+
+If you captured Actor shell/search commands, optionally pipe them into
+`python3 .map/scripts/map_step_runner.py detect_research_consumption_drift "$BRANCH" "$SUBTASK_ID"`.
+This detector is advisory only: it reports repeated repository-wide searches
+after high-confidence research without blocking normal work.
 
 ### MONITOR
 

--- a/.claude/agents/actor.md
+++ b/.claude/agents/actor.md
@@ -222,15 +222,20 @@ Task(
 ## Using Research Results
 
 1. Check `confidence` score:
-   - >= 0.7: Use findings directly
-   - 0.5-0.7: Consider broader search
-   - < 0.5: Proceed with caution, may need user input
+   - >= 0.7: Trust the cited findings and start with narrow reads
+   - 0.5-0.7: Use cited findings, then broaden only where evidence is missing
+   - < 0.5: Proceed with caution, broad search may be necessary
 
 2. Use `relevant_locations` for implementation:
    - Signatures show you what to call/extend
    - Line ranges help you find the right place
 
-3. Read full code only if signatures aren't enough:
+3. Read cited code before broad search when confidence is high:
+   - For confidence >= 0.7 with `relevant_locations`, read 1-3 cited ranges first
+   - Do not repeat repository-wide `rg`/`grep`/`find`/`git grep` unless you state why
+   - Valid reasons: low confidence, no relevant locations, missing symbol, failed narrow read, changed hypothesis, or stale research
+
+4. Read full code only if signatures aren't enough:
    - Use Read(path, offset=lines[0], limit=lines[1]-lines[0]+1)  # lines = [start, end], inclusive
    - Don't read all locations — only what you actually need
 

--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -256,7 +256,7 @@ Later phases read with:
 RESEARCH_FINDINGS=$(python3 .map/scripts/map_step_runner.py load_research "$BRANCH" "$SUBTASK_ID")
 ```
 
-The artifact lands under `.map/<branch>/research/<subtask_id>__<kind>.md` and must satisfy the research evidence JSON contract (`status`, `confidence`, `search_stats`, and at most 5 `relevant_locations` with safe relative paths and line ranges). Use `load_research` to fill the `{research_findings}` placeholder in Actor and Monitor prompts below.
+The artifact lands under `.map/<branch>/research/<subtask_id>__<kind>.md` and must satisfy the research evidence JSON contract (`status`, `confidence`, `search_stats`, and at most 5 `relevant_locations` with safe relative paths and line ranges). Use `load_research` to fill the `{research_findings}` placeholder in Actor and Monitor prompts below. Actor must consume high-confidence research before re-exploring: if `confidence >= 0.7` and `relevant_locations` are present, first read 1-3 cited ranges; later repository-wide `rg`/`grep`/`find`/`git grep` needs a stated reason, such as low confidence, missing symbol, failed narrow read, changed hypothesis, or stale research. Low-confidence/location-free research may broaden sooner, but the gap must be named.
 
 ### Phase: TEST_WRITER (2.25) - TDD Mode Only
 
@@ -315,7 +315,7 @@ If `status_mismatch == true`, surface `recovery_instruction` and re-invoke Actor
 Run `python3 .map/scripts/map_step_runner.py detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"`. If
 `recommended_gate == "validate_callers"`, append `external_callers` to the Monitor
 `<documents>` context and require Monitor to validate each external caller's contract.
-Full recipe: [efficient-reference.md](efficient-reference.md).
+Full recipe: [efficient-reference.md](efficient-reference.md). Optional research-consumption advisory: pipe captured Actor shell/search commands into `python3 .map/scripts/map_step_runner.py detect_research_consumption_drift "$BRANCH" "$SUBTASK_ID"`; if it reports `advisory: true`, add the missing broad-search reason or do the cited narrow read before Monitor.
 
 ### Phase: MONITOR (2.4) - Required
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -943,6 +943,20 @@ def _empty_token_bucket() -> dict[str, float]:
 _RESEARCH_AGENT_NAMES = frozenset({"research-agent", "researcher"})
 _ACTOR_MONITOR_AGENT_NAMES = frozenset({"actor", "monitor"})
 _RESEARCH_LOW_CONFIDENCE_THRESHOLD = 0.5
+_RESEARCH_HIGH_CONFIDENCE_THRESHOLD = 0.7
+_RESEARCH_BROAD_SEARCH_REASON_RE = re.compile(
+    r"\b(?:reason|because)\s*[:=]\s*([^;&\n]+)", re.IGNORECASE
+)
+_RESEARCH_BROAD_SEARCH_REASON_TERMS = (
+    "low confidence",
+    "missing symbol",
+    "failed narrow read",
+    "changed hypothesis",
+    "stale research",
+    "no relevant locations",
+    "location missing",
+    "locations missing",
+)
 
 
 def _empty_token_counter_bucket() -> dict[str, float]:
@@ -6994,6 +7008,269 @@ def load_research(
     return "\n".join(parts).rstrip() + "\n"
 
 
+def _research_evidence_summary(content: str) -> dict[str, object]:
+    """Extract confidence/location metadata from strict research JSON."""
+    stripped = content.strip()
+    if not stripped:
+        return {"valid": False, "confidence": None, "location_count": 0}
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"valid": False, "confidence": None, "location_count": 0}
+    if not isinstance(parsed, dict):
+        return {"valid": False, "confidence": None, "location_count": 0}
+
+    confidence_value = parsed.get("confidence")
+    confidence: Optional[float]
+    if isinstance(confidence_value, bool) or not isinstance(
+        confidence_value, (int, float)
+    ):
+        confidence = None
+    else:
+        confidence = float(confidence_value)
+
+    locations_value = parsed.get("relevant_locations")
+    locations = locations_value if isinstance(locations_value, list) else []
+    return {
+        "valid": confidence is not None and isinstance(locations_value, list),
+        "confidence": confidence,
+        "location_count": len(locations),
+    }
+
+
+def _research_consumption_contract_block(research_text: str) -> str:
+    """Return Actor-facing read/search discipline derived from research metadata."""
+    summary = _research_evidence_summary(research_text)
+    confidence = summary.get("confidence")
+    location_count_value = summary.get("location_count")
+    location_count = location_count_value if isinstance(location_count_value, int) else 0
+    if not isinstance(confidence, float):
+        return ""
+
+    if confidence >= _RESEARCH_HIGH_CONFIDENCE_THRESHOLD and location_count > 0:
+        return "\n".join(
+            [
+                "# Research Consumption Contract:",
+                f"  confidence={confidence:.2f}; relevant_locations={location_count}",
+                "  First read 1-3 cited ranges that match this subtask before broad search.",
+                "  Repository-wide rg/grep/find/git grep after that needs a stated reason:",
+                "  low confidence, missing symbol, failed narrow read, changed hypothesis, or stale research.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "# Research Consumption Contract:",
+            f"  confidence={confidence:.2f}; relevant_locations={location_count}",
+            "  Research is low-confidence or location-free; broad search is allowed,",
+            "  but name the evidence gap and prefer cited locations where useful.",
+        ]
+    )
+
+
+def _collect_command_strings(value: object) -> list[str]:
+    commands: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key in {"command", "cmd", "shell_command"} and isinstance(nested, str):
+                commands.append(nested)
+            else:
+                commands.extend(_collect_command_strings(nested))
+    elif isinstance(value, list):
+        for item in value:
+            commands.extend(_collect_command_strings(item))
+    return commands
+
+
+def _iter_command_strings(command_log: str) -> list[str]:
+    stripped = command_log.strip()
+    if not stripped:
+        return []
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        parsed = None
+    if parsed is not None:
+        commands = _collect_command_strings(parsed)
+        if commands:
+            return commands
+
+    commands: list[str] = []
+    for raw_line in command_log.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed_line = json.loads(line)
+        except json.JSONDecodeError:
+            commands.append(line)
+            continue
+        parsed_commands = _collect_command_strings(parsed_line)
+        if parsed_commands:
+            commands.extend(parsed_commands)
+        else:
+            commands.append(line)
+    return commands
+
+
+def _shell_tokens(command: str) -> list[str]:
+    return [
+        token.strip("'\"")
+        for token in re.findall(r"(?:[^\s'\"]+|'[^']*'|\"[^\"]*\")+", command)
+    ]
+
+
+def _non_option_tokens(tokens: list[str]) -> list[str]:
+    values: list[str] = []
+    skip_next = False
+    options_with_values = {
+        "-e",
+        "--regexp",
+        "-g",
+        "--glob",
+        "-t",
+        "--type",
+        "--include",
+        "--exclude",
+    }
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in options_with_values:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        values.append(token)
+    return values
+
+
+def _is_repo_wide_broad_search(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    lowered = [token.lower() for token in tokens]
+    if not lowered:
+        return False
+
+    for index, token in enumerate(lowered):
+        if token == "rg":
+            after = tokens[index + 1 :]
+            non_options = _non_option_tokens(after)
+            if "--files" in after:
+                return not non_options or any(path in {".", "./", "$PWD"} for path in non_options)
+            path_operands = non_options[1:]
+            return not path_operands or any(path in {".", "./", "$PWD"} for path in path_operands)
+
+        if token == "grep":
+            after = tokens[index + 1 :]
+            if not any(flag.startswith("-") and ("R" in flag or "r" in flag) for flag in after):
+                continue
+            non_options = _non_option_tokens(after)
+            path_operands = non_options[1:]
+            return not path_operands or any(path in {".", "./", "$PWD"} for path in path_operands)
+
+        if token == "find":
+            after = lowered[index + 1 :]
+            return not after or after[0] in {".", "./", "$pwd"}
+
+        if token == "git" and index + 1 < len(lowered) and lowered[index + 1] == "grep":
+            after = lowered[index + 2 :]
+            if "--" not in after:
+                return True
+            pathspecs = after[after.index("--") + 1 :]
+            return not pathspecs or any(path in {".", "./", "$pwd"} for path in pathspecs)
+
+    return False
+
+
+def _command_has_stated_broad_search_reason(command: str) -> bool:
+    match = _RESEARCH_BROAD_SEARCH_REASON_RE.search(command)
+    if not match:
+        return False
+    reason = match.group(1).strip().lower()
+    return any(term in reason for term in _RESEARCH_BROAD_SEARCH_REASON_TERMS)
+
+
+def detect_research_consumption_drift(
+    branch: str,
+    subtask_id: str,
+    command_log: str,
+) -> dict[str, object]:
+    """Advisory detector for broad re-exploration after high-confidence research.
+
+    The detector is intentionally non-blocking. It only flags repo-wide search
+    commands after strict JSON research says confidence is high and locations are
+    available; scoped searches and reasoned broad searches remain allowed.
+    """
+    research_text = load_research(branch, subtask_id)
+    if not research_text.strip():
+        return {
+            "status": "no_research",
+            "advisory": False,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    summary = _research_evidence_summary(research_text)
+    confidence = summary.get("confidence")
+    location_count_value = summary.get("location_count")
+    location_count = location_count_value if isinstance(location_count_value, int) else 0
+    if not isinstance(confidence, float):
+        return {
+            "status": "invalid_research",
+            "advisory": False,
+            "confidence": None,
+            "location_count": location_count,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    commands = _iter_command_strings(command_log)
+    if not commands:
+        return {
+            "status": "no_input",
+            "advisory": False,
+            "confidence": confidence,
+            "location_count": location_count,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    high_confidence = confidence >= _RESEARCH_HIGH_CONFIDENCE_THRESHOLD and location_count > 0
+    discouraged: list[dict[str, str]] = []
+    allowed: list[dict[str, str]] = []
+    for command in commands:
+        if not _is_repo_wide_broad_search(command):
+            continue
+        if not high_confidence:
+            allowed.append({"command": command, "reason": "research not high-confidence with locations"})
+        elif _command_has_stated_broad_search_reason(command):
+            allowed.append({"command": command, "reason": "stated reason"})
+        else:
+            discouraged.append(
+                {
+                    "command": command,
+                    "reason": "high-confidence research cited locations; read cited ranges first or state why broad search is needed",
+                }
+            )
+
+    return {
+        "status": "success" if high_confidence else "research_allows_broad_search",
+        "advisory": bool(discouraged),
+        "confidence": confidence,
+        "location_count": location_count,
+        "commands_seen": len(commands),
+        "broad_search_count": len(allowed) + len(discouraged),
+        "discouraged_broad_searches": discouraged,
+        "allowed_broad_searches": allowed,
+        "recommendation": (
+            "Read 1-3 cited relevant_locations before broad search, or add a reason."
+            if discouraged
+            else "No research-consumption drift detected."
+        ),
+    }
+
+
 def _claude_code_log_dir(project_dir: Path) -> Optional[Path]:
     """Claude Code stores per-session jsonl logs under
     ``~/.claude/projects/<project-path-with-slashes-as-dashes>/``.
@@ -9568,6 +9845,12 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
                     f"# Research Findings ({current_subtask_id}, kind={_research_kind}):"
                 )
                 parts.append(_research_text)
+                _consumption_contract = _research_consumption_contract_block(
+                    _research_text
+                )
+                if _consumption_contract:
+                    parts.append("")
+                    parts.append(_consumption_contract)
                 break
     except (ValueError, OSError):
         pass
@@ -10325,6 +10608,16 @@ if __name__ == "__main__":
         # can decide full-suite vs scoped without `set -e` tripping on an
         # advisory signal.
         report = detect_symbol_blast_radius(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "detect_research_consumption_drift" and len(sys.argv) >= 4:
+        # CLI: detect_research_consumption_drift <branch> <subtask_id>
+        # Reads captured Actor shell/search commands from stdin. Advisory only:
+        # exit 0 always so broad-search drift can be surfaced without blocking
+        # normal workflows.
+        report = detect_research_consumption_drift(
+            sys.argv[2], sys.argv[3], sys.stdin.read()
+        )
         print(json.dumps(report, indent=2))
 
     elif func_name == "detect_actor_files_changed_mismatch" and len(sys.argv) >= 4:

--- a/src/mapify_cli/templates/agents/actor.md
+++ b/src/mapify_cli/templates/agents/actor.md
@@ -222,15 +222,20 @@ Task(
 ## Using Research Results
 
 1. Check `confidence` score:
-   - >= 0.7: Use findings directly
-   - 0.5-0.7: Consider broader search
-   - < 0.5: Proceed with caution, may need user input
+   - >= 0.7: Trust the cited findings and start with narrow reads
+   - 0.5-0.7: Use cited findings, then broaden only where evidence is missing
+   - < 0.5: Proceed with caution, broad search may be necessary
 
 2. Use `relevant_locations` for implementation:
    - Signatures show you what to call/extend
    - Line ranges help you find the right place
 
-3. Read full code only if signatures aren't enough:
+3. Read cited code before broad search when confidence is high:
+   - For confidence >= 0.7 with `relevant_locations`, read 1-3 cited ranges first
+   - Do not repeat repository-wide `rg`/`grep`/`find`/`git grep` unless you state why
+   - Valid reasons: low confidence, no relevant locations, missing symbol, failed narrow read, changed hypothesis, or stale research
+
+4. Read full code only if signatures aren't enough:
    - Use Read(path, offset=lines[0], limit=lines[1]-lines[0]+1)  # lines = [start, end], inclusive
    - Don't read all locations — only what you actually need
 

--- a/src/mapify_cli/templates/codex/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-efficient/SKILL.md
@@ -175,6 +175,13 @@ python3 .map/scripts/map_step_runner.py validate_research "$BRANCH" "$SUBTASK_ID
 python3 .map/scripts/map_orchestrator.py validate_step "$STEP_ID"
 ```
 
+Actor must consume high-confidence research before re-exploring: if
+`confidence >= 0.7` and `relevant_locations` are present, first read 1-3 cited
+ranges that match the subtask. Any later repository-wide `rg`/`grep`/`find`/
+`git grep` needs a stated reason, such as low confidence, missing symbol, failed
+narrow read, changed hypothesis, or stale research. Low-confidence or
+location-free research may broaden sooner, but the gap must be named.
+
 ### TEST_WRITER And TEST_FAIL_GATE
 
 Only run these in TDD mode. Write failing tests first, run them, and proceed to
@@ -202,6 +209,11 @@ Before Monitor, run the required pre-dispatch gates from
 python3 .map/scripts/map_step_runner.py detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" --declared "$FILES_CSV"
 python3 .map/scripts/map_step_runner.py detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"
 ```
+
+If you captured Actor shell/search commands, optionally pipe them into
+`python3 .map/scripts/map_step_runner.py detect_research_consumption_drift "$BRANCH" "$SUBTASK_ID"`.
+This detector is advisory only: it reports repeated repository-wide searches
+after high-confidence research without blocking normal work.
 
 ### MONITOR
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -943,6 +943,20 @@ def _empty_token_bucket() -> dict[str, float]:
 _RESEARCH_AGENT_NAMES = frozenset({"research-agent", "researcher"})
 _ACTOR_MONITOR_AGENT_NAMES = frozenset({"actor", "monitor"})
 _RESEARCH_LOW_CONFIDENCE_THRESHOLD = 0.5
+_RESEARCH_HIGH_CONFIDENCE_THRESHOLD = 0.7
+_RESEARCH_BROAD_SEARCH_REASON_RE = re.compile(
+    r"\b(?:reason|because)\s*[:=]\s*([^;&\n]+)", re.IGNORECASE
+)
+_RESEARCH_BROAD_SEARCH_REASON_TERMS = (
+    "low confidence",
+    "missing symbol",
+    "failed narrow read",
+    "changed hypothesis",
+    "stale research",
+    "no relevant locations",
+    "location missing",
+    "locations missing",
+)
 
 
 def _empty_token_counter_bucket() -> dict[str, float]:
@@ -6994,6 +7008,269 @@ def load_research(
     return "\n".join(parts).rstrip() + "\n"
 
 
+def _research_evidence_summary(content: str) -> dict[str, object]:
+    """Extract confidence/location metadata from strict research JSON."""
+    stripped = content.strip()
+    if not stripped:
+        return {"valid": False, "confidence": None, "location_count": 0}
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"valid": False, "confidence": None, "location_count": 0}
+    if not isinstance(parsed, dict):
+        return {"valid": False, "confidence": None, "location_count": 0}
+
+    confidence_value = parsed.get("confidence")
+    confidence: Optional[float]
+    if isinstance(confidence_value, bool) or not isinstance(
+        confidence_value, (int, float)
+    ):
+        confidence = None
+    else:
+        confidence = float(confidence_value)
+
+    locations_value = parsed.get("relevant_locations")
+    locations = locations_value if isinstance(locations_value, list) else []
+    return {
+        "valid": confidence is not None and isinstance(locations_value, list),
+        "confidence": confidence,
+        "location_count": len(locations),
+    }
+
+
+def _research_consumption_contract_block(research_text: str) -> str:
+    """Return Actor-facing read/search discipline derived from research metadata."""
+    summary = _research_evidence_summary(research_text)
+    confidence = summary.get("confidence")
+    location_count_value = summary.get("location_count")
+    location_count = location_count_value if isinstance(location_count_value, int) else 0
+    if not isinstance(confidence, float):
+        return ""
+
+    if confidence >= _RESEARCH_HIGH_CONFIDENCE_THRESHOLD and location_count > 0:
+        return "\n".join(
+            [
+                "# Research Consumption Contract:",
+                f"  confidence={confidence:.2f}; relevant_locations={location_count}",
+                "  First read 1-3 cited ranges that match this subtask before broad search.",
+                "  Repository-wide rg/grep/find/git grep after that needs a stated reason:",
+                "  low confidence, missing symbol, failed narrow read, changed hypothesis, or stale research.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "# Research Consumption Contract:",
+            f"  confidence={confidence:.2f}; relevant_locations={location_count}",
+            "  Research is low-confidence or location-free; broad search is allowed,",
+            "  but name the evidence gap and prefer cited locations where useful.",
+        ]
+    )
+
+
+def _collect_command_strings(value: object) -> list[str]:
+    commands: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key in {"command", "cmd", "shell_command"} and isinstance(nested, str):
+                commands.append(nested)
+            else:
+                commands.extend(_collect_command_strings(nested))
+    elif isinstance(value, list):
+        for item in value:
+            commands.extend(_collect_command_strings(item))
+    return commands
+
+
+def _iter_command_strings(command_log: str) -> list[str]:
+    stripped = command_log.strip()
+    if not stripped:
+        return []
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        parsed = None
+    if parsed is not None:
+        commands = _collect_command_strings(parsed)
+        if commands:
+            return commands
+
+    commands: list[str] = []
+    for raw_line in command_log.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed_line = json.loads(line)
+        except json.JSONDecodeError:
+            commands.append(line)
+            continue
+        parsed_commands = _collect_command_strings(parsed_line)
+        if parsed_commands:
+            commands.extend(parsed_commands)
+        else:
+            commands.append(line)
+    return commands
+
+
+def _shell_tokens(command: str) -> list[str]:
+    return [
+        token.strip("'\"")
+        for token in re.findall(r"(?:[^\s'\"]+|'[^']*'|\"[^\"]*\")+", command)
+    ]
+
+
+def _non_option_tokens(tokens: list[str]) -> list[str]:
+    values: list[str] = []
+    skip_next = False
+    options_with_values = {
+        "-e",
+        "--regexp",
+        "-g",
+        "--glob",
+        "-t",
+        "--type",
+        "--include",
+        "--exclude",
+    }
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in options_with_values:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        values.append(token)
+    return values
+
+
+def _is_repo_wide_broad_search(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    lowered = [token.lower() for token in tokens]
+    if not lowered:
+        return False
+
+    for index, token in enumerate(lowered):
+        if token == "rg":
+            after = tokens[index + 1 :]
+            non_options = _non_option_tokens(after)
+            if "--files" in after:
+                return not non_options or any(path in {".", "./", "$PWD"} for path in non_options)
+            path_operands = non_options[1:]
+            return not path_operands or any(path in {".", "./", "$PWD"} for path in path_operands)
+
+        if token == "grep":
+            after = tokens[index + 1 :]
+            if not any(flag.startswith("-") and ("R" in flag or "r" in flag) for flag in after):
+                continue
+            non_options = _non_option_tokens(after)
+            path_operands = non_options[1:]
+            return not path_operands or any(path in {".", "./", "$PWD"} for path in path_operands)
+
+        if token == "find":
+            after = lowered[index + 1 :]
+            return not after or after[0] in {".", "./", "$pwd"}
+
+        if token == "git" and index + 1 < len(lowered) and lowered[index + 1] == "grep":
+            after = lowered[index + 2 :]
+            if "--" not in after:
+                return True
+            pathspecs = after[after.index("--") + 1 :]
+            return not pathspecs or any(path in {".", "./", "$pwd"} for path in pathspecs)
+
+    return False
+
+
+def _command_has_stated_broad_search_reason(command: str) -> bool:
+    match = _RESEARCH_BROAD_SEARCH_REASON_RE.search(command)
+    if not match:
+        return False
+    reason = match.group(1).strip().lower()
+    return any(term in reason for term in _RESEARCH_BROAD_SEARCH_REASON_TERMS)
+
+
+def detect_research_consumption_drift(
+    branch: str,
+    subtask_id: str,
+    command_log: str,
+) -> dict[str, object]:
+    """Advisory detector for broad re-exploration after high-confidence research.
+
+    The detector is intentionally non-blocking. It only flags repo-wide search
+    commands after strict JSON research says confidence is high and locations are
+    available; scoped searches and reasoned broad searches remain allowed.
+    """
+    research_text = load_research(branch, subtask_id)
+    if not research_text.strip():
+        return {
+            "status": "no_research",
+            "advisory": False,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    summary = _research_evidence_summary(research_text)
+    confidence = summary.get("confidence")
+    location_count_value = summary.get("location_count")
+    location_count = location_count_value if isinstance(location_count_value, int) else 0
+    if not isinstance(confidence, float):
+        return {
+            "status": "invalid_research",
+            "advisory": False,
+            "confidence": None,
+            "location_count": location_count,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    commands = _iter_command_strings(command_log)
+    if not commands:
+        return {
+            "status": "no_input",
+            "advisory": False,
+            "confidence": confidence,
+            "location_count": location_count,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    high_confidence = confidence >= _RESEARCH_HIGH_CONFIDENCE_THRESHOLD and location_count > 0
+    discouraged: list[dict[str, str]] = []
+    allowed: list[dict[str, str]] = []
+    for command in commands:
+        if not _is_repo_wide_broad_search(command):
+            continue
+        if not high_confidence:
+            allowed.append({"command": command, "reason": "research not high-confidence with locations"})
+        elif _command_has_stated_broad_search_reason(command):
+            allowed.append({"command": command, "reason": "stated reason"})
+        else:
+            discouraged.append(
+                {
+                    "command": command,
+                    "reason": "high-confidence research cited locations; read cited ranges first or state why broad search is needed",
+                }
+            )
+
+    return {
+        "status": "success" if high_confidence else "research_allows_broad_search",
+        "advisory": bool(discouraged),
+        "confidence": confidence,
+        "location_count": location_count,
+        "commands_seen": len(commands),
+        "broad_search_count": len(allowed) + len(discouraged),
+        "discouraged_broad_searches": discouraged,
+        "allowed_broad_searches": allowed,
+        "recommendation": (
+            "Read 1-3 cited relevant_locations before broad search, or add a reason."
+            if discouraged
+            else "No research-consumption drift detected."
+        ),
+    }
+
+
 def _claude_code_log_dir(project_dir: Path) -> Optional[Path]:
     """Claude Code stores per-session jsonl logs under
     ``~/.claude/projects/<project-path-with-slashes-as-dashes>/``.
@@ -9568,6 +9845,12 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
                     f"# Research Findings ({current_subtask_id}, kind={_research_kind}):"
                 )
                 parts.append(_research_text)
+                _consumption_contract = _research_consumption_contract_block(
+                    _research_text
+                )
+                if _consumption_contract:
+                    parts.append("")
+                    parts.append(_consumption_contract)
                 break
     except (ValueError, OSError):
         pass
@@ -10325,6 +10608,16 @@ if __name__ == "__main__":
         # can decide full-suite vs scoped without `set -e` tripping on an
         # advisory signal.
         report = detect_symbol_blast_radius(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "detect_research_consumption_drift" and len(sys.argv) >= 4:
+        # CLI: detect_research_consumption_drift <branch> <subtask_id>
+        # Reads captured Actor shell/search commands from stdin. Advisory only:
+        # exit 0 always so broad-search drift can be surfaced without blocking
+        # normal workflows.
+        report = detect_research_consumption_drift(
+            sys.argv[2], sys.argv[3], sys.stdin.read()
+        )
         print(json.dumps(report, indent=2))
 
     elif func_name == "detect_actor_files_changed_mismatch" and len(sys.argv) >= 4:

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -256,7 +256,7 @@ Later phases read with:
 RESEARCH_FINDINGS=$(python3 .map/scripts/map_step_runner.py load_research "$BRANCH" "$SUBTASK_ID")
 ```
 
-The artifact lands under `.map/<branch>/research/<subtask_id>__<kind>.md` and must satisfy the research evidence JSON contract (`status`, `confidence`, `search_stats`, and at most 5 `relevant_locations` with safe relative paths and line ranges). Use `load_research` to fill the `{research_findings}` placeholder in Actor and Monitor prompts below.
+The artifact lands under `.map/<branch>/research/<subtask_id>__<kind>.md` and must satisfy the research evidence JSON contract (`status`, `confidence`, `search_stats`, and at most 5 `relevant_locations` with safe relative paths and line ranges). Use `load_research` to fill the `{research_findings}` placeholder in Actor and Monitor prompts below. Actor must consume high-confidence research before re-exploring: if `confidence >= 0.7` and `relevant_locations` are present, first read 1-3 cited ranges; later repository-wide `rg`/`grep`/`find`/`git grep` needs a stated reason, such as low confidence, missing symbol, failed narrow read, changed hypothesis, or stale research. Low-confidence/location-free research may broaden sooner, but the gap must be named.
 
 ### Phase: TEST_WRITER (2.25) - TDD Mode Only
 
@@ -315,7 +315,7 @@ If `status_mismatch == true`, surface `recovery_instruction` and re-invoke Actor
 Run `python3 .map/scripts/map_step_runner.py detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"`. If
 `recommended_gate == "validate_callers"`, append `external_callers` to the Monitor
 `<documents>` context and require Monitor to validate each external caller's contract.
-Full recipe: [efficient-reference.md](efficient-reference.md).
+Full recipe: [efficient-reference.md](efficient-reference.md). Optional research-consumption advisory: pipe captured Actor shell/search commands into `python3 .map/scripts/map_step_runner.py detect_research_consumption_drift "$BRANCH" "$SUBTASK_ID"`; if it reports `advisory: true`, add the missing broad-search reason or do the cited narrow read before Monitor.
 
 ### Phase: MONITOR (2.4) - Required
 

--- a/src/mapify_cli/templates_src/agents/actor.md.jinja
+++ b/src/mapify_cli/templates_src/agents/actor.md.jinja
@@ -222,15 +222,20 @@ Task(
 ## Using Research Results
 
 1. Check `confidence` score:
-   - >= 0.7: Use findings directly
-   - 0.5-0.7: Consider broader search
-   - < 0.5: Proceed with caution, may need user input
+   - >= 0.7: Trust the cited findings and start with narrow reads
+   - 0.5-0.7: Use cited findings, then broaden only where evidence is missing
+   - < 0.5: Proceed with caution, broad search may be necessary
 
 2. Use `relevant_locations` for implementation:
    - Signatures show you what to call/extend
    - Line ranges help you find the right place
 
-3. Read full code only if signatures aren't enough:
+3. Read cited code before broad search when confidence is high:
+   - For confidence >= 0.7 with `relevant_locations`, read 1-3 cited ranges first
+   - Do not repeat repository-wide `rg`/`grep`/`find`/`git grep` unless you state why
+   - Valid reasons: low confidence, no relevant locations, missing symbol, failed narrow read, changed hypothesis, or stale research
+
+4. Read full code only if signatures aren't enough:
    - Use Read(path, offset=lines[0], limit=lines[1]-lines[0]+1)  # lines = [start, end], inclusive
    - Don't read all locations — only what you actually need
 

--- a/src/mapify_cli/templates_src/codex/skills/map-efficient/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-efficient/SKILL.md.jinja
@@ -175,6 +175,13 @@ python3 .map/scripts/map_step_runner.py validate_research "$BRANCH" "$SUBTASK_ID
 python3 .map/scripts/map_orchestrator.py validate_step "$STEP_ID"
 ```
 
+Actor must consume high-confidence research before re-exploring: if
+`confidence >= 0.7` and `relevant_locations` are present, first read 1-3 cited
+ranges that match the subtask. Any later repository-wide `rg`/`grep`/`find`/
+`git grep` needs a stated reason, such as low confidence, missing symbol, failed
+narrow read, changed hypothesis, or stale research. Low-confidence or
+location-free research may broaden sooner, but the gap must be named.
+
 ### TEST_WRITER And TEST_FAIL_GATE
 
 Only run these in TDD mode. Write failing tests first, run them, and proceed to
@@ -202,6 +209,11 @@ Before Monitor, run the required pre-dispatch gates from
 python3 .map/scripts/map_step_runner.py detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" --declared "$FILES_CSV"
 python3 .map/scripts/map_step_runner.py detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"
 ```
+
+If you captured Actor shell/search commands, optionally pipe them into
+`python3 .map/scripts/map_step_runner.py detect_research_consumption_drift "$BRANCH" "$SUBTASK_ID"`.
+This detector is advisory only: it reports repeated repository-wide searches
+after high-confidence research without blocking normal work.
 
 ### MONITOR
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -943,6 +943,20 @@ def _empty_token_bucket() -> dict[str, float]:
 _RESEARCH_AGENT_NAMES = frozenset({"research-agent", "researcher"})
 _ACTOR_MONITOR_AGENT_NAMES = frozenset({"actor", "monitor"})
 _RESEARCH_LOW_CONFIDENCE_THRESHOLD = 0.5
+_RESEARCH_HIGH_CONFIDENCE_THRESHOLD = 0.7
+_RESEARCH_BROAD_SEARCH_REASON_RE = re.compile(
+    r"\b(?:reason|because)\s*[:=]\s*([^;&\n]+)", re.IGNORECASE
+)
+_RESEARCH_BROAD_SEARCH_REASON_TERMS = (
+    "low confidence",
+    "missing symbol",
+    "failed narrow read",
+    "changed hypothesis",
+    "stale research",
+    "no relevant locations",
+    "location missing",
+    "locations missing",
+)
 
 
 def _empty_token_counter_bucket() -> dict[str, float]:
@@ -6994,6 +7008,269 @@ def load_research(
     return "\n".join(parts).rstrip() + "\n"
 
 
+def _research_evidence_summary(content: str) -> dict[str, object]:
+    """Extract confidence/location metadata from strict research JSON."""
+    stripped = content.strip()
+    if not stripped:
+        return {"valid": False, "confidence": None, "location_count": 0}
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"valid": False, "confidence": None, "location_count": 0}
+    if not isinstance(parsed, dict):
+        return {"valid": False, "confidence": None, "location_count": 0}
+
+    confidence_value = parsed.get("confidence")
+    confidence: Optional[float]
+    if isinstance(confidence_value, bool) or not isinstance(
+        confidence_value, (int, float)
+    ):
+        confidence = None
+    else:
+        confidence = float(confidence_value)
+
+    locations_value = parsed.get("relevant_locations")
+    locations = locations_value if isinstance(locations_value, list) else []
+    return {
+        "valid": confidence is not None and isinstance(locations_value, list),
+        "confidence": confidence,
+        "location_count": len(locations),
+    }
+
+
+def _research_consumption_contract_block(research_text: str) -> str:
+    """Return Actor-facing read/search discipline derived from research metadata."""
+    summary = _research_evidence_summary(research_text)
+    confidence = summary.get("confidence")
+    location_count_value = summary.get("location_count")
+    location_count = location_count_value if isinstance(location_count_value, int) else 0
+    if not isinstance(confidence, float):
+        return ""
+
+    if confidence >= _RESEARCH_HIGH_CONFIDENCE_THRESHOLD and location_count > 0:
+        return "\n".join(
+            [
+                "# Research Consumption Contract:",
+                f"  confidence={confidence:.2f}; relevant_locations={location_count}",
+                "  First read 1-3 cited ranges that match this subtask before broad search.",
+                "  Repository-wide rg/grep/find/git grep after that needs a stated reason:",
+                "  low confidence, missing symbol, failed narrow read, changed hypothesis, or stale research.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "# Research Consumption Contract:",
+            f"  confidence={confidence:.2f}; relevant_locations={location_count}",
+            "  Research is low-confidence or location-free; broad search is allowed,",
+            "  but name the evidence gap and prefer cited locations where useful.",
+        ]
+    )
+
+
+def _collect_command_strings(value: object) -> list[str]:
+    commands: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key in {"command", "cmd", "shell_command"} and isinstance(nested, str):
+                commands.append(nested)
+            else:
+                commands.extend(_collect_command_strings(nested))
+    elif isinstance(value, list):
+        for item in value:
+            commands.extend(_collect_command_strings(item))
+    return commands
+
+
+def _iter_command_strings(command_log: str) -> list[str]:
+    stripped = command_log.strip()
+    if not stripped:
+        return []
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        parsed = None
+    if parsed is not None:
+        commands = _collect_command_strings(parsed)
+        if commands:
+            return commands
+
+    commands: list[str] = []
+    for raw_line in command_log.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed_line = json.loads(line)
+        except json.JSONDecodeError:
+            commands.append(line)
+            continue
+        parsed_commands = _collect_command_strings(parsed_line)
+        if parsed_commands:
+            commands.extend(parsed_commands)
+        else:
+            commands.append(line)
+    return commands
+
+
+def _shell_tokens(command: str) -> list[str]:
+    return [
+        token.strip("'\"")
+        for token in re.findall(r"(?:[^\s'\"]+|'[^']*'|\"[^\"]*\")+", command)
+    ]
+
+
+def _non_option_tokens(tokens: list[str]) -> list[str]:
+    values: list[str] = []
+    skip_next = False
+    options_with_values = {
+        "-e",
+        "--regexp",
+        "-g",
+        "--glob",
+        "-t",
+        "--type",
+        "--include",
+        "--exclude",
+    }
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in options_with_values:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        values.append(token)
+    return values
+
+
+def _is_repo_wide_broad_search(command: str) -> bool:
+    tokens = _shell_tokens(command)
+    lowered = [token.lower() for token in tokens]
+    if not lowered:
+        return False
+
+    for index, token in enumerate(lowered):
+        if token == "rg":
+            after = tokens[index + 1 :]
+            non_options = _non_option_tokens(after)
+            if "--files" in after:
+                return not non_options or any(path in {".", "./", "$PWD"} for path in non_options)
+            path_operands = non_options[1:]
+            return not path_operands or any(path in {".", "./", "$PWD"} for path in path_operands)
+
+        if token == "grep":
+            after = tokens[index + 1 :]
+            if not any(flag.startswith("-") and ("R" in flag or "r" in flag) for flag in after):
+                continue
+            non_options = _non_option_tokens(after)
+            path_operands = non_options[1:]
+            return not path_operands or any(path in {".", "./", "$PWD"} for path in path_operands)
+
+        if token == "find":
+            after = lowered[index + 1 :]
+            return not after or after[0] in {".", "./", "$pwd"}
+
+        if token == "git" and index + 1 < len(lowered) and lowered[index + 1] == "grep":
+            after = lowered[index + 2 :]
+            if "--" not in after:
+                return True
+            pathspecs = after[after.index("--") + 1 :]
+            return not pathspecs or any(path in {".", "./", "$pwd"} for path in pathspecs)
+
+    return False
+
+
+def _command_has_stated_broad_search_reason(command: str) -> bool:
+    match = _RESEARCH_BROAD_SEARCH_REASON_RE.search(command)
+    if not match:
+        return False
+    reason = match.group(1).strip().lower()
+    return any(term in reason for term in _RESEARCH_BROAD_SEARCH_REASON_TERMS)
+
+
+def detect_research_consumption_drift(
+    branch: str,
+    subtask_id: str,
+    command_log: str,
+) -> dict[str, object]:
+    """Advisory detector for broad re-exploration after high-confidence research.
+
+    The detector is intentionally non-blocking. It only flags repo-wide search
+    commands after strict JSON research says confidence is high and locations are
+    available; scoped searches and reasoned broad searches remain allowed.
+    """
+    research_text = load_research(branch, subtask_id)
+    if not research_text.strip():
+        return {
+            "status": "no_research",
+            "advisory": False,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    summary = _research_evidence_summary(research_text)
+    confidence = summary.get("confidence")
+    location_count_value = summary.get("location_count")
+    location_count = location_count_value if isinstance(location_count_value, int) else 0
+    if not isinstance(confidence, float):
+        return {
+            "status": "invalid_research",
+            "advisory": False,
+            "confidence": None,
+            "location_count": location_count,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    commands = _iter_command_strings(command_log)
+    if not commands:
+        return {
+            "status": "no_input",
+            "advisory": False,
+            "confidence": confidence,
+            "location_count": location_count,
+            "discouraged_broad_searches": [],
+            "allowed_broad_searches": [],
+        }
+
+    high_confidence = confidence >= _RESEARCH_HIGH_CONFIDENCE_THRESHOLD and location_count > 0
+    discouraged: list[dict[str, str]] = []
+    allowed: list[dict[str, str]] = []
+    for command in commands:
+        if not _is_repo_wide_broad_search(command):
+            continue
+        if not high_confidence:
+            allowed.append({"command": command, "reason": "research not high-confidence with locations"})
+        elif _command_has_stated_broad_search_reason(command):
+            allowed.append({"command": command, "reason": "stated reason"})
+        else:
+            discouraged.append(
+                {
+                    "command": command,
+                    "reason": "high-confidence research cited locations; read cited ranges first or state why broad search is needed",
+                }
+            )
+
+    return {
+        "status": "success" if high_confidence else "research_allows_broad_search",
+        "advisory": bool(discouraged),
+        "confidence": confidence,
+        "location_count": location_count,
+        "commands_seen": len(commands),
+        "broad_search_count": len(allowed) + len(discouraged),
+        "discouraged_broad_searches": discouraged,
+        "allowed_broad_searches": allowed,
+        "recommendation": (
+            "Read 1-3 cited relevant_locations before broad search, or add a reason."
+            if discouraged
+            else "No research-consumption drift detected."
+        ),
+    }
+
+
 def _claude_code_log_dir(project_dir: Path) -> Optional[Path]:
     """Claude Code stores per-session jsonl logs under
     ``~/.claude/projects/<project-path-with-slashes-as-dashes>/``.
@@ -9568,6 +9845,12 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
                     f"# Research Findings ({current_subtask_id}, kind={_research_kind}):"
                 )
                 parts.append(_research_text)
+                _consumption_contract = _research_consumption_contract_block(
+                    _research_text
+                )
+                if _consumption_contract:
+                    parts.append("")
+                    parts.append(_consumption_contract)
                 break
     except (ValueError, OSError):
         pass
@@ -10325,6 +10608,16 @@ if __name__ == "__main__":
         # can decide full-suite vs scoped without `set -e` tripping on an
         # advisory signal.
         report = detect_symbol_blast_radius(sys.argv[2], sys.argv[3])
+        print(json.dumps(report, indent=2))
+
+    elif func_name == "detect_research_consumption_drift" and len(sys.argv) >= 4:
+        # CLI: detect_research_consumption_drift <branch> <subtask_id>
+        # Reads captured Actor shell/search commands from stdin. Advisory only:
+        # exit 0 always so broad-search drift can be surfaced without blocking
+        # normal workflows.
+        report = detect_research_consumption_drift(
+            sys.argv[2], sys.argv[3], sys.stdin.read()
+        )
         print(json.dumps(report, indent=2))
 
     elif func_name == "detect_actor_files_changed_mismatch" and len(sys.argv) >= 4:

--- a/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
@@ -256,7 +256,7 @@ Later phases read with:
 RESEARCH_FINDINGS=$(python3 .map/scripts/map_step_runner.py load_research "$BRANCH" "$SUBTASK_ID")
 ```
 
-The artifact lands under `.map/<branch>/research/<subtask_id>__<kind>.md` and must satisfy the research evidence JSON contract (`status`, `confidence`, `search_stats`, and at most 5 `relevant_locations` with safe relative paths and line ranges). Use `load_research` to fill the `{research_findings}` placeholder in Actor and Monitor prompts below.
+The artifact lands under `.map/<branch>/research/<subtask_id>__<kind>.md` and must satisfy the research evidence JSON contract (`status`, `confidence`, `search_stats`, and at most 5 `relevant_locations` with safe relative paths and line ranges). Use `load_research` to fill the `{research_findings}` placeholder in Actor and Monitor prompts below. Actor must consume high-confidence research before re-exploring: if `confidence >= 0.7` and `relevant_locations` are present, first read 1-3 cited ranges; later repository-wide `rg`/`grep`/`find`/`git grep` needs a stated reason, such as low confidence, missing symbol, failed narrow read, changed hypothesis, or stale research. Low-confidence/location-free research may broaden sooner, but the gap must be named.
 
 ### Phase: TEST_WRITER (2.25) - TDD Mode Only
 
@@ -315,7 +315,7 @@ If `status_mismatch == true`, surface `recovery_instruction` and re-invoke Actor
 Run `python3 .map/scripts/map_step_runner.py detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID"`. If
 `recommended_gate == "validate_callers"`, append `external_callers` to the Monitor
 `<documents>` context and require Monitor to validate each external caller's contract.
-Full recipe: [efficient-reference.md](efficient-reference.md).
+Full recipe: [efficient-reference.md](efficient-reference.md). Optional research-consumption advisory: pipe captured Actor shell/search commands into `python3 .map/scripts/map_step_runner.py detect_research_consumption_drift "$BRANCH" "$SUBTASK_ID"`; if it reports `advisory: true`, add the missing broad-search reason or do the cited narrow read before Monitor.
 
 ### Phase: MONITOR (2.4) - Required
 

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -5083,6 +5083,23 @@ class TestBuildContextBlockInlinesResearch:
         assert "# Research Findings (ST-001, kind=actor):" in result
         assert "Pivotal finding: foo wraps bar." in result
 
+    def test_high_confidence_research_adds_consumption_contract(
+        self, branch_workspace, tmp_path
+    ):
+        _write_research_source(tmp_path)
+        bp = {"subtasks": [{"id": "ST-001", "title": "x"}]}
+        (branch_workspace / "blueprint.json").write_text(json.dumps(bp))
+        map_step_runner.save_research(
+            "test-branch", "ST-001", json.dumps(_valid_research_payload())
+        )
+
+        result = map_step_runner.build_context_block("test-branch", "ST-001")
+
+        assert "# Research Consumption Contract:" in result
+        assert "confidence=0.90" in result
+        assert "First read 1-3 cited ranges" in result
+        assert "Repository-wide rg/grep/find/git grep" in result
+
     def test_no_research_section_when_artifact_absent(self, branch_workspace):
         bp = {"subtasks": [{"id": "ST-001", "title": "x"}]}
         (branch_workspace / "blueprint.json").write_text(json.dumps(bp))
@@ -5873,6 +5890,62 @@ class TestSaveLoadResearch:
 
         assert report["valid"] is False
         assert report["status"] == "missing"
+
+    def test_consumption_detector_flags_unreasoned_broad_search(
+        self, branch_workspace, tmp_path
+    ):
+        del branch_workspace
+        _write_research_source(tmp_path)
+        map_step_runner.save_research(
+            "test-branch", "ST-001", json.dumps(_valid_research_payload())
+        )
+
+        report = map_step_runner.detect_research_consumption_drift(
+            "test-branch", "ST-001", "rg handle\nfind . -name '*.py'"
+        )
+
+        assert report["status"] == "success"
+        assert report["advisory"] is True
+        assert report["broad_search_count"] == 2
+        assert len(report["discouraged_broad_searches"]) == 2
+        assert "Read 1-3 cited" in report["recommendation"]
+
+    def test_consumption_detector_allows_reasoned_or_scoped_searches(
+        self, branch_workspace, tmp_path
+    ):
+        del branch_workspace
+        _write_research_source(tmp_path)
+        map_step_runner.save_research(
+            "test-branch", "ST-001", json.dumps(_valid_research_payload())
+        )
+
+        report = map_step_runner.detect_research_consumption_drift(
+            "test-branch",
+            "ST-001",
+            "rg handle src/service.py\nrg missing . # reason: missing symbol after cited read",
+        )
+
+        assert report["advisory"] is False
+        assert report["broad_search_count"] == 1
+        assert len(report["allowed_broad_searches"]) == 1
+        assert report["discouraged_broad_searches"] == []
+
+    def test_consumption_detector_allows_low_confidence_broad_search(
+        self, branch_workspace, tmp_path
+    ):
+        del branch_workspace
+        _write_research_source(tmp_path)
+        payload = _valid_research_payload()
+        payload["confidence"] = 0.4
+        map_step_runner.save_research("test-branch", "ST-001", json.dumps(payload))
+
+        report = map_step_runner.detect_research_consumption_drift(
+            "test-branch", "ST-001", "git grep handle"
+        )
+
+        assert report["status"] == "research_allows_broad_search"
+        assert report["advisory"] is False
+        assert len(report["allowed_broad_searches"]) == 1
 
     def test_cli_save_reads_stdin_load_writes_stdout(self, branch_workspace, tmp_path):
         """End-to-end CLI: save_research consumes stdin, load_research prints stdout."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2198,6 +2198,15 @@ class TestMapEfficientSaveResearchWiring:
         assert "`research-agent` is conditional" in content
         assert "Call `research-agent` for the current subtask" not in content
 
+    def test_map_efficient_requires_research_consumption_before_broad_search(
+        self, skill_path: Path
+    ) -> None:
+        content = skill_path.read_text(encoding="utf-8")
+        assert "Actor must consume high-confidence research before re-exploring" in content
+        assert "`confidence >= 0.7`" in content
+        assert "first read 1-3 cited ranges" in content
+        assert "detect_research_consumption_drift" in content
+
     def test_codex_research_policy_matches_claude_contract(self) -> None:
         project_root = Path(__file__).parent.parent
         for relative_path in [
@@ -2210,6 +2219,8 @@ class TestMapEfficientSaveResearchWiring:
             assert "`researcher`" in content
             assert "when independent exploration is useful" in content
             assert "If the subtask truly needs no Actor/Monitor" in content
+            assert "Actor must consume high-confidence research before re-exploring" in content
+            assert "detect_research_consumption_drift" in content
 
     def test_hook_hint_mentions_required_artifact_not_required_subagent(self) -> None:
         project_root = Path(__file__).parent.parent
@@ -2231,6 +2242,17 @@ class TestMapEfficientSaveResearchWiring:
             assert "research-agent conditional" in content
             assert "Use research-agent for broad/high-risk/unclear discovery" in content
             assert "save direct current-session findings" in content
+
+    def test_actor_prompt_requires_narrow_reads_for_high_confidence_research(self) -> None:
+        project_root = Path(__file__).parent.parent
+        for relative_path in [
+            Path(".claude/agents/actor.md"),
+            Path("src/mapify_cli/templates/agents/actor.md"),
+        ]:
+            content = (project_root / relative_path).read_text(encoding="utf-8")
+            assert "Read cited code before broad search" in content
+            assert "For confidence >= 0.7 with `relevant_locations`" in content
+            assert "repository-wide `rg`/`grep`/`find`/`git grep`" in content
 
 
 class TestResearchProviderParity:


### PR DESCRIPTION
## Summary
- teach Actor/map-efficient to start from high-confidence research citations before broad repo search
- add an advisory detect_research_consumption_drift CLI for unreasoned repo-wide rg/grep/find/git grep after high-confidence research
- add regression coverage for prompt wording, context-block injection, and detector allowed/discouraged cases

Closes #203

## Tests
- make check