### PR TITLE
feat(map-explain): respect user language + cut wall-of-text verbosity (#224)

### DIFF
--- a/.agents/skills/map-explain/SKILL.md
+++ b/.agents/skills/map-explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-explain
-description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, line-by-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
+description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, load-bearing-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
 ---
 
 # $map-explain — Deep Walkthrough
@@ -13,6 +13,12 @@ description: "Deep walkthrough of code, a diff, or the whole project — problem
 - Bootstrapping a new contributor on an existing project
 
 **Related skills:** `$map-plan` (decomposition before execution), `$map-fast` (small implementations), `$map-check` (post-execution verification).
+
+---
+
+## Output language
+
+Write the explanation in the user's established language — honor the language already set in context (the conversation's language and the host/global `AGENTS.md` / `CLAUDE.md` language convention) rather than defaulting to English. Translate only the prose. Keep code, identifiers, commands, error messages, and `file:line` references in English.
 
 ---
 
@@ -51,19 +57,15 @@ shell_command:
 
 ### Mode A — Project overview (current branch is `main`/`master`, OR `HEAD` == `$BASE`)
 
-No branch diff to explain — walk the **whole repository**. Map the 10 sections below onto the project, not a single file:
+No branch diff to explain — walk the **whole repository**. Apply the output spec below at the project level, not a single-file level:
 
-- Section 1 (problem): what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
-- Section 2 (entities): top-level modules / packages / services. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
-- Section 3 (how they differ): responsibility boundaries — what each entity owns and explicitly does NOT do.
-- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
-- Section 5 (data flow): how data moves between entities — file formats, schemas, IPC, state files, databases.
-- Sections 6–7: pick the 3–6 most load-bearing files/functions and walk those line by line. Do NOT try to cover every line in the repo.
-- Section 8 (state & side effects): what the project writes to disk, network, or shared services; what survives across runs.
-- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
-- Section 10 (breakage modes): kinds of changes that routinely break this project — derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, or learned-patterns docs.
+- *Mental model in 60 seconds*: what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
+- *Decomposition*: top-level modules / packages / services and their responsibility boundaries. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- *Execution flow*: what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- *Load-bearing lines*: pick the 3–6 most load-bearing files/functions and walk only those. Do NOT cover every line in the repo.
+- *Assumptions & breakage*: runtime, OS, language version, external services, secrets, env vars, plus the kinds of changes that routinely break this project (`CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, learned-patterns docs).
 
-Skip the "For PRs, also explain" section in this mode — no diff exists.
+There is no diff, so skip the before→after block.
 
 Bootstrap commands:
 
@@ -78,7 +80,7 @@ shell_command:
 
 ### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
 
-The target is the current branch's diff against the upstream base. Treat it like a PR and **also** produce the "For PRs, also explain" section.
+The target is the current branch's diff against the upstream base. Treat it like a PR and **lead with the before→after block**.
 
 ```
 shell_command:
@@ -98,40 +100,84 @@ shell_command:
 
 ---
 
-## What the explanation must contain
+## Size the explanation first
 
-Teach the target step by step:
+Classify the target by size and set a word budget. Budgets are **ceilings, not targets** — when in doubt, cut.
 
-1. what problem it solves,
-2. what entities exist,
-3. how they differ,
-4. how execution flows,
-5. how data flows,
-6. what every important line does,
-7. why each non-trivial line is needed,
-8. what state changes and side effects happen,
-9. what assumptions the code relies on,
-10. what could break if I modify it.
+| Tier | Trigger | Word budget | Load-bearing line cap |
+|---|---|---|---|
+| Tiny | ≤50 lines / single symbol | 300–700 | full line detail OK |
+| Small | 31–150 lines | 600–1,200 | ≤10 |
+| Medium | 151–300 lines | 900–1,600 | ≤12 |
+| Large | 301–600 lines / multi-file | 1,200–2,200 | ≤18 |
+| Huge | >600 lines | 1,800–2,800 | ≤25 |
 
-### Rules
+Snippet caps: never quote more than 3 lines at once; ~20 quoted lines total across the whole explanation. Summarize the rest by `file:line` reference.
 
-- do not use terms before explaining them;
-- do not skip "obvious" lines;
-- do not hide behind abstractions or jargon;
+## Output spec
+
+Open with one framing line, then the blocks below **in order**. Tag each header with a read-tier so the reader can decide what to skip: `[MUST READ]`, `[READ IF MODIFYING]`, `[SKIM]`. Emit a block only when it applies (see "Adaptive sections").
+
+`Target: <type> · Size: <tier> · Budget: <range> words`
+
+1. **Mental model in 60 seconds** `[MUST READ]` — ≤100 words / ≤5 sentences: what it is, its job, the one thing you most need to know, and the one thing most likely to surprise you.
+2. **Before → after** `[MUST READ]` — *PR/diff targets only; this goes first because the delta is the most important context for a diff.* A small table:
+
+   | Aspect | Before | After | Runtime effect |
+   |---|---|---|---|
+
+3. **Execution flow** `[MUST READ]` — entry point → branches → where they converge.
+4. **Decomposition** `[SKIM]` — a small table of entities/responsibilities: what each owns and what it explicitly does NOT do. Skip for a single function.
+5. **Load-bearing lines** `[READ IF MODIFYING]` — the one table defined below.
+6. **Assumptions & breakage** `[SKIM]` — what the code relies on (runtime, services, invariants) and what changes routinely break it.
+7. **Key insights** — plus common misunderstandings.
+
+Close with a single line — not a "Skipped" header: `Omitted: <list> — irrelevant for <reason>`. Then offer 2–3 **natural-language** follow-ups (e.g. "Explain the authorization path line by line", "Focus only on the data flow"). Do NOT print fake CLI flags — the CLI cannot honor them.
+
+## Load-bearing lines (replaces line-by-line)
+
+A line is **load-bearing** — and earns a row — only if it:
+
+- mutates external/system state;
+- branches on a non-trivial condition;
+- crosses an abstraction boundary or public contract;
+- does validation, authorization, normalization, or parsing;
+- handles an error, retry, fallback, or edge case;
+- encodes a non-obvious invariant;
+- would silently change behavior if removed.
+
+Skip (do not quote or explain): type annotations, logging, trivial assignments, boilerplate imports, standard decorators, getters/setters whose name equals their behavior.
+
+Worked filter: in `if user.is_admin or has_scope(token, "write"):` the condition is load-bearing (an authorization branch); a neighboring `logger.debug(f"checking {user.id}")` is not.
+
+Emit them as one table — this merges the old "what every line does" and "why each line" into a single pass so the same code is never explained twice:
+
+| Where (file:line) | What it does | Why it matters / what breaks if changed |
+|---|---|---|
+
+- **Repeated shapes once.** When the target repeats a pattern (N handlers, routes, switch cases, validators, mappers), explain the shared shape once, then list only the meaningful exceptions. Never re-explain the same shape N times.
+- **Diffs: changed lines only.** For a PR/branch diff, apply this table to changed lines, not the whole file.
+- **Density.** One sentence for WHAT per row; add a second only when WHY is non-obvious.
+
+## Adaptive sections (menu, not checklist)
+
+Emit a block only when it carries signal for this target:
+
+- Single function → skip *Decomposition*.
+- Pure function → skip side-effect discussion.
+- PR diff → fold "what differs" into *Before → after*; do not also write a separate differences section.
+- A category that is trivial for this target → compress to one sentence rather than a full block.
+
+Never emit a header just to write "Skipped" — list everything omitted in the closing `Omitted:` line instead.
+
+## Rules
+
+- **Be dense.** Prefer one precise sentence over three vague ones. Prefer statements of purpose and consequence over procedural description.
+- do not use a term before explaining it; do not hide behind jargon;
 - separate intuition, exact mechanism, and practical meaning;
-- if something is inferred rather than explicit, prefix it with `Inferred:`.
-
-### For PRs / diffs, also explain
-
-- what behavior likely existed before,
-- what behavior exists after,
-- and how the diff changes runtime behavior.
-
-### End with
-
-- key insights,
-- common misunderstandings,
-- a short precise summary.
+- mark an inference with `Inferred:` only when it required reading multiple files or guessing intent — not for direct observations any competent reader would make.
+- No preamble, no apology, no closing pleasantries. Begin with the substance.
+- Ban filler openers: "This line…", "Here we have…", "It is important to note…", "Essentially…", "In other words…", "Note that…".
 
 ---
 
@@ -139,10 +185,9 @@ Teach the target step by step:
 
 1. **Locate the target** per the rules above (file / symbol / PR ref / snippet / empty).
 2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
-3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
-4. **Mark inferences** with `Inferred:` so the reader knows the confidence level.
-5. **Quote, do not paraphrase,** the lines you explain. Use `file:line` references.
-6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target.
+3. **Size it, then emit the output spec in order.** Front-load the mental model; the structure is part of the teaching, but only emit blocks that apply.
+4. **Quote, do not paraphrase,** the load-bearing lines you explain. Use `file:line` references, and respect the snippet caps.
+5. **Stop at the target's boundary.** Explain only what is needed to understand this target, not the whole codebase.
 
 ---
 
@@ -162,5 +207,5 @@ $map-explain HEAD~1..HEAD
 
 - **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
 - **`HEAD == $BASE`** — the current branch already matches the upstream base; there is no diff. The skill falls into Mode A (project overview); if that's not what you wanted, check `git status` and confirm your commits are on this branch.
-- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so each line can be explained without truncation.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so the load-bearing table fits within the tier budget.
 - **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/.claude/skills/map-explain/SKILL.md
+++ b/.claude/skills/map-explain/SKILL.md
@@ -10,6 +10,10 @@ argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch d
 
 **Target:** $ARGUMENTS
 
+## Output language
+
+Write the explanation in the user's established language — honor the language already set in context (the conversation's language and the host/global `CLAUDE.md` language convention) rather than defaulting to English. Translate only the prose. Keep code, identifiers, commands, error messages, and `file:line` references in English.
+
 ## Effort and Parallelism Policy
 
 ```yaml
@@ -47,19 +51,15 @@ Then choose **one** of the two modes below and follow it.
 
 ### Mode A — Project overview (current branch is `main` or `master`, OR `HEAD` == `$BASE`)
 
-There is no branch diff to explain — explain the project as a whole instead. Produce a single project-level walkthrough that follows the 10 sections below at the **repository** level, not at a single-file level:
+There is no branch diff to explain — explain the project as a whole. Apply the **output spec** below at the **repository** level instead of a single-file level:
 
-- Section 1 (problem): what this repository exists to do — derive from `README.md` first, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
-- Section 2 (entities): the top-level modules / packages / services that make up the project (read the top-level directory listing, primary entry points, and any package/manifest files like `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
-- Section 3 (how they differ): the responsibility boundary between those entities — what each one owns and what it explicitly does NOT do.
-- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle — whichever applies). Trace from entry point through the main code paths.
-- Section 5 (data flow): what data moves between the entities — file formats, schemas, IPC, state files, databases.
-- Sections 6–7: do NOT try to cover every line in the repo. Instead, pick the 3–6 most architecturally load-bearing files/functions and walk those.
-- Section 8 (state & side effects): what the project writes to disk, the network, or shared services; what survives across runs.
-- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
-- Section 10 (breakage modes): what kinds of changes routinely break this project, based on `CONTRIBUTING.md`, `CHANGELOG.md`, recent commit messages, or learned-patterns docs if present.
+- *Mental model in 60 seconds*: what this repository exists to do — derive from `README.md`, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
+- *Decomposition*: the top-level modules / packages / services and the responsibility boundary between them — read the directory listing, primary entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- *Execution flow*: what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- *Load-bearing lines*: do NOT cover every line in the repo. Pick the 3–6 most architecturally load-bearing files/functions and walk only those.
+- *Assumptions & breakage*: runtime, OS, language version, external services, secrets, env vars, plus the kinds of changes that routinely break this project (derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, learned-patterns docs).
 
-Skip the "For PRs, also explain" section in this mode — there is no diff.
+There is no diff, so skip the before→after block.
 
 Useful commands to bootstrap:
 
@@ -72,7 +72,7 @@ git --no-pager log --oneline -n 20
 
 ### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
 
-The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — also produce the "For PRs, also explain" section.
+The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — lead with the before→after block.
 
 ```bash
 # Three-dot diff = "what this branch changed relative to base".
@@ -85,49 +85,92 @@ git --no-pager diff "$BASE"...HEAD
 
 - If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
 
-Explain it so I can build a complete mental model of it, not just a summary.
+## Size the explanation first
 
-I want you to teach it step by step:
+Classify the target by size and set a word budget. Budgets are **ceilings, not targets** — when in doubt, cut.
 
-1. what problem it solves,
-2. what entities exist,
-3. how they differ,
-4. how execution flows,
-5. how data flows,
-6. what every important line does,
-7. why each non-trivial line is needed,
-8. what state changes and side effects happen,
-9. what assumptions the code relies on,
-10. what could break if I modify it.
+| Tier | Trigger | Word budget | Load-bearing line cap |
+|---|---|---|---|
+| Tiny | ≤50 lines / single symbol | 300–700 | full line detail OK |
+| Small | 31–150 lines | 600–1,200 | ≤10 |
+| Medium | 151–300 lines | 900–1,600 | ≤12 |
+| Large | 301–600 lines / multi-file | 1,200–2,200 | ≤18 |
+| Huge | >600 lines | 1,800–2,800 | ≤25 |
+
+Snippet caps: never quote more than 3 lines at once; ~20 quoted lines total across the whole explanation. Summarize the rest by reference (`file:line`) rather than pasting it.
+
+## Output spec
+
+Open with one framing line, then the blocks below **in order**. Tag each header with a read-tier so the reader can decide what to skip: `[MUST READ]`, `[READ IF MODIFYING]`, `[SKIM]`. Emit a block only when it applies (see "Adaptive sections").
+
+`Target: <type> · Size: <tier> · Budget: <range> words`
+
+1. **Mental model in 60 seconds** `[MUST READ]` — ≤100 words / ≤5 sentences: what it is, its job, the one thing you most need to know, and the one thing most likely to surprise you.
+2. **Before → after** `[MUST READ]` — *PR/diff targets only; this goes first because the delta is the most important context for a diff.* A small table:
+
+   | Aspect | Before | After | Runtime effect |
+   |---|---|---|---|
+
+3. **Execution flow** `[MUST READ]` — entry point → branches → where they converge.
+4. **Decomposition** `[SKIM]` — a small table of the entities/responsibilities: what each owns and what it explicitly does NOT do. Skip for a single function.
+5. **Load-bearing lines** `[READ IF MODIFYING]` — the one table defined below.
+6. **Assumptions & breakage** `[SKIM]` — what the code relies on (runtime, services, invariants) and what changes routinely break it.
+7. **Key insights** — plus common misunderstandings.
+
+Close with a single line — not a "Skipped" header: `Omitted: <list> — irrelevant for <reason>`. Then offer 2–3 **natural-language** follow-ups (e.g. "Explain the authorization path line by line", "Focus only on the data flow"). Do NOT print fake CLI flags like `--focus flow` — the CLI cannot honor them.
+
+## Load-bearing lines (replaces line-by-line)
+
+A line is **load-bearing** — and earns a row — only if it:
+
+- mutates external/system state;
+- branches on a non-trivial condition;
+- crosses an abstraction boundary or public contract;
+- does validation, authorization, normalization, or parsing;
+- handles an error, retry, fallback, or edge case;
+- encodes a non-obvious invariant;
+- would silently change behavior if removed.
+
+Skip (do not quote or explain): type annotations, logging, trivial assignments, boilerplate imports, standard decorators, getters/setters whose name equals their behavior.
+
+Worked filter: in `if user.is_admin or has_scope(token, "write"):` the condition is load-bearing (an authorization branch); a neighboring `logger.debug(f"checking {user.id}")` is not.
+
+Emit them as one table — this merges the old "what every line does" and "why each line" into a single pass so the same code is never explained twice:
+
+| Where (file:line) | What it does | Why it matters / what breaks if changed |
+|---|---|---|
+
+- **Repeated shapes once.** When the target repeats a pattern (N handlers, routes, switch cases, validators, mappers), explain the shared shape once, then list only the meaningful exceptions. Never re-explain the same shape N times.
+- **Diffs: changed lines only.** For a PR/branch diff, apply this table to changed lines, not the whole file.
+- **Density.** One sentence for WHAT per row; add a second only when WHY is non-obvious.
+
+## Adaptive sections (menu, not checklist)
+
+Emit a block only when it carries signal for this target:
+
+- Single function → skip *Decomposition*.
+- Pure function → skip side-effect discussion.
+- PR diff → fold "what differs" into *Before → after*; do not also write a separate differences section.
+- A category that is trivial for this target → compress to one sentence rather than a full block.
+
+Never emit a header just to write "Skipped" — list everything omitted in the closing `Omitted:` line instead.
 
 ## Rules
 
-- do not use terms before explaining them;
-- do not skip "obvious" lines;
-- do not hide behind abstractions or jargon;
-- separate intuition, exact mechanism, and practical meaning;
-- if something is inferred rather than explicit, mark it clearly.
-
-## For PRs, also explain
-
-- what behavior likely existed before,
-- what behavior exists after,
-- and how the diff changes runtime behavior.
-
-## End with
-
-- key insights,
-- common misunderstandings,
-- and a short precise summary.
+- **Be dense.** Prefer one precise sentence over three vague ones. Prefer statements of purpose and consequence over procedural description.
+- Do not use a term before explaining it; do not hide behind jargon.
+- Separate intuition, exact mechanism, and practical meaning.
+- Mark an inference with `Inferred:` only when it required reading multiple files or guessing intent — not for direct observations any competent reader would make.
+- No preamble, no apology, no closing pleasantries. Begin with the substance.
+- Ban filler openers: "This line…", "Here we have…", "It is important to note…", "Essentially…", "In other words…", "Note that…".
 
 ## How to apply
 
-1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase to find the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
+1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase for the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
 2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
-3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
-4. **Mark inferences.** When asserting something the source does not directly state (e.g., "this is likely called from the request handler"), prefix it with `Inferred:` so the reader knows the confidence level.
-5. **Quote, do not paraphrase, the lines you explain.** Use `file:line` references so the reader can navigate.
-6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target's behavior.
+3. **Size it, then emit the output spec in order.** Front-load the mental model; the structure is part of the teaching, but only emit blocks that apply.
+4. **Quote, do not paraphrase, the load-bearing lines you explain.** Use `file:line` references so the reader can navigate, and respect the snippet caps.
+5. **Stop at the target's boundary.** Explain only what is needed to understand this target's behavior, not the whole codebase.
 
 ## Examples
 
@@ -143,5 +186,5 @@ I want you to teach it step by step:
 
 - **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
 - **"HEAD == $BASE"** — the current branch already matches the upstream base, so there is no diff. The skill falls into Mode A (project overview); if that is not what you wanted, check `git status` and confirm your commits are on this branch.
-- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) instead of the full branch diff so each line can be explained without truncation.
-- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see un-marked guesses, ask the skill to re-emit with explicit confidence tags.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so the load-bearing table fits within the tier budget.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The scorer is exposed as `mapify research-eval score` and covered by the
   no-provider E2E artifact-contract suite.
 
+### Changed
+- **`/map-explain` now respects the user's language and scales depth to target
+  size (#224).** The skill writes prose in the user's established language
+  (code, identifiers, commands, and `file:line` refs stay English) instead of
+  always defaulting to English. The rigid always-emit-all-10-sections /
+  explain-every-line structure is replaced by a signal-first output spec:
+  size tiers with word-budget ceilings and load-bearing-line caps, a front-loaded
+  "Mental model in 60 seconds" block, read-tier section tags
+  (`[MUST READ]`/`[READ IF MODIFYING]`/`[SKIM]`), a single load-bearing-lines
+  table (merging the old "what every line does" + "why each line" sections,
+  repeated shapes explained once), before→after-first ordering for diffs,
+  adaptive sections with an `Omitted:` footer, and natural-language follow-up
+  offers. Applies to both the Claude and Codex surfaces.
+
 ## [3.16.0] - 2026-06-15
 
 ### Added

--- a/src/mapify_cli/templates/codex/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-explain
-description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, line-by-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
+description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, load-bearing-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
 ---
 
 # $map-explain — Deep Walkthrough
@@ -13,6 +13,12 @@ description: "Deep walkthrough of code, a diff, or the whole project — problem
 - Bootstrapping a new contributor on an existing project
 
 **Related skills:** `$map-plan` (decomposition before execution), `$map-fast` (small implementations), `$map-check` (post-execution verification).
+
+---
+
+## Output language
+
+Write the explanation in the user's established language — honor the language already set in context (the conversation's language and the host/global `AGENTS.md` / `CLAUDE.md` language convention) rather than defaulting to English. Translate only the prose. Keep code, identifiers, commands, error messages, and `file:line` references in English.
 
 ---
 
@@ -51,19 +57,15 @@ shell_command:
 
 ### Mode A — Project overview (current branch is `main`/`master`, OR `HEAD` == `$BASE`)
 
-No branch diff to explain — walk the **whole repository**. Map the 10 sections below onto the project, not a single file:
+No branch diff to explain — walk the **whole repository**. Apply the output spec below at the project level, not a single-file level:
 
-- Section 1 (problem): what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
-- Section 2 (entities): top-level modules / packages / services. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
-- Section 3 (how they differ): responsibility boundaries — what each entity owns and explicitly does NOT do.
-- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
-- Section 5 (data flow): how data moves between entities — file formats, schemas, IPC, state files, databases.
-- Sections 6–7: pick the 3–6 most load-bearing files/functions and walk those line by line. Do NOT try to cover every line in the repo.
-- Section 8 (state & side effects): what the project writes to disk, network, or shared services; what survives across runs.
-- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
-- Section 10 (breakage modes): kinds of changes that routinely break this project — derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, or learned-patterns docs.
+- *Mental model in 60 seconds*: what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
+- *Decomposition*: top-level modules / packages / services and their responsibility boundaries. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- *Execution flow*: what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- *Load-bearing lines*: pick the 3–6 most load-bearing files/functions and walk only those. Do NOT cover every line in the repo.
+- *Assumptions & breakage*: runtime, OS, language version, external services, secrets, env vars, plus the kinds of changes that routinely break this project (`CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, learned-patterns docs).
 
-Skip the "For PRs, also explain" section in this mode — no diff exists.
+There is no diff, so skip the before→after block.
 
 Bootstrap commands:
 
@@ -78,7 +80,7 @@ shell_command:
 
 ### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
 
-The target is the current branch's diff against the upstream base. Treat it like a PR and **also** produce the "For PRs, also explain" section.
+The target is the current branch's diff against the upstream base. Treat it like a PR and **lead with the before→after block**.
 
 ```
 shell_command:
@@ -98,40 +100,84 @@ shell_command:
 
 ---
 
-## What the explanation must contain
+## Size the explanation first
 
-Teach the target step by step:
+Classify the target by size and set a word budget. Budgets are **ceilings, not targets** — when in doubt, cut.
 
-1. what problem it solves,
-2. what entities exist,
-3. how they differ,
-4. how execution flows,
-5. how data flows,
-6. what every important line does,
-7. why each non-trivial line is needed,
-8. what state changes and side effects happen,
-9. what assumptions the code relies on,
-10. what could break if I modify it.
+| Tier | Trigger | Word budget | Load-bearing line cap |
+|---|---|---|---|
+| Tiny | ≤50 lines / single symbol | 300–700 | full line detail OK |
+| Small | 31–150 lines | 600–1,200 | ≤10 |
+| Medium | 151–300 lines | 900–1,600 | ≤12 |
+| Large | 301–600 lines / multi-file | 1,200–2,200 | ≤18 |
+| Huge | >600 lines | 1,800–2,800 | ≤25 |
 
-### Rules
+Snippet caps: never quote more than 3 lines at once; ~20 quoted lines total across the whole explanation. Summarize the rest by `file:line` reference.
 
-- do not use terms before explaining them;
-- do not skip "obvious" lines;
-- do not hide behind abstractions or jargon;
+## Output spec
+
+Open with one framing line, then the blocks below **in order**. Tag each header with a read-tier so the reader can decide what to skip: `[MUST READ]`, `[READ IF MODIFYING]`, `[SKIM]`. Emit a block only when it applies (see "Adaptive sections").
+
+`Target: <type> · Size: <tier> · Budget: <range> words`
+
+1. **Mental model in 60 seconds** `[MUST READ]` — ≤100 words / ≤5 sentences: what it is, its job, the one thing you most need to know, and the one thing most likely to surprise you.
+2. **Before → after** `[MUST READ]` — *PR/diff targets only; this goes first because the delta is the most important context for a diff.* A small table:
+
+   | Aspect | Before | After | Runtime effect |
+   |---|---|---|---|
+
+3. **Execution flow** `[MUST READ]` — entry point → branches → where they converge.
+4. **Decomposition** `[SKIM]` — a small table of entities/responsibilities: what each owns and what it explicitly does NOT do. Skip for a single function.
+5. **Load-bearing lines** `[READ IF MODIFYING]` — the one table defined below.
+6. **Assumptions & breakage** `[SKIM]` — what the code relies on (runtime, services, invariants) and what changes routinely break it.
+7. **Key insights** — plus common misunderstandings.
+
+Close with a single line — not a "Skipped" header: `Omitted: <list> — irrelevant for <reason>`. Then offer 2–3 **natural-language** follow-ups (e.g. "Explain the authorization path line by line", "Focus only on the data flow"). Do NOT print fake CLI flags — the CLI cannot honor them.
+
+## Load-bearing lines (replaces line-by-line)
+
+A line is **load-bearing** — and earns a row — only if it:
+
+- mutates external/system state;
+- branches on a non-trivial condition;
+- crosses an abstraction boundary or public contract;
+- does validation, authorization, normalization, or parsing;
+- handles an error, retry, fallback, or edge case;
+- encodes a non-obvious invariant;
+- would silently change behavior if removed.
+
+Skip (do not quote or explain): type annotations, logging, trivial assignments, boilerplate imports, standard decorators, getters/setters whose name equals their behavior.
+
+Worked filter: in `if user.is_admin or has_scope(token, "write"):` the condition is load-bearing (an authorization branch); a neighboring `logger.debug(f"checking {user.id}")` is not.
+
+Emit them as one table — this merges the old "what every line does" and "why each line" into a single pass so the same code is never explained twice:
+
+| Where (file:line) | What it does | Why it matters / what breaks if changed |
+|---|---|---|
+
+- **Repeated shapes once.** When the target repeats a pattern (N handlers, routes, switch cases, validators, mappers), explain the shared shape once, then list only the meaningful exceptions. Never re-explain the same shape N times.
+- **Diffs: changed lines only.** For a PR/branch diff, apply this table to changed lines, not the whole file.
+- **Density.** One sentence for WHAT per row; add a second only when WHY is non-obvious.
+
+## Adaptive sections (menu, not checklist)
+
+Emit a block only when it carries signal for this target:
+
+- Single function → skip *Decomposition*.
+- Pure function → skip side-effect discussion.
+- PR diff → fold "what differs" into *Before → after*; do not also write a separate differences section.
+- A category that is trivial for this target → compress to one sentence rather than a full block.
+
+Never emit a header just to write "Skipped" — list everything omitted in the closing `Omitted:` line instead.
+
+## Rules
+
+- **Be dense.** Prefer one precise sentence over three vague ones. Prefer statements of purpose and consequence over procedural description.
+- do not use a term before explaining it; do not hide behind jargon;
 - separate intuition, exact mechanism, and practical meaning;
-- if something is inferred rather than explicit, prefix it with `Inferred:`.
-
-### For PRs / diffs, also explain
-
-- what behavior likely existed before,
-- what behavior exists after,
-- and how the diff changes runtime behavior.
-
-### End with
-
-- key insights,
-- common misunderstandings,
-- a short precise summary.
+- mark an inference with `Inferred:` only when it required reading multiple files or guessing intent — not for direct observations any competent reader would make.
+- No preamble, no apology, no closing pleasantries. Begin with the substance.
+- Ban filler openers: "This line…", "Here we have…", "It is important to note…", "Essentially…", "In other words…", "Note that…".
 
 ---
 
@@ -139,10 +185,9 @@ Teach the target step by step:
 
 1. **Locate the target** per the rules above (file / symbol / PR ref / snippet / empty).
 2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
-3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
-4. **Mark inferences** with `Inferred:` so the reader knows the confidence level.
-5. **Quote, do not paraphrase,** the lines you explain. Use `file:line` references.
-6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target.
+3. **Size it, then emit the output spec in order.** Front-load the mental model; the structure is part of the teaching, but only emit blocks that apply.
+4. **Quote, do not paraphrase,** the load-bearing lines you explain. Use `file:line` references, and respect the snippet caps.
+5. **Stop at the target's boundary.** Explain only what is needed to understand this target, not the whole codebase.
 
 ---
 
@@ -162,5 +207,5 @@ $map-explain HEAD~1..HEAD
 
 - **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
 - **`HEAD == $BASE`** — the current branch already matches the upstream base; there is no diff. The skill falls into Mode A (project overview); if that's not what you wanted, check `git status` and confirm your commits are on this branch.
-- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so each line can be explained without truncation.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so the load-bearing table fits within the tier budget.
 - **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/src/mapify_cli/templates/skills/map-explain/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-explain/SKILL.md
@@ -10,6 +10,10 @@ argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch d
 
 **Target:** $ARGUMENTS
 
+## Output language
+
+Write the explanation in the user's established language — honor the language already set in context (the conversation's language and the host/global `CLAUDE.md` language convention) rather than defaulting to English. Translate only the prose. Keep code, identifiers, commands, error messages, and `file:line` references in English.
+
 ## Effort and Parallelism Policy
 
 ```yaml
@@ -47,19 +51,15 @@ Then choose **one** of the two modes below and follow it.
 
 ### Mode A — Project overview (current branch is `main` or `master`, OR `HEAD` == `$BASE`)
 
-There is no branch diff to explain — explain the project as a whole instead. Produce a single project-level walkthrough that follows the 10 sections below at the **repository** level, not at a single-file level:
+There is no branch diff to explain — explain the project as a whole. Apply the **output spec** below at the **repository** level instead of a single-file level:
 
-- Section 1 (problem): what this repository exists to do — derive from `README.md` first, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
-- Section 2 (entities): the top-level modules / packages / services that make up the project (read the top-level directory listing, primary entry points, and any package/manifest files like `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
-- Section 3 (how they differ): the responsibility boundary between those entities — what each one owns and what it explicitly does NOT do.
-- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle — whichever applies). Trace from entry point through the main code paths.
-- Section 5 (data flow): what data moves between the entities — file formats, schemas, IPC, state files, databases.
-- Sections 6–7: do NOT try to cover every line in the repo. Instead, pick the 3–6 most architecturally load-bearing files/functions and walk those.
-- Section 8 (state & side effects): what the project writes to disk, the network, or shared services; what survives across runs.
-- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
-- Section 10 (breakage modes): what kinds of changes routinely break this project, based on `CONTRIBUTING.md`, `CHANGELOG.md`, recent commit messages, or learned-patterns docs if present.
+- *Mental model in 60 seconds*: what this repository exists to do — derive from `README.md`, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
+- *Decomposition*: the top-level modules / packages / services and the responsibility boundary between them — read the directory listing, primary entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- *Execution flow*: what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- *Load-bearing lines*: do NOT cover every line in the repo. Pick the 3–6 most architecturally load-bearing files/functions and walk only those.
+- *Assumptions & breakage*: runtime, OS, language version, external services, secrets, env vars, plus the kinds of changes that routinely break this project (derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, learned-patterns docs).
 
-Skip the "For PRs, also explain" section in this mode — there is no diff.
+There is no diff, so skip the before→after block.
 
 Useful commands to bootstrap:
 
@@ -72,7 +72,7 @@ git --no-pager log --oneline -n 20
 
 ### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
 
-The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — also produce the "For PRs, also explain" section.
+The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — lead with the before→after block.
 
 ```bash
 # Three-dot diff = "what this branch changed relative to base".
@@ -85,49 +85,92 @@ git --no-pager diff "$BASE"...HEAD
 
 - If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
 
-Explain it so I can build a complete mental model of it, not just a summary.
+## Size the explanation first
 
-I want you to teach it step by step:
+Classify the target by size and set a word budget. Budgets are **ceilings, not targets** — when in doubt, cut.
 
-1. what problem it solves,
-2. what entities exist,
-3. how they differ,
-4. how execution flows,
-5. how data flows,
-6. what every important line does,
-7. why each non-trivial line is needed,
-8. what state changes and side effects happen,
-9. what assumptions the code relies on,
-10. what could break if I modify it.
+| Tier | Trigger | Word budget | Load-bearing line cap |
+|---|---|---|---|
+| Tiny | ≤50 lines / single symbol | 300–700 | full line detail OK |
+| Small | 31–150 lines | 600–1,200 | ≤10 |
+| Medium | 151–300 lines | 900–1,600 | ≤12 |
+| Large | 301–600 lines / multi-file | 1,200–2,200 | ≤18 |
+| Huge | >600 lines | 1,800–2,800 | ≤25 |
+
+Snippet caps: never quote more than 3 lines at once; ~20 quoted lines total across the whole explanation. Summarize the rest by reference (`file:line`) rather than pasting it.
+
+## Output spec
+
+Open with one framing line, then the blocks below **in order**. Tag each header with a read-tier so the reader can decide what to skip: `[MUST READ]`, `[READ IF MODIFYING]`, `[SKIM]`. Emit a block only when it applies (see "Adaptive sections").
+
+`Target: <type> · Size: <tier> · Budget: <range> words`
+
+1. **Mental model in 60 seconds** `[MUST READ]` — ≤100 words / ≤5 sentences: what it is, its job, the one thing you most need to know, and the one thing most likely to surprise you.
+2. **Before → after** `[MUST READ]` — *PR/diff targets only; this goes first because the delta is the most important context for a diff.* A small table:
+
+   | Aspect | Before | After | Runtime effect |
+   |---|---|---|---|
+
+3. **Execution flow** `[MUST READ]` — entry point → branches → where they converge.
+4. **Decomposition** `[SKIM]` — a small table of the entities/responsibilities: what each owns and what it explicitly does NOT do. Skip for a single function.
+5. **Load-bearing lines** `[READ IF MODIFYING]` — the one table defined below.
+6. **Assumptions & breakage** `[SKIM]` — what the code relies on (runtime, services, invariants) and what changes routinely break it.
+7. **Key insights** — plus common misunderstandings.
+
+Close with a single line — not a "Skipped" header: `Omitted: <list> — irrelevant for <reason>`. Then offer 2–3 **natural-language** follow-ups (e.g. "Explain the authorization path line by line", "Focus only on the data flow"). Do NOT print fake CLI flags like `--focus flow` — the CLI cannot honor them.
+
+## Load-bearing lines (replaces line-by-line)
+
+A line is **load-bearing** — and earns a row — only if it:
+
+- mutates external/system state;
+- branches on a non-trivial condition;
+- crosses an abstraction boundary or public contract;
+- does validation, authorization, normalization, or parsing;
+- handles an error, retry, fallback, or edge case;
+- encodes a non-obvious invariant;
+- would silently change behavior if removed.
+
+Skip (do not quote or explain): type annotations, logging, trivial assignments, boilerplate imports, standard decorators, getters/setters whose name equals their behavior.
+
+Worked filter: in `if user.is_admin or has_scope(token, "write"):` the condition is load-bearing (an authorization branch); a neighboring `logger.debug(f"checking {user.id}")` is not.
+
+Emit them as one table — this merges the old "what every line does" and "why each line" into a single pass so the same code is never explained twice:
+
+| Where (file:line) | What it does | Why it matters / what breaks if changed |
+|---|---|---|
+
+- **Repeated shapes once.** When the target repeats a pattern (N handlers, routes, switch cases, validators, mappers), explain the shared shape once, then list only the meaningful exceptions. Never re-explain the same shape N times.
+- **Diffs: changed lines only.** For a PR/branch diff, apply this table to changed lines, not the whole file.
+- **Density.** One sentence for WHAT per row; add a second only when WHY is non-obvious.
+
+## Adaptive sections (menu, not checklist)
+
+Emit a block only when it carries signal for this target:
+
+- Single function → skip *Decomposition*.
+- Pure function → skip side-effect discussion.
+- PR diff → fold "what differs" into *Before → after*; do not also write a separate differences section.
+- A category that is trivial for this target → compress to one sentence rather than a full block.
+
+Never emit a header just to write "Skipped" — list everything omitted in the closing `Omitted:` line instead.
 
 ## Rules
 
-- do not use terms before explaining them;
-- do not skip "obvious" lines;
-- do not hide behind abstractions or jargon;
-- separate intuition, exact mechanism, and practical meaning;
-- if something is inferred rather than explicit, mark it clearly.
-
-## For PRs, also explain
-
-- what behavior likely existed before,
-- what behavior exists after,
-- and how the diff changes runtime behavior.
-
-## End with
-
-- key insights,
-- common misunderstandings,
-- and a short precise summary.
+- **Be dense.** Prefer one precise sentence over three vague ones. Prefer statements of purpose and consequence over procedural description.
+- Do not use a term before explaining it; do not hide behind jargon.
+- Separate intuition, exact mechanism, and practical meaning.
+- Mark an inference with `Inferred:` only when it required reading multiple files or guessing intent — not for direct observations any competent reader would make.
+- No preamble, no apology, no closing pleasantries. Begin with the substance.
+- Ban filler openers: "This line…", "Here we have…", "It is important to note…", "Essentially…", "In other words…", "Note that…".
 
 ## How to apply
 
-1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase to find the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
+1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase for the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
 2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
-3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
-4. **Mark inferences.** When asserting something the source does not directly state (e.g., "this is likely called from the request handler"), prefix it with `Inferred:` so the reader knows the confidence level.
-5. **Quote, do not paraphrase, the lines you explain.** Use `file:line` references so the reader can navigate.
-6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target's behavior.
+3. **Size it, then emit the output spec in order.** Front-load the mental model; the structure is part of the teaching, but only emit blocks that apply.
+4. **Quote, do not paraphrase, the load-bearing lines you explain.** Use `file:line` references so the reader can navigate, and respect the snippet caps.
+5. **Stop at the target's boundary.** Explain only what is needed to understand this target's behavior, not the whole codebase.
 
 ## Examples
 
@@ -143,5 +186,5 @@ I want you to teach it step by step:
 
 - **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
 - **"HEAD == $BASE"** — the current branch already matches the upstream base, so there is no diff. The skill falls into Mode A (project overview); if that is not what you wanted, check `git status` and confirm your commits are on this branch.
-- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) instead of the full branch diff so each line can be explained without truncation.
-- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see un-marked guesses, ask the skill to re-emit with explicit confidence tags.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so the load-bearing table fits within the tier budget.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/src/mapify_cli/templates_src/codex/skills/map-explain/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-explain/SKILL.md.jinja
@@ -1,6 +1,6 @@
 ---
 name: map-explain
-description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, line-by-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
+description: "Deep walkthrough of code, a diff, or the whole project — problem, entities, flow, load-bearing-line rationale, side effects, assumptions, breakage. Use when learning unfamiliar code or auditing a diff."
 ---
 
 # $map-explain — Deep Walkthrough
@@ -13,6 +13,12 @@ description: "Deep walkthrough of code, a diff, or the whole project — problem
 - Bootstrapping a new contributor on an existing project
 
 **Related skills:** `$map-plan` (decomposition before execution), `$map-fast` (small implementations), `$map-check` (post-execution verification).
+
+---
+
+## Output language
+
+Write the explanation in the user's established language — honor the language already set in context (the conversation's language and the host/global `AGENTS.md` / `CLAUDE.md` language convention) rather than defaulting to English. Translate only the prose. Keep code, identifiers, commands, error messages, and `file:line` references in English.
 
 ---
 
@@ -51,19 +57,15 @@ shell_command:
 
 ### Mode A — Project overview (current branch is `main`/`master`, OR `HEAD` == `$BASE`)
 
-No branch diff to explain — walk the **whole repository**. Map the 10 sections below onto the project, not a single file:
+No branch diff to explain — walk the **whole repository**. Apply the output spec below at the project level, not a single-file level:
 
-- Section 1 (problem): what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
-- Section 2 (entities): top-level modules / packages / services. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
-- Section 3 (how they differ): responsibility boundaries — what each entity owns and explicitly does NOT do.
-- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
-- Section 5 (data flow): how data moves between entities — file formats, schemas, IPC, state files, databases.
-- Sections 6–7: pick the 3–6 most load-bearing files/functions and walk those line by line. Do NOT try to cover every line in the repo.
-- Section 8 (state & side effects): what the project writes to disk, network, or shared services; what survives across runs.
-- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
-- Section 10 (breakage modes): kinds of changes that routinely break this project — derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, or learned-patterns docs.
+- *Mental model in 60 seconds*: what this repository exists to do — derive from `README.md`, then `docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md` / `AGENTS.md`.
+- *Decomposition*: top-level modules / packages / services and their responsibility boundaries. Read the directory listing, entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- *Execution flow*: what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- *Load-bearing lines*: pick the 3–6 most load-bearing files/functions and walk only those. Do NOT cover every line in the repo.
+- *Assumptions & breakage*: runtime, OS, language version, external services, secrets, env vars, plus the kinds of changes that routinely break this project (`CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, learned-patterns docs).
 
-Skip the "For PRs, also explain" section in this mode — no diff exists.
+There is no diff, so skip the before→after block.
 
 Bootstrap commands:
 
@@ -78,7 +80,7 @@ shell_command:
 
 ### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
 
-The target is the current branch's diff against the upstream base. Treat it like a PR and **also** produce the "For PRs, also explain" section.
+The target is the current branch's diff against the upstream base. Treat it like a PR and **lead with the before→after block**.
 
 ```
 shell_command:
@@ -98,40 +100,84 @@ shell_command:
 
 ---
 
-## What the explanation must contain
+## Size the explanation first
 
-Teach the target step by step:
+Classify the target by size and set a word budget. Budgets are **ceilings, not targets** — when in doubt, cut.
 
-1. what problem it solves,
-2. what entities exist,
-3. how they differ,
-4. how execution flows,
-5. how data flows,
-6. what every important line does,
-7. why each non-trivial line is needed,
-8. what state changes and side effects happen,
-9. what assumptions the code relies on,
-10. what could break if I modify it.
+| Tier | Trigger | Word budget | Load-bearing line cap |
+|---|---|---|---|
+| Tiny | ≤50 lines / single symbol | 300–700 | full line detail OK |
+| Small | 31–150 lines | 600–1,200 | ≤10 |
+| Medium | 151–300 lines | 900–1,600 | ≤12 |
+| Large | 301–600 lines / multi-file | 1,200–2,200 | ≤18 |
+| Huge | >600 lines | 1,800–2,800 | ≤25 |
 
-### Rules
+Snippet caps: never quote more than 3 lines at once; ~20 quoted lines total across the whole explanation. Summarize the rest by `file:line` reference.
 
-- do not use terms before explaining them;
-- do not skip "obvious" lines;
-- do not hide behind abstractions or jargon;
+## Output spec
+
+Open with one framing line, then the blocks below **in order**. Tag each header with a read-tier so the reader can decide what to skip: `[MUST READ]`, `[READ IF MODIFYING]`, `[SKIM]`. Emit a block only when it applies (see "Adaptive sections").
+
+`Target: <type> · Size: <tier> · Budget: <range> words`
+
+1. **Mental model in 60 seconds** `[MUST READ]` — ≤100 words / ≤5 sentences: what it is, its job, the one thing you most need to know, and the one thing most likely to surprise you.
+2. **Before → after** `[MUST READ]` — *PR/diff targets only; this goes first because the delta is the most important context for a diff.* A small table:
+
+   | Aspect | Before | After | Runtime effect |
+   |---|---|---|---|
+
+3. **Execution flow** `[MUST READ]` — entry point → branches → where they converge.
+4. **Decomposition** `[SKIM]` — a small table of entities/responsibilities: what each owns and what it explicitly does NOT do. Skip for a single function.
+5. **Load-bearing lines** `[READ IF MODIFYING]` — the one table defined below.
+6. **Assumptions & breakage** `[SKIM]` — what the code relies on (runtime, services, invariants) and what changes routinely break it.
+7. **Key insights** — plus common misunderstandings.
+
+Close with a single line — not a "Skipped" header: `Omitted: <list> — irrelevant for <reason>`. Then offer 2–3 **natural-language** follow-ups (e.g. "Explain the authorization path line by line", "Focus only on the data flow"). Do NOT print fake CLI flags — the CLI cannot honor them.
+
+## Load-bearing lines (replaces line-by-line)
+
+A line is **load-bearing** — and earns a row — only if it:
+
+- mutates external/system state;
+- branches on a non-trivial condition;
+- crosses an abstraction boundary or public contract;
+- does validation, authorization, normalization, or parsing;
+- handles an error, retry, fallback, or edge case;
+- encodes a non-obvious invariant;
+- would silently change behavior if removed.
+
+Skip (do not quote or explain): type annotations, logging, trivial assignments, boilerplate imports, standard decorators, getters/setters whose name equals their behavior.
+
+Worked filter: in `if user.is_admin or has_scope(token, "write"):` the condition is load-bearing (an authorization branch); a neighboring `logger.debug(f"checking {user.id}")` is not.
+
+Emit them as one table — this merges the old "what every line does" and "why each line" into a single pass so the same code is never explained twice:
+
+| Where (file:line) | What it does | Why it matters / what breaks if changed |
+|---|---|---|
+
+- **Repeated shapes once.** When the target repeats a pattern (N handlers, routes, switch cases, validators, mappers), explain the shared shape once, then list only the meaningful exceptions. Never re-explain the same shape N times.
+- **Diffs: changed lines only.** For a PR/branch diff, apply this table to changed lines, not the whole file.
+- **Density.** One sentence for WHAT per row; add a second only when WHY is non-obvious.
+
+## Adaptive sections (menu, not checklist)
+
+Emit a block only when it carries signal for this target:
+
+- Single function → skip *Decomposition*.
+- Pure function → skip side-effect discussion.
+- PR diff → fold "what differs" into *Before → after*; do not also write a separate differences section.
+- A category that is trivial for this target → compress to one sentence rather than a full block.
+
+Never emit a header just to write "Skipped" — list everything omitted in the closing `Omitted:` line instead.
+
+## Rules
+
+- **Be dense.** Prefer one precise sentence over three vague ones. Prefer statements of purpose and consequence over procedural description.
+- do not use a term before explaining it; do not hide behind jargon;
 - separate intuition, exact mechanism, and practical meaning;
-- if something is inferred rather than explicit, prefix it with `Inferred:`.
-
-### For PRs / diffs, also explain
-
-- what behavior likely existed before,
-- what behavior exists after,
-- and how the diff changes runtime behavior.
-
-### End with
-
-- key insights,
-- common misunderstandings,
-- a short precise summary.
+- mark an inference with `Inferred:` only when it required reading multiple files or guessing intent — not for direct observations any competent reader would make.
+- No preamble, no apology, no closing pleasantries. Begin with the substance.
+- Ban filler openers: "This line…", "Here we have…", "It is important to note…", "Essentially…", "In other words…", "Note that…".
 
 ---
 
@@ -139,10 +185,9 @@ Teach the target step by step:
 
 1. **Locate the target** per the rules above (file / symbol / PR ref / snippet / empty).
 2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
-3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
-4. **Mark inferences** with `Inferred:` so the reader knows the confidence level.
-5. **Quote, do not paraphrase,** the lines you explain. Use `file:line` references.
-6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target.
+3. **Size it, then emit the output spec in order.** Front-load the mental model; the structure is part of the teaching, but only emit blocks that apply.
+4. **Quote, do not paraphrase,** the load-bearing lines you explain. Use `file:line` references, and respect the snippet caps.
+5. **Stop at the target's boundary.** Explain only what is needed to understand this target, not the whole codebase.
 
 ---
 
@@ -162,5 +207,5 @@ $map-explain HEAD~1..HEAD
 
 - **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
 - **`HEAD == $BASE`** — the current branch already matches the upstream base; there is no diff. The skill falls into Mode A (project overview); if that's not what you wanted, check `git status` and confirm your commits are on this branch.
-- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so each line can be explained without truncation.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so the load-bearing table fits within the tier budget.
 - **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.

--- a/src/mapify_cli/templates_src/skills/map-explain/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-explain/SKILL.md.jinja
@@ -10,6 +10,10 @@ argument-hint: "[file path | symbol | PR ref | code snippet | empty for branch d
 
 **Target:** $ARGUMENTS
 
+## Output language
+
+Write the explanation in the user's established language — honor the language already set in context (the conversation's language and the host/global `CLAUDE.md` language convention) rather than defaulting to English. Translate only the prose. Keep code, identifiers, commands, error messages, and `file:line` references in English.
+
 ## Effort and Parallelism Policy
 
 ```yaml
@@ -47,19 +51,15 @@ Then choose **one** of the two modes below and follow it.
 
 ### Mode A — Project overview (current branch is `main` or `master`, OR `HEAD` == `$BASE`)
 
-There is no branch diff to explain — explain the project as a whole instead. Produce a single project-level walkthrough that follows the 10 sections below at the **repository** level, not at a single-file level:
+There is no branch diff to explain — explain the project as a whole. Apply the **output spec** below at the **repository** level instead of a single-file level:
 
-- Section 1 (problem): what this repository exists to do — derive from `README.md` first, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
-- Section 2 (entities): the top-level modules / packages / services that make up the project (read the top-level directory listing, primary entry points, and any package/manifest files like `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
-- Section 3 (how they differ): the responsibility boundary between those entities — what each one owns and what it explicitly does NOT do.
-- Section 4 (execution flow): what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle — whichever applies). Trace from entry point through the main code paths.
-- Section 5 (data flow): what data moves between the entities — file formats, schemas, IPC, state files, databases.
-- Sections 6–7: do NOT try to cover every line in the repo. Instead, pick the 3–6 most architecturally load-bearing files/functions and walk those.
-- Section 8 (state & side effects): what the project writes to disk, the network, or shared services; what survives across runs.
-- Section 9 (assumptions): runtime, OS, language version, external services, secrets, env vars, network access.
-- Section 10 (breakage modes): what kinds of changes routinely break this project, based on `CONTRIBUTING.md`, `CHANGELOG.md`, recent commit messages, or learned-patterns docs if present.
+- *Mental model in 60 seconds*: what this repository exists to do — derive from `README.md`, then top-level docs (`docs/ARCHITECTURE.md`, `docs/USAGE.md`, `CLAUDE.md`).
+- *Decomposition*: the top-level modules / packages / services and the responsibility boundary between them — read the directory listing, primary entry points, and manifests (`pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`).
+- *Execution flow*: what happens when the primary entry point runs (CLI invocation, server startup, request lifecycle).
+- *Load-bearing lines*: do NOT cover every line in the repo. Pick the 3–6 most architecturally load-bearing files/functions and walk only those.
+- *Assumptions & breakage*: runtime, OS, language version, external services, secrets, env vars, plus the kinds of changes that routinely break this project (derive from `CONTRIBUTING.md`, `CHANGELOG.md`, recent commits, learned-patterns docs).
 
-Skip the "For PRs, also explain" section in this mode — there is no diff.
+There is no diff, so skip the before→after block.
 
 Useful commands to bootstrap:
 
@@ -72,7 +72,7 @@ git --no-pager log --oneline -n 20
 
 ### Mode B — Branch diff (current branch is NOT `main`/`master` and `HEAD` != `$BASE`)
 
-The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — also produce the "For PRs, also explain" section.
+The target is the current branch's diff against the upstream base. Treat the resulting diff exactly like a PR target — lead with the before→after block.
 
 ```bash
 # Three-dot diff = "what this branch changed relative to base".
@@ -85,49 +85,92 @@ git --no-pager diff "$BASE"...HEAD
 
 - If the working tree has uncommitted changes you also want explained, say so and include `git diff` (unstaged) and `git diff --cached` (staged) on top of whatever the chosen mode produced.
 
-Explain it so I can build a complete mental model of it, not just a summary.
+## Size the explanation first
 
-I want you to teach it step by step:
+Classify the target by size and set a word budget. Budgets are **ceilings, not targets** — when in doubt, cut.
 
-1. what problem it solves,
-2. what entities exist,
-3. how they differ,
-4. how execution flows,
-5. how data flows,
-6. what every important line does,
-7. why each non-trivial line is needed,
-8. what state changes and side effects happen,
-9. what assumptions the code relies on,
-10. what could break if I modify it.
+| Tier | Trigger | Word budget | Load-bearing line cap |
+|---|---|---|---|
+| Tiny | ≤50 lines / single symbol | 300–700 | full line detail OK |
+| Small | 31–150 lines | 600–1,200 | ≤10 |
+| Medium | 151–300 lines | 900–1,600 | ≤12 |
+| Large | 301–600 lines / multi-file | 1,200–2,200 | ≤18 |
+| Huge | >600 lines | 1,800–2,800 | ≤25 |
+
+Snippet caps: never quote more than 3 lines at once; ~20 quoted lines total across the whole explanation. Summarize the rest by reference (`file:line`) rather than pasting it.
+
+## Output spec
+
+Open with one framing line, then the blocks below **in order**. Tag each header with a read-tier so the reader can decide what to skip: `[MUST READ]`, `[READ IF MODIFYING]`, `[SKIM]`. Emit a block only when it applies (see "Adaptive sections").
+
+`Target: <type> · Size: <tier> · Budget: <range> words`
+
+1. **Mental model in 60 seconds** `[MUST READ]` — ≤100 words / ≤5 sentences: what it is, its job, the one thing you most need to know, and the one thing most likely to surprise you.
+2. **Before → after** `[MUST READ]` — *PR/diff targets only; this goes first because the delta is the most important context for a diff.* A small table:
+
+   | Aspect | Before | After | Runtime effect |
+   |---|---|---|---|
+
+3. **Execution flow** `[MUST READ]` — entry point → branches → where they converge.
+4. **Decomposition** `[SKIM]` — a small table of the entities/responsibilities: what each owns and what it explicitly does NOT do. Skip for a single function.
+5. **Load-bearing lines** `[READ IF MODIFYING]` — the one table defined below.
+6. **Assumptions & breakage** `[SKIM]` — what the code relies on (runtime, services, invariants) and what changes routinely break it.
+7. **Key insights** — plus common misunderstandings.
+
+Close with a single line — not a "Skipped" header: `Omitted: <list> — irrelevant for <reason>`. Then offer 2–3 **natural-language** follow-ups (e.g. "Explain the authorization path line by line", "Focus only on the data flow"). Do NOT print fake CLI flags like `--focus flow` — the CLI cannot honor them.
+
+## Load-bearing lines (replaces line-by-line)
+
+A line is **load-bearing** — and earns a row — only if it:
+
+- mutates external/system state;
+- branches on a non-trivial condition;
+- crosses an abstraction boundary or public contract;
+- does validation, authorization, normalization, or parsing;
+- handles an error, retry, fallback, or edge case;
+- encodes a non-obvious invariant;
+- would silently change behavior if removed.
+
+Skip (do not quote or explain): type annotations, logging, trivial assignments, boilerplate imports, standard decorators, getters/setters whose name equals their behavior.
+
+Worked filter: in `if user.is_admin or has_scope(token, "write"):` the condition is load-bearing (an authorization branch); a neighboring `logger.debug(f"checking {user.id}")` is not.
+
+Emit them as one table — this merges the old "what every line does" and "why each line" into a single pass so the same code is never explained twice:
+
+| Where (file:line) | What it does | Why it matters / what breaks if changed |
+|---|---|---|
+
+- **Repeated shapes once.** When the target repeats a pattern (N handlers, routes, switch cases, validators, mappers), explain the shared shape once, then list only the meaningful exceptions. Never re-explain the same shape N times.
+- **Diffs: changed lines only.** For a PR/branch diff, apply this table to changed lines, not the whole file.
+- **Density.** One sentence for WHAT per row; add a second only when WHY is non-obvious.
+
+## Adaptive sections (menu, not checklist)
+
+Emit a block only when it carries signal for this target:
+
+- Single function → skip *Decomposition*.
+- Pure function → skip side-effect discussion.
+- PR diff → fold "what differs" into *Before → after*; do not also write a separate differences section.
+- A category that is trivial for this target → compress to one sentence rather than a full block.
+
+Never emit a header just to write "Skipped" — list everything omitted in the closing `Omitted:` line instead.
 
 ## Rules
 
-- do not use terms before explaining them;
-- do not skip "obvious" lines;
-- do not hide behind abstractions or jargon;
-- separate intuition, exact mechanism, and practical meaning;
-- if something is inferred rather than explicit, mark it clearly.
-
-## For PRs, also explain
-
-- what behavior likely existed before,
-- what behavior exists after,
-- and how the diff changes runtime behavior.
-
-## End with
-
-- key insights,
-- common misunderstandings,
-- and a short precise summary.
+- **Be dense.** Prefer one precise sentence over three vague ones. Prefer statements of purpose and consequence over procedural description.
+- Do not use a term before explaining it; do not hide behind jargon.
+- Separate intuition, exact mechanism, and practical meaning.
+- Mark an inference with `Inferred:` only when it required reading multiple files or guessing intent — not for direct observations any competent reader would make.
+- No preamble, no apology, no closing pleasantries. Begin with the substance.
+- Ban filler openers: "This line…", "Here we have…", "It is important to note…", "Essentially…", "In other words…", "Note that…".
 
 ## How to apply
 
-1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase to find the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
+1. **Locate the target.** If `$ARGUMENTS` is empty, pick **Mode A** (project overview) or **Mode B** (branch diff) per the rules above. If it's a file path, read the whole file. If it's a symbol, grep the codebase for the definition and primary call sites. If it's a PR ref (`#N`, branch name, commit SHA), fetch the diff with `git show` / `gh pr diff`. If it's an inline snippet, treat the snippet itself as the target.
 2. **Read enough context to answer "why this exists."** Imports, callers, tests, and adjacent files often carry intent the target itself does not.
-3. **Walk the 10 sections in order.** Do not collapse them into a single prose blob — the structure is part of the teaching.
-4. **Mark inferences.** When asserting something the source does not directly state (e.g., "this is likely called from the request handler"), prefix it with `Inferred:` so the reader knows the confidence level.
-5. **Quote, do not paraphrase, the lines you explain.** Use `file:line` references so the reader can navigate.
-6. **Stop at the target's boundary.** Do not explain the whole codebase — only what is needed to understand this target's behavior.
+3. **Size it, then emit the output spec in order.** Front-load the mental model; the structure is part of the teaching, but only emit blocks that apply.
+4. **Quote, do not paraphrase, the load-bearing lines you explain.** Use `file:line` references so the reader can navigate, and respect the snippet caps.
+5. **Stop at the target's boundary.** Explain only what is needed to understand this target's behavior, not the whole codebase.
 
 ## Examples
 
@@ -143,5 +186,5 @@ I want you to teach it step by step:
 
 - **"neither origin/main nor origin/master exists"** — the repo has no upstream named `origin`, or its default branch is not `main`/`master`. Either add an `origin` remote, or pass an explicit target (file path / symbol / PR ref) instead of running with no arguments.
 - **"HEAD == $BASE"** — the current branch already matches the upstream base, so there is no diff. The skill falls into Mode A (project overview); if that is not what you wanted, check `git status` and confirm your commits are on this branch.
-- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) instead of the full branch diff so each line can be explained without truncation.
-- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see un-marked guesses, ask the skill to re-emit with explicit confidence tags.
+- **Diff is enormous and the walkthrough turns shallow** — pass a narrower target (single file, single symbol, or `HEAD~1..HEAD`) so the load-bearing table fits within the tier budget.
+- **Output mixes inference with source claims** — every non-explicit assertion must be prefixed with `Inferred:`. If you see unmarked guesses, ask the skill to re-emit with explicit confidence tags.


### PR DESCRIPTION
## Summary

Fixes the two `/map-explain` UX defects from #224:

1. **Output language was hardcoded to English** — the skill had zero language rules and silently overrode the user's established language. Added an explicit rule: write prose in the user's language; keep code, identifiers, commands, error messages, and `file:line` refs in English.
2. **Output was a wall of text** — the rigid always-emit-all-10-sections + explain-every-line structure produced ~4000 words on a 600-line diff. Replaced with a signal-first output spec.

Implements the LLM-council deliberation (council id in the issue) plus the owner-validated worked template from the issue comment. No re-consultation needed — the design was already settled and validated on a real 600-line Go controller diff.

## What changed (both Claude + Codex surfaces)

- **Output-language rule** near the top of the skill body.
- **Size tiers** with word-budget *ceilings* and load-bearing-line caps (Tiny→Huge).
- **Front-loaded "Mental model in 60 seconds"** (`[MUST READ]`, ≤100 words).
- **Read-tier section tags** (`[MUST READ]` / `[READ IF MODIFYING]` / `[SKIM]`).
- **Load-bearing lines** replaces line-by-line: mechanical definition + skip list + worked filter; **one table** merging the old "what every line does" (§6) and "why each line" (§7); repeated shapes explained once; diffs → changed lines only.
- **Before→after first** for PR/diff targets.
- **Adaptive sections** (menu, not checklist) + single `Omitted:` footer line.
- **Natural-language follow-up offers** (no fake CLI flags).
- Deleted `do not skip "obvious" lines`; banned filler openers; tightened the `Inferred:` rule.

## Invariants honored

- Edited only the `.jinja` sources in `templates_src/`; ran `make render-templates` to propagate to all generated trees (`.claude/`, `.agents/`, both `templates/` mirrors).
- `make check` green: **2511 passed, 3 skipped**, render parity ✅.
- No prod deploy target in the Makefile (`release` is a manual build + PyPI prompt); this is a skill-content change, no version bump.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)