### PR TITLE
ci: update Codecov v7 coverage input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       uses: codecov/codecov-action@v7
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
 
   build:


### PR DESCRIPTION
## Summary
- Replace the deprecated Codecov v4/v5-style file input with the v7 files input.
- Removes the GitHub Actions warning surfaced by the Node 24 action upgrade.

## Verification
- make check
- git diff --check

Follow-up for #206 and #189 after PR #211.