### PR TITLE
feat(map-efficient): persist offloaded-output recovery in Actor/Monitor prompts (#236)

### DIFF
--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -289,6 +289,7 @@ Task(
 <task>
 Implement exactly the current subtask. Preserve validation_criteria, coverage_map tags, hard_constraints, and soft_constraints tradeoffs. Do not expand scope.
 Do not edit unrelated files, add or upgrade dependencies, or refactor neighboring code unless the current subtask contract explicitly requires it. Report any required scope expansion as a blocker/tradeoff.
+Before re-running broad discovery (re-grep, re-read a large file, re-run the full test suite), check `.map/<branch>/compacted/MANIFEST.md` and `Read` the cited sidecar to recover the earlier output — re-run the tool only when recent edits, a new test run, an updated schema, or the task itself indicates the target has changed since capture.
 </task>
 <expected_output>
 Return ONLY a JSON object (no markdown fences, no prose before/after) with files_changed (array of written paths), tests_run (array of "command — pass/fail"), validation_notes (string), and blocker (string or null). Write and run code via tools FIRST — this JSON is a post-work manifest; never put code, diffs, or logs inside it. Detail: [efficient-reference.md](efficient-reference.md).
@@ -331,6 +332,7 @@ Task(
 </documents>
 <task>
 Validate the implementation against the current subtask's AAG contract, validation_criteria, bracketed coverage_map tags, hard_constraints, and relevant soft_constraints/tradeoff_rationale.
+Treat a sidecar under `.map/<branch>/compacted/` as evidence of what was checked, never as sole proof of correctness — ground every verdict in live source and a current test run.
 </task>
 <expected_output>
 Return JSON with valid, summary, issues, files_changed, tests_run, and escalation_required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outputs may contain secrets, so every sidecar is written `0o600` and a
   self-contained `.gitignore` (`*`) is dropped into `compacted/` on creation so
   it is never committed regardless of the host repo's ignore rules; bodies are
-  never redacted. Persistent Actor/Monitor prompt guidance is deferred to a
-  follow-up (eval-gated); recovery currently works via the ephemeral
-  post-compact pointer.
+  never redacted. Persistent Actor/Monitor prompt guidance landed as the
+  eval-gated follow-up #236 (below); the ephemeral post-compact pointer still
+  re-primes the next turn.
+- **Actor and Monitor persistently recover offloaded tool outputs across turns
+  (#236, follow-up to #232).** The #232 post-compact pointer only re-primed the
+  next turn; the map-efficient Actor and Monitor dispatched `<task>` prompts now
+  carry persistent guidance so recover-before-rediscover survives compaction
+  across turns. **Actor:** before re-running broad discovery (re-grep, re-read a
+  large file, re-run the full test suite), check
+  `.map/<branch>/compacted/MANIFEST.md` and `Read` the cited sidecar to recover
+  the earlier output, re-running the tool **only** on a concrete staleness
+  signal (recent edits, a new test run, an updated schema, or the task asking
+  for current state) — the default is sidecar reuse, not over-eager
+  re-discovery. **Monitor:** a sidecar is evidence of *what was checked*, never
+  sole proof of correctness — every verdict stays grounded in live source and a
+  current test run. Wording was validated with llm-council against the
+  documented eval risk (over-trust of stale snapshots vs. skipping needed fresh
+  discovery); the map-efficient `SKILL.md` line budget was bumped 502 → 504 for
+  the two prompt lines, which must live in the dispatched body.
 
 ### Fixed
 - **`record_test_baseline` silently skipped the MANDATORY pre-flight baseline in

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -289,6 +289,7 @@ Task(
 <task>
 Implement exactly the current subtask. Preserve validation_criteria, coverage_map tags, hard_constraints, and soft_constraints tradeoffs. Do not expand scope.
 Do not edit unrelated files, add or upgrade dependencies, or refactor neighboring code unless the current subtask contract explicitly requires it. Report any required scope expansion as a blocker/tradeoff.
+Before re-running broad discovery (re-grep, re-read a large file, re-run the full test suite), check `.map/<branch>/compacted/MANIFEST.md` and `Read` the cited sidecar to recover the earlier output — re-run the tool only when recent edits, a new test run, an updated schema, or the task itself indicates the target has changed since capture.
 </task>
 <expected_output>
 Return ONLY a JSON object (no markdown fences, no prose before/after) with files_changed (array of written paths), tests_run (array of "command — pass/fail"), validation_notes (string), and blocker (string or null). Write and run code via tools FIRST — this JSON is a post-work manifest; never put code, diffs, or logs inside it. Detail: [efficient-reference.md](efficient-reference.md).
@@ -331,6 +332,7 @@ Task(
 </documents>
 <task>
 Validate the implementation against the current subtask's AAG contract, validation_criteria, bracketed coverage_map tags, hard_constraints, and relevant soft_constraints/tradeoff_rationale.
+Treat a sidecar under `.map/<branch>/compacted/` as evidence of what was checked, never as sole proof of correctness — ground every verdict in live source and a current test run.
 </task>
 <expected_output>
 Return JSON with valid, summary, issues, files_changed, tests_run, and escalation_required.

--- a/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
@@ -289,6 +289,7 @@ Task(
 <task>
 Implement exactly the current subtask. Preserve validation_criteria, coverage_map tags, hard_constraints, and soft_constraints tradeoffs. Do not expand scope.
 Do not edit unrelated files, add or upgrade dependencies, or refactor neighboring code unless the current subtask contract explicitly requires it. Report any required scope expansion as a blocker/tradeoff.
+Before re-running broad discovery (re-grep, re-read a large file, re-run the full test suite), check `.map/<branch>/compacted/MANIFEST.md` and `Read` the cited sidecar to recover the earlier output — re-run the tool only when recent edits, a new test run, an updated schema, or the task itself indicates the target has changed since capture.
 </task>
 <expected_output>
 Return ONLY a JSON object (no markdown fences, no prose before/after) with files_changed (array of written paths), tests_run (array of "command — pass/fail"), validation_notes (string), and blocker (string or null). Write and run code via tools FIRST — this JSON is a post-work manifest; never put code, diffs, or logs inside it. Detail: [efficient-reference.md](efficient-reference.md).
@@ -331,6 +332,7 @@ Task(
 </documents>
 <task>
 Validate the implementation against the current subtask's AAG contract, validation_criteria, bracketed coverage_map tags, hard_constraints, and relevant soft_constraints/tradeoff_rationale.
+Treat a sidecar under `.map/<branch>/compacted/` as evidence of what was checked, never as sole proof of correctness — ground every verdict in live source and a current test run.
 </task>
 <expected_output>
 Return JSON with valid, summary, issues, files_changed, tests_run, and escalation_required.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -454,9 +454,13 @@ class TestSkillStructure:
 
                 # Budget bumped from 500 → 502: C2 fence addition (ST-011) added
                 # <!-- map:start --> and <!-- map:end --> (2 lines) to every SKILL.md.
+                # Budget bumped from 502 → 504 (#236): one persistent recover-from-
+                # offloaded-sidecar line was added to each of the Actor and Monitor
+                # dispatched <task> prompts in map-efficient/SKILL.md. These are the
+                # actual agent prompt bodies, so they cannot move to the reference file.
                 # Do NOT remove content to fit — bump the budget instead (per learned rule
                 # 'always-loaded skill body line budget').
-                assert len(content.splitlines()) <= 502, (
+                assert len(content.splitlines()) <= 504, (
                     f"{skill_file} should keep the active workflow path compact; "
                     "move examples, rationale, and troubleshooting into supporting files."
                 )
@@ -1152,6 +1156,56 @@ class TestXMLPromptEnvelopeContracts:
                 f"ACTOR <expected_output> must name the '{key}' field required "
                 "by AGENT_OUTPUT_SCHEMAS['actor']."
             )
+
+    @pytest.mark.parametrize("skills_root", PROMPT_TONE_SKILL_ROOTS)
+    def test_map_efficient_actor_monitor_recover_offloaded_outputs(
+        self, project_root, skills_root
+    ):
+        """Regression for #236: the Actor and Monitor dispatched <task> prompts
+        must carry persistent guidance to recover offloaded tool outputs from the
+        compaction manifest (#232) instead of re-running broad discovery, while
+        still defaulting to live source/tests for current correctness. The
+        post-compact hook pointer is ephemeral (re-primes the next turn only);
+        without these prompt lines the recover-before-rediscover behavior does
+        not survive across turns.
+        """
+        skill_md = project_root / skills_root / "map-efficient" / "SKILL.md"
+        content = skill_md.read_text(encoding="utf-8")
+
+        def _task_block(section_start: str, section_end: str) -> str:
+            section = content.split(section_start, maxsplit=1)[1]
+            section = section.split(section_end, maxsplit=1)[0]
+            task = section.split("<task>", maxsplit=1)[1]
+            return task.split("</task>", maxsplit=1)[0]
+
+        actor_task = _task_block(
+            "### Phase: ACTOR (2.3)", "### Actor truncated-response gate"
+        )
+        # Recovery entry point is scoped to "re-running broad discovery" — not an
+        # unconditional "always check the manifest first".
+        assert "compacted/MANIFEST.md" in actor_task, (
+            "ACTOR <task> must point at .map/<branch>/compacted/MANIFEST.md so the "
+            "agent can recover offloaded tool outputs instead of re-running broad "
+            "discovery (#236)."
+        )
+        # The staleness guard must DEFAULT to sidecar reuse and re-run only on a
+        # concrete positive signal — guards against over-trust AND over-rediscovery.
+        assert "re-run the tool only when" in actor_task, (
+            "ACTOR <task> must gate re-running on a concrete staleness signal so "
+            "the default is sidecar reuse, not over-eager re-discovery (#236)."
+        )
+
+        monitor_task = _task_block(
+            "### Phase: MONITOR (2.4)", "# After Monitor returns:"
+        )
+        assert "never as sole proof of correctness" in monitor_task, (
+            "MONITOR <task> must forbid basing a verdict solely on an offloaded "
+            "sidecar (#236)."
+        )
+        assert "live source and a current test run" in monitor_task, (
+            "MONITOR <task> must ground every verdict in live source and a current "
+            "test run — not a stale snapshot (#236)."
+        )
 
 
 class TestContractSizedSubtaskSkillContracts:


### PR DESCRIPTION
## What & why

Follow-up to #232 (PR #235). #232 ships compaction tool-output offload + recovery via an **ephemeral** post-compact `additionalContext` pointer that only re-primes the *next* turn. This adds **persistent** guidance to the map-efficient Actor and Monitor dispatched `<task>` prompts so the recover-before-rediscover behavior survives across turns.

Split out of #235 deliberately because it carries **eval risk** (a prompt change can cause over-trust of stale snapshots or skipping legitimately-needed fresh discovery); coupling it with the infra change would make a regression harder to bisect.

## Changes

- **Actor `<task>`** (one line): before re-running broad discovery (re-grep / re-read a large file / re-run the full test suite), check `.map/<branch>/compacted/MANIFEST.md` and `Read` the cited sidecar to recover the earlier output — **re-run the tool only on a concrete staleness signal** (recent edits, a new test run, an updated schema, or the task asking for current state). Default is sidecar reuse, not over-eager re-discovery.
- **Monitor `<task>`** (one line): a sidecar is evidence of *what was checked*, **never sole proof of correctness** — every verdict stays grounded in live source and a current test run.
- Edited the `.jinja` source and re-rendered (`make render-templates`); both rendered trees updated.
- Bumped the map-efficient `SKILL.md` line budget **502 → 504** — these are the actual dispatched agent prompt bodies, so they cannot move to the (non-budgeted) reference file.
- Added regression test `test_map_efficient_actor_monitor_recover_offloaded_outputs` (both rendered trees) asserting each prompt carries the guidance.

## Eval-gate

Wording validated with **llm-council** against the two documented failure modes. Key refinements adopted: flip the Actor guard from a vague "may have changed" hedge to a concrete positive staleness trigger (so the default is reuse → Positive eval), and use "current" rather than "fresh" test run in Monitor (so a still-valid sidecar isn't needlessly re-run).

- Positive eval (recover, don't re-run): served by the default-reuse framing + MANIFEST anchor.
- Negative eval (changed source → re-read live): served by the concrete staleness trigger + Monitor "never sole proof".

## Testing

- `make check` — green: ruff `All checks passed!`, mypy `Success: no issues found in 61 source files`, **2553 passed / 3 skipped**, `check-render` ✅ (generated trees match `templates_src`).
- Negative-proof: the four asserted strings are absent in `HEAD` (test is non-vacuous — red before the fix, green after).

Closes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
