### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   validate-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -71,10 +71,10 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -108,7 +108,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -118,10 +118,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -139,7 +139,7 @@ jobs:
         python -m twine check dist/*
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist-${{ github.run_id }}
         path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -67,7 +67,7 @@ jobs:
         echo "✓ Version validation passed: tag and pyproject.toml both at $TAG_VERSION"
 
     - name: Download build artifacts from CI
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist-${{ github.run_id }}
         path: dist/

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
## Summary\n- Update GitHub-hosted workflow actions to Node 24-compatible major versions.\n- Cover CI, release, and TestPyPI workflows.\n- Update artifact upload/download and Codecov actions called out by the deprecation warnings.\n\n## Verification\n- make check\n- Confirmed no remaining checkout@v4/setup-python@v5/upload-artifact@v4/download-artifact@v4/codecov@v4 refs.\n- actionlint not installed locally.\n\nNo Makefile deploy/prod target exists, so no prod deploy was run.\n\nCloses #206\nCloses #189