### PR TITLE
fix(map-efficient): align Actor prompt with JSON truncation gate (#227)

### DIFF
--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -291,7 +291,7 @@ Implement exactly the current subtask. Preserve validation_criteria, coverage_ma
 Do not edit unrelated files, add or upgrade dependencies, or refactor neighboring code unless the current subtask contract explicitly requires it. Report any required scope expansion as a blocker/tradeoff.
 </task>
 <expected_output>
-Return files_changed, tests_run, validation_notes, and any blocker.
+Return ONLY a JSON object (no markdown fences, no prose before/after) with files_changed (array of written paths), tests_run (array of "command — pass/fail"), validation_notes (string), and blocker (string or null). Write and run code via tools FIRST — this JSON is a post-work manifest; never put code, diffs, or logs inside it. Detail: [efficient-reference.md](efficient-reference.md).
 </expected_output>
 """
 )

--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -109,6 +109,15 @@ echo "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
     detect_truncated_agent_output --agent actor
 ```
 
+> **Why JSON (not prose):** Actor and this detector share one contract
+> (`AGENT_OUTPUT_SCHEMAS["actor"]`), exactly as Monitor does. The JSON is a
+> *post-work manifest*, never a code container — the Actor writes and runs code
+> via its tools FIRST, then summarizes. Keeping the four fields short (file
+> paths, test commands, a notes string, a blocker) keeps truncation
+> machine-checkable without diverting the agent into serialization or escaping
+> code/diffs into JSON strings. The `<expected_output>` block in `SKILL.md`
+> states this; do not relax the detector to accept prose.
+
 If `truncated: true`:
 1. Log via `log_agent_failure --agent actor --phase pre-monitor --failure-label truncated --reasons '<reasons>'`
    and re-invoke Actor ONCE using the prompt from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`/map-efficient` Actor truncation gate false-positived on every clean run
+  (#227).** The pre-Monitor `detect_truncated_agent_output --agent actor` gate
+  requires the Actor response to parse as a JSON object
+  (`files_changed`/`tests_run`/`validation_notes`/`blocker`), but the ACTOR
+  `<expected_output>` prompted for free-form prose — so every complete, correct
+  Actor response was flagged `truncated: true`, forcing a needless re-invoke
+  (token waste) or a manual operator override on each subtask. The ACTOR prompt
+  now instructs a strict JSON manifest mirroring the MONITOR contract: code is
+  written via tools first, then summarized into the four-field envelope (no code
+  or diffs inside the JSON). Detector and retry machinery are unchanged. The
+  rationale is documented in `efficient-reference.md`.
+
 ## [3.17.1] - 2026-06-18
 
 ### Fixed

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -291,7 +291,7 @@ Implement exactly the current subtask. Preserve validation_criteria, coverage_ma
 Do not edit unrelated files, add or upgrade dependencies, or refactor neighboring code unless the current subtask contract explicitly requires it. Report any required scope expansion as a blocker/tradeoff.
 </task>
 <expected_output>
-Return files_changed, tests_run, validation_notes, and any blocker.
+Return ONLY a JSON object (no markdown fences, no prose before/after) with files_changed (array of written paths), tests_run (array of "command — pass/fail"), validation_notes (string), and blocker (string or null). Write and run code via tools FIRST — this JSON is a post-work manifest; never put code, diffs, or logs inside it. Detail: [efficient-reference.md](efficient-reference.md).
 </expected_output>
 """
 )

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -109,6 +109,15 @@ echo "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
     detect_truncated_agent_output --agent actor
 ```
 
+> **Why JSON (not prose):** Actor and this detector share one contract
+> (`AGENT_OUTPUT_SCHEMAS["actor"]`), exactly as Monitor does. The JSON is a
+> *post-work manifest*, never a code container — the Actor writes and runs code
+> via its tools FIRST, then summarizes. Keeping the four fields short (file
+> paths, test commands, a notes string, a blocker) keeps truncation
+> machine-checkable without diverting the agent into serialization or escaping
+> code/diffs into JSON strings. The `<expected_output>` block in `SKILL.md`
+> states this; do not relax the detector to accept prose.
+
 If `truncated: true`:
 1. Log via `log_agent_failure --agent actor --phase pre-monitor --failure-label truncated --reasons '<reasons>'`
    and re-invoke Actor ONCE using the prompt from

--- a/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
@@ -291,7 +291,7 @@ Implement exactly the current subtask. Preserve validation_criteria, coverage_ma
 Do not edit unrelated files, add or upgrade dependencies, or refactor neighboring code unless the current subtask contract explicitly requires it. Report any required scope expansion as a blocker/tradeoff.
 </task>
 <expected_output>
-Return files_changed, tests_run, validation_notes, and any blocker.
+Return ONLY a JSON object (no markdown fences, no prose before/after) with files_changed (array of written paths), tests_run (array of "command — pass/fail"), validation_notes (string), and blocker (string or null). Write and run code via tools FIRST — this JSON is a post-work manifest; never put code, diffs, or logs inside it. Detail: [efficient-reference.md](efficient-reference.md).
 </expected_output>
 """
 )

--- a/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
@@ -109,6 +109,15 @@ echo "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
     detect_truncated_agent_output --agent actor
 ```
 
+> **Why JSON (not prose):** Actor and this detector share one contract
+> (`AGENT_OUTPUT_SCHEMAS["actor"]`), exactly as Monitor does. The JSON is a
+> *post-work manifest*, never a code container — the Actor writes and runs code
+> via its tools FIRST, then summarizes. Keeping the four fields short (file
+> paths, test commands, a notes string, a blocker) keeps truncation
+> machine-checkable without diverting the agent into serialization or escaping
+> code/diffs into JSON strings. The `<expected_output>` block in `SKILL.md`
+> states this; do not relax the detector to accept prose.
+
 If `truncated: true`:
 1. Log via `log_agent_failure --agent actor --phase pre-monitor --failure-label truncated --reasons '<reasons>'`
    and re-invoke Actor ONCE using the prompt from

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1095,6 +1095,64 @@ class TestXMLPromptEnvelopeContracts:
                 "so long-context inputs are read before instructions."
             )
 
+    @pytest.mark.parametrize("skills_root", PROMPT_TONE_SKILL_ROOTS)
+    def test_map_efficient_actor_expected_output_instructs_json_envelope(
+        self, project_root, skills_root
+    ):
+        """Regression for #227: the ACTOR <expected_output> must instruct a
+        strict JSON envelope so the prompt AGREES with the actor-mode
+        truncation gate (`detect_truncated_agent_output --agent actor`), which
+        requires a JSON object with the AGENT_OUTPUT_SCHEMAS["actor"] keys. The
+        prior prose form ("Return files_changed, tests_run, validation_notes,
+        and any blocker.") parsed as non-JSON, so the gate false-flagged every
+        clean Actor response as truncated and forced needless re-invokes.
+        """
+        import sys
+
+        scripts_path = (
+            project_root
+            / "src"
+            / "mapify_cli"
+            / "templates"
+            / "map"
+            / "scripts"
+        )
+        if str(scripts_path) not in sys.path:
+            sys.path.insert(0, str(scripts_path))
+        import map_step_runner  # type: ignore[import-not-found]
+
+        actor_required = tuple(
+            map_step_runner.AGENT_OUTPUT_SCHEMAS["actor"]["required_keys"]
+        )
+
+        skill_md = project_root / skills_root / "map-efficient" / "SKILL.md"
+        content = skill_md.read_text(encoding="utf-8")
+
+        actor_section = content.split("### Phase: ACTOR (2.3)", maxsplit=1)[1]
+        actor_section = actor_section.split(
+            "### Actor truncated-response gate", maxsplit=1
+        )[0]
+        expected_output = actor_section.split("<expected_output>", maxsplit=1)[1]
+        expected_output = expected_output.split("</expected_output>", maxsplit=1)[0]
+
+        # Must instruct a strict JSON object (mirrors the MONITOR contract), so
+        # the truncation detector's JSON parse succeeds on a complete response.
+        assert "JSON" in expected_output, (
+            "ACTOR <expected_output> must instruct a JSON envelope so it agrees "
+            "with detect_truncated_agent_output --agent actor (requires JSON)."
+        )
+        assert "ONLY" in expected_output, (
+            "ACTOR <expected_output> must require ONLY a JSON object (no prose "
+            "before/after) so the truncation detector parses it cleanly."
+        )
+        # Every detector-required actor key must be named in the prompt — this
+        # is the single-source contract the gate enforces.
+        for key in actor_required:
+            assert key in expected_output, (
+                f"ACTOR <expected_output> must name the '{key}' field required "
+                "by AGENT_OUTPUT_SCHEMAS['actor']."
+            )
+
 
 class TestContractSizedSubtaskSkillContracts:
     """Regression tests for user-visible subtask size and concern guardrails."""


### PR DESCRIPTION
## What

`/map-efficient`'s MANDATORY pre-Monitor Actor truncation gate
(`detect_truncated_agent_output --agent actor`) requires the Actor response to
parse as a JSON object with keys `files_changed`/`tests_run`/`validation_notes`/
`blocker`. But the ACTOR `<expected_output>` prompted the Actor for **prose**
("Return files_changed, tests_run, validation_notes, and any blocker."). So
every clean, complete Actor response parsed as non-JSON and was flagged
`truncated: true` — forcing a needless Actor re-invoke (token waste) or a manual
operator override on **every** subtask.

## Why this fix (option a, not b)

The whole recovery stack already presumes JSON: `AGENT_OUTPUT_SCHEMAS["actor"]`
defines the JSON skeleton as the single source of truth, `build_json_retry_prompt
--agent actor` emits "Emit ONLY one JSON object", the detector docstring states
the rule "presumes the agent was prompted for the JSON envelope", the sibling
Monitor already works this way, and `efficient-reference.md` already extracts
`.files_changed` via `jq`. The prompt was the lone outlier. Aligning the prompt
(option a) is the smallest diff and keeps truncation deterministic; relaxing the
detector to accept prose (option b) would replace a machine-checkable signal with
a fragile heuristic and touch detector + retry builder + tests.

Design vetted via **llm-council** (unanimous for option a). Eval-risk mitigation
baked in: the JSON is a **post-work manifest only** — the Actor writes/runs code
via tools first, then summarizes; no code/diffs inside the envelope, so the
code-writing agent isn't diverted into serialization.

## Changes

- `templates_src/skills/map-efficient/SKILL.md.jinja`: ACTOR `<expected_output>`
  now instructs a strict 4-field JSON manifest (net-zero line edit — 502 budget
  intact).
- `efficient-reference.md(.jinja)`: rationale note ("why JSON, not prose";
  manifest contract). Not budget-gated.
- Generated trees re-rendered (`make render-templates`); `make check-render` green.
- `tests/test_skills.py`: regression `test_map_efficient_actor_expected_output_instructs_json_envelope`
  ties the ACTOR prompt to the runtime `AGENT_OUTPUT_SCHEMAS["actor"]` required
  keys across both shipped trees. Negative-proof: RED on the old prose, GREEN on
  the new contract.
- `CHANGELOG.md`: Unreleased → Fixed entry.

## Testing

- `make check` → 2513 passed, 3 skipped; `make check-render` green.
- New regression test passes on both `.claude/` and `templates/` trees.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)