### PR TITLE
Expose research localization eval through CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#200).** Maintainers can parse ResearchEvidence JSON or `path:line[-end]`
   text citations, validate them against a fixture repo, and compute file-level
   plus line-overlap precision/recall/F1 without live provider credentials.
+  The scorer is exposed as `mapify research-eval score` and covered by the
+  no-provider E2E artifact-contract suite.
 
 ## [3.16.0] - 2026-06-15
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1578,7 +1578,7 @@ must not.
 
 ### Research Localization Evals
 
-Use `mapify_cli.research_eval` when a research-agent/researcher change needs a
+Use `mapify research-eval score` when a research-agent/researcher change needs a
 deterministic quality check without provider credentials. The scorer accepts the
 same ResearchEvidence JSON saved by `save_research`, or fallback text containing
 `path:line[-end]` citations, normalizes safe relative paths, validates line ranges
@@ -1601,6 +1601,26 @@ score = score_research_output(
 assert score.file_level.f1 == 1.0
 assert score.line_level.recall >= 0.8
 assert score.malformed_count == 0
+```
+
+For CI/e2e usage, prefer the CLI surface:
+
+```bash
+mapify research-eval score research.json expected.json \
+  --repo-root tests/fixtures/research_eval/service_repo \
+  --fail-under-file-f1 1.0 \
+  --fail-under-line-f1 0.8
+```
+
+`expected.json` can be either a raw list of locations or an object with an
+`expected_locations` list:
+
+```json
+{
+  "expected_locations": [
+    {"path": "src/service.py", "lines": [20, 28]}
+  ]
+}
 ```
 
 Prefer expected targets that name the smallest useful file/range, not every file

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -145,6 +145,13 @@ skill_eval_app = typer.Typer(
 
 app.add_typer(skill_eval_app, name="skill-eval")
 
+research_eval_app = typer.Typer(
+    name="research-eval",
+    help="Evaluate research-agent localization quality without provider calls",
+)
+
+app.add_typer(research_eval_app, name="research-eval")
+
 
 def version_callback(value: bool):
     """Callback to show version and exit."""
@@ -1386,6 +1393,113 @@ def upgrade():
         "[dim]To refresh this project's MAP files with the new templates, run "
         "[cyan]mapify init . --force[/cyan].[/dim]"
     )
+
+
+# Research localization eval commands
+
+
+@research_eval_app.command("score")
+def research_eval_score(
+    output_file: Path = typer.Argument(
+        ...,
+        help="ResearchEvidence JSON/text output file to score",
+    ),
+    expected_file: Path = typer.Argument(
+        ...,
+        help="JSON list, or object with expected_locations, of target file ranges",
+    ),
+    repo_root: Optional[Path] = typer.Option(
+        None,
+        "--repo-root",
+        help="Fixture repository root for path and line-range validation",
+    ),
+    fail_under_file_f1: float = typer.Option(
+        0.0,
+        "--fail-under-file-f1",
+        min=0.0,
+        max=1.0,
+        help="Exit 1 when file-level F1 is below this threshold",
+    ),
+    fail_under_line_f1: float = typer.Option(
+        0.0,
+        "--fail-under-line-f1",
+        min=0.0,
+        max=1.0,
+        help="Exit 1 when line-overlap F1 is below this threshold",
+    ),
+    overbroad_line_threshold: int = typer.Option(
+        50,
+        "--overbroad-line-threshold",
+        min=1,
+        help="Count predicted locations above this line span as over-broad",
+    ),
+    fail_on_malformed: bool = typer.Option(
+        True,
+        "--fail-on-malformed/--allow-malformed",
+        help="Exit 1 when parsed output contains malformed locations",
+    ),
+) -> None:
+    """Score research-agent localization against known fixture targets.
+
+    Exit codes:
+      0 - Score meets thresholds
+      1 - Score below threshold or malformed output found
+      2 - Input files are missing or malformed
+    """
+    import json
+
+    from mapify_cli.research_eval import (
+        load_expected_locations,
+        score_research_output,
+        score_to_dict,
+    )
+
+    try:
+        output = output_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        console.print(f"[bold red]Error:[/bold red] cannot read output file: {exc}")
+        raise typer.Exit(2)
+
+    try:
+        expected = load_expected_locations(expected_file)
+    except (OSError, ValueError) as exc:
+        console.print(f"[bold red]Error:[/bold red] cannot load expected targets: {exc}")
+        raise typer.Exit(2)
+
+    root = repo_root.resolve() if repo_root else Path.cwd()
+    score = score_research_output(
+        output,
+        expected,
+        repo_root=root,
+        overbroad_line_threshold=overbroad_line_threshold,
+    )
+
+    failed_reasons: list[str] = []
+    if score.file_level.f1 < fail_under_file_f1:
+        failed_reasons.append(
+            f"file_level.f1 {score.file_level.f1:.3f} < {fail_under_file_f1:.3f}"
+        )
+    if score.line_level.f1 < fail_under_line_f1:
+        failed_reasons.append(
+            f"line_level.f1 {score.line_level.f1:.3f} < {fail_under_line_f1:.3f}"
+        )
+    if fail_on_malformed and score.malformed_count > 0:
+        failed_reasons.append(f"malformed_count {score.malformed_count} > 0")
+
+    payload = {
+        "passed": not failed_reasons,
+        "failed_reasons": failed_reasons,
+        "thresholds": {
+            "fail_under_file_f1": fail_under_file_f1,
+            "fail_under_line_f1": fail_under_line_f1,
+            "fail_on_malformed": fail_on_malformed,
+            "overbroad_line_threshold": overbroad_line_threshold,
+        },
+        "score": score_to_dict(score),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if failed_reasons:
+        raise typer.Exit(1)
 
 
 # Skill-eval commands

--- a/src/mapify_cli/research_eval.py
+++ b/src/mapify_cli/research_eval.py
@@ -9,7 +9,7 @@ with ``path:line[-end]`` citations, against known fixture targets.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 import json
 from pathlib import Path, PurePosixPath
 import re
@@ -199,6 +199,33 @@ def score_research_locations(
         missing_locations=tuple(missing),
         extra_locations=extra,
     )
+
+
+def load_expected_locations(path: Path) -> list[dict[str, Any]]:
+    """Load expected research localization targets from a JSON file.
+
+    Accepted shapes:
+    - ``[{"path": "src/x.py", "lines": [1, 3]}]``
+    - ``{"expected_locations": [{"path": "src/x.py", "lines": [1, 3]}]}``
+    """
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"expected locations JSON is malformed: {exc.msg}") from exc
+
+    if isinstance(raw, Mapping):
+        raw = raw.get("expected_locations")
+    if not isinstance(raw, list):
+        raise ValueError("expected locations must be a list or expected_locations object")
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"expected_locations[{index}] must be an object")
+    return raw
+
+
+def score_to_dict(score: ResearchLocalizationScore) -> dict[str, Any]:
+    return asdict(score)
 
 
 def _extract_candidates(

--- a/tests/integration/test_e2e_artifact_contracts.py
+++ b/tests/integration/test_e2e_artifact_contracts.py
@@ -112,6 +112,78 @@ def _write_valid_research(workspace: Path, subtask_id: str) -> None:
     )
 
 
+class TestResearchLocalizationEvalContract:
+    """Research localization eval is part of the no-provider E2E contract."""
+
+    def test_mapify_research_eval_scores_fixture_repo(self, tmp_path: Path) -> None:
+        from typer.testing import CliRunner
+
+        from mapify_cli import app
+
+        source = tmp_path / "src" / "service.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(
+            "".join(f"line {index}\n" for index in range(1, 41)),
+            encoding="utf-8",
+        )
+        research_output = tmp_path / "research.json"
+        research_output.write_text(
+            json.dumps(
+                {
+                    "status": "OK",
+                    "confidence": 0.9,
+                    "search_stats": {
+                        "files_scanned": 1,
+                        "total_matches_found": 1,
+                        "results_truncated": False,
+                    },
+                    "relevant_locations": [
+                        {
+                            "path": "src/service.py",
+                            "lines": [20, 22],
+                            "relevance": "Primary implementation branch.",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        expected = tmp_path / "expected.json"
+        expected.write_text(
+            json.dumps(
+                {
+                    "expected_locations": [
+                        {"path": "src/service.py", "lines": [20, 22]}
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "research-eval",
+                "score",
+                str(research_output),
+                str(expected),
+                "--repo-root",
+                str(tmp_path),
+                "--fail-under-file-f1",
+                "1.0",
+                "--fail-under-line-f1",
+                "1.0",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["passed"] is True
+        assert payload["score"]["exact_match_count"] == 1
+        assert payload["score"]["file_level"]["f1"] == 1.0
+        assert payload["score"]["line_level"]["f1"] == 1.0
+
+
 # =====================================================================
 # Phase 1: map-plan artifact production
 # =====================================================================


### PR DESCRIPTION
## Summary
- expose deterministic research localization scoring as `mapify research-eval score`
- add a no-provider E2E artifact-contract test that invokes the CLI on a mini fixture repo
- document the CLI/e2e usage and expected target JSON format

Follow-up to #213 / #200.

## Tests
- `uv run pytest tests/test_research_eval.py tests/integration/test_e2e_artifact_contracts.py::TestResearchLocalizationEvalContract -v`
- `make lint`
- `make check`
- `uv run mapify research-eval --help`