### PR TITLE
fix(map-efficient): detect test baseline harness in monorepo subdirs (#229)

### DIFF
--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -223,12 +223,35 @@ Auto-detects from project markers:
 - `go.mod` → `go test ./...`
 - `Cargo.toml` → `cargo test`
 
+Detection probes the **repo root first**. If the root has no harness it
+**shallow-scans the immediate subdirectories (one level)** for a module that
+does — the common monorepo layout (e.g. `component-manager/go.mod` with no
+root `go.mod`). A single matching subdir is used automatically and the command
+runs from that dir; the report records `module_dir` and `run_dir` so the chosen
+location is never silent.
+
+When the root has no harness and **more than one** subdir qualifies, detection
+**refuses to guess**: it returns `status="skipped"` with `candidate_module_dirs`
+listing them. Re-run pointing at the right module (`--module-dir`/`--cwd` are
+aliases):
+```bash
+python3 .map/scripts/map_step_runner.py record_test_baseline "$BRANCH" \
+  --module-dir component-manager
+```
+A `status="skipped"` baseline is a **hard signal, not a no-op**: the
+cross-subtask regression gate then has no baseline and cannot tell an introduced
+regression from a pre-existing failure. Resolve it (pass `--module-dir` or
+`--command`) before running subtasks — do not proceed on a silent empty baseline.
+
 Override the auto-detect when the full run is too slow for a
 pre-flight (or you want a narrower target):
 ```bash
 python3 .map/scripts/map_step_runner.py record_test_baseline "$BRANCH" \
   --command "pytest tests/smoke" --timeout 60
 ```
+`--module-dir` and `--command` compose: `--module-dir` sets where the command
+runs, `--command` sets what runs (auto-detected within the module dir if
+omitted).
 
 Persists to `.map/<branch>/test_baseline.json`. Parse pre-existing
 failures back via:

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -7852,10 +7852,114 @@ def list_diagnostics_baseline(branch: str) -> dict[str, object]:
         return {"status": "error", "message": f"read failed: {exc}"}
 
 
+# Directories that never hold a project's test harness — skipped during the
+# shallow monorepo-subdir scan so a candidate is not picked from build output,
+# vendored deps, or tool caches.
+_HARNESS_SCAN_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".map",
+        ".claude",
+        ".codex",
+        ".agents",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".idea",
+        ".vscode",
+        "vendor",
+        "target",
+        "dist",
+        "build",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+    }
+)
+
+
+def _probe_test_harness(directory: Path) -> str:
+    """Auto-detect a test command for a SINGLE directory. Cheap probes only.
+
+    Returns the command (``make test`` / ``pytest`` / ``go test ./...`` /
+    ``cargo test``), or ``""`` when the directory holds no recognised harness
+    marker. ``make test`` only wins when the Makefile actually defines a
+    ``test:`` target.
+    """
+    try:
+        if (directory / "Makefile").exists():
+            try:
+                mk_text = (directory / "Makefile").read_text(encoding="utf-8")
+                if re.search(r"^test:", mk_text, re.MULTILINE):
+                    return "make test"
+            except OSError:
+                pass
+        if (directory / "pyproject.toml").exists() or (directory / "pytest.ini").exists():
+            return "pytest"
+        if (directory / "go.mod").exists():
+            return "go test ./..."
+        if (directory / "Cargo.toml").exists():
+            return "cargo test"
+    except OSError:
+        pass
+    return ""
+
+
+def _detect_baseline_harness(project_dir: Path) -> dict[str, object]:
+    """Resolve the test harness + the directory to run it in.
+
+    Probes the repo root first (the common single-package layout). When the
+    root has no harness, shallow-scans the immediate subdirectories (ONE level
+    deep — the common monorepo-subdir layout, e.g. ``component-manager/go.mod``)
+    for module dirs that contain a harness.
+
+    Returns one of:
+      - ``{"command", "run_dir", "from_root", "module_dir"}`` — a resolved
+        harness (root or a single unambiguous subdir);
+      - ``{"ambiguous": [name, ...]}`` — more than one candidate subdir, so the
+        caller MUST NOT guess; it asks the operator for ``--module-dir``;
+      - ``{}`` — no harness at root or any immediate subdir.
+    """
+    root_cmd = _probe_test_harness(project_dir)
+    if root_cmd:
+        return {
+            "command": root_cmd,
+            "run_dir": project_dir,
+            "from_root": True,
+            "module_dir": None,
+        }
+
+    candidates: list[tuple[str, str]] = []
+    try:
+        entries = sorted(p for p in project_dir.iterdir() if p.is_dir())
+    except OSError:
+        entries = []
+    for sub in entries:
+        if sub.name.startswith(".") or sub.name in _HARNESS_SCAN_SKIP_DIRS:
+            continue
+        cmd = _probe_test_harness(sub)
+        if cmd:
+            candidates.append((sub.name, cmd))
+
+    if len(candidates) == 1:
+        name, cmd = candidates[0]
+        return {
+            "command": cmd,
+            "run_dir": project_dir / name,
+            "from_root": False,
+            "module_dir": name,
+        }
+    if len(candidates) > 1:
+        return {"ambiguous": [name for name, _ in candidates]}
+    return {}
+
+
 def record_test_baseline(
     branch: str,
     test_command: str = "",
     *,
+    module_dir: str = "",
     timeout_seconds: int = 120,
 ) -> dict[str, object]:
     """Record a pre-flight test baseline so subtasks can distinguish
@@ -7872,10 +7976,18 @@ def record_test_baseline(
       - ``pytest`` (no arguments) if pyproject.toml or pytest.ini present
       - ``go test ./...`` if go.mod present
       - ``cargo test`` if Cargo.toml present
-    Empty auto-detect ⇒ status="skipped" (no test harness found).
+    Detection probes the repo root first; if the root has no harness it
+    shallow-scans the immediate subdirectories (one level) for a single
+    obvious module dir (the common monorepo-subdir layout) and runs the
+    command from there. ``module_dir`` (CLI ``--module-dir`` / ``--cwd``)
+    forces a specific module dir, bypassing the scan. When the root has no
+    harness and MORE THAN ONE subdir qualifies, detection refuses to guess
+    and returns ``status="skipped"`` naming the candidates, so the empty
+    baseline is loud rather than silent.
 
-    Returns dict with status, command, returncode, baseline_failures (list of
-    failing test names parsed from stdout), and elapsed_seconds.
+    Returns dict with status, command, run_dir, module_dir, returncode,
+    baseline_failures (list of failing test names parsed from stdout), and
+    elapsed_seconds.
     """
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
     branch_name = _sanitize_branch(branch)
@@ -7883,31 +7995,81 @@ def record_test_baseline(
     baseline_dir.mkdir(parents=True, exist_ok=True)
     baseline_path = baseline_dir / "test_baseline.json"
 
+    # Resolve the command and the directory to run it in. Precedence:
+    #   1. explicit --module-dir (run there; auto-detect the command if absent)
+    #   2. explicit --command (run at the repo root)
+    #   3. auto-detect: repo root, else a single monorepo-subdir module
+    run_dir = project_dir
+    detected_module_dir: str | None = None
     cmd_str = test_command.strip()
     auto_detected_command = ""
-    if not cmd_str:
-        # Auto-detect a sensible default. Cheap shell probes only.
-        if (project_dir / "Makefile").exists():
-            try:
-                mk_text = (project_dir / "Makefile").read_text(encoding="utf-8")
-                if re.search(r"^test:", mk_text, re.MULTILINE):
-                    auto_detected_command = "make test"
-            except OSError:
-                pass
-        if not auto_detected_command:
-            if (project_dir / "pyproject.toml").exists() or (project_dir / "pytest.ini").exists():
-                auto_detected_command = "pytest"
-            elif (project_dir / "go.mod").exists():
-                auto_detected_command = "go test ./..."
-            elif (project_dir / "Cargo.toml").exists():
-                auto_detected_command = "cargo test"
-        cmd_str = auto_detected_command
+
+    module_dir_arg = module_dir.strip()
+    if module_dir_arg:
+        candidate = (project_dir / module_dir_arg).resolve()
+        # Keep the run dir inside the project tree and require it to exist —
+        # a bad --module-dir is a caller error, surfaced loudly (exit 1).
+        if not candidate.is_dir() or not candidate.is_relative_to(project_dir):
+            payload = {
+                "branch": branch_name,
+                "status": "error",
+                "reason": (
+                    f"--module-dir {module_dir_arg!r} is not a directory inside "
+                    f"the project ({project_dir})."
+                ),
+                "recorded_at": _utc_timestamp(),
+            }
+            baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return payload
+        run_dir = candidate
+        detected_module_dir = module_dir_arg
+        if not cmd_str:
+            auto_detected_command = _probe_test_harness(run_dir)
+            cmd_str = auto_detected_command
+    elif not cmd_str:
+        detection = _detect_baseline_harness(project_dir)
+        ambiguous = detection.get("ambiguous")
+        if ambiguous:
+            names = [str(n) for n in ambiguous]  # type: ignore[union-attr]
+            payload = {
+                "branch": branch_name,
+                "status": "skipped",
+                "reason": (
+                    "no test harness at the repo root, and multiple candidate "
+                    f"module dirs were found ({', '.join(names)}). Refusing to "
+                    "guess — re-run with `--module-dir <dir>` (or `--command "
+                    '"<test cmd>"`) to point the baseline at the right module. '
+                    "The cross-subtask regression gate needs a real baseline; an "
+                    "empty one cannot distinguish introduced from pre-existing "
+                    "failures."
+                ),
+                "candidate_module_dirs": names,
+                "recorded_at": _utc_timestamp(),
+            }
+            baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return payload
+        detected_cmd = detection.get("command")
+        if detected_cmd:
+            cmd_str = str(detected_cmd)
+            auto_detected_command = cmd_str
+            resolved_run_dir = detection.get("run_dir")
+            if isinstance(resolved_run_dir, Path):
+                run_dir = resolved_run_dir
+            module_name = detection.get("module_dir")
+            detected_module_dir = str(module_name) if module_name else None
 
     if not cmd_str:
         payload = {
             "branch": branch_name,
             "status": "skipped",
-            "reason": "no test harness detected (Makefile / pytest / go.mod / Cargo.toml)",
+            "reason": (
+                "no test harness detected (Makefile with test: / pyproject.toml / "
+                "pytest.ini / go.mod / Cargo.toml) at the repo root or any "
+                'immediate subdirectory. Re-run with `--command "<test cmd>"` or '
+                "`--module-dir <dir>` so the cross-subtask regression gate has a "
+                "real baseline — without one it cannot tell an introduced "
+                "regression from a pre-existing failure."
+            ),
             "recorded_at": _utc_timestamp(),
         }
         baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -7918,7 +8080,7 @@ def record_test_baseline(
         proc = subprocess.run(
             cmd_str,
             shell=True,
-            cwd=project_dir,
+            cwd=run_dir,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
@@ -7965,6 +8127,8 @@ def record_test_baseline(
         "status": "success" if returncode == 0 else "baseline_failures",
         "command": cmd_str,
         "auto_detected": bool(auto_detected_command),
+        "module_dir": detected_module_dir,
+        "run_dir": str(run_dir),
         "returncode": returncode,
         "timed_out": timed_out,
         "elapsed_seconds": elapsed,
@@ -11073,20 +11237,30 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
 
     elif func_name == "record_test_baseline":
-        # CLI: record_test_baseline <branch> [--command "..."] [--timeout N]
+        # CLI: record_test_baseline <branch> [--command "..."]
+        #       [--module-dir DIR | --cwd DIR] [--timeout N]
         # Snapshot pre-existing test failures so later subtasks can
         # distinguish "I broke this" from "this was broken before plan
-        # started". Auto-detects test command when omitted.
+        # started". Auto-detects the test command when omitted, probing the
+        # repo root then a single monorepo-subdir module; --module-dir/--cwd
+        # forces a module dir for ambiguous/deeply-nested layouts.
         if len(sys.argv) < 3:
-            print(json.dumps({"status": "error", "message": "usage: record_test_baseline <branch> [--command ...]"}), file=sys.stderr)
+            print(json.dumps({"status": "error", "message": "usage: record_test_baseline <branch> [--command ...] [--module-dir DIR]"}), file=sys.stderr)
             sys.exit(1)
         baseline_branch = sys.argv[2]
         baseline_cmd = ""
+        baseline_module_dir = ""
         baseline_timeout = 120
         if "--command" in sys.argv:
             c_idx = sys.argv.index("--command")
             if c_idx + 1 < len(sys.argv):
                 baseline_cmd = sys.argv[c_idx + 1]
+        for module_flag in ("--module-dir", "--cwd"):
+            if module_flag in sys.argv:
+                m_idx = sys.argv.index(module_flag)
+                if m_idx + 1 < len(sys.argv):
+                    baseline_module_dir = sys.argv[m_idx + 1]
+                    break
         if "--timeout" in sys.argv:
             t_idx = sys.argv.index("--timeout")
             if t_idx + 1 < len(sys.argv):
@@ -11096,7 +11270,10 @@ if __name__ == "__main__":
                     print(json.dumps({"status": "error", "message": "--timeout must be int"}), file=sys.stderr)
                     sys.exit(1)
         report = record_test_baseline(
-            baseline_branch, baseline_cmd, timeout_seconds=baseline_timeout
+            baseline_branch,
+            baseline_cmd,
+            module_dir=baseline_module_dir,
+            timeout_seconds=baseline_timeout,
         )
         print(json.dumps(report, indent=2))
         # Exit 0 even on baseline_failures — the WHOLE point is to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`record_test_baseline` silently skipped the MANDATORY pre-flight baseline in
+  monorepos (#229).** Auto-detect probed only the repo root, so when the module
+  lives in a subdir (e.g. `component-manager/go.mod` with no root harness) it
+  returned `status="skipped"` and the whole run proceeded with an empty baseline
+  — the cross-subtask regression gate could then no longer tell an introduced
+  regression from a pre-existing failure. Detection now probes the repo root
+  first, then shallow-scans the immediate subdirectories (one level) for a
+  single module that has a harness and runs the command from that dir (recording
+  `module_dir`/`run_dir`). When more than one subdir qualifies it refuses to
+  guess and skips loudly with `candidate_module_dirs`; the no-harness skip now
+  names the `--command`/`--module-dir` escape hatch. A new `--module-dir`/`--cwd`
+  flag forces the module dir for ambiguous or deeply-nested layouts. Documented
+  in `efficient-reference.md`.
 - **`/map-efficient` Actor truncation gate false-positived on every clean run
   (#227).** The pre-Monitor `detect_truncated_agent_output --agent actor` gate
   requires the Actor response to parse as a JSON object

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -7852,10 +7852,114 @@ def list_diagnostics_baseline(branch: str) -> dict[str, object]:
         return {"status": "error", "message": f"read failed: {exc}"}
 
 
+# Directories that never hold a project's test harness — skipped during the
+# shallow monorepo-subdir scan so a candidate is not picked from build output,
+# vendored deps, or tool caches.
+_HARNESS_SCAN_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".map",
+        ".claude",
+        ".codex",
+        ".agents",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".idea",
+        ".vscode",
+        "vendor",
+        "target",
+        "dist",
+        "build",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+    }
+)
+
+
+def _probe_test_harness(directory: Path) -> str:
+    """Auto-detect a test command for a SINGLE directory. Cheap probes only.
+
+    Returns the command (``make test`` / ``pytest`` / ``go test ./...`` /
+    ``cargo test``), or ``""`` when the directory holds no recognised harness
+    marker. ``make test`` only wins when the Makefile actually defines a
+    ``test:`` target.
+    """
+    try:
+        if (directory / "Makefile").exists():
+            try:
+                mk_text = (directory / "Makefile").read_text(encoding="utf-8")
+                if re.search(r"^test:", mk_text, re.MULTILINE):
+                    return "make test"
+            except OSError:
+                pass
+        if (directory / "pyproject.toml").exists() or (directory / "pytest.ini").exists():
+            return "pytest"
+        if (directory / "go.mod").exists():
+            return "go test ./..."
+        if (directory / "Cargo.toml").exists():
+            return "cargo test"
+    except OSError:
+        pass
+    return ""
+
+
+def _detect_baseline_harness(project_dir: Path) -> dict[str, object]:
+    """Resolve the test harness + the directory to run it in.
+
+    Probes the repo root first (the common single-package layout). When the
+    root has no harness, shallow-scans the immediate subdirectories (ONE level
+    deep — the common monorepo-subdir layout, e.g. ``component-manager/go.mod``)
+    for module dirs that contain a harness.
+
+    Returns one of:
+      - ``{"command", "run_dir", "from_root", "module_dir"}`` — a resolved
+        harness (root or a single unambiguous subdir);
+      - ``{"ambiguous": [name, ...]}`` — more than one candidate subdir, so the
+        caller MUST NOT guess; it asks the operator for ``--module-dir``;
+      - ``{}`` — no harness at root or any immediate subdir.
+    """
+    root_cmd = _probe_test_harness(project_dir)
+    if root_cmd:
+        return {
+            "command": root_cmd,
+            "run_dir": project_dir,
+            "from_root": True,
+            "module_dir": None,
+        }
+
+    candidates: list[tuple[str, str]] = []
+    try:
+        entries = sorted(p for p in project_dir.iterdir() if p.is_dir())
+    except OSError:
+        entries = []
+    for sub in entries:
+        if sub.name.startswith(".") or sub.name in _HARNESS_SCAN_SKIP_DIRS:
+            continue
+        cmd = _probe_test_harness(sub)
+        if cmd:
+            candidates.append((sub.name, cmd))
+
+    if len(candidates) == 1:
+        name, cmd = candidates[0]
+        return {
+            "command": cmd,
+            "run_dir": project_dir / name,
+            "from_root": False,
+            "module_dir": name,
+        }
+    if len(candidates) > 1:
+        return {"ambiguous": [name for name, _ in candidates]}
+    return {}
+
+
 def record_test_baseline(
     branch: str,
     test_command: str = "",
     *,
+    module_dir: str = "",
     timeout_seconds: int = 120,
 ) -> dict[str, object]:
     """Record a pre-flight test baseline so subtasks can distinguish
@@ -7872,10 +7976,18 @@ def record_test_baseline(
       - ``pytest`` (no arguments) if pyproject.toml or pytest.ini present
       - ``go test ./...`` if go.mod present
       - ``cargo test`` if Cargo.toml present
-    Empty auto-detect ⇒ status="skipped" (no test harness found).
+    Detection probes the repo root first; if the root has no harness it
+    shallow-scans the immediate subdirectories (one level) for a single
+    obvious module dir (the common monorepo-subdir layout) and runs the
+    command from there. ``module_dir`` (CLI ``--module-dir`` / ``--cwd``)
+    forces a specific module dir, bypassing the scan. When the root has no
+    harness and MORE THAN ONE subdir qualifies, detection refuses to guess
+    and returns ``status="skipped"`` naming the candidates, so the empty
+    baseline is loud rather than silent.
 
-    Returns dict with status, command, returncode, baseline_failures (list of
-    failing test names parsed from stdout), and elapsed_seconds.
+    Returns dict with status, command, run_dir, module_dir, returncode,
+    baseline_failures (list of failing test names parsed from stdout), and
+    elapsed_seconds.
     """
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
     branch_name = _sanitize_branch(branch)
@@ -7883,31 +7995,81 @@ def record_test_baseline(
     baseline_dir.mkdir(parents=True, exist_ok=True)
     baseline_path = baseline_dir / "test_baseline.json"
 
+    # Resolve the command and the directory to run it in. Precedence:
+    #   1. explicit --module-dir (run there; auto-detect the command if absent)
+    #   2. explicit --command (run at the repo root)
+    #   3. auto-detect: repo root, else a single monorepo-subdir module
+    run_dir = project_dir
+    detected_module_dir: str | None = None
     cmd_str = test_command.strip()
     auto_detected_command = ""
-    if not cmd_str:
-        # Auto-detect a sensible default. Cheap shell probes only.
-        if (project_dir / "Makefile").exists():
-            try:
-                mk_text = (project_dir / "Makefile").read_text(encoding="utf-8")
-                if re.search(r"^test:", mk_text, re.MULTILINE):
-                    auto_detected_command = "make test"
-            except OSError:
-                pass
-        if not auto_detected_command:
-            if (project_dir / "pyproject.toml").exists() or (project_dir / "pytest.ini").exists():
-                auto_detected_command = "pytest"
-            elif (project_dir / "go.mod").exists():
-                auto_detected_command = "go test ./..."
-            elif (project_dir / "Cargo.toml").exists():
-                auto_detected_command = "cargo test"
-        cmd_str = auto_detected_command
+
+    module_dir_arg = module_dir.strip()
+    if module_dir_arg:
+        candidate = (project_dir / module_dir_arg).resolve()
+        # Keep the run dir inside the project tree and require it to exist —
+        # a bad --module-dir is a caller error, surfaced loudly (exit 1).
+        if not candidate.is_dir() or not candidate.is_relative_to(project_dir):
+            payload = {
+                "branch": branch_name,
+                "status": "error",
+                "reason": (
+                    f"--module-dir {module_dir_arg!r} is not a directory inside "
+                    f"the project ({project_dir})."
+                ),
+                "recorded_at": _utc_timestamp(),
+            }
+            baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return payload
+        run_dir = candidate
+        detected_module_dir = module_dir_arg
+        if not cmd_str:
+            auto_detected_command = _probe_test_harness(run_dir)
+            cmd_str = auto_detected_command
+    elif not cmd_str:
+        detection = _detect_baseline_harness(project_dir)
+        ambiguous = detection.get("ambiguous")
+        if ambiguous:
+            names = [str(n) for n in ambiguous]  # type: ignore[union-attr]
+            payload = {
+                "branch": branch_name,
+                "status": "skipped",
+                "reason": (
+                    "no test harness at the repo root, and multiple candidate "
+                    f"module dirs were found ({', '.join(names)}). Refusing to "
+                    "guess — re-run with `--module-dir <dir>` (or `--command "
+                    '"<test cmd>"`) to point the baseline at the right module. '
+                    "The cross-subtask regression gate needs a real baseline; an "
+                    "empty one cannot distinguish introduced from pre-existing "
+                    "failures."
+                ),
+                "candidate_module_dirs": names,
+                "recorded_at": _utc_timestamp(),
+            }
+            baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return payload
+        detected_cmd = detection.get("command")
+        if detected_cmd:
+            cmd_str = str(detected_cmd)
+            auto_detected_command = cmd_str
+            resolved_run_dir = detection.get("run_dir")
+            if isinstance(resolved_run_dir, Path):
+                run_dir = resolved_run_dir
+            module_name = detection.get("module_dir")
+            detected_module_dir = str(module_name) if module_name else None
 
     if not cmd_str:
         payload = {
             "branch": branch_name,
             "status": "skipped",
-            "reason": "no test harness detected (Makefile / pytest / go.mod / Cargo.toml)",
+            "reason": (
+                "no test harness detected (Makefile with test: / pyproject.toml / "
+                "pytest.ini / go.mod / Cargo.toml) at the repo root or any "
+                'immediate subdirectory. Re-run with `--command "<test cmd>"` or '
+                "`--module-dir <dir>` so the cross-subtask regression gate has a "
+                "real baseline — without one it cannot tell an introduced "
+                "regression from a pre-existing failure."
+            ),
             "recorded_at": _utc_timestamp(),
         }
         baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -7918,7 +8080,7 @@ def record_test_baseline(
         proc = subprocess.run(
             cmd_str,
             shell=True,
-            cwd=project_dir,
+            cwd=run_dir,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
@@ -7965,6 +8127,8 @@ def record_test_baseline(
         "status": "success" if returncode == 0 else "baseline_failures",
         "command": cmd_str,
         "auto_detected": bool(auto_detected_command),
+        "module_dir": detected_module_dir,
+        "run_dir": str(run_dir),
         "returncode": returncode,
         "timed_out": timed_out,
         "elapsed_seconds": elapsed,
@@ -11073,20 +11237,30 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
 
     elif func_name == "record_test_baseline":
-        # CLI: record_test_baseline <branch> [--command "..."] [--timeout N]
+        # CLI: record_test_baseline <branch> [--command "..."]
+        #       [--module-dir DIR | --cwd DIR] [--timeout N]
         # Snapshot pre-existing test failures so later subtasks can
         # distinguish "I broke this" from "this was broken before plan
-        # started". Auto-detects test command when omitted.
+        # started". Auto-detects the test command when omitted, probing the
+        # repo root then a single monorepo-subdir module; --module-dir/--cwd
+        # forces a module dir for ambiguous/deeply-nested layouts.
         if len(sys.argv) < 3:
-            print(json.dumps({"status": "error", "message": "usage: record_test_baseline <branch> [--command ...]"}), file=sys.stderr)
+            print(json.dumps({"status": "error", "message": "usage: record_test_baseline <branch> [--command ...] [--module-dir DIR]"}), file=sys.stderr)
             sys.exit(1)
         baseline_branch = sys.argv[2]
         baseline_cmd = ""
+        baseline_module_dir = ""
         baseline_timeout = 120
         if "--command" in sys.argv:
             c_idx = sys.argv.index("--command")
             if c_idx + 1 < len(sys.argv):
                 baseline_cmd = sys.argv[c_idx + 1]
+        for module_flag in ("--module-dir", "--cwd"):
+            if module_flag in sys.argv:
+                m_idx = sys.argv.index(module_flag)
+                if m_idx + 1 < len(sys.argv):
+                    baseline_module_dir = sys.argv[m_idx + 1]
+                    break
         if "--timeout" in sys.argv:
             t_idx = sys.argv.index("--timeout")
             if t_idx + 1 < len(sys.argv):
@@ -11096,7 +11270,10 @@ if __name__ == "__main__":
                     print(json.dumps({"status": "error", "message": "--timeout must be int"}), file=sys.stderr)
                     sys.exit(1)
         report = record_test_baseline(
-            baseline_branch, baseline_cmd, timeout_seconds=baseline_timeout
+            baseline_branch,
+            baseline_cmd,
+            module_dir=baseline_module_dir,
+            timeout_seconds=baseline_timeout,
         )
         print(json.dumps(report, indent=2))
         # Exit 0 even on baseline_failures — the WHOLE point is to

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -223,12 +223,35 @@ Auto-detects from project markers:
 - `go.mod` → `go test ./...`
 - `Cargo.toml` → `cargo test`
 
+Detection probes the **repo root first**. If the root has no harness it
+**shallow-scans the immediate subdirectories (one level)** for a module that
+does — the common monorepo layout (e.g. `component-manager/go.mod` with no
+root `go.mod`). A single matching subdir is used automatically and the command
+runs from that dir; the report records `module_dir` and `run_dir` so the chosen
+location is never silent.
+
+When the root has no harness and **more than one** subdir qualifies, detection
+**refuses to guess**: it returns `status="skipped"` with `candidate_module_dirs`
+listing them. Re-run pointing at the right module (`--module-dir`/`--cwd` are
+aliases):
+```bash
+python3 .map/scripts/map_step_runner.py record_test_baseline "$BRANCH" \
+  --module-dir component-manager
+```
+A `status="skipped"` baseline is a **hard signal, not a no-op**: the
+cross-subtask regression gate then has no baseline and cannot tell an introduced
+regression from a pre-existing failure. Resolve it (pass `--module-dir` or
+`--command`) before running subtasks — do not proceed on a silent empty baseline.
+
 Override the auto-detect when the full run is too slow for a
 pre-flight (or you want a narrower target):
 ```bash
 python3 .map/scripts/map_step_runner.py record_test_baseline "$BRANCH" \
   --command "pytest tests/smoke" --timeout 60
 ```
+`--module-dir` and `--command` compose: `--module-dir` sets where the command
+runs, `--command` sets what runs (auto-detected within the module dir if
+omitted).
 
 Persists to `.map/<branch>/test_baseline.json`. Parse pre-existing
 failures back via:

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -7852,10 +7852,114 @@ def list_diagnostics_baseline(branch: str) -> dict[str, object]:
         return {"status": "error", "message": f"read failed: {exc}"}
 
 
+# Directories that never hold a project's test harness — skipped during the
+# shallow monorepo-subdir scan so a candidate is not picked from build output,
+# vendored deps, or tool caches.
+_HARNESS_SCAN_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".map",
+        ".claude",
+        ".codex",
+        ".agents",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".idea",
+        ".vscode",
+        "vendor",
+        "target",
+        "dist",
+        "build",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+    }
+)
+
+
+def _probe_test_harness(directory: Path) -> str:
+    """Auto-detect a test command for a SINGLE directory. Cheap probes only.
+
+    Returns the command (``make test`` / ``pytest`` / ``go test ./...`` /
+    ``cargo test``), or ``""`` when the directory holds no recognised harness
+    marker. ``make test`` only wins when the Makefile actually defines a
+    ``test:`` target.
+    """
+    try:
+        if (directory / "Makefile").exists():
+            try:
+                mk_text = (directory / "Makefile").read_text(encoding="utf-8")
+                if re.search(r"^test:", mk_text, re.MULTILINE):
+                    return "make test"
+            except OSError:
+                pass
+        if (directory / "pyproject.toml").exists() or (directory / "pytest.ini").exists():
+            return "pytest"
+        if (directory / "go.mod").exists():
+            return "go test ./..."
+        if (directory / "Cargo.toml").exists():
+            return "cargo test"
+    except OSError:
+        pass
+    return ""
+
+
+def _detect_baseline_harness(project_dir: Path) -> dict[str, object]:
+    """Resolve the test harness + the directory to run it in.
+
+    Probes the repo root first (the common single-package layout). When the
+    root has no harness, shallow-scans the immediate subdirectories (ONE level
+    deep — the common monorepo-subdir layout, e.g. ``component-manager/go.mod``)
+    for module dirs that contain a harness.
+
+    Returns one of:
+      - ``{"command", "run_dir", "from_root", "module_dir"}`` — a resolved
+        harness (root or a single unambiguous subdir);
+      - ``{"ambiguous": [name, ...]}`` — more than one candidate subdir, so the
+        caller MUST NOT guess; it asks the operator for ``--module-dir``;
+      - ``{}`` — no harness at root or any immediate subdir.
+    """
+    root_cmd = _probe_test_harness(project_dir)
+    if root_cmd:
+        return {
+            "command": root_cmd,
+            "run_dir": project_dir,
+            "from_root": True,
+            "module_dir": None,
+        }
+
+    candidates: list[tuple[str, str]] = []
+    try:
+        entries = sorted(p for p in project_dir.iterdir() if p.is_dir())
+    except OSError:
+        entries = []
+    for sub in entries:
+        if sub.name.startswith(".") or sub.name in _HARNESS_SCAN_SKIP_DIRS:
+            continue
+        cmd = _probe_test_harness(sub)
+        if cmd:
+            candidates.append((sub.name, cmd))
+
+    if len(candidates) == 1:
+        name, cmd = candidates[0]
+        return {
+            "command": cmd,
+            "run_dir": project_dir / name,
+            "from_root": False,
+            "module_dir": name,
+        }
+    if len(candidates) > 1:
+        return {"ambiguous": [name for name, _ in candidates]}
+    return {}
+
+
 def record_test_baseline(
     branch: str,
     test_command: str = "",
     *,
+    module_dir: str = "",
     timeout_seconds: int = 120,
 ) -> dict[str, object]:
     """Record a pre-flight test baseline so subtasks can distinguish
@@ -7872,10 +7976,18 @@ def record_test_baseline(
       - ``pytest`` (no arguments) if pyproject.toml or pytest.ini present
       - ``go test ./...`` if go.mod present
       - ``cargo test`` if Cargo.toml present
-    Empty auto-detect ⇒ status="skipped" (no test harness found).
+    Detection probes the repo root first; if the root has no harness it
+    shallow-scans the immediate subdirectories (one level) for a single
+    obvious module dir (the common monorepo-subdir layout) and runs the
+    command from there. ``module_dir`` (CLI ``--module-dir`` / ``--cwd``)
+    forces a specific module dir, bypassing the scan. When the root has no
+    harness and MORE THAN ONE subdir qualifies, detection refuses to guess
+    and returns ``status="skipped"`` naming the candidates, so the empty
+    baseline is loud rather than silent.
 
-    Returns dict with status, command, returncode, baseline_failures (list of
-    failing test names parsed from stdout), and elapsed_seconds.
+    Returns dict with status, command, run_dir, module_dir, returncode,
+    baseline_failures (list of failing test names parsed from stdout), and
+    elapsed_seconds.
     """
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())).resolve()
     branch_name = _sanitize_branch(branch)
@@ -7883,31 +7995,81 @@ def record_test_baseline(
     baseline_dir.mkdir(parents=True, exist_ok=True)
     baseline_path = baseline_dir / "test_baseline.json"
 
+    # Resolve the command and the directory to run it in. Precedence:
+    #   1. explicit --module-dir (run there; auto-detect the command if absent)
+    #   2. explicit --command (run at the repo root)
+    #   3. auto-detect: repo root, else a single monorepo-subdir module
+    run_dir = project_dir
+    detected_module_dir: str | None = None
     cmd_str = test_command.strip()
     auto_detected_command = ""
-    if not cmd_str:
-        # Auto-detect a sensible default. Cheap shell probes only.
-        if (project_dir / "Makefile").exists():
-            try:
-                mk_text = (project_dir / "Makefile").read_text(encoding="utf-8")
-                if re.search(r"^test:", mk_text, re.MULTILINE):
-                    auto_detected_command = "make test"
-            except OSError:
-                pass
-        if not auto_detected_command:
-            if (project_dir / "pyproject.toml").exists() or (project_dir / "pytest.ini").exists():
-                auto_detected_command = "pytest"
-            elif (project_dir / "go.mod").exists():
-                auto_detected_command = "go test ./..."
-            elif (project_dir / "Cargo.toml").exists():
-                auto_detected_command = "cargo test"
-        cmd_str = auto_detected_command
+
+    module_dir_arg = module_dir.strip()
+    if module_dir_arg:
+        candidate = (project_dir / module_dir_arg).resolve()
+        # Keep the run dir inside the project tree and require it to exist —
+        # a bad --module-dir is a caller error, surfaced loudly (exit 1).
+        if not candidate.is_dir() or not candidate.is_relative_to(project_dir):
+            payload = {
+                "branch": branch_name,
+                "status": "error",
+                "reason": (
+                    f"--module-dir {module_dir_arg!r} is not a directory inside "
+                    f"the project ({project_dir})."
+                ),
+                "recorded_at": _utc_timestamp(),
+            }
+            baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return payload
+        run_dir = candidate
+        detected_module_dir = module_dir_arg
+        if not cmd_str:
+            auto_detected_command = _probe_test_harness(run_dir)
+            cmd_str = auto_detected_command
+    elif not cmd_str:
+        detection = _detect_baseline_harness(project_dir)
+        ambiguous = detection.get("ambiguous")
+        if ambiguous:
+            names = [str(n) for n in ambiguous]  # type: ignore[union-attr]
+            payload = {
+                "branch": branch_name,
+                "status": "skipped",
+                "reason": (
+                    "no test harness at the repo root, and multiple candidate "
+                    f"module dirs were found ({', '.join(names)}). Refusing to "
+                    "guess — re-run with `--module-dir <dir>` (or `--command "
+                    '"<test cmd>"`) to point the baseline at the right module. '
+                    "The cross-subtask regression gate needs a real baseline; an "
+                    "empty one cannot distinguish introduced from pre-existing "
+                    "failures."
+                ),
+                "candidate_module_dirs": names,
+                "recorded_at": _utc_timestamp(),
+            }
+            baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return payload
+        detected_cmd = detection.get("command")
+        if detected_cmd:
+            cmd_str = str(detected_cmd)
+            auto_detected_command = cmd_str
+            resolved_run_dir = detection.get("run_dir")
+            if isinstance(resolved_run_dir, Path):
+                run_dir = resolved_run_dir
+            module_name = detection.get("module_dir")
+            detected_module_dir = str(module_name) if module_name else None
 
     if not cmd_str:
         payload = {
             "branch": branch_name,
             "status": "skipped",
-            "reason": "no test harness detected (Makefile / pytest / go.mod / Cargo.toml)",
+            "reason": (
+                "no test harness detected (Makefile with test: / pyproject.toml / "
+                "pytest.ini / go.mod / Cargo.toml) at the repo root or any "
+                'immediate subdirectory. Re-run with `--command "<test cmd>"` or '
+                "`--module-dir <dir>` so the cross-subtask regression gate has a "
+                "real baseline — without one it cannot tell an introduced "
+                "regression from a pre-existing failure."
+            ),
             "recorded_at": _utc_timestamp(),
         }
         baseline_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -7918,7 +8080,7 @@ def record_test_baseline(
         proc = subprocess.run(
             cmd_str,
             shell=True,
-            cwd=project_dir,
+            cwd=run_dir,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
@@ -7965,6 +8127,8 @@ def record_test_baseline(
         "status": "success" if returncode == 0 else "baseline_failures",
         "command": cmd_str,
         "auto_detected": bool(auto_detected_command),
+        "module_dir": detected_module_dir,
+        "run_dir": str(run_dir),
         "returncode": returncode,
         "timed_out": timed_out,
         "elapsed_seconds": elapsed,
@@ -11073,20 +11237,30 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
 
     elif func_name == "record_test_baseline":
-        # CLI: record_test_baseline <branch> [--command "..."] [--timeout N]
+        # CLI: record_test_baseline <branch> [--command "..."]
+        #       [--module-dir DIR | --cwd DIR] [--timeout N]
         # Snapshot pre-existing test failures so later subtasks can
         # distinguish "I broke this" from "this was broken before plan
-        # started". Auto-detects test command when omitted.
+        # started". Auto-detects the test command when omitted, probing the
+        # repo root then a single monorepo-subdir module; --module-dir/--cwd
+        # forces a module dir for ambiguous/deeply-nested layouts.
         if len(sys.argv) < 3:
-            print(json.dumps({"status": "error", "message": "usage: record_test_baseline <branch> [--command ...]"}), file=sys.stderr)
+            print(json.dumps({"status": "error", "message": "usage: record_test_baseline <branch> [--command ...] [--module-dir DIR]"}), file=sys.stderr)
             sys.exit(1)
         baseline_branch = sys.argv[2]
         baseline_cmd = ""
+        baseline_module_dir = ""
         baseline_timeout = 120
         if "--command" in sys.argv:
             c_idx = sys.argv.index("--command")
             if c_idx + 1 < len(sys.argv):
                 baseline_cmd = sys.argv[c_idx + 1]
+        for module_flag in ("--module-dir", "--cwd"):
+            if module_flag in sys.argv:
+                m_idx = sys.argv.index(module_flag)
+                if m_idx + 1 < len(sys.argv):
+                    baseline_module_dir = sys.argv[m_idx + 1]
+                    break
         if "--timeout" in sys.argv:
             t_idx = sys.argv.index("--timeout")
             if t_idx + 1 < len(sys.argv):
@@ -11096,7 +11270,10 @@ if __name__ == "__main__":
                     print(json.dumps({"status": "error", "message": "--timeout must be int"}), file=sys.stderr)
                     sys.exit(1)
         report = record_test_baseline(
-            baseline_branch, baseline_cmd, timeout_seconds=baseline_timeout
+            baseline_branch,
+            baseline_cmd,
+            module_dir=baseline_module_dir,
+            timeout_seconds=baseline_timeout,
         )
         print(json.dumps(report, indent=2))
         # Exit 0 even on baseline_failures — the WHOLE point is to

--- a/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
@@ -223,12 +223,35 @@ Auto-detects from project markers:
 - `go.mod` → `go test ./...`
 - `Cargo.toml` → `cargo test`
 
+Detection probes the **repo root first**. If the root has no harness it
+**shallow-scans the immediate subdirectories (one level)** for a module that
+does — the common monorepo layout (e.g. `component-manager/go.mod` with no
+root `go.mod`). A single matching subdir is used automatically and the command
+runs from that dir; the report records `module_dir` and `run_dir` so the chosen
+location is never silent.
+
+When the root has no harness and **more than one** subdir qualifies, detection
+**refuses to guess**: it returns `status="skipped"` with `candidate_module_dirs`
+listing them. Re-run pointing at the right module (`--module-dir`/`--cwd` are
+aliases):
+```bash
+python3 .map/scripts/map_step_runner.py record_test_baseline "$BRANCH" \
+  --module-dir component-manager
+```
+A `status="skipped"` baseline is a **hard signal, not a no-op**: the
+cross-subtask regression gate then has no baseline and cannot tell an introduced
+regression from a pre-existing failure. Resolve it (pass `--module-dir` or
+`--command`) before running subtasks — do not proceed on a silent empty baseline.
+
 Override the auto-detect when the full run is too slow for a
 pre-flight (or you want a narrower target):
 ```bash
 python3 .map/scripts/map_step_runner.py record_test_baseline "$BRANCH" \
   --command "pytest tests/smoke" --timeout 60
 ```
+`--module-dir` and `--command` compose: `--module-dir` sets where the command
+runs, `--command` sets what runs (auto-detected within the module dir if
+omitted).
 
 Persists to `.map/<branch>/test_baseline.json`. Parse pre-existing
 failures back via:

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3176,7 +3176,7 @@ class TestBuildContextBlock:
         (branch_workspace.parent / "config.yaml").write_text(
             "compression_policy: auto\ncompression_threshold_tokens: 100\n"
         )
-        monkeypatch.setattr(map_step_runner, "_claude_code_log_dir", lambda _p: log_dir)
+        monkeypatch.setattr(map_step_runner, "_claude_code_log_dir", lambda _p: log_dir)  # pyright: ignore[reportUnusedParameter]
 
         result = map_step_runner.subtask_boundary_compact_check("test-branch")
 
@@ -4897,6 +4897,171 @@ class TestRecordTestBaseline:
         # auto-detected from pyproject.toml elsewhere). The contract:
         # the call should not raise and should write a baseline file.
         assert report["status"] in ("skipped", "success", "baseline_failures")
+
+    # --- #229: monorepo-subdir auto-detect -------------------------------
+
+    def test_detect_harness_prefers_repo_root(self, tmp_path):
+        """Root harness wins; no subdir scan when the root has one."""
+        (tmp_path / "pyproject.toml").write_text("[tool]\n", encoding="utf-8")
+        (tmp_path / "svc").mkdir()
+        (tmp_path / "svc" / "go.mod").write_text("module svc\n", encoding="utf-8")
+        detection = map_step_runner._detect_baseline_harness(tmp_path)
+        assert detection["command"] == "pytest"
+        assert detection["from_root"] is True
+        assert detection["module_dir"] is None
+        assert detection["run_dir"] == tmp_path
+
+    def test_detect_harness_single_monorepo_subdir(self, tmp_path):
+        """Root has no harness; a single subdir module is selected (the #229 case)."""
+        module = tmp_path / "component-manager"
+        module.mkdir()
+        (module / "go.mod").write_text("module cm\n", encoding="utf-8")
+        detection = map_step_runner._detect_baseline_harness(tmp_path)
+        assert detection["command"] == "go test ./..."
+        assert detection["from_root"] is False
+        assert detection["module_dir"] == "component-manager"
+        assert detection["run_dir"] == module
+
+    def test_detect_harness_ambiguous_subdirs_refuses_to_guess(self, tmp_path):
+        """More than one candidate subdir → no guess, candidates returned."""
+        for name in ("svc-a", "svc-b"):
+            d = tmp_path / name
+            d.mkdir()
+            (d / "go.mod").write_text(f"module {name}\n", encoding="utf-8")
+        detection = map_step_runner._detect_baseline_harness(tmp_path)
+        assert detection.get("command") is None
+        assert sorted(detection["ambiguous"]) == ["svc-a", "svc-b"]
+
+    def test_detect_harness_skips_noise_dirs(self, tmp_path):
+        """Harness markers inside vendored/cache dirs never become candidates."""
+        for noise in ("node_modules", ".venv", "vendor"):
+            d = tmp_path / noise
+            d.mkdir()
+            (d / "go.mod").write_text("module x\n", encoding="utf-8")
+        detection = map_step_runner._detect_baseline_harness(tmp_path)
+        assert detection == {}
+
+    def test_baseline_auto_detects_monorepo_subdir_and_runs_there(
+        self, branch_workspace, monkeypatch
+    ):
+        """Full record path: auto-detected subdir command runs with cwd=subdir."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        module = repo / "component-manager"
+        module.mkdir()
+        (module / "go.mod").write_text("module cm\n", encoding="utf-8")
+
+        captured: dict[str, object] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["cwd"] = kwargs.get("cwd")
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(map_step_runner.subprocess, "run", fake_run)
+        report = map_step_runner.record_test_baseline("test-branch")
+        assert report["status"] == "success"
+        assert report["command"] == "go test ./..."
+        assert report["auto_detected"] is True
+        assert report["module_dir"] == "component-manager"
+        assert Path(report["run_dir"]).resolve() == module.resolve()
+        # The command actually ran from the module dir, not the repo root.
+        assert captured["cmd"] == "go test ./..."
+        assert Path(str(captured["cwd"])).resolve() == module.resolve()
+
+    def test_baseline_ambiguous_subdirs_skips_loudly(
+        self, branch_workspace, monkeypatch
+    ):
+        """Ambiguous monorepo → skipped with actionable reason, not silent."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        for name in ("svc-a", "svc-b"):
+            d = repo / name
+            d.mkdir()
+            (d / "go.mod").write_text(f"module {name}\n", encoding="utf-8")
+        report = map_step_runner.record_test_baseline("test-branch")
+        assert report["status"] == "skipped"
+        assert sorted(report["candidate_module_dirs"]) == ["svc-a", "svc-b"]
+        assert "--module-dir" in report["reason"]
+
+    def test_baseline_no_harness_skip_reason_is_actionable(
+        self, branch_workspace, monkeypatch
+    ):
+        """The empty-baseline skip names the escape hatch so it is not silent."""
+        repo = branch_workspace.parents[1]
+        empty = repo / "clean"
+        empty.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(empty))
+        report = map_step_runner.record_test_baseline("test-branch")
+        assert report["status"] == "skipped"
+        assert "--module-dir" in report["reason"]
+        assert "--command" in report["reason"]
+
+    def test_baseline_module_dir_runs_command_in_that_dir(
+        self, branch_workspace, monkeypatch
+    ):
+        """Explicit --module-dir routes the subprocess cwd to that module dir."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        module = repo / "component-manager"
+        module.mkdir()
+        report = map_step_runner.record_test_baseline(
+            "test-branch", "touch ran_here.txt", module_dir="component-manager"
+        )
+        assert report["status"] == "success"
+        assert report["module_dir"] == "component-manager"
+        assert (module / "ran_here.txt").exists()
+        assert not (repo / "ran_here.txt").exists()
+
+    def test_baseline_invalid_module_dir_is_error(
+        self, branch_workspace, monkeypatch
+    ):
+        """A non-existent --module-dir is a loud caller error, not a skip."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.record_test_baseline(
+            "test-branch", module_dir="does-not-exist"
+        )
+        assert report["status"] == "error"
+        assert "does-not-exist" in report["reason"]
+
+    def test_baseline_module_dir_path_escape_rejected(
+        self, branch_workspace, monkeypatch
+    ):
+        """--module-dir pointing outside the project tree is rejected."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.record_test_baseline(
+            "test-branch", module_dir=".."
+        )
+        assert report["status"] == "error"
+
+    def test_baseline_cli_accepts_module_dir_flag(self, tmp_path):
+        """CLI: --module-dir is parsed and routes the run dir (subprocess path)."""
+        (tmp_path / ".map" / "test-branch").mkdir(parents=True)
+        module = tmp_path / "component-manager"
+        module.mkdir()
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_PATH / "map_step_runner.py"),
+                "record_test_baseline",
+                "test-branch",
+                "--command",
+                "touch ran_here.txt",
+                "--module-dir",
+                "component-manager",
+            ],
+            cwd=tmp_path,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": str(tmp_path)},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "success"
+        assert payload["module_dir"] == "component-manager"
+        assert (module / "ran_here.txt").exists()
 
     def test_list_baseline_failures_returns_recorded_entries(
         self, branch_workspace, monkeypatch, tmp_path


### PR DESCRIPTION
## What

`record_test_baseline` auto-detected the test harness by probing **only the repo root**. In a monorepo where the module lives in a subdir (e.g. `component-manager/go.mod` with no root harness) it returned `status="skipped"` and the **whole run proceeded with an empty pre-flight baseline** — the cross-subtask regression gate (`detect_cross_subtask_regression_risk`) could then no longer distinguish an *introduced* regression from a *pre-existing* failure. The failure was silent.

## Why it matters

The pre-flight baseline is MANDATORY at INIT_STATE. A silently-empty baseline disables the regression gate for the entire run — exactly the monorepo-subdir layout the maintainer hits in practice.

## Changes

- **Root-first, then shallow subdir scan.** Detection probes the repo root first; if the root has no harness it shallow-scans the **immediate subdirectories (one level)** for a single module that has a harness and runs the command from that dir. The report records `module_dir` and `run_dir`, so the chosen location is never silent.
- **Refuses to guess when ambiguous.** If the root has no harness and **more than one** subdir qualifies, it returns `status="skipped"` with `candidate_module_dirs` listing them — no silent wrong-module guess.
- **Loud, actionable skips.** The no-harness skip now names the `--command` / `--module-dir` escape hatch instead of a bare "no harness detected".
- **New `--module-dir` / `--cwd` flag** forces a module dir for ambiguous or deeply-nested layouts; composes with `--command` (where to run vs what to run). Noise dirs (`node_modules`, `.venv`, `vendor`, build/cache dirs, dotdirs) are skipped during the scan.
- Edited the `.jinja` source and re-rendered all generated trees (`make check-render` green). Documented the monorepo behavior + flag in `efficient-reference.md` (SKILL.md is at its line budget, so detail lives in the reference per the always-loaded-body rule).

## Tests

New regression tests in `TestRecordTestBaseline`: root-preference, single-subdir auto-detect (the #229 case), ambiguous refusal, noise-dir skipping, full-path cwd routing (mocked subprocess), explicit `--module-dir` cwd routing (observable marker file), invalid/path-escape `--module-dir` → loud error, and a CLI subprocess test for the new flag.

Validation:
- `make check` → lint + mypy + `pyright src` clean, **2524 passed, 3 skipped**, `check-render` green.

Deploy:
- No prod-deploy target in the Makefile → no deploy step.

Closes #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)