### PR TITLE
feat(compaction): offload pruned tool outputs for on-demand retrieval (#232)

### DIFF
--- a/.claude/hooks/post-compact-context.py
+++ b/.claude/hooks/post-compact-context.py
@@ -200,6 +200,28 @@ def build_reprime(branch: str, branch_dir: Path) -> str | None:
     return truncate_text("\n".join(lines), REPRIME_LIMIT)
 
 
+def offloaded_outputs_pointer(branch: str, branch_dir: Path) -> str | None:
+    """Pointer to tool outputs offloaded before compaction, if any (#232).
+
+    Rebuilds the manifest from the append-only index and returns the recovery
+    line. Lazy-imports mapify_cli and degrades to ``None`` (silent) when it is
+    unavailable or nothing was offloaded.
+    """
+    try:
+        sys.path.insert(0, str(PROJECT_DIR / "src"))
+        try:
+            from mapify_cli.tool_output_offload import (
+                build_manifest,
+                recovery_pointer_text,
+            )
+        except ImportError:
+            return None
+        build_manifest(branch_dir / "compacted")
+        return recovery_pointer_text(branch, branch_dir)
+    except Exception:
+        return None
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)
@@ -228,6 +250,12 @@ def main() -> None:
                 )
         except (IOError, OSError):
             pass
+
+    # Point at any tool outputs offloaded before compaction (#232) so the agent
+    # re-reads a sidecar instead of re-running broad discovery.
+    offload_pointer = offloaded_outputs_pointer(branch, branch_dir)
+    if offload_pointer:
+        parts.append(offload_pointer)
 
     # Check for workflow restore point
     restore = branch_dir / "restore_point.json"

--- a/.claude/hooks/pre-compact-save-transcript.py
+++ b/.claude/hooks/pre-compact-save-transcript.py
@@ -129,6 +129,37 @@ def parse_transcript(transcript_path: Path) -> str:
     return "\n".join(lines)
 
 
+def maybe_offload_tool_outputs(transcript_path: str, branch_dir: Path) -> None:
+    """Offload large tool-result bodies before compaction drops them (#232).
+
+    Only runs when ``compression_policy != never`` so a default install never
+    creates ``.map/<branch>/compacted/``. Lazy-imports mapify_cli and degrades
+    to a silent no-op if it is not importable. Never raises — a PreCompact hook
+    must not break compaction.
+    """
+    try:
+        sys.path.insert(0, str(PROJECT_DIR / "src"))
+        try:
+            from mapify_cli.config.project_config import load_map_config
+            from mapify_cli.tool_output_offload import (
+                offload_transcript_tool_outputs,
+            )
+        except ImportError:
+            return
+        config = load_map_config(PROJECT_DIR)
+        if config.compression_policy == "never":
+            return
+        summary = offload_transcript_tool_outputs(Path(transcript_path), branch_dir)
+        if summary.written:
+            print(
+                f"[pre-compact-save] Offloaded {summary.written} tool output(s) "
+                f"to {branch_dir / 'compacted'}",
+                file=sys.stderr,
+            )
+    except Exception:  # never break compaction
+        pass
+
+
 def main() -> None:
     if os.environ.get("MAP_INVOKED_BY"):
         sys.exit(0)
@@ -189,6 +220,10 @@ def main() -> None:
         )
     except (IOError, OSError):
         pass
+
+    # Offload full-resolution tool-result bodies so dropped outputs stay
+    # recoverable instead of forcing a re-run of broad discovery (#232).
+    maybe_offload_tool_outputs(transcript_path, branch_dir)
 
     print("{}")
     sys.exit(0)

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -3705,6 +3705,25 @@ def _emit_context_budget_warning(branch: str, transcript_path: Optional[str]) ->
         threshold=threshold,
         focus=_map_config_str(project_dir, "compression_focus", ""),
     )
+
+    # Offload large tool-result bodies before the (recommended) compaction drops
+    # them, then point the operator/agent at the sidecars (#232). Provider-
+    # agnostic: reuses the same transcript this warning already read. Lazy import
+    # with graceful fallback — never block the warning on a missing mapify_cli.
+    branch_dir = project_dir / ".map" / branch
+    try:
+        from mapify_cli.tool_output_offload import (  # noqa: PLC0415
+            offload_transcript_tool_outputs,
+            recovery_pointer_text,
+        )
+
+        offload_transcript_tool_outputs(path, branch_dir)
+        pointer = recovery_pointer_text(branch, branch_dir)
+        if pointer:
+            message = f"{message}\n\n{pointer}"
+    except Exception:  # noqa: BLE001 — warning must never raise
+        pass
+
     # stderr keeps stdout clean for JSON consumers (the orchestrator's
     # contract is JSON-on-stdout for every command).
     print(message, file=sys.stderr)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Compaction now offloads large tool outputs for on-demand retrieval instead
+  of dropping them (#232).** Before context compaction prunes old/large
+  tool-result bodies (grep output, test logs, whole-file reads), MAP now saves
+  each one at full resolution to a retrievable sidecar under
+  `.map/<branch>/compacted/` (an append-only `index.ndjson`, an agent-readable
+  `MANIFEST.md`, and per-output `*.txt` files with a self-describing header).
+  After compaction the post-compact hook points the agent at the manifest so a
+  dropped output is re-read from its sidecar **instead of re-running broad
+  discovery** — the exact re-discovery cost #203 fights. Provider-agnostic: the
+  Claude PreCompact hook and the Codex orchestrator budget warning both capture
+  at the same pre-drop point, sharing one `mapify_cli.tool_output_offload`
+  module. Gated by `compression_policy` — with the default `never` no offload
+  happens and `.map/<branch>/compacted/` is never created. Selection is
+  size-based (≥10K chars any tool, or ≥2K for `Bash`/`Read`/`Grep`/`Glob`;
+  `TodoWrite`/`AskUserQuestion`/`ExitPlanMode` never offloaded); the directory
+  is FIFO-capped (300 files / 100 MiB, evictions logged). **Security:** tool
+  outputs may contain secrets, so every sidecar is written `0o600` and a
+  self-contained `.gitignore` (`*`) is dropped into `compacted/` on creation so
+  it is never committed regardless of the host repo's ignore rules; bodies are
+  never redacted. Persistent Actor/Monitor prompt guidance is deferred to a
+  follow-up (eval-gated); recovery currently works via the ephemeral
+  post-compact pointer.
+
 ### Fixed
 - **`record_test_baseline` silently skipped the MANDATORY pre-flight baseline in
   monorepos (#229).** Auto-detect probed only the repo root, so when the module

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ mapify init . --compression aggressive            # nudge at 0.4 x threshold
 mapify init . --compression-threshold 250000      # Opus 1M / 50+ subtask plans
 ```
 
-Actor and reviewer prompts always carry the full bundled context — context-block truncation was removed. If the conversation grows beyond your model's window, opt into `/compact` via `--compression auto` or trigger it manually. See [docs/USAGE.md#context-budget-policy](docs/USAGE.md).
+Actor and reviewer prompts always carry the full bundled context — context-block truncation was removed. If the conversation grows beyond your model's window, opt into `/compact` via `--compression auto` or trigger it manually. When a policy other than `never` is active, MAP also offloads large tool outputs (grep/test/file-read results) to `.map/<branch>/compacted/` before `/compact` drops them, so a dropped output is re-read from its sidecar instead of re-running broad discovery (these sidecars can hold secrets — they are `0o600` and self-ignored from git; never push `.map/`). See [docs/USAGE.md#context-budget-policy](docs/USAGE.md).
 
 **Stack Overflow for Agents (SOFA)** read-only prior-art search — **off by default**, no network or credentials unless you enable it:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1955,6 +1955,32 @@ Filesystem (persists forever)           Conversation Memory (clears on compactio
 - Task plan: `.map/<branch>/task_plan_*.md` (subtask decomposition with validation criteria)
 - Recovery: `/map-resume` command (detects branch checkpoint and offers to resume)
 
+#### Tool-output offload (#232)
+
+State persistence (above) protects *workflow* state; it does not protect the
+**raw tool outputs** (grep results, test logs, file reads) that `/compact`
+drops. Re-acquiring a dropped output means re-running broad discovery — the exact
+cost `#203` (typed research result) works to avoid. The offload layer captures
+those bodies before they are dropped:
+
+- **Producer-owns-parse.** One runtime module, `mapify_cli.tool_output_offload`,
+  parses the transcript and writes sidecars; the PreCompact hook (Claude) and the
+  orchestrator budget warning (Codex) are thin callers that lazy-import it and
+  no-op when it is unavailable. The parse-to-sidecar boundary lives in the
+  module, so both providers and the unit tests share one implementation.
+- **Pre-drop capture.** At `PreCompact` the transcript still holds full bodies
+  (the same window the transcript-saver uses); qualifying bodies (size-based
+  selection) are written `0o600` to `.map/<branch>/compacted/` with an
+  append-only `index.ndjson` and an agent-readable `MANIFEST.md`. Dedup by
+  `tool_use_id`; FIFO-capped.
+- **Recovery, not authority.** The post-compact `SessionStart(compact)` hook
+  injects a pointer to the manifest so the agent re-reads the specific sidecar
+  instead of re-running the tool. Snapshots are point-in-time; live source,
+  tests, and schemas stay authoritative for current truth.
+- **Gating.** Bound to `compression_policy`; the default `never` creates nothing.
+  A self-contained `compacted/.gitignore` (`*`) keeps the (possibly
+  secret-bearing) outputs out of git regardless of host repo ignore rules.
+
 ### Automatic Recovery (Phase 2)
 
 **Problem:** Manual recovery (Phase 1) requires users to reference checkpoint files after compaction, adding cognitive load and causing 60% workflow abandonment rate.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -531,6 +531,27 @@ built-in auto-compact has already run. For Codex sessions the same
 recommendation is emitted to stderr by `map_orchestrator.py` when invoked
 with `--transcript-path` (or env `MAPIFY_TRANSCRIPT_PATH`).
 
+#### Tool-output offload (recover dropped outputs, don't re-run discovery)
+
+When the policy is `auto`/`aggressive`, MAP also **offloads** large tool-result
+bodies (grep output, test logs, whole-file reads) before a `/compact` drops
+them. Each is saved at full resolution under `.map/<branch>/compacted/`
+(`index.ndjson` + a scannable `MANIFEST.md` + per-output `*.txt` sidecars). After
+compaction the post-compact hook points the agent at the manifest so a dropped
+output is **re-read from its sidecar instead of re-running the original broad
+tool** (Codex agents get the same pointer on stderr). The snapshots are
+point-in-time; live source, tests, and schemas remain the authority for current
+truth. With the default `never` policy nothing is offloaded and the directory is
+never created.
+
+> ⚠️ **Security.** Offloaded sidecars contain raw tool output, which may include
+> secrets (tokens in command output, env dumps, credential file reads). Each
+> file is written `0o600` and `compacted/.gitignore` (`*`) is created so the
+> directory is never committed — but **never sync, share, or push `.map/` to a
+> public remote**, and treat `.map/<branch>/compacted/` as sensitive. Bodies are
+> stored verbatim (no redaction). To disable offload entirely, keep
+> `compression_policy: never`.
+
 Actor prompts built by `build_context_block` and reviewer fan-out prompts
 built by `build_review_prompts` no longer truncate their input: the full
 bundled context (subtask description, research findings, affected_files,

--- a/docs/context-compression-plan.md
+++ b/docs/context-compression-plan.md
@@ -144,6 +144,50 @@ Run `make render-templates`. If the new hook does not propagate to
 - `README.md` — one-line mention in quick-start.
 - `CHANGELOG.md` — entry under `Unreleased`.
 
+## Tool-output offload (#232)
+
+The soft-nudge design above keeps MAP *within* the window but the harness's
+`/compact` still **drops** old/large tool-result bodies (grep output, test logs,
+whole-file reads). Once dropped, the only recovery is re-running the tool — i.e.
+redoing the broad discovery #203 works to avoid. Offload closes that gap:
+
+- **Capture point.** At `PreCompact` the full transcript (bodies included) is
+  still readable — the same point the existing transcript-saver uses. The offload
+  reads the transcript JSONL, extracts each qualifying tool-result body, and
+  writes it at full resolution to `.map/<branch>/compacted/`. The Codex path does
+  the same in the orchestrator's budget warning (`_emit_context_budget_warning`),
+  reusing the transcript it already reads. Both share one runtime module,
+  `mapify_cli.tool_output_offload`, imported lazily with a silent no-op fallback.
+- **Why PreCompact (not PostToolUse).** `compression_policy` defaults to `never`,
+  and MAP compaction is manual-`/compact`-nudge-driven, so an always-on
+  PostToolUse hook would tax the default-off majority on every tool call.
+  PreCompact runs only at compaction time. Residual risk: if `PreCompact` does
+  not fire on Claude Code's automatic 83.5% compaction *and* that fires before
+  any nudged manual `/compact`, that round's bodies are not captured. Eager
+  PostToolUse capture is a documented future enhancement if field data shows
+  PreCompact misses.
+- **Selection.** Size-based, not age-based (the hook cannot know which bodies the
+  harness will drop): offload `≥10_000` chars for any tool, or `≥2_000` chars for
+  broad-discovery tools (`Bash`/`Read`/`Grep`/`Glob`); never offload
+  `TodoWrite`/`AskUserQuestion`/`ExitPlanMode`.
+- **Layout** under `.map/<branch>/compacted/`: `index.ndjson` (append-only,
+  `schema_version`), `MANIFEST.md` (agent-readable table, rebuilt from the index
+  at post-compact), `<tool>-<tool_use_id>.txt` sidecars with a self-describing
+  header, plus `.evictions.log`/`.errors.log`. Dedup by `tool_use_id`; FIFO cap
+  (300 files / 100 MiB).
+- **Recovery.** The post-compact `SessionStart(compact)` hook rebuilds the
+  manifest and injects a pointer telling the agent to read the specific sidecar
+  instead of re-running broad discovery; live source/tests/schemas remain the
+  authority for current truth. Codex agents get the same pointer via the stderr
+  budget warning.
+- **Gating & security.** No offload under `compression_policy=never` — the
+  `compacted/` directory is never created. Tool outputs can hold secrets, so each
+  sidecar is `0o600` and `compacted/.gitignore` (`*`) is written on creation;
+  bodies are never redacted (a partial scrubber gives false confidence). See the
+  USAGE security note.
+- **Deferred.** Persistent Actor/Monitor prompt guidance about the manifest is an
+  eval-gated follow-up; v1 recovery relies on the ephemeral post-compact pointer.
+
 ## Explicitly out of scope
 
 - Replacing or disabling Claude Code's built-in 83.5% auto-compact — it stays as a

--- a/src/mapify_cli/templates/.gitignore
+++ b/src/mapify_cli/templates/.gitignore
@@ -1,5 +1,8 @@
 # Phase E cross-session memory: scratch WAL is transient (never commit)
 .map/*/sessions/scratch/
+# Offloaded tool outputs (#232) may contain secrets — never commit. A
+# self-contained .map/<branch>/compacted/.gitignore enforces this too.
+.map/*/compacted/
 # Digests (.map/*/sessions/*.md) are committed by default. To keep them
 # local, set MAP_MEMORY_COMMIT_DIGESTS=0 and uncomment the next line:
 # .map/*/sessions/

--- a/src/mapify_cli/templates/hooks/post-compact-context.py
+++ b/src/mapify_cli/templates/hooks/post-compact-context.py
@@ -200,6 +200,28 @@ def build_reprime(branch: str, branch_dir: Path) -> str | None:
     return truncate_text("\n".join(lines), REPRIME_LIMIT)
 
 
+def offloaded_outputs_pointer(branch: str, branch_dir: Path) -> str | None:
+    """Pointer to tool outputs offloaded before compaction, if any (#232).
+
+    Rebuilds the manifest from the append-only index and returns the recovery
+    line. Lazy-imports mapify_cli and degrades to ``None`` (silent) when it is
+    unavailable or nothing was offloaded.
+    """
+    try:
+        sys.path.insert(0, str(PROJECT_DIR / "src"))
+        try:
+            from mapify_cli.tool_output_offload import (
+                build_manifest,
+                recovery_pointer_text,
+            )
+        except ImportError:
+            return None
+        build_manifest(branch_dir / "compacted")
+        return recovery_pointer_text(branch, branch_dir)
+    except Exception:
+        return None
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)
@@ -228,6 +250,12 @@ def main() -> None:
                 )
         except (IOError, OSError):
             pass
+
+    # Point at any tool outputs offloaded before compaction (#232) so the agent
+    # re-reads a sidecar instead of re-running broad discovery.
+    offload_pointer = offloaded_outputs_pointer(branch, branch_dir)
+    if offload_pointer:
+        parts.append(offload_pointer)
 
     # Check for workflow restore point
     restore = branch_dir / "restore_point.json"

--- a/src/mapify_cli/templates/hooks/pre-compact-save-transcript.py
+++ b/src/mapify_cli/templates/hooks/pre-compact-save-transcript.py
@@ -129,6 +129,37 @@ def parse_transcript(transcript_path: Path) -> str:
     return "\n".join(lines)
 
 
+def maybe_offload_tool_outputs(transcript_path: str, branch_dir: Path) -> None:
+    """Offload large tool-result bodies before compaction drops them (#232).
+
+    Only runs when ``compression_policy != never`` so a default install never
+    creates ``.map/<branch>/compacted/``. Lazy-imports mapify_cli and degrades
+    to a silent no-op if it is not importable. Never raises — a PreCompact hook
+    must not break compaction.
+    """
+    try:
+        sys.path.insert(0, str(PROJECT_DIR / "src"))
+        try:
+            from mapify_cli.config.project_config import load_map_config
+            from mapify_cli.tool_output_offload import (
+                offload_transcript_tool_outputs,
+            )
+        except ImportError:
+            return
+        config = load_map_config(PROJECT_DIR)
+        if config.compression_policy == "never":
+            return
+        summary = offload_transcript_tool_outputs(Path(transcript_path), branch_dir)
+        if summary.written:
+            print(
+                f"[pre-compact-save] Offloaded {summary.written} tool output(s) "
+                f"to {branch_dir / 'compacted'}",
+                file=sys.stderr,
+            )
+    except Exception:  # never break compaction
+        pass
+
+
 def main() -> None:
     if os.environ.get("MAP_INVOKED_BY"):
         sys.exit(0)
@@ -189,6 +220,10 @@ def main() -> None:
         )
     except (IOError, OSError):
         pass
+
+    # Offload full-resolution tool-result bodies so dropped outputs stay
+    # recoverable instead of forcing a re-run of broad discovery (#232).
+    maybe_offload_tool_outputs(transcript_path, branch_dir)
 
     print("{}")
     sys.exit(0)

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -3705,6 +3705,25 @@ def _emit_context_budget_warning(branch: str, transcript_path: Optional[str]) ->
         threshold=threshold,
         focus=_map_config_str(project_dir, "compression_focus", ""),
     )
+
+    # Offload large tool-result bodies before the (recommended) compaction drops
+    # them, then point the operator/agent at the sidecars (#232). Provider-
+    # agnostic: reuses the same transcript this warning already read. Lazy import
+    # with graceful fallback — never block the warning on a missing mapify_cli.
+    branch_dir = project_dir / ".map" / branch
+    try:
+        from mapify_cli.tool_output_offload import (  # noqa: PLC0415
+            offload_transcript_tool_outputs,
+            recovery_pointer_text,
+        )
+
+        offload_transcript_tool_outputs(path, branch_dir)
+        pointer = recovery_pointer_text(branch, branch_dir)
+        if pointer:
+            message = f"{message}\n\n{pointer}"
+    except Exception:  # noqa: BLE001 — warning must never raise
+        pass
+
     # stderr keeps stdout clean for JSON consumers (the orchestrator's
     # contract is JSON-on-stdout for every command).
     print(message, file=sys.stderr)

--- a/src/mapify_cli/templates_src/.gitignore.jinja
+++ b/src/mapify_cli/templates_src/.gitignore.jinja
@@ -1,5 +1,8 @@
 # Phase E cross-session memory: scratch WAL is transient (never commit)
 .map/*/sessions/scratch/
+# Offloaded tool outputs (#232) may contain secrets — never commit. A
+# self-contained .map/<branch>/compacted/.gitignore enforces this too.
+.map/*/compacted/
 # Digests (.map/*/sessions/*.md) are committed by default. To keep them
 # local, set MAP_MEMORY_COMMIT_DIGESTS=0 and uncomment the next line:
 # .map/*/sessions/

--- a/src/mapify_cli/templates_src/hooks/post-compact-context.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/post-compact-context.py.jinja
@@ -200,6 +200,28 @@ def build_reprime(branch: str, branch_dir: Path) -> str | None:
     return truncate_text("\n".join(lines), REPRIME_LIMIT)
 
 
+def offloaded_outputs_pointer(branch: str, branch_dir: Path) -> str | None:
+    """Pointer to tool outputs offloaded before compaction, if any (#232).
+
+    Rebuilds the manifest from the append-only index and returns the recovery
+    line. Lazy-imports mapify_cli and degrades to ``None`` (silent) when it is
+    unavailable or nothing was offloaded.
+    """
+    try:
+        sys.path.insert(0, str(PROJECT_DIR / "src"))
+        try:
+            from mapify_cli.tool_output_offload import (
+                build_manifest,
+                recovery_pointer_text,
+            )
+        except ImportError:
+            return None
+        build_manifest(branch_dir / "compacted")
+        return recovery_pointer_text(branch, branch_dir)
+    except Exception:
+        return None
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)
@@ -228,6 +250,12 @@ def main() -> None:
                 )
         except (IOError, OSError):
             pass
+
+    # Point at any tool outputs offloaded before compaction (#232) so the agent
+    # re-reads a sidecar instead of re-running broad discovery.
+    offload_pointer = offloaded_outputs_pointer(branch, branch_dir)
+    if offload_pointer:
+        parts.append(offload_pointer)
 
     # Check for workflow restore point
     restore = branch_dir / "restore_point.json"

--- a/src/mapify_cli/templates_src/hooks/pre-compact-save-transcript.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/pre-compact-save-transcript.py.jinja
@@ -129,6 +129,37 @@ def parse_transcript(transcript_path: Path) -> str:
     return "\n".join(lines)
 
 
+def maybe_offload_tool_outputs(transcript_path: str, branch_dir: Path) -> None:
+    """Offload large tool-result bodies before compaction drops them (#232).
+
+    Only runs when ``compression_policy != never`` so a default install never
+    creates ``.map/<branch>/compacted/``. Lazy-imports mapify_cli and degrades
+    to a silent no-op if it is not importable. Never raises — a PreCompact hook
+    must not break compaction.
+    """
+    try:
+        sys.path.insert(0, str(PROJECT_DIR / "src"))
+        try:
+            from mapify_cli.config.project_config import load_map_config
+            from mapify_cli.tool_output_offload import (
+                offload_transcript_tool_outputs,
+            )
+        except ImportError:
+            return
+        config = load_map_config(PROJECT_DIR)
+        if config.compression_policy == "never":
+            return
+        summary = offload_transcript_tool_outputs(Path(transcript_path), branch_dir)
+        if summary.written:
+            print(
+                f"[pre-compact-save] Offloaded {summary.written} tool output(s) "
+                f"to {branch_dir / 'compacted'}",
+                file=sys.stderr,
+            )
+    except Exception:  # never break compaction
+        pass
+
+
 def main() -> None:
     if os.environ.get("MAP_INVOKED_BY"):
         sys.exit(0)
@@ -189,6 +220,10 @@ def main() -> None:
         )
     except (IOError, OSError):
         pass
+
+    # Offload full-resolution tool-result bodies so dropped outputs stay
+    # recoverable instead of forcing a re-run of broad discovery (#232).
+    maybe_offload_tool_outputs(transcript_path, branch_dir)
 
     print("{}")
     sys.exit(0)

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -3705,6 +3705,25 @@ def _emit_context_budget_warning(branch: str, transcript_path: Optional[str]) ->
         threshold=threshold,
         focus=_map_config_str(project_dir, "compression_focus", ""),
     )
+
+    # Offload large tool-result bodies before the (recommended) compaction drops
+    # them, then point the operator/agent at the sidecars (#232). Provider-
+    # agnostic: reuses the same transcript this warning already read. Lazy import
+    # with graceful fallback — never block the warning on a missing mapify_cli.
+    branch_dir = project_dir / ".map" / branch
+    try:
+        from mapify_cli.tool_output_offload import (  # noqa: PLC0415
+            offload_transcript_tool_outputs,
+            recovery_pointer_text,
+        )
+
+        offload_transcript_tool_outputs(path, branch_dir)
+        pointer = recovery_pointer_text(branch, branch_dir)
+        if pointer:
+            message = f"{message}\n\n{pointer}"
+    except Exception:  # noqa: BLE001 — warning must never raise
+        pass
+
     # stderr keeps stdout clean for JSON consumers (the orchestrator's
     # contract is JSON-on-stdout for every command).
     print(message, file=sys.stderr)

--- a/src/mapify_cli/tool_output_offload.py
+++ b/src/mapify_cli/tool_output_offload.py
@@ -1,0 +1,524 @@
+"""Offload large tool-result bodies before context compaction.
+
+MAP's compaction is a *soft nudge*: when the token budget is crossed the
+framework asks the assistant (Claude Code) or the operator (Codex) to run the
+harness ``/compact`` command, and the harness drops old/large tool-result
+bodies (grep output, test logs, whole-file reads) to stay within the context
+window. Once dropped, the only way to recover such an output is to re-run the
+tool — i.e. redo the broad discovery the workflow already paid for.
+
+This module captures those bodies *before* a compaction drops them and writes
+each one, at full resolution, to a retrievable sidecar under
+``.map/<branch>/compacted/``. An agent that needs a dropped output later reads
+the sidecar instead of re-running the tool.
+
+Design notes (see GitHub issue #232 and ``docs/context-compression-plan.md``):
+
+- **Single source of truth.** This is plain ``mapify_cli`` runtime code (like
+  ``token_budget.py``). The PreCompact hook and the Codex orchestrator both
+  call it via a lazy import that degrades to a silent no-op when ``mapify_cli``
+  is not importable — so there is no hand-duplicated copy to drift.
+- **Pre-drop capture point.** The PreCompact hook fires before the harness
+  compacts and the transcript still holds the full bodies; the Codex
+  orchestrator captures at the same budget-warning point. The transcript JSONL
+  stores tool-result bodies as UTF-8 text, so no binary handling is needed.
+- **Gating.** The caller is responsible for checking ``compression_policy`` and
+  only invoking this module when the policy is not ``never`` — so a default
+  (``never``) install never creates ``.map/<branch>/compacted/`` at all.
+- **Security.** Tool outputs can contain secrets, so every sidecar is written
+  ``0o600`` and a ``.gitignore`` containing ``*`` is dropped into the directory
+  on creation; the bodies are never redacted (a partial scrubber gives false
+  confidence). See ``docs/USAGE.md`` for the operator warning.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Index schema version — bump if the ndjson record shape changes so old
+# manifests can be detected and rebuilt rather than mis-parsed.
+INDEX_SCHEMA_VERSION = 1
+
+# Selection thresholds (characters). A body this large is worth recovering for
+# any tool; below ``DISCOVERY_MIN`` we only bother for broad-discovery tools.
+LARGE_ANY_CHARS = 10_000
+DISCOVERY_MIN_CHARS = 2_000
+
+# Tools whose output is broad discovery — expensive to re-run, cheap to keep.
+BROAD_DISCOVERY_TOOLS = frozenset({"Bash", "Read", "Grep", "Glob"})
+
+# Tools whose output is never worth a sidecar (tiny, ephemeral, or interactive).
+DENYLIST_TOOLS = frozenset({"TodoWrite", "AskUserQuestion", "ExitPlanMode"})
+
+# Directory-growth caps. Eviction is FIFO (oldest offload first). Generous
+# enough to hold a long workflow's discovery, bounded enough to never balloon
+# ``.map/``.
+DEFAULT_MAX_FILES = 300
+DEFAULT_MAX_TOTAL_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+_COMPACTED_DIRNAME = "compacted"
+_INDEX_NAME = "index.ndjson"
+_MANIFEST_NAME = "MANIFEST.md"
+_EVICTIONS_LOG = ".evictions.log"
+_ERRORS_LOG = ".errors.log"
+
+# Strip C0 control characters (except nothing — newlines/tabs are flattened to
+# spaces first) so a one-line input summary stays jq-/markdown-safe. Mirrors the
+# sanitisation rule used elsewhere in the framework.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_UNSAFE_FILENAME = re.compile(r"[^A-Za-z0-9_.-]")
+
+
+@dataclass(frozen=True)
+class ToolOutput:
+    """A single tool-result body extracted from a transcript."""
+
+    tool_use_id: str
+    tool_name: str
+    input_summary: str
+    body: str
+
+    @property
+    def byte_len(self) -> int:
+        return len(self.body.encode("utf-8", "replace"))
+
+
+@dataclass
+class OffloadSummary:
+    """Result of an offload pass — what was written / skipped / evicted."""
+
+    written: int = 0
+    skipped_existing: int = 0
+    evicted: int = 0
+    errors: int = 0
+    compacted_dir: Path | None = None
+    written_ids: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Transcript parsing
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _sanitize_summary(text: str, limit: int = 200) -> str:
+    """Collapse whitespace, strip control chars, bound length — one safe line."""
+    flat = text.replace("\r\n", "\n").replace("\r", "\n")
+    flat = flat.replace("\n", " ").replace("\t", " ")
+    flat = _CONTROL_CHARS.sub("", flat)
+    flat = " ".join(flat.split())
+    if len(flat) > limit:
+        return flat[: max(0, limit - 1)].rstrip() + "…"
+    return flat
+
+
+def _summarize_input(tool_input: object) -> str:
+    """Human-readable one-liner describing what the tool was asked to do."""
+    if not isinstance(tool_input, dict):
+        return _sanitize_summary(str(tool_input))
+    # Prefer the field that identifies the work for common tools.
+    for key in ("command", "file_path", "pattern", "path", "query", "url"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return _sanitize_summary(value)
+    try:
+        return _sanitize_summary(json.dumps(tool_input, ensure_ascii=False))
+    except (TypeError, ValueError):
+        return _sanitize_summary(str(tool_input))
+
+
+def _result_body_to_text(content: object) -> str:
+    """Flatten a ``tool_result`` ``content`` field to a single text body."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict) and item.get("type") == "text":
+            text = item.get("text", "")
+            if isinstance(text, str):
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def extract_tool_outputs(transcript_path: Path) -> list[ToolOutput]:
+    """Parse a Claude Code transcript JSONL into a list of tool-result bodies.
+
+    Walks the transcript once, mapping each ``tool_use`` id to its tool name and
+    input, then pairs every ``tool_result`` block with that metadata via its
+    ``tool_use_id``. Malformed lines are skipped, never fatal. Returns outputs
+    in transcript order; later duplicates of the same ``tool_use_id`` are
+    ignored (the first body wins).
+    """
+    transcript_path = Path(transcript_path)
+    if not transcript_path.is_file():
+        return []
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.debug("tool_output_offload: cannot read %s: %s", transcript_path, exc)
+        return []
+
+    meta: dict[str, tuple[str, str]] = {}  # tool_use_id -> (name, input_summary)
+    results: dict[str, str] = {}  # tool_use_id -> body (first wins)
+    order: list[str] = []
+
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        message = entry.get("message")
+        content = message.get("content") if isinstance(message, dict) else None
+
+        # tool_result entries sometimes appear at the top level rather than
+        # nested in a user message; normalise both into one content list.
+        blocks: list[object] = []
+        if isinstance(content, list):
+            blocks.extend(content)
+        if entry.get("type") == "tool_result":
+            blocks.append(entry)
+
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "tool_use":
+                tid = block.get("id")
+                if isinstance(tid, str) and tid:
+                    name = block.get("name")
+                    name = name if isinstance(name, str) and name else "unknown"
+                    meta[tid] = (name, _summarize_input(block.get("input")))
+            elif btype == "tool_result":
+                tid = block.get("tool_use_id")
+                if isinstance(tid, str) and tid and tid not in results:
+                    body = _result_body_to_text(block.get("content", ""))
+                    results[tid] = body
+                    order.append(tid)
+
+    outputs: list[ToolOutput] = []
+    for tid in order:
+        name, summary = meta.get(tid, ("unknown", ""))
+        outputs.append(
+            ToolOutput(
+                tool_use_id=tid,
+                tool_name=name,
+                input_summary=summary,
+                body=results[tid],
+            )
+        )
+    return outputs
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def should_offload(tool_name: str, body_len: int) -> bool:
+    """Return True if a tool-result body is worth offloading.
+
+    Size-based, not age-based: the hook cannot know which bodies the harness
+    will actually drop, so it captures every body large enough to be worth
+    recovering and lets the FIFO cap bound disk use.
+    """
+    if tool_name in DENYLIST_TOOLS:
+        return False
+    if body_len >= LARGE_ANY_CHARS:
+        return True
+    if body_len >= DISCOVERY_MIN_CHARS and tool_name in BROAD_DISCOVERY_TOOLS:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Sidecar / index IO
+# ---------------------------------------------------------------------------
+
+
+def _sidecar_filename(output: ToolOutput) -> str:
+    safe_tool = _UNSAFE_FILENAME.sub("", output.tool_name) or "tool"
+    safe_id = _UNSAFE_FILENAME.sub("", output.tool_use_id)[:48] or "noid"
+    return f"{safe_tool}-{safe_id}.txt"
+
+
+def _sidecar_text(output: ToolOutput, saved_at: str) -> str:
+    """Full body prefixed with a self-describing header (survives standalone)."""
+    return (
+        f"# map:offloaded tool_use_id={output.tool_use_id} "
+        f"tool={output.tool_name} bytes={output.byte_len} saved={saved_at}\n"
+        f"# input: {output.input_summary}\n"
+        "# Authority: point-in-time snapshot; live source/tests/schemas win "
+        "for current truth.\n"
+        "# --- body below ---\n"
+        f"{output.body}"
+    )
+
+
+def _atomic_write(path: Path, text: str, *, mode: int = 0o600) -> None:
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_text(text, encoding="utf-8")
+    try:
+        os.chmod(tmp, mode)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def _ensure_compacted_dir(branch_dir: Path) -> Path:
+    """Create ``compacted/`` (0700) with a self-contained ``.gitignore``.
+
+    The shipped repo-root ``.gitignore`` does not cover this path, and tool
+    outputs may contain secrets, so the directory ignores its own contents
+    regardless of how the host repo's ignore rules are configured.
+    """
+    compacted = branch_dir / _COMPACTED_DIRNAME
+    compacted.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(compacted, 0o700)
+    except OSError:
+        pass
+    gitignore = compacted / ".gitignore"
+    if not gitignore.exists():
+        try:
+            gitignore.write_text(
+                "# map: offloaded tool outputs may contain secrets — never commit\n"
+                "*\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+    return compacted
+
+
+def _read_index(compacted: Path) -> list[dict]:
+    index = compacted / _INDEX_NAME
+    if not index.is_file():
+        return []
+    records: list[dict] = []
+    try:
+        for raw in index.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(rec, dict) and rec.get("tool_use_id"):
+                records.append(rec)
+    except (OSError, UnicodeDecodeError):
+        return []
+    return records
+
+
+def _append_index(compacted: Path, record: dict) -> None:
+    index = compacted / _INDEX_NAME
+    line = json.dumps(record, ensure_ascii=False)
+    with index.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+    try:
+        os.chmod(index, 0o600)
+    except OSError:
+        pass
+
+
+def _log_line(compacted: Path, name: str, message: str) -> None:
+    try:
+        with (compacted / name).open("a", encoding="utf-8") as fh:
+            fh.write(f"{_now_iso()} {message}\n")
+    except OSError:
+        pass
+
+
+def _rewrite_index(compacted: Path, records: list[dict]) -> None:
+    text = "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in records)
+    _atomic_write(compacted / _INDEX_NAME, text, mode=0o600)
+
+
+def _enforce_cap(
+    compacted: Path, *, max_files: int, max_total_bytes: int
+) -> int:
+    """Evict oldest sidecars until under both caps. Returns evicted count."""
+    records = _read_index(compacted)
+    evicted = 0
+
+    def total_bytes(recs: list[dict]) -> int:
+        return sum(int(r.get("bytes", 0) or 0) for r in recs)
+
+    while records and (
+        len(records) > max_files or total_bytes(records) > max_total_bytes
+    ):
+        victim = records.pop(0)  # FIFO: oldest first
+        sidecar = victim.get("sidecar")
+        if isinstance(sidecar, str):
+            try:
+                (compacted / sidecar).unlink(missing_ok=True)
+            except OSError:
+                pass
+        _log_line(
+            compacted,
+            _EVICTIONS_LOG,
+            f"evicted {victim.get('sidecar')} "
+            f"(tool={victim.get('tool')} bytes={victim.get('bytes')})",
+        )
+        evicted += 1
+
+    if evicted:
+        _rewrite_index(compacted, records)
+    return evicted
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(compacted: Path) -> Path | None:
+    """(Re)build the agent-readable ``MANIFEST.md`` from ``index.ndjson``.
+
+    Returns the manifest path, or ``None`` if there is nothing to index.
+    """
+    records = _read_index(compacted)
+    if not records:
+        return None
+    lines = [
+        "# Offloaded tool outputs",
+        "",
+        "Large tool-result bodies saved before context compaction so you can "
+        "recover them **without re-running broad discovery** (re-grep, re-read, "
+        "re-test). Read the sidecar file directly.",
+        "",
+        "> Authority: these are point-in-time snapshots from when the tool ran. "
+        "For any question about *current* truth, live source, tests, and "
+        "schemas win.",
+        "",
+        "| tool | input | bytes | saved | sidecar |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for rec in records:
+        tool = str(rec.get("tool", "")).replace("|", "\\|")
+        summary = str(rec.get("input_summary", "")).replace("|", "\\|")
+        size = int(rec.get("bytes", 0) or 0)
+        saved = str(rec.get("saved_at", ""))
+        sidecar = str(rec.get("sidecar", ""))
+        lines.append(
+            f"| {tool} | {summary} | {size:,} | {saved} | {sidecar} |"
+        )
+    manifest = compacted / _MANIFEST_NAME
+    _atomic_write(manifest, "\n".join(lines) + "\n", mode=0o600)
+    return manifest
+
+
+def recovery_pointer_text(branch: str, branch_dir: Path) -> str | None:
+    """The additionalContext / stderr line pointing agents at the offloads.
+
+    Returns ``None`` when nothing has been offloaded, so callers emit the
+    pointer only when there is something to recover.
+    """
+    compacted = branch_dir / _COMPACTED_DIRNAME
+    if not _read_index(compacted):
+        return None
+    return (
+        f"Large tool outputs from before compaction were saved under "
+        f".map/{branch}/{_COMPACTED_DIRNAME}/. See "
+        f".map/{branch}/{_COMPACTED_DIRNAME}/{_MANIFEST_NAME} for a scannable "
+        f"index, then read the specific sidecar instead of re-running broad "
+        f"discovery (re-grep / re-read / re-test). Authority: live source, "
+        f"tests, and schemas beat these snapshots for current truth."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def offload_transcript_tool_outputs(
+    transcript_path: Path,
+    branch_dir: Path,
+    *,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+) -> OffloadSummary:
+    """Offload every qualifying tool-result body in *transcript_path*.
+
+    Idempotent: a ``tool_use_id`` already present in the index is skipped, so
+    repeated compactions in one run never duplicate or rewrite a sidecar. The
+    ``compacted/`` directory is created only when there is at least one body to
+    write, so a policy=auto session with no large outputs leaves no trace.
+
+    Never raises on per-output IO problems — those are logged to
+    ``.errors.log`` and counted; the caller still wraps the whole call
+    defensively because a hook must not break compaction.
+    """
+    summary = OffloadSummary()
+    outputs = extract_tool_outputs(transcript_path)
+    candidates = [
+        o for o in outputs if should_offload(o.tool_name, len(o.body))
+    ]
+    if not candidates:
+        return summary
+
+    compacted = _ensure_compacted_dir(branch_dir)
+    summary.compacted_dir = compacted
+    existing_ids = {r["tool_use_id"] for r in _read_index(compacted)}
+
+    for output in candidates:
+        if output.tool_use_id in existing_ids:
+            summary.skipped_existing += 1
+            continue
+        saved_at = _now_iso()
+        sidecar_name = _sidecar_filename(output)
+        try:
+            _atomic_write(
+                compacted / sidecar_name,
+                _sidecar_text(output, saved_at),
+                mode=0o600,
+            )
+            _append_index(
+                compacted,
+                {
+                    "schema_version": INDEX_SCHEMA_VERSION,
+                    "tool_use_id": output.tool_use_id,
+                    "tool": output.tool_name,
+                    "input_summary": output.input_summary,
+                    "bytes": output.byte_len,
+                    "sidecar": sidecar_name,
+                    "saved_at": saved_at,
+                },
+            )
+        except OSError as exc:
+            summary.errors += 1
+            _log_line(
+                compacted, _ERRORS_LOG, f"offload {output.tool_use_id} failed: {exc}"
+            )
+            continue
+        existing_ids.add(output.tool_use_id)
+        summary.written += 1
+        summary.written_ids.append(output.tool_use_id)
+
+    summary.evicted = _enforce_cap(
+        compacted, max_files=max_files, max_total_bytes=max_total_bytes
+    )
+    build_manifest(compacted)
+    return summary

--- a/tests/test_compaction_offload_integration.py
+++ b/tests/test_compaction_offload_integration.py
@@ -1,0 +1,145 @@
+"""End-to-end integration for compaction tool-output offload (issue #232).
+
+Runs the *real generated* PreCompact and post-compact hooks as subprocesses to
+prove the full wiring: a large tool output is offloaded before compaction and is
+recoverable afterwards without re-running the tool, and a ``never`` policy is a
+byte-identical no-op (acceptance criteria 1-3).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRECOMPACT_HOOK = REPO_ROOT / ".claude" / "hooks" / "pre-compact-save-transcript.py"
+POSTCOMPACT_HOOK = REPO_ROOT / ".claude" / "hooks" / "post-compact-context.py"
+
+pytestmark = pytest.mark.skipif(
+    not PRECOMPACT_HOOK.is_file() or not POSTCOMPACT_HOOK.is_file(),
+    reason="generated hooks not present (run `make render-templates`)",
+)
+
+BIG_GREP_BODY = "src/foo.py:42: TODO fix\n" * 800  # well over the size threshold
+
+
+def _run_hook(hook: Path, project_dir: Path, stdin_obj: dict) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    # Pin mapify_cli resolution to THIS worktree (avoid editable cross-clone).
+    env["PYTHONPATH"] = str(REPO_ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    env.pop("MAP_INVOKED_BY", None)
+    return subprocess.run(
+        [sys.executable, str(hook)],
+        input=json.dumps(stdin_obj),
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def _make_project(tmp_path: Path, policy: str) -> tuple[Path, Path]:
+    project = tmp_path / "proj"
+    (project / ".map").mkdir(parents=True)
+    (project / ".map" / "config.yaml").write_text(
+        f"compression_policy: {policy}\n", encoding="utf-8"
+    )
+    transcript = project / "transcript.jsonl"
+    entries = [
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_grep1",
+                        "name": "Bash",
+                        "input": {"command": "grep -rn TODO src/"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_grep1",
+                        "content": [{"type": "text", "text": BIG_GREP_BODY}],
+                    }
+                ],
+            },
+        },
+    ]
+    transcript.write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8"
+    )
+    return project, transcript
+
+
+def _branch_dir(project: Path) -> Path:
+    # tmp dir is not a git repo → hook falls back to the "default" branch.
+    return project / ".map" / "default"
+
+
+def test_offload_and_recover_when_policy_auto(tmp_path):
+    project, transcript = _make_project(tmp_path, policy="auto")
+
+    pre = _run_hook(
+        PRECOMPACT_HOOK,
+        project,
+        {"transcript_path": str(transcript), "session_id": "s1"},
+    )
+    assert pre.returncode == 0, pre.stderr
+
+    compacted = _branch_dir(project) / "compacted"
+    sidecars = list(compacted.glob("Bash-*.txt"))
+    assert len(sidecars) == 1, f"expected one sidecar, got {sidecars} ({pre.stderr})"
+
+    # Acceptance #2: the dropped output is fully recoverable from the sidecar —
+    # the original body is present, so re-running grep is unnecessary.
+    recovered = sidecars[0].read_text(encoding="utf-8")
+    assert "src/foo.py:42: TODO fix" in recovered
+    assert recovered.count("TODO fix") == 800
+
+    # The directory ignores its own (possibly secret-bearing) contents.
+    assert (compacted / ".gitignore").read_text().strip().endswith("*")
+
+    # post-compact hook surfaces the recovery pointer.
+    post = _run_hook(POSTCOMPACT_HOOK, project, {})
+    assert post.returncode == 0, post.stderr
+    payload = json.loads(post.stdout)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    assert "compacted/MANIFEST.md" in ctx
+    assert "instead of re-running broad discovery" in ctx
+
+
+def test_never_policy_is_byte_identical_no_op(tmp_path):
+    project, transcript = _make_project(tmp_path, policy="never")
+
+    pre = _run_hook(
+        PRECOMPACT_HOOK,
+        project,
+        {"transcript_path": str(transcript), "session_id": "s1"},
+    )
+    assert pre.returncode == 0, pre.stderr
+
+    # Acceptance #3: no offload artifacts created under the default policy.
+    assert not (_branch_dir(project) / "compacted").exists()
+    # Existing behavior preserved: the transcript archive is still written.
+    archives = list(_branch_dir(project).glob("transcript-*.md"))
+    assert len(archives) == 1
+
+    # post-compact hook emits no offload pointer when nothing was offloaded.
+    post = _run_hook(POSTCOMPACT_HOOK, project, {})
+    assert post.returncode == 0, post.stderr
+    assert "compacted/MANIFEST.md" not in post.stdout

--- a/tests/test_tool_output_offload.py
+++ b/tests/test_tool_output_offload.py
@@ -1,0 +1,338 @@
+"""Tests for src/mapify_cli/tool_output_offload.py (GitHub issue #232)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from mapify_cli.tool_output_offload import (
+    DENYLIST_TOOLS,
+    DISCOVERY_MIN_CHARS,
+    INDEX_SCHEMA_VERSION,
+    LARGE_ANY_CHARS,
+    build_manifest,
+    extract_tool_outputs,
+    offload_transcript_tool_outputs,
+    recovery_pointer_text,
+    should_offload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_use(tid: str, name: str, tool_input: dict) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": tid, "name": name, "input": tool_input}
+            ],
+        },
+    }
+
+
+def _tool_result(tid: str, body: str) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tid,
+                    "content": [{"type": "text", "text": body}],
+                }
+            ],
+        },
+    }
+
+
+def _write_transcript(path: Path, entries: list[dict]) -> Path:
+    path.write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def _pair(tid: str, name: str, tool_input: dict, body: str) -> list[dict]:
+    return [_tool_use(tid, name, tool_input), _tool_result(tid, body)]
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+class TestShouldOffload:
+    def test_large_body_any_tool_offloaded(self):
+        assert should_offload("WebFetch", LARGE_ANY_CHARS) is True
+
+    def test_small_body_skipped_even_for_discovery_tool(self):
+        assert should_offload("Bash", 499) is False
+        assert should_offload("Bash", DISCOVERY_MIN_CHARS - 1) is False
+
+    def test_medium_discovery_tool_offloaded(self):
+        assert should_offload("Bash", DISCOVERY_MIN_CHARS) is True
+        assert should_offload("Grep", DISCOVERY_MIN_CHARS + 1) is True
+
+    def test_medium_non_discovery_tool_skipped(self):
+        # Between DISCOVERY_MIN and LARGE_ANY, non-discovery tools are skipped.
+        assert should_offload("WebFetch", DISCOVERY_MIN_CHARS + 1) is False
+
+    @pytest.mark.parametrize("tool", sorted(DENYLIST_TOOLS))
+    def test_denylist_never_offloaded(self, tool):
+        assert should_offload(tool, LARGE_ANY_CHARS * 10) is False
+
+
+# ---------------------------------------------------------------------------
+# Transcript parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractToolOutputs:
+    def test_pairs_tool_use_with_result(self, tmp_path):
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Bash", {"command": "grep -r TODO src/"}, "hit\n" * 5),
+        )
+        outputs = extract_tool_outputs(t)
+        assert len(outputs) == 1
+        assert outputs[0].tool_use_id == "toolu_1"
+        assert outputs[0].tool_name == "Bash"
+        assert outputs[0].input_summary == "grep -r TODO src/"
+        assert outputs[0].body == "hit\n" * 5
+
+    def test_string_content_result(self, tmp_path):
+        entries = [
+            _tool_use("toolu_x", "Read", {"file_path": "/a/b.py"}),
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_x", "content": "raw body"}
+                    ],
+                },
+            },
+        ]
+        outputs = extract_tool_outputs(_write_transcript(tmp_path / "t.jsonl", entries))
+        assert outputs[0].body == "raw body"
+        assert outputs[0].input_summary == "/a/b.py"
+
+    def test_missing_metadata_defaults_to_unknown(self, tmp_path):
+        # tool_result with no preceding tool_use → name unknown, still extracted.
+        t = _write_transcript(tmp_path / "t.jsonl", [_tool_result("orphan", "body")])
+        outputs = extract_tool_outputs(t)
+        assert len(outputs) == 1
+        assert outputs[0].tool_name == "unknown"
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        good = _pair("toolu_1", "Bash", {"command": "ls"}, "x")
+        path.write_text(
+            "not json\n" + json.dumps(good[0]) + "\n{ broken\n" + json.dumps(good[1]) + "\n",
+            encoding="utf-8",
+        )
+        outputs = extract_tool_outputs(path)
+        assert len(outputs) == 1
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert extract_tool_outputs(tmp_path / "nope.jsonl") == []
+
+    def test_duplicate_tool_use_id_first_body_wins(self, tmp_path):
+        entries = [
+            _tool_use("toolu_1", "Bash", {"command": "ls"}),
+            _tool_result("toolu_1", "first"),
+            _tool_result("toolu_1", "second"),
+        ]
+        outputs = extract_tool_outputs(_write_transcript(tmp_path / "t.jsonl", entries))
+        assert len(outputs) == 1
+        assert outputs[0].body == "first"
+
+
+# ---------------------------------------------------------------------------
+# Offload end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestOffload:
+    def _big(self, marker: str) -> str:
+        return marker + ("x" * (LARGE_ANY_CHARS + 10))
+
+    def test_offloads_large_skips_small(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        entries = (
+            _pair("toolu_big", "Bash", {"command": "grep -r X"}, self._big("BIG"))
+            + _pair("toolu_small", "Bash", {"command": "echo hi"}, "tiny")
+        )
+        t = _write_transcript(tmp_path / "t.jsonl", entries)
+
+        summary = offload_transcript_tool_outputs(t, branch_dir)
+
+        assert summary.written == 1
+        assert summary.written_ids == ["toolu_big"]
+        compacted = branch_dir / "compacted"
+        sidecars = list(compacted.glob("Bash-*.txt"))
+        assert len(sidecars) == 1
+        text = sidecars[0].read_text(encoding="utf-8")
+        assert "BIG" in text
+        assert "# map:offloaded tool_use_id=toolu_big" in text
+        assert "Authority:" in text
+
+    def test_full_body_preserved_not_truncated(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        body = "LINE\n" * (LARGE_ANY_CHARS // 4)  # well over 1000 chars
+        t = _write_transcript(
+            tmp_path / "t.jsonl", _pair("toolu_1", "Read", {"file_path": "/big.py"}, body)
+        )
+        offload_transcript_tool_outputs(t, branch_dir)
+        sidecar = next((branch_dir / "compacted").glob("Read-*.txt"))
+        assert body in sidecar.read_text(encoding="utf-8")
+
+    def test_index_record_shape(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Grep", {"pattern": "needle"}, self._big("G")),
+        )
+        offload_transcript_tool_outputs(t, branch_dir)
+        index = (branch_dir / "compacted" / "index.ndjson").read_text().splitlines()
+        assert len(index) == 1
+        rec = json.loads(index[0])
+        assert rec["schema_version"] == INDEX_SCHEMA_VERSION
+        assert rec["tool_use_id"] == "toolu_1"
+        assert rec["tool"] == "Grep"
+        assert rec["input_summary"] == "needle"
+        assert rec["bytes"] >= LARGE_ANY_CHARS
+        assert rec["sidecar"].startswith("Grep-")
+        assert rec["saved_at"]
+
+    def test_dedup_idempotent_across_runs(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Bash", {"command": "grep X"}, self._big("A")),
+        )
+        first = offload_transcript_tool_outputs(t, branch_dir)
+        second = offload_transcript_tool_outputs(t, branch_dir)
+        assert first.written == 1
+        assert second.written == 0
+        assert second.skipped_existing == 1
+        # index has exactly one line; one sidecar on disk.
+        index = (branch_dir / "compacted" / "index.ndjson").read_text().splitlines()
+        assert len(index) == 1
+        assert len(list((branch_dir / "compacted").glob("Bash-*.txt"))) == 1
+
+    def test_no_candidates_creates_no_directory(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl", _pair("toolu_1", "Bash", {"command": "echo"}, "tiny")
+        )
+        summary = offload_transcript_tool_outputs(t, branch_dir)
+        assert summary.written == 0
+        assert not (branch_dir / "compacted").exists()
+
+    def test_gitignore_written_on_creation(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Bash", {"command": "grep X"}, self._big("A")),
+        )
+        offload_transcript_tool_outputs(t, branch_dir)
+        gitignore = branch_dir / "compacted" / ".gitignore"
+        assert gitignore.exists()
+        assert gitignore.read_text().strip().endswith("*")
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_sidecar_is_chmod_0600(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Bash", {"command": "grep X"}, self._big("A")),
+        )
+        offload_transcript_tool_outputs(t, branch_dir)
+        sidecar = next((branch_dir / "compacted").glob("Bash-*.txt"))
+        mode = stat.S_IMODE(sidecar.stat().st_mode)
+        assert mode == 0o600
+
+    def test_cap_evicts_oldest_fifo(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        entries: list[dict] = []
+        for i in range(4):
+            entries += _pair(
+                f"toolu_{i}", "Bash", {"command": f"grep {i}"}, self._big(f"M{i}")
+            )
+        t = _write_transcript(tmp_path / "t.jsonl", entries)
+
+        summary = offload_transcript_tool_outputs(t, branch_dir, max_files=2)
+
+        assert summary.written == 4
+        assert summary.evicted == 2
+        index = (branch_dir / "compacted" / "index.ndjson").read_text().splitlines()
+        ids = [json.loads(line)["tool_use_id"] for line in index]
+        assert ids == ["toolu_2", "toolu_3"]  # oldest two evicted
+        remaining = {p.name for p in (branch_dir / "compacted").glob("Bash-*.txt")}
+        assert len(remaining) == 2
+        evictions = (branch_dir / "compacted" / ".evictions.log").read_text()
+        assert "evicted" in evictions
+
+    def test_manifest_built_and_lists_entries(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Grep", {"pattern": "needle"}, self._big("G")),
+        )
+        offload_transcript_tool_outputs(t, branch_dir)
+        manifest = (branch_dir / "compacted" / "MANIFEST.md").read_text()
+        assert "Offloaded tool outputs" in manifest
+        assert "needle" in manifest
+        assert "Grep-" in manifest
+        assert "live source" in manifest.lower()
+
+    def test_build_manifest_none_when_empty(self, tmp_path):
+        compacted = tmp_path / "compacted"
+        compacted.mkdir()
+        assert build_manifest(compacted) is None
+
+
+# ---------------------------------------------------------------------------
+# Recovery pointer
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryPointer:
+    def test_none_when_nothing_offloaded(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        assert recovery_pointer_text("br", branch_dir) is None
+
+    def test_pointer_after_offload(self, tmp_path):
+        branch_dir = tmp_path / ".map" / "br"
+        branch_dir.mkdir(parents=True)
+        t = _write_transcript(
+            tmp_path / "t.jsonl",
+            _pair("toolu_1", "Bash", {"command": "grep X"}, "x" * (LARGE_ANY_CHARS + 1)),
+        )
+        offload_transcript_tool_outputs(t, branch_dir)
+        pointer = recovery_pointer_text("br", branch_dir)
+        assert pointer is not None
+        assert ".map/br/compacted/MANIFEST.md" in pointer
+        assert "do not" not in pointer.lower() or "instead of re-running" in pointer
+        assert "live source" in pointer.lower()


### PR DESCRIPTION
## What & why

Closes #232.

MAP's compaction is a **soft nudge** — the harness's `/compact` drops old/large tool-result bodies (grep output, test logs, whole-file reads). Once dropped, the only recovery is re-running the tool, redoing the broad discovery #203 fights to avoid. This PR captures those bodies **before** they are dropped and makes them re-readable on demand.

## How

- **Capture point.** At `PreCompact` the full transcript (bodies included) is still readable — the same window the existing transcript-saver uses. A new runtime module `mapify_cli.tool_output_offload` parses the transcript and writes each qualifying body at full resolution to `.map/<branch>/compacted/`. The Codex path does the same in the orchestrator's budget warning, reusing the transcript it already reads. Thin hooks/orchestrator lazy-import the module and no-op on `ImportError` (single source of truth, *producer-owns-parse*).
- **Layout** under `.map/<branch>/compacted/`: append-only `index.ndjson` (`schema_version`), agent-readable `MANIFEST.md` (rebuilt at post-compact), `<tool>-<tool_use_id>.txt` sidecars with a self-describing header, `.evictions.log`/`.errors.log`. Dedup by `tool_use_id`; FIFO cap (300 files / 100 MiB).
- **Recovery.** The post-compact `SessionStart(compact)` hook injects a pointer to the manifest so the agent re-reads the specific sidecar **instead of re-running broad discovery**. Codex agents get the same pointer on stderr. Snapshots are point-in-time — live source/tests/schemas stay authoritative.
- **Selection** is size-based (≥10K chars any tool, or ≥2K for `Bash`/`Read`/`Grep`/`Glob`; `TodoWrite`/`AskUserQuestion`/`ExitPlanMode` never offloaded).

## Design decision: PreCompact, not PostToolUse

Consulted llm-council (deep) + verified hook semantics via claude-code-guide. The council recommended an always-on PostToolUse primary; I diverged on two concrete facts: (1) `compression_policy` defaults to **`never`**, so an always-on per-tool-call hook would tax the default-off majority for an off-by-default feature; (2) MAP compaction is **manual-`/compact`-nudge-driven**, so PreCompact's manual path is the primary one regardless (and it also fires on auto-compact). Residual risk (PreCompact not firing on auto-compact before any manual `/compact`) is documented; eager PostToolUse capture is a noted future enhancement.

## Security

Tool outputs can contain secrets, so each sidecar is `0o600` and a self-contained `compacted/.gitignore` (`*`) is written on creation — the directory is never committed regardless of host repo ignore rules (the shipped `.gitignore` does not otherwise cover this path). Defense-in-depth line added to the shipped `.gitignore`. Bodies are **not** redacted (council consensus: a partial scrubber gives false confidence).

## Acceptance criteria (#232)

- [x] Compaction emits retrievable sidecars, not bare drops, for tool-result bodies.
- [x] Pointer format the agent can follow; integration test recovers a dropped-then-needed output **without** re-running the tool.
- [x] Gated by `compression_policy`; `never` is a byte-identical no-op (directory never created).

## Tests

- `tests/test_tool_output_offload.py` — unit: selection, transcript parsing, dedup idempotency, FIFO cap/eviction, manifest, recovery pointer, `compacted/.gitignore`, `0o600`.
- `tests/test_compaction_offload_integration.py` — runs the **real generated** PreCompact + post-compact hooks as subprocesses: offload+recover under `auto`; byte-identical no-op under `never`.
- `make check` green (2551 passed, 3 skipped); `make check-render` green; Pyright 0/0/0 on changed files.

## Docs

`docs/context-compression-plan.md` (new offload section), `docs/ARCHITECTURE.md` (Compaction Resilience), `docs/USAGE.md` (offload + security note), `README.md`, `CHANGELOG.md`.

## Deferred (eval-gated follow-up)

Persistent Actor/Monitor prompt guidance about the manifest is deferred to a gated follow-up issue (avoids coupling an eval-risky prompt change with infra). v1 recovery works via the ephemeral post-compact pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)