### PR TITLE
Add research localization quality scoring

### DIFF
--- a/.map/scripts/validate_spec_citations.py
+++ b/.map/scripts/validate_spec_citations.py
@@ -39,7 +39,7 @@ _CITATION_RE = re.compile(
     :
     (?P<line>\d+)
     (?:-(?P<endline>\d+))?
-    (?=[\s,;)\]'`"]|$)
+    (?=[\s,.;)\]'`"]|$)
     """,
     re.VERBOSE | re.MULTILINE,
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Research-agent localization quality can now be scored deterministically
+  (#200).** Maintainers can parse ResearchEvidence JSON or `path:line[-end]`
+  text citations, validate them against a fixture repo, and compute file-level
+  plus line-overlap precision/recall/F1 without live provider credentials.
+
 ## [3.16.0] - 2026-06-15
 
 ### Added

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1576,6 +1576,39 @@ must not.
 | Greenfield or new-file work | Save direct findings that name the intended new surface and why existing locations are absent. |
 | Docs-only/no-op with no Actor/Monitor needed | Use `mark_subtask_complete --reason`; otherwise save direct docs research before Actor. |
 
+### Research Localization Evals
+
+Use `mapify_cli.research_eval` when a research-agent/researcher change needs a
+deterministic quality check without provider credentials. The scorer accepts the
+same ResearchEvidence JSON saved by `save_research`, or fallback text containing
+`path:line[-end]` citations, normalizes safe relative paths, validates line ranges
+against a fixture repo, deduplicates repeated citations, and reports file-level
+and line-overlap precision/recall/F1.
+
+To add a new eval case, create a tiny fixture repo in a pytest `tmp_path` (or a
+reusable fixture directory), write the files whose line ranges should be found,
+store the research output as a string, and compare it with known targets:
+
+```python
+from mapify_cli.research_eval import ResearchLocation, score_research_output
+
+score = score_research_output(
+    research_output,
+    [ResearchLocation("src/service.py", 20, 28)],
+    repo_root=fixture_repo,
+)
+
+assert score.file_level.f1 == 1.0
+assert score.line_level.recall >= 0.8
+assert score.malformed_count == 0
+```
+
+Prefer expected targets that name the smallest useful file/range, not every file
+an agent could mention. This keeps the eval focused on localization quality:
+exact hits should score 1.0, partial overlap should get partial credit, missing
+targets lower recall, broad ranges lower line precision, duplicates are counted
+but deduplicated for scoring, and malformed paths are reported separately.
+
 ### Cost Comparison Example
 
 **Scenario:** Implement a feature with 4 subtasks

--- a/src/mapify_cli/research_eval.py
+++ b/src/mapify_cli/research_eval.py
@@ -1,0 +1,453 @@
+"""Deterministic localization-quality scoring for research-agent output.
+
+The research-agent is only useful when it returns compact, actionable
+file/line evidence. This module intentionally has no provider dependency: tests
+and maintainers can score saved ResearchEvidence JSON, or markdown-like text
+with ``path:line[-end]`` citations, against known fixture targets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any
+
+
+_CITATION_RE = re.compile(
+    r"""
+    (?<![:\w])
+    (?P<path>
+        [\w./\-]+
+        \.(?:py|md|sh|toml|yaml|yml|json|js|ts|go|rs|tsx|jsx)
+    )
+    :
+    (?P<line>\d+)
+    (?:-(?P<endline>\d+))?
+    (?=[\s,.;)\]'`"]|$)
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+_SKIP_PREFIXES = ("http://", "https://", "/Users/", "/home/", "~/", "$HOME")
+
+
+@dataclass(frozen=True)
+class ResearchLocation:
+    """A normalized inclusive repo-relative file range."""
+
+    path: str
+    start_line: int
+    end_line: int
+
+    @property
+    def line_count(self) -> int:
+        return self.end_line - self.start_line + 1
+
+
+@dataclass(frozen=True)
+class MalformedLocation:
+    raw: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ParsedResearchLocations:
+    locations: tuple[ResearchLocation, ...]
+    duplicates: tuple[ResearchLocation, ...]
+    malformed: tuple[MalformedLocation, ...]
+
+
+@dataclass(frozen=True)
+class MetricScore:
+    precision: float
+    recall: float
+    f1: float
+
+
+@dataclass(frozen=True)
+class ResearchLocalizationScore:
+    expected_count: int
+    predicted_count: int
+    exact_match_count: int
+    partial_match_count: int
+    duplicate_count: int
+    malformed_count: int
+    overbroad_count: int
+    file_level: MetricScore
+    line_level: MetricScore
+    missing_locations: tuple[ResearchLocation, ...]
+    extra_locations: tuple[ResearchLocation, ...]
+
+
+def parse_research_locations(
+    output: str,
+    *,
+    repo_root: Path | None = None,
+) -> ParsedResearchLocations:
+    """Parse research output into normalized file/range citations.
+
+    Strict ResearchEvidence JSON with ``relevant_locations`` is preferred. If the
+    output is not that JSON shape, the parser falls back to markdown/text
+    ``path:line[-end]`` citations. Malformed citations are reported instead of
+    raising so eval runs can score bad outputs deterministically.
+    """
+
+    candidates, malformed = _extract_candidates(output)
+    locations: list[ResearchLocation] = []
+    duplicates: list[ResearchLocation] = []
+    seen: set[ResearchLocation] = set()
+
+    for raw_path, start_line, end_line in candidates:
+        location, error = _normalize_location(
+            raw_path,
+            start_line,
+            end_line,
+            repo_root=repo_root,
+        )
+        if error is not None:
+            malformed.append(error)
+            continue
+        if location is None:
+            malformed.append(
+                MalformedLocation(raw=raw_path, reason="location normalization failed")
+            )
+            continue
+        if location in seen:
+            duplicates.append(location)
+            continue
+        seen.add(location)
+        locations.append(location)
+
+    return ParsedResearchLocations(
+        locations=tuple(locations),
+        duplicates=tuple(duplicates),
+        malformed=tuple(malformed),
+    )
+
+
+def score_research_output(
+    output: str,
+    expected_locations: Sequence[ResearchLocation | Mapping[str, Any]],
+    *,
+    repo_root: Path | None = None,
+    overbroad_line_threshold: int = 50,
+) -> ResearchLocalizationScore:
+    """Parse and score research output against expected target locations."""
+
+    parsed = parse_research_locations(output, repo_root=repo_root)
+    return score_research_locations(
+        expected_locations,
+        parsed.locations,
+        duplicate_count=len(parsed.duplicates),
+        malformed_count=len(parsed.malformed),
+        overbroad_line_threshold=overbroad_line_threshold,
+    )
+
+
+def score_research_locations(
+    expected_locations: Sequence[ResearchLocation | Mapping[str, Any]],
+    predicted_locations: Sequence[ResearchLocation | Mapping[str, Any]],
+    *,
+    duplicate_count: int = 0,
+    malformed_count: int = 0,
+    overbroad_line_threshold: int = 50,
+) -> ResearchLocalizationScore:
+    """Score normalized predictions against expected repo locations."""
+
+    expected = tuple(_coerce_location(location) for location in expected_locations)
+    predicted = tuple(_coerce_location(location) for location in predicted_locations)
+
+    expected_set = set(expected)
+    predicted_set = set(predicted)
+    exact_match_count = len(expected_set & predicted_set)
+
+    missing: list[ResearchLocation] = []
+    partial_match_count = 0
+    for target in expected:
+        if target in predicted_set:
+            continue
+        if any(_overlaps(target, candidate) for candidate in predicted):
+            partial_match_count += 1
+        else:
+            missing.append(target)
+
+    extra = tuple(
+        candidate
+        for candidate in predicted
+        if not any(_overlaps(candidate, target) for target in expected)
+    )
+    overbroad_count = sum(
+        1 for candidate in predicted if candidate.line_count > overbroad_line_threshold
+    )
+
+    file_level = _score_file_level(expected, predicted)
+    line_level = _score_line_level(expected, predicted)
+
+    return ResearchLocalizationScore(
+        expected_count=len(expected),
+        predicted_count=len(predicted),
+        exact_match_count=exact_match_count,
+        partial_match_count=partial_match_count,
+        duplicate_count=duplicate_count,
+        malformed_count=malformed_count,
+        overbroad_count=overbroad_count,
+        file_level=file_level,
+        line_level=line_level,
+        missing_locations=tuple(missing),
+        extra_locations=extra,
+    )
+
+
+def _extract_candidates(
+    output: str,
+) -> tuple[list[tuple[str, int, int]], list[MalformedLocation]]:
+    stripped = output.strip()
+    malformed: list[MalformedLocation] = []
+    if not stripped:
+        return [], [MalformedLocation(raw="", reason="output is empty")]
+
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if isinstance(parsed, Mapping):
+        raw_locations = parsed.get("relevant_locations")
+        if isinstance(raw_locations, list):
+            return _extract_json_candidates(raw_locations)
+        malformed.append(
+            MalformedLocation(
+                raw="relevant_locations",
+                reason="JSON output has no relevant_locations list",
+            )
+        )
+
+    candidates: list[tuple[str, int, int]] = []
+    for match in _CITATION_RE.finditer(output):
+        start_line = int(match.group("line"))
+        end_line = int(match.group("endline") or start_line)
+        candidates.append((match.group("path"), start_line, end_line))
+    return candidates, malformed
+
+
+def _extract_json_candidates(
+    raw_locations: Sequence[object],
+) -> tuple[list[tuple[str, int, int]], list[MalformedLocation]]:
+    candidates: list[tuple[str, int, int]] = []
+    malformed: list[MalformedLocation] = []
+    for index, raw_location in enumerate(raw_locations):
+        prefix = f"relevant_locations[{index}]"
+        if not isinstance(raw_location, Mapping):
+            malformed.append(
+                MalformedLocation(raw=prefix, reason="location must be an object")
+            )
+            continue
+
+        path_value = raw_location.get("path")
+        if not isinstance(path_value, str):
+            malformed.append(
+                MalformedLocation(raw=f"{prefix}.path", reason="path must be a string")
+            )
+            continue
+
+        raw_lines = raw_location.get("lines", raw_location.get("line_range"))
+        if _is_int_not_bool(raw_location.get("line")):
+            line = int(raw_location["line"])
+            candidates.append((path_value, line, line))
+        elif (
+            isinstance(raw_lines, list)
+            and len(raw_lines) == 2
+            and all(_is_int_not_bool(part) for part in raw_lines)
+        ):
+            candidates.append((path_value, int(raw_lines[0]), int(raw_lines[1])))
+        else:
+            malformed.append(
+                MalformedLocation(
+                    raw=f"{prefix}.lines",
+                    reason="lines must be [start, end] positive integers",
+                )
+            )
+    return candidates, malformed
+
+
+def _normalize_location(
+    raw_path: str,
+    start_line: int,
+    end_line: int,
+    *,
+    repo_root: Path | None,
+) -> tuple[ResearchLocation | None, MalformedLocation | None]:
+    path_text = raw_path.strip()
+    if not path_text:
+        return None, MalformedLocation(raw=raw_path, reason="path is empty")
+    if any(path_text.startswith(prefix) for prefix in _SKIP_PREFIXES):
+        return None, MalformedLocation(raw=path_text, reason="path is outside repo")
+
+    pure_path = PurePosixPath(path_text)
+    if (
+        pure_path.is_absolute()
+        or path_text.startswith("~")
+        or "\\" in path_text
+        or any(part == ".." for part in pure_path.parts)
+    ):
+        return None, MalformedLocation(raw=path_text, reason="path is not safe relative")
+
+    if start_line < 1 or end_line < start_line:
+        return None, MalformedLocation(raw=path_text, reason="line range is invalid")
+
+    normalized_path = "/".join(pure_path.parts)
+    if repo_root is not None:
+        target = repo_root / Path(*pure_path.parts)
+        if not target.is_file():
+            return None, MalformedLocation(raw=path_text, reason="file does not exist")
+        try:
+            line_count = len(target.read_text(encoding="utf-8").splitlines())
+        except OSError as exc:
+            return None, MalformedLocation(raw=path_text, reason=f"could not read file: {exc}")
+        if end_line > line_count:
+            return None, MalformedLocation(
+                raw=f"{path_text}:{start_line}-{end_line}",
+                reason=f"line range exceeds file length ({line_count})",
+            )
+
+    return ResearchLocation(normalized_path, start_line, end_line), None
+
+
+def _coerce_location(location: ResearchLocation | Mapping[str, Any]) -> ResearchLocation:
+    if isinstance(location, ResearchLocation):
+        return location
+    if not isinstance(location, Mapping):
+        raise TypeError("location must be ResearchLocation or mapping")
+
+    path = location.get("path")
+    raw_lines = location.get("lines", location.get("line_range"))
+    if _is_int_not_bool(location.get("line")):
+        start_line = int(location["line"])
+        end_line = start_line
+    elif (
+        isinstance(raw_lines, list)
+        and len(raw_lines) == 2
+        and all(_is_int_not_bool(part) for part in raw_lines)
+    ):
+        start_line = int(raw_lines[0])
+        end_line = int(raw_lines[1])
+    else:
+        raise ValueError("location must include line or lines=[start, end]")
+
+    if not isinstance(path, str):
+        raise ValueError("location path must be a string")
+    normalized, error = _normalize_location(
+        path,
+        start_line,
+        end_line,
+        repo_root=None,
+    )
+    if error is not None or normalized is None:
+        reason = error.reason if error is not None else "invalid location"
+        raise ValueError(reason)
+    return normalized
+
+
+def _score_file_level(
+    expected: Sequence[ResearchLocation],
+    predicted: Sequence[ResearchLocation],
+) -> MetricScore:
+    expected_files = {location.path for location in expected}
+    predicted_files = {location.path for location in predicted}
+    true_positive = len(expected_files & predicted_files)
+    return _metric(
+        true_positive=true_positive,
+        predicted_total=len(predicted_files),
+        expected_total=len(expected_files),
+    )
+
+
+def _score_line_level(
+    expected: Sequence[ResearchLocation],
+    predicted: Sequence[ResearchLocation],
+) -> MetricScore:
+    expected_ranges = _ranges_by_path(expected)
+    predicted_ranges = _ranges_by_path(predicted)
+    expected_total = sum(_range_length(ranges) for ranges in expected_ranges.values())
+    predicted_total = sum(_range_length(ranges) for ranges in predicted_ranges.values())
+    overlap = 0
+    for path, ranges in predicted_ranges.items():
+        overlap += _intersection_length(ranges, expected_ranges.get(path, ()))
+    return _metric(
+        true_positive=overlap,
+        predicted_total=predicted_total,
+        expected_total=expected_total,
+    )
+
+
+def _metric(
+    *,
+    true_positive: int,
+    predicted_total: int,
+    expected_total: int,
+) -> MetricScore:
+    if predicted_total == 0:
+        precision = 1.0 if expected_total == 0 else 0.0
+    else:
+        precision = true_positive / predicted_total
+    recall = 1.0 if expected_total == 0 else true_positive / expected_total
+    if precision + recall == 0:
+        f1 = 0.0
+    else:
+        f1 = 2 * precision * recall / (precision + recall)
+    return MetricScore(precision=precision, recall=recall, f1=f1)
+
+
+def _ranges_by_path(
+    locations: Sequence[ResearchLocation],
+) -> dict[str, tuple[tuple[int, int], ...]]:
+    grouped: dict[str, list[tuple[int, int]]] = {}
+    for location in locations:
+        grouped.setdefault(location.path, []).append(
+            (location.start_line, location.end_line)
+        )
+    return {path: _merge_ranges(ranges) for path, ranges in grouped.items()}
+
+
+def _merge_ranges(ranges: Sequence[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(ranges):
+        if not merged or start > merged[-1][1] + 1:
+            merged.append((start, end))
+        else:
+            previous_start, previous_end = merged[-1]
+            merged[-1] = (previous_start, max(previous_end, end))
+    return tuple(merged)
+
+
+def _range_length(ranges: Sequence[tuple[int, int]]) -> int:
+    return sum(end - start + 1 for start, end in ranges)
+
+
+def _intersection_length(
+    left: Sequence[tuple[int, int]],
+    right: Sequence[tuple[int, int]],
+) -> int:
+    total = 0
+    for left_start, left_end in left:
+        for right_start, right_end in right:
+            start = max(left_start, right_start)
+            end = min(left_end, right_end)
+            if start <= end:
+                total += end - start + 1
+    return total
+
+
+def _overlaps(left: ResearchLocation, right: ResearchLocation) -> bool:
+    return (
+        left.path == right.path
+        and left.start_line <= right.end_line
+        and right.start_line <= left.end_line
+    )
+
+
+def _is_int_not_bool(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)

--- a/src/mapify_cli/templates/map/scripts/validate_spec_citations.py
+++ b/src/mapify_cli/templates/map/scripts/validate_spec_citations.py
@@ -39,7 +39,7 @@ _CITATION_RE = re.compile(
     :
     (?P<line>\d+)
     (?:-(?P<endline>\d+))?
-    (?=[\s,;)\]'`"]|$)
+    (?=[\s,.;)\]'`"]|$)
     """,
     re.VERBOSE | re.MULTILINE,
 )

--- a/src/mapify_cli/templates_src/map/scripts/validate_spec_citations.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/validate_spec_citations.py.jinja
@@ -39,7 +39,7 @@ _CITATION_RE = re.compile(
     :
     (?P<line>\d+)
     (?:-(?P<endline>\d+))?
-    (?=[\s,;)\]'`"]|$)
+    (?=[\s,.;)\]'`"]|$)
     """,
     re.VERBOSE | re.MULTILINE,
 )

--- a/tests/test_research_eval.py
+++ b/tests/test_research_eval.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mapify_cli.research_eval import (
+    ResearchLocation,
+    parse_research_locations,
+    score_research_output,
+)
+
+
+def _write_file(repo: Path, path: str, line_count: int = 80) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "".join(f"line {index}\n" for index in range(1, line_count + 1)),
+        encoding="utf-8",
+    )
+
+
+def _research_json(*locations: dict[str, object]) -> str:
+    return json.dumps(
+        {
+            "status": "OK",
+            "confidence": 0.9,
+            "search_stats": {
+                "files_scanned": 1,
+                "total_matches_found": len(locations),
+                "results_truncated": False,
+            },
+            "relevant_locations": list(locations),
+        }
+    )
+
+
+def test_scores_exact_json_research_locations(tmp_path: Path) -> None:
+    _write_file(tmp_path, "src/service.py")
+    output = _research_json(
+        {
+            "path": "src/service.py",
+            "lines": [2, 3],
+            "relevance": "Primary implementation.",
+        }
+    )
+
+    score = score_research_output(
+        output,
+        [ResearchLocation("src/service.py", 2, 3)],
+        repo_root=tmp_path,
+    )
+
+    assert score.expected_count == 1
+    assert score.predicted_count == 1
+    assert score.exact_match_count == 1
+    assert score.file_level.precision == 1.0
+    assert score.file_level.recall == 1.0
+    assert score.line_level.f1 == 1.0
+    assert score.malformed_count == 0
+
+
+def test_scores_partial_line_overlap(tmp_path: Path) -> None:
+    _write_file(tmp_path, "src/service.py")
+    output = _research_json(
+        {
+            "path": "src/service.py",
+            "lines": [2, 4],
+            "relevance": "Near the expected implementation.",
+        }
+    )
+
+    score = score_research_output(
+        output,
+        [ResearchLocation("src/service.py", 3, 5)],
+        repo_root=tmp_path,
+    )
+
+    assert score.exact_match_count == 0
+    assert score.partial_match_count == 1
+    assert score.line_level.precision == pytest.approx(2 / 3)
+    assert score.line_level.recall == pytest.approx(2 / 3)
+
+
+def test_scores_missing_expected_location(tmp_path: Path) -> None:
+    _write_file(tmp_path, "src/service.py")
+    output = _research_json()
+
+    score = score_research_output(
+        output,
+        [ResearchLocation("src/service.py", 10, 12)],
+        repo_root=tmp_path,
+    )
+
+    assert score.predicted_count == 0
+    assert score.file_level.recall == 0.0
+    assert score.line_level.recall == 0.0
+    assert score.missing_locations == (ResearchLocation("src/service.py", 10, 12),)
+
+
+def test_penalizes_over_broad_text_citation(tmp_path: Path) -> None:
+    _write_file(tmp_path, "src/service.py")
+
+    score = score_research_output(
+        "The important code is src/service.py:1-60.",
+        [ResearchLocation("src/service.py", 20, 22)],
+        repo_root=tmp_path,
+        overbroad_line_threshold=20,
+    )
+
+    assert score.file_level.precision == 1.0
+    assert score.file_level.recall == 1.0
+    assert score.line_level.precision == pytest.approx(3 / 60)
+    assert score.line_level.recall == 1.0
+    assert score.overbroad_count == 1
+
+
+def test_deduplicates_repeated_text_citations(tmp_path: Path) -> None:
+    _write_file(tmp_path, "src/service.py")
+
+    parsed = parse_research_locations(
+        "src/service.py:10-12 and again src/service.py:10-12",
+        repo_root=tmp_path,
+    )
+    score = score_research_output(
+        "src/service.py:10-12 and again src/service.py:10-12",
+        [ResearchLocation("src/service.py", 10, 12)],
+        repo_root=tmp_path,
+    )
+
+    assert parsed.locations == (ResearchLocation("src/service.py", 10, 12),)
+    assert parsed.duplicates == (ResearchLocation("src/service.py", 10, 12),)
+    assert score.predicted_count == 1
+    assert score.duplicate_count == 1
+    assert score.line_level.f1 == 1.0
+
+
+def test_reports_malformed_paths_and_ranges(tmp_path: Path) -> None:
+    _write_file(tmp_path, "src/service.py", line_count=5)
+    output = _research_json(
+        {"path": "../secret.py", "lines": [1, 1], "relevance": "unsafe"},
+        {"path": "src/missing.py", "lines": [1, 1], "relevance": "absent"},
+        {"path": "src/service.py", "lines": [8, 9], "relevance": "stale"},
+    )
+
+    score = score_research_output(
+        output,
+        [ResearchLocation("src/service.py", 1, 1)],
+        repo_root=tmp_path,
+    )
+    parsed = parse_research_locations(output, repo_root=tmp_path)
+
+    assert score.predicted_count == 0
+    assert score.malformed_count == 3
+    assert score.file_level.recall == 0.0
+    assert {item.reason for item in parsed.malformed} == {
+        "path is not safe relative",
+        "file does not exist",
+        "line range exceeds file length (5)",
+    }

--- a/tests/test_validate_spec_citations.py
+++ b/tests/test_validate_spec_citations.py
@@ -55,6 +55,16 @@ def test_passes_when_cited_line_contains_identifier(validator, tmp_path: Path):
     assert result["details"][0]["status"] == "ok"
 
 
+def test_accepts_sentence_period_after_citation(validator, tmp_path: Path):
+    repo = _seed_repo(tmp_path, {"src/pkg/mod.py": "first\nIDENT_TOKEN = 1\n"})
+    spec = _write_spec(repo, "See `IDENT_TOKEN` at `src/pkg/mod.py:2`.")
+
+    result = validator.validate_spec(spec, repo)
+
+    assert result["passed"] is True
+    assert result["total_citations"] == 1
+
+
 def test_flags_stale_citation_when_identifier_moved(validator, tmp_path: Path):
     repo = _seed_repo(
         tmp_path,


### PR DESCRIPTION
## Summary\n- add deterministic research localization parser/scorer for ResearchEvidence JSON and path:line text citations\n- score file-level and line-overlap precision/recall/F1, duplicates, malformed paths, missing and over-broad locations\n- document how maintainers can add credential-free research localization eval cases\n- allow sentence-final periods after file:line citations in the spec citation validator\n\nCloses #200\n\n## Tests\n- uv run pytest tests/test_research_eval.py tests/test_validate_spec_citations.py -v\n- make lint\n- make check