### PR TITLE
Guard Monitor against YAGNI misprunes

### DIFF
--- a/.claude/agents/monitor.md
+++ b/.claude/agents/monitor.md
@@ -75,6 +75,8 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 
 You must NOT reject on the basis of style, elegance, or volume, even if the Evaluator scored simplicity low. Your reject criteria remain contract violation, build/test failure, security, data loss, missing required behavior, or other AUTO-REJECT items below. Style, elegance, and volume concerns are LOW/NON-BLOCKING unless they create one of those concrete failures.
 
+**Misprune guard (when `<map_context>` includes `Approved Blueprint Snapshot`):** Treat the original request/goal, hard constraints, coverage_map, and `Active approved plan scope` as the user-approved blueprint. If Actor omits active approved scope because it appears optional, YAGNI, or smaller, return `valid:false` with category `misprune`. Treat `Rejected removals / Deferred YAGNI parking lot` as approved omissions: do NOT require those items unless they were restored into active scope. If Actor implements a rejected-removal item without restoration, report it as scope drift (blocking only when it violates mutation boundary, contract, safety, or explicit user approval).
+
 **Escalation Framework:**
 
 🔴 **AUTO-REJECT (valid: false, must fix):**

--- a/.codex/agents/monitor.toml
+++ b/.codex/agents/monitor.toml
@@ -65,6 +65,15 @@ failure, security, data loss, missing required behavior, or other AUTO-REJECT it
 below. Style, elegance, and volume concerns are LOW/NON-BLOCKING unless they create one
 of those concrete failures.
 
+Misprune guard (when <map_context> includes Approved Blueprint Snapshot): Treat the
+original request/goal, hard constraints, coverage_map, and Active approved plan scope as
+the user-approved blueprint. If Actor omits active approved scope because it appears
+optional, YAGNI, or smaller, return valid:false with category "misprune". Treat
+Rejected removals / Deferred YAGNI parking lot as approved omissions: do NOT require
+those items unless they were restored into active scope. If Actor implements a
+rejected-removal item without restoration, report it as scope drift (blocking only when
+it violates mutation boundary, contract, safety, or explicit user approval).
+
 ---
 
 # Escalation Framework

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -9826,6 +9826,114 @@ def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
     }
 
 
+def _format_blueprint_item(item: object) -> str:
+    """Render a blueprint list item as a compact evidence line."""
+    if not isinstance(item, dict):
+        return str(item)
+    item_id = item.get("id")
+    description = item.get("description") or item.get("title") or item.get("summary")
+    if item_id and description:
+        text = f"{item_id}: {description}"
+    elif item_id:
+        text = str(item_id)
+    elif description:
+        text = str(description)
+    else:
+        text = json.dumps(item, sort_keys=True)
+    source = item.get("source")
+    if source:
+        text = f"{text} (source: {source})"
+    return text
+
+
+def _append_blueprint_list(
+    lines: list[str], heading: str, values: object
+) -> None:
+    if not isinstance(values, list) or not values:
+        return
+    lines.append(heading)
+    for value in values:
+        lines.append(f"  - {_format_blueprint_item(value)}")
+
+
+def _approved_blueprint_snapshot_lines(
+    blueprint: Mapping[str, object], goal: str
+) -> list[str]:
+    """Return Monitor-facing plan scope, including approved omissions.
+
+    Monitor must compare Actor output against the user-approved plan scope, not
+    against an implicit "smaller is better" rewrite. The rejected-removals list
+    is the explicit allow-list for work the user approved omitting.
+    """
+    lines = [
+        "# Approved Blueprint Snapshot (Monitor misprune guard):",
+        f"Original request / goal: {goal}",
+    ]
+    summary = blueprint.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        lines.append(f"Blueprint summary: {summary.strip()}")
+
+    _append_blueprint_list(lines, "Hard constraints:", blueprint.get("hard_constraints"))
+    _append_blueprint_list(lines, "Soft constraints:", blueprint.get("soft_constraints"))
+
+    subtasks = blueprint.get("subtasks")
+    if isinstance(subtasks, list) and subtasks:
+        lines.append("Active approved plan scope:")
+        for subtask in subtasks:
+            if not isinstance(subtask, dict):
+                continue
+            subtask_id = subtask.get("id", "ST-???")
+            title = subtask.get("title", "Untitled")
+            metadata = []
+            requiredness = subtask.get("requiredness")
+            if isinstance(requiredness, str):
+                metadata.append(f"requiredness={requiredness}")
+            pruneable = subtask.get("pruneable")
+            if isinstance(pruneable, bool):
+                metadata.append(f"pruneable={pruneable}")
+            restored_from = subtask.get("restored_from_deferred_yagni")
+            if isinstance(restored_from, str) and restored_from.strip():
+                metadata.append(f"restored_from={restored_from.strip()}")
+            suffix = f" ({', '.join(metadata)})" if metadata else ""
+            lines.append(f"  - {subtask_id}: {title}{suffix}")
+            criteria = subtask.get("validation_criteria")
+            if isinstance(criteria, list) and criteria:
+                rendered_criteria = "; ".join(str(item) for item in criteria)
+                lines.append(f"    validation_criteria: {rendered_criteria}")
+
+    coverage_map = blueprint.get("coverage_map")
+    if isinstance(coverage_map, dict) and coverage_map:
+        lines.append("Coverage map:")
+        for key, owner in coverage_map.items():
+            lines.append(f"  - {key} -> {owner}")
+
+    lines.append("Rejected removals / Deferred YAGNI parking lot:")
+    deferred_yagni = blueprint.get("deferred_yagni")
+    if isinstance(deferred_yagni, list) and deferred_yagni:
+        lines.append(
+            "Do not require these items unless the user restores them into "
+            "the active blueprint."
+        )
+        for item in deferred_yagni:
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id", "YG-???")
+            title = item.get("title", "Untitled")
+            rationale = item.get("rationale", "No rationale recorded")
+            restore_hint = item.get("restore_hint", "No restore hint recorded")
+            lines.append(
+                f"  - {item_id}: {title} -- {rationale}; restore: {restore_hint}"
+            )
+    else:
+        lines.append("  - none; no omitted work is approved.")
+    lines.append(
+        "Monitor rule: flag a misprune when Actor omits active approved plan "
+        "scope, hard constraints, or coverage_map owners; do not require "
+        "rejected-removal items unless restored."
+    )
+    return lines
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 
@@ -9963,21 +10071,8 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
         parts.append("")
         parts.append(doctrine_block)
     parts.extend(current_details)
-    deferred_yagni = blueprint.get("deferred_yagni")
-    if isinstance(deferred_yagni, list) and deferred_yagni:
-        parts.append("")
-        parts.append("# Deferred YAGNI Parking Lot (user-approved omissions):")
-        parts.append(
-            "Do not implement these items unless the user restores them into the active blueprint."
-        )
-        for item in deferred_yagni:
-            if not isinstance(item, dict):
-                continue
-            item_id = item.get("id", "YG-???")
-            title = item.get("title", "Untitled")
-            rationale = item.get("rationale", "No rationale recorded")
-            restore_hint = item.get("restore_hint", "No restore hint recorded")
-            parts.append(f"  - {item_id}: {title} -- {rationale}; restore: {restore_hint}")
+    parts.append("")
+    parts.extend(_approved_blueprint_snapshot_lines(blueprint, goal))
     if upstream_lines:
         parts.append("")
         parts.append(f"# Upstream Results (dependencies of {current_subtask_id}):")

--- a/src/mapify_cli/templates/agents/monitor.md
+++ b/src/mapify_cli/templates/agents/monitor.md
@@ -75,6 +75,8 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 
 You must NOT reject on the basis of style, elegance, or volume, even if the Evaluator scored simplicity low. Your reject criteria remain contract violation, build/test failure, security, data loss, missing required behavior, or other AUTO-REJECT items below. Style, elegance, and volume concerns are LOW/NON-BLOCKING unless they create one of those concrete failures.
 
+**Misprune guard (when `<map_context>` includes `Approved Blueprint Snapshot`):** Treat the original request/goal, hard constraints, coverage_map, and `Active approved plan scope` as the user-approved blueprint. If Actor omits active approved scope because it appears optional, YAGNI, or smaller, return `valid:false` with category `misprune`. Treat `Rejected removals / Deferred YAGNI parking lot` as approved omissions: do NOT require those items unless they were restored into active scope. If Actor implements a rejected-removal item without restoration, report it as scope drift (blocking only when it violates mutation boundary, contract, safety, or explicit user approval).
+
 **Escalation Framework:**
 
 🔴 **AUTO-REJECT (valid: false, must fix):**

--- a/src/mapify_cli/templates/codex/agents/monitor.toml
+++ b/src/mapify_cli/templates/codex/agents/monitor.toml
@@ -65,6 +65,15 @@ failure, security, data loss, missing required behavior, or other AUTO-REJECT it
 below. Style, elegance, and volume concerns are LOW/NON-BLOCKING unless they create one
 of those concrete failures.
 
+Misprune guard (when <map_context> includes Approved Blueprint Snapshot): Treat the
+original request/goal, hard constraints, coverage_map, and Active approved plan scope as
+the user-approved blueprint. If Actor omits active approved scope because it appears
+optional, YAGNI, or smaller, return valid:false with category "misprune". Treat
+Rejected removals / Deferred YAGNI parking lot as approved omissions: do NOT require
+those items unless they were restored into active scope. If Actor implements a
+rejected-removal item without restoration, report it as scope drift (blocking only when
+it violates mutation boundary, contract, safety, or explicit user approval).
+
 ---
 
 # Escalation Framework

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -9826,6 +9826,114 @@ def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
     }
 
 
+def _format_blueprint_item(item: object) -> str:
+    """Render a blueprint list item as a compact evidence line."""
+    if not isinstance(item, dict):
+        return str(item)
+    item_id = item.get("id")
+    description = item.get("description") or item.get("title") or item.get("summary")
+    if item_id and description:
+        text = f"{item_id}: {description}"
+    elif item_id:
+        text = str(item_id)
+    elif description:
+        text = str(description)
+    else:
+        text = json.dumps(item, sort_keys=True)
+    source = item.get("source")
+    if source:
+        text = f"{text} (source: {source})"
+    return text
+
+
+def _append_blueprint_list(
+    lines: list[str], heading: str, values: object
+) -> None:
+    if not isinstance(values, list) or not values:
+        return
+    lines.append(heading)
+    for value in values:
+        lines.append(f"  - {_format_blueprint_item(value)}")
+
+
+def _approved_blueprint_snapshot_lines(
+    blueprint: Mapping[str, object], goal: str
+) -> list[str]:
+    """Return Monitor-facing plan scope, including approved omissions.
+
+    Monitor must compare Actor output against the user-approved plan scope, not
+    against an implicit "smaller is better" rewrite. The rejected-removals list
+    is the explicit allow-list for work the user approved omitting.
+    """
+    lines = [
+        "# Approved Blueprint Snapshot (Monitor misprune guard):",
+        f"Original request / goal: {goal}",
+    ]
+    summary = blueprint.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        lines.append(f"Blueprint summary: {summary.strip()}")
+
+    _append_blueprint_list(lines, "Hard constraints:", blueprint.get("hard_constraints"))
+    _append_blueprint_list(lines, "Soft constraints:", blueprint.get("soft_constraints"))
+
+    subtasks = blueprint.get("subtasks")
+    if isinstance(subtasks, list) and subtasks:
+        lines.append("Active approved plan scope:")
+        for subtask in subtasks:
+            if not isinstance(subtask, dict):
+                continue
+            subtask_id = subtask.get("id", "ST-???")
+            title = subtask.get("title", "Untitled")
+            metadata = []
+            requiredness = subtask.get("requiredness")
+            if isinstance(requiredness, str):
+                metadata.append(f"requiredness={requiredness}")
+            pruneable = subtask.get("pruneable")
+            if isinstance(pruneable, bool):
+                metadata.append(f"pruneable={pruneable}")
+            restored_from = subtask.get("restored_from_deferred_yagni")
+            if isinstance(restored_from, str) and restored_from.strip():
+                metadata.append(f"restored_from={restored_from.strip()}")
+            suffix = f" ({', '.join(metadata)})" if metadata else ""
+            lines.append(f"  - {subtask_id}: {title}{suffix}")
+            criteria = subtask.get("validation_criteria")
+            if isinstance(criteria, list) and criteria:
+                rendered_criteria = "; ".join(str(item) for item in criteria)
+                lines.append(f"    validation_criteria: {rendered_criteria}")
+
+    coverage_map = blueprint.get("coverage_map")
+    if isinstance(coverage_map, dict) and coverage_map:
+        lines.append("Coverage map:")
+        for key, owner in coverage_map.items():
+            lines.append(f"  - {key} -> {owner}")
+
+    lines.append("Rejected removals / Deferred YAGNI parking lot:")
+    deferred_yagni = blueprint.get("deferred_yagni")
+    if isinstance(deferred_yagni, list) and deferred_yagni:
+        lines.append(
+            "Do not require these items unless the user restores them into "
+            "the active blueprint."
+        )
+        for item in deferred_yagni:
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id", "YG-???")
+            title = item.get("title", "Untitled")
+            rationale = item.get("rationale", "No rationale recorded")
+            restore_hint = item.get("restore_hint", "No restore hint recorded")
+            lines.append(
+                f"  - {item_id}: {title} -- {rationale}; restore: {restore_hint}"
+            )
+    else:
+        lines.append("  - none; no omitted work is approved.")
+    lines.append(
+        "Monitor rule: flag a misprune when Actor omits active approved plan "
+        "scope, hard constraints, or coverage_map owners; do not require "
+        "rejected-removal items unless restored."
+    )
+    return lines
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 
@@ -9963,21 +10071,8 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
         parts.append("")
         parts.append(doctrine_block)
     parts.extend(current_details)
-    deferred_yagni = blueprint.get("deferred_yagni")
-    if isinstance(deferred_yagni, list) and deferred_yagni:
-        parts.append("")
-        parts.append("# Deferred YAGNI Parking Lot (user-approved omissions):")
-        parts.append(
-            "Do not implement these items unless the user restores them into the active blueprint."
-        )
-        for item in deferred_yagni:
-            if not isinstance(item, dict):
-                continue
-            item_id = item.get("id", "YG-???")
-            title = item.get("title", "Untitled")
-            rationale = item.get("rationale", "No rationale recorded")
-            restore_hint = item.get("restore_hint", "No restore hint recorded")
-            parts.append(f"  - {item_id}: {title} -- {rationale}; restore: {restore_hint}")
+    parts.append("")
+    parts.extend(_approved_blueprint_snapshot_lines(blueprint, goal))
     if upstream_lines:
         parts.append("")
         parts.append(f"# Upstream Results (dependencies of {current_subtask_id}):")

--- a/src/mapify_cli/templates_src/agents/monitor.md.jinja
+++ b/src/mapify_cli/templates_src/agents/monitor.md.jinja
@@ -75,6 +75,8 @@ If implementation deviates from the AAG contract — `valid: false` — regardle
 
 You must NOT reject on the basis of style, elegance, or volume, even if the Evaluator scored simplicity low. Your reject criteria remain contract violation, build/test failure, security, data loss, missing required behavior, or other AUTO-REJECT items below. Style, elegance, and volume concerns are LOW/NON-BLOCKING unless they create one of those concrete failures.
 
+**Misprune guard (when `<map_context>` includes `Approved Blueprint Snapshot`):** Treat the original request/goal, hard constraints, coverage_map, and `Active approved plan scope` as the user-approved blueprint. If Actor omits active approved scope because it appears optional, YAGNI, or smaller, return `valid:false` with category `misprune`. Treat `Rejected removals / Deferred YAGNI parking lot` as approved omissions: do NOT require those items unless they were restored into active scope. If Actor implements a rejected-removal item without restoration, report it as scope drift (blocking only when it violates mutation boundary, contract, safety, or explicit user approval).
+
 **Escalation Framework:**
 
 🔴 **AUTO-REJECT (valid: false, must fix):**

--- a/src/mapify_cli/templates_src/codex/agents/monitor.toml.jinja
+++ b/src/mapify_cli/templates_src/codex/agents/monitor.toml.jinja
@@ -65,6 +65,15 @@ failure, security, data loss, missing required behavior, or other AUTO-REJECT it
 below. Style, elegance, and volume concerns are LOW/NON-BLOCKING unless they create one
 of those concrete failures.
 
+Misprune guard (when <map_context> includes Approved Blueprint Snapshot): Treat the
+original request/goal, hard constraints, coverage_map, and Active approved plan scope as
+the user-approved blueprint. If Actor omits active approved scope because it appears
+optional, YAGNI, or smaller, return valid:false with category "misprune". Treat
+Rejected removals / Deferred YAGNI parking lot as approved omissions: do NOT require
+those items unless they were restored into active scope. If Actor implements a
+rejected-removal item without restoration, report it as scope drift (blocking only when
+it violates mutation boundary, contract, safety, or explicit user approval).
+
 ---
 
 # Escalation Framework

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -9826,6 +9826,114 @@ def detect_symbol_blast_radius(branch: str, subtask_id: str) -> dict:
     }
 
 
+def _format_blueprint_item(item: object) -> str:
+    """Render a blueprint list item as a compact evidence line."""
+    if not isinstance(item, dict):
+        return str(item)
+    item_id = item.get("id")
+    description = item.get("description") or item.get("title") or item.get("summary")
+    if item_id and description:
+        text = f"{item_id}: {description}"
+    elif item_id:
+        text = str(item_id)
+    elif description:
+        text = str(description)
+    else:
+        text = json.dumps(item, sort_keys=True)
+    source = item.get("source")
+    if source:
+        text = f"{text} (source: {source})"
+    return text
+
+
+def _append_blueprint_list(
+    lines: list[str], heading: str, values: object
+) -> None:
+    if not isinstance(values, list) or not values:
+        return
+    lines.append(heading)
+    for value in values:
+        lines.append(f"  - {_format_blueprint_item(value)}")
+
+
+def _approved_blueprint_snapshot_lines(
+    blueprint: Mapping[str, object], goal: str
+) -> list[str]:
+    """Return Monitor-facing plan scope, including approved omissions.
+
+    Monitor must compare Actor output against the user-approved plan scope, not
+    against an implicit "smaller is better" rewrite. The rejected-removals list
+    is the explicit allow-list for work the user approved omitting.
+    """
+    lines = [
+        "# Approved Blueprint Snapshot (Monitor misprune guard):",
+        f"Original request / goal: {goal}",
+    ]
+    summary = blueprint.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        lines.append(f"Blueprint summary: {summary.strip()}")
+
+    _append_blueprint_list(lines, "Hard constraints:", blueprint.get("hard_constraints"))
+    _append_blueprint_list(lines, "Soft constraints:", blueprint.get("soft_constraints"))
+
+    subtasks = blueprint.get("subtasks")
+    if isinstance(subtasks, list) and subtasks:
+        lines.append("Active approved plan scope:")
+        for subtask in subtasks:
+            if not isinstance(subtask, dict):
+                continue
+            subtask_id = subtask.get("id", "ST-???")
+            title = subtask.get("title", "Untitled")
+            metadata = []
+            requiredness = subtask.get("requiredness")
+            if isinstance(requiredness, str):
+                metadata.append(f"requiredness={requiredness}")
+            pruneable = subtask.get("pruneable")
+            if isinstance(pruneable, bool):
+                metadata.append(f"pruneable={pruneable}")
+            restored_from = subtask.get("restored_from_deferred_yagni")
+            if isinstance(restored_from, str) and restored_from.strip():
+                metadata.append(f"restored_from={restored_from.strip()}")
+            suffix = f" ({', '.join(metadata)})" if metadata else ""
+            lines.append(f"  - {subtask_id}: {title}{suffix}")
+            criteria = subtask.get("validation_criteria")
+            if isinstance(criteria, list) and criteria:
+                rendered_criteria = "; ".join(str(item) for item in criteria)
+                lines.append(f"    validation_criteria: {rendered_criteria}")
+
+    coverage_map = blueprint.get("coverage_map")
+    if isinstance(coverage_map, dict) and coverage_map:
+        lines.append("Coverage map:")
+        for key, owner in coverage_map.items():
+            lines.append(f"  - {key} -> {owner}")
+
+    lines.append("Rejected removals / Deferred YAGNI parking lot:")
+    deferred_yagni = blueprint.get("deferred_yagni")
+    if isinstance(deferred_yagni, list) and deferred_yagni:
+        lines.append(
+            "Do not require these items unless the user restores them into "
+            "the active blueprint."
+        )
+        for item in deferred_yagni:
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id", "YG-???")
+            title = item.get("title", "Untitled")
+            rationale = item.get("rationale", "No rationale recorded")
+            restore_hint = item.get("restore_hint", "No restore hint recorded")
+            lines.append(
+                f"  - {item_id}: {title} -- {rationale}; restore: {restore_hint}"
+            )
+    else:
+        lines.append("  - none; no omitted work is approved.")
+    lines.append(
+        "Monitor rule: flag a misprune when Actor omits active approved plan "
+        "scope, hard constraints, or coverage_map owners; do not require "
+        "rejected-removal items unless restored."
+    )
+    return lines
+
+
 def build_context_block(branch: str, current_subtask_id: str) -> str:
     """Build structured context block for Actor prompt.
 
@@ -9963,21 +10071,8 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
         parts.append("")
         parts.append(doctrine_block)
     parts.extend(current_details)
-    deferred_yagni = blueprint.get("deferred_yagni")
-    if isinstance(deferred_yagni, list) and deferred_yagni:
-        parts.append("")
-        parts.append("# Deferred YAGNI Parking Lot (user-approved omissions):")
-        parts.append(
-            "Do not implement these items unless the user restores them into the active blueprint."
-        )
-        for item in deferred_yagni:
-            if not isinstance(item, dict):
-                continue
-            item_id = item.get("id", "YG-???")
-            title = item.get("title", "Untitled")
-            rationale = item.get("rationale", "No rationale recorded")
-            restore_hint = item.get("restore_hint", "No restore hint recorded")
-            parts.append(f"  - {item_id}: {title} -- {rationale}; restore: {restore_hint}")
+    parts.append("")
+    parts.extend(_approved_blueprint_snapshot_lines(blueprint, goal))
     if upstream_lines:
         parts.append("")
         parts.append(f"# Upstream Results (dependencies of {current_subtask_id}):")

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3045,6 +3045,57 @@ class TestBuildContextBlock:
         assert "ST-001: files=" in result
         assert "<MAP_Minimality_Doctrine>" not in result
 
+    def test_build_context_block_includes_monitor_misprune_guard_context(
+        self, branch_workspace
+    ):
+        bp = {
+            "summary": "Ship approved plan scope, not a smaller rewrite.",
+            **_blueprint_constraint_fields(),
+            "subtasks": [
+                {
+                    "id": "ST-001",
+                    "title": "Restore user-requested export",
+                    "aag_contract": "Actor -> restore_export() -> export works",
+                    "requiredness": "explicit",
+                    "pruneable": False,
+                    "restored_from_deferred_yagni": "YG-001",
+                    "validation_criteria": [
+                        "VC1 [AC-1]: export remains in active scope",
+                    ],
+                    "dependencies": [],
+                }
+            ],
+            "coverage_map": {"AC-1": "ST-001", "SC-1": "ST-001"},
+            "deferred_yagni": [
+                {
+                    "id": "YG-002",
+                    "title": "Add illustrative screenshots",
+                    "rationale": "Helpful but not acceptance-critical.",
+                    "restore_hint": "Restore only if the user asks for docs polish.",
+                }
+            ],
+        }
+        (branch_workspace / "blueprint.json").write_text(json.dumps(bp))
+        (branch_workspace / "task_plan_test-branch.md").write_text(
+            "## Goal\nUser asked for the export path to remain available.\n"
+        )
+
+        result = map_step_runner.build_context_block("test-branch", "ST-001")
+
+        assert "# Approved Blueprint Snapshot (Monitor misprune guard):" in result
+        assert "Original request / goal: User asked for the export path" in result
+        assert "Hard constraints:" in result
+        assert "AC-1: Timeouts must show a retryable message" in result
+        assert "Active approved plan scope:" in result
+        assert "ST-001: Restore user-requested export" in result
+        assert "requiredness=explicit" in result
+        assert "restored_from=YG-001" in result
+        assert "Coverage map:" in result
+        assert "AC-1 -> ST-001" in result
+        assert "Rejected removals / Deferred YAGNI parking lot:" in result
+        assert "YG-002: Add illustrative screenshots" in result
+        assert "Monitor rule: flag a misprune" in result
+
     def test_build_context_block_includes_minimality_doctrine_when_enabled(
         self, branch_workspace
     ):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1297,6 +1297,32 @@ class TestEvidenceFirstVerdictContracts:
         assert "summaries" in content
 
 
+class TestMonitorMispruneGuardContracts:
+    """Regression tests for issue #184 Monitor misprune guard context."""
+
+    @pytest.fixture
+    def project_root(self):
+        return Path(__file__).parent.parent
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            Path(".claude/agents/monitor.md"),
+            Path(".codex/agents/monitor.toml"),
+        ],
+    )
+    def test_monitor_prompts_compare_against_approved_blueprint(
+        self, project_root, relative_path
+    ):
+        content = (project_root / relative_path).read_text(encoding="utf-8")
+
+        assert "Misprune guard" in content
+        assert "Approved Blueprint Snapshot" in content
+        assert "Active approved plan scope" in content
+        assert "Rejected removals / Deferred YAGNI parking lot" in content
+        assert "misprune" in content
+
+
 class TestEvidenceFirstPromptContracts:
     """Regression tests for evidence-grounded agent outputs.
 


### PR DESCRIPTION
## Summary
- Add an approved blueprint snapshot to MAP context blocks so Monitor sees original goal, active plan scope, constraints, coverage map, and approved omissions together.
- Teach Claude and Codex Monitor prompts to block active-scope omissions as misprunes while respecting deferred YAGNI omissions unless restored.
- Add regression tests for the context block and generated Monitor prompt parity.

Refs #184

## Validation
- uv run pytest tests/test_map_step_runner.py::TestBuildContextBlock::test_build_context_block_includes_monitor_misprune_guard_context tests/test_skills.py::TestMonitorMispruneGuardContracts -q
- make check

## Deploy
- No prod deploy target in Makefile.