### PR TITLE
docs(architecture): Agent-Boundary Doctrine + audit every hand-off (#230)

### DIFF
--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -2,9 +2,11 @@
 name: documentation-reviewer
 description: Reviews technical documentation for completeness, external dependencies, and architectural consistency
 model: sonnet
-version: 3.1.0
-last_updated: 2025-11-27
+version: 3.1.1
+last_updated: 2026-06-19
 ---
+
+> **Dispatch status:** Optional / user-dispatchable agent — not auto-wired into any shipped MAP skill pipeline (no `subagent_type="documentation-reviewer"` dispatch site exists). Invoke manually via `Task(subagent_type="documentation-reviewer", …)`. Retained per the Agent-Boundary Doctrine in `docs/ARCHITECTURE.md` because it emits a unique, non-relay verdict (docs-vs-source-architecture review).
 
 # QUICK REFERENCE (Read First)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent-Boundary Doctrine: written down + every live hand-off audited
+  `independent | relay` (#230).** `docs/ARCHITECTURE.md` now carries the explicit
+  criterion — keep a separate sub-agent **only** when it adds an independent /
+  adversarial perspective; collapse any **pure-relay** hop (a context that only
+  paraphrases a prior agent's output, emitting no new verdict) into its caller.
+  It is a *substance* rule, not a *wiring* rule. The doctrine includes a ground-truth
+  audit (classified from actual `subagent_type="…"` dispatch sites, not docs): all
+  8 pipeline-dispatched agents emit independent verdicts and none is a relay; the
+  only relay hops the doctrine condemns — the Self-MoA `synthesizer`/`debate-arbiter`
+  — were already collapsed in #240. The audit also resolves the orphaned
+  `documentation-reviewer` (zero skill dispatch sites) as a **deliberate keep**: it
+  emits a unique, non-relay verdict, so it is retained as an **optional,
+  user-dispatchable** agent (invoke via `Task(subagent_type="documentation-reviewer")`)
+  and now self-declares a `Dispatch status:` annotation. A new
+  `tests/test_agent_dispatch_audit.py` enforces the invariant going forward: any
+  agent shipped with no dispatch site and not marked optional fails the gate,
+  preventing a silent orphan from recurring.
 - **Hand-authored RESEARCH artifacts now self-correct on the first reject, and
   the exact contract is documented (#228, follow-up to #197).** The documented
   `save_research` path ("save direct current-session findings") used to cost 2-3

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -397,6 +397,32 @@ MAP Framework implements cognitive architecture inspired by prefrontal cortex fu
 - Workflow logs in `.map/workflow_logs/`
 - Metrics tracked in `.claude/metrics/agent_metrics.jsonl`
 
+### Agent-Boundary Doctrine
+
+MAP is a hierarchical multi-agent orchestrator, but more agents is not automatically better: every extra agent hop costs an additional LLM call and risks paraphrasing fidelity loss. The doctrine below decides when a separate sub-agent is justified. It is a **substance rule, not a wiring rule** — what matters is whether the agent emits an *independent verdict*, not how many skills happen to call it.
+
+> **The test:** keep a separate agent **only** when it contributes an *independent or adversarial perspective* — a verdict, score, decomposition, or discovery that the caller's own context could not be trusted to produce about its own work. **Collapse** any hop that is a *pure relay* — a context whose only job is to reformat or paraphrase a prior agent's output and pass it on, emitting no new verdict — into the caller.
+
+Why the distinction matters (motivation from the Atlassian Rovo "long-horizon" result, issue #230): Rovo replaced a coordinator→capability-subagent hierarchy with a single-context loop and improved accuracy, because the orchestrator→subagent hop was *pure relay overhead* (one LLM call whose only job was to paraphrase tool results upward). That result does **not** argue for collapsing MAP to one context: MAP's Monitor / Predictor / Evaluator / FinalVerifier are **adversarial / independent-verification** roles where the *separation is the value* — an independent context catches what a single self-reviewing context rationalizes away. Collapsing those would destroy MAP's core benefit. The lesson is the criterion above, applied per hop.
+
+**Audit (ground truth = `subagent_type="…"` dispatch sites in `src/mapify_cli/templates_src/skills/**/SKILL.md.jinja`, not docs).** Every shipped agent classified `independent | relay`:
+
+| Agent | Dispatched by (`file:line`, jinja source) | Emits | Class |
+|-------|--------------------------------------------|-------|-------|
+| TaskDecomposer | `map-efficient:152`, `map-fast:73`, `map-debug:80`, `map-plan:204` | atomic subtask plan + coverage map | **Independent** (decomposition) |
+| ResearchAgent | `map-plan:98` (+ `map-efficient` RESEARCH phase 2.2, conditional) | discovery findings as typed artifact | **Independent** (producer) |
+| Actor | `map-efficient:282`, `map-fast:99`, `map-tdd:129/280`, `map-debug:124/148` | code diff + change manifest | **Independent** (producer — does the work, not a relay) |
+| Monitor | `map-efficient:325`, `map-fast:124`, `map-debug:181`, `map-plan:169`, `map-review:297` | pass/fail review verdict | **Independent** (adversarial) |
+| Predictor | `map-debug:226`, `map-review:298` | impact / regression risk | **Independent** (adversarial) |
+| Evaluator | `map-debug:252`, `map-review:299-300` | quality scores + Monitor-severity audit | **Independent** (adversarial) |
+| FinalVerifier | `map-efficient:470`, `map-check:147` | whole-task PASS / REVISE / BLOCK | **Independent** (adversarial) |
+| Reflector | `map-learn:119` | extracted lessons / rules | **Independent** |
+| DocumentationReviewer | *(no skill dispatch — manual `Task(subagent_type="documentation-reviewer")` only)* | docs-vs-source-architecture verdict | **Independent**, *not auto-wired* — intentionally user-dispatchable (see below) |
+
+**Conclusion — no relay hops remain.** Each of the 8 pipeline-dispatched agents emits its own independent verdict; none is a pure relay. The only relay hops the doctrine condemns — the Self-MoA `synthesizer` (which paraphrased 3× Actor/Monitor outputs into one, adding no new verdict) and its `debate-arbiter` sibling — were already collapsed and removed in **PR #240** (commit `17c69bc`); their dispatch never existed in any skill, so they were also orphaned. That satisfies the "measured keep/collapse decision" for the Self-MoA Synthesizer hop named in #230: the decision was *collapse*, already executed.
+
+**DocumentationReviewer is a deliberate keep, not dead weight.** It has zero skill-initiated dispatch sites, but — unlike the removed `synthesizer`/`debate-arbiter` — it is **not a relay**: it produces a unique docs-vs-source-architecture verdict (external-URL validation, completeness scoring, consistency checks) that no other agent duplicates. Under the substance rule it *passes* the doctrine; its missing caller is a discoverability gap, not redundancy. It is therefore retained as an **optional, user-dispatchable** agent — invoke manually via `Task(subagent_type="documentation-reviewer", …)`. Wiring it into a pipeline (e.g. `/map-release`) is deferred feature work, out of scope for this docs-and-audit change. Re-evaluate the keep if no manual adoption emerges over the next few releases.
+
 ### .map/ Artifact Specifications
 
 MAP Framework stores workflow artifacts in the `.map/` directory. All artifacts follow JSON schemas defined in `src/mapify_cli/schemas.py`.
@@ -1134,6 +1160,8 @@ If you forked the skill-backed `/map-efficient` workflow, you must manually inte
 - `mcp__sequential-thinking__sequentialthinking`: Structure reasoning process
 
 ### 7. DocumentationReviewer
+
+**Dispatch status:** Optional / **user-dispatchable** — not auto-wired into any shipped MAP skill pipeline (no `subagent_type="documentation-reviewer"` dispatch site exists). Invoke manually via `Task(subagent_type="documentation-reviewer", …)`. Retained per the [Agent-Boundary Doctrine](#agent-boundary-doctrine) because it emits a unique, non-relay verdict. See that section for the audit.
 
 **Responsibility:** Check documentation completeness and correctness.
 

--- a/src/mapify_cli/templates/agents/documentation-reviewer.md
+++ b/src/mapify_cli/templates/agents/documentation-reviewer.md
@@ -2,9 +2,11 @@
 name: documentation-reviewer
 description: Reviews technical documentation for completeness, external dependencies, and architectural consistency
 model: sonnet
-version: 3.1.0
-last_updated: 2025-11-27
+version: 3.1.1
+last_updated: 2026-06-19
 ---
+
+> **Dispatch status:** Optional / user-dispatchable agent — not auto-wired into any shipped MAP skill pipeline (no `subagent_type="documentation-reviewer"` dispatch site exists). Invoke manually via `Task(subagent_type="documentation-reviewer", …)`. Retained per the Agent-Boundary Doctrine in `docs/ARCHITECTURE.md` because it emits a unique, non-relay verdict (docs-vs-source-architecture review).
 
 # QUICK REFERENCE (Read First)
 

--- a/src/mapify_cli/templates_src/agents/documentation-reviewer.md.jinja
+++ b/src/mapify_cli/templates_src/agents/documentation-reviewer.md.jinja
@@ -2,9 +2,11 @@
 name: documentation-reviewer
 description: Reviews technical documentation for completeness, external dependencies, and architectural consistency
 model: sonnet
-version: 3.1.0
-last_updated: 2025-11-27
+version: 3.1.1
+last_updated: 2026-06-19
 ---
+
+> **Dispatch status:** Optional / user-dispatchable agent — not auto-wired into any shipped MAP skill pipeline (no `subagent_type="documentation-reviewer"` dispatch site exists). Invoke manually via `Task(subagent_type="documentation-reviewer", …)`. Retained per the Agent-Boundary Doctrine in `docs/ARCHITECTURE.md` because it emits a unique, non-relay verdict (docs-vs-source-architecture review).
 
 # QUICK REFERENCE (Read First)
 

--- a/tests/test_agent_dispatch_audit.py
+++ b/tests/test_agent_dispatch_audit.py
@@ -1,0 +1,92 @@
+"""
+Enforces the Agent-Boundary Doctrine (issue #230).
+
+Every shipped agent must either:
+  - be dispatched by at least one skill (a ``subagent_type="<name>"`` site in a
+    skill ``*.jinja`` source), OR
+  - be explicitly listed as a documented, user-dispatchable / optional agent.
+
+This prevents a future agent from silently shipping with no caller (a "silent
+orphan") — the dead-weight class removed in PR #240 (the Self-MoA ``synthesizer``
+and ``debate-arbiter`` relays). It also pins ``documentation-reviewer`` as a
+*deliberate* keep: it emits a unique, non-relay verdict but has no skill dispatch,
+so it is retained as an optional agent and must carry a visible annotation.
+
+See docs/ARCHITECTURE.md → "Agent-Boundary Doctrine".
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+AGENTS_SRC = REPO / "src" / "mapify_cli" / "templates_src" / "agents"
+SKILLS_SRC = REPO / "src" / "mapify_cli" / "templates_src" / "skills"
+ARCHITECTURE = REPO / "docs" / "ARCHITECTURE.md"
+
+# Agents that intentionally have NO skill-initiated dispatch site. Retained per the
+# Agent-Boundary Doctrine because they emit a unique, non-relay verdict and are
+# invocable manually via Task(subagent_type="<name>"). Each MUST carry a
+# "Dispatch status:" annotation in its template so the undispatched state is deliberate.
+DOCUMENTED_OPTIONAL_AGENTS = {"documentation-reviewer"}
+
+_DISPATCH_RE = re.compile(r'subagent_type=["\']([a-z0-9-]+)["\']')
+
+
+def _shipped_agent_names() -> set[str]:
+    suffix = ".md.jinja"
+    return {p.name[: -len(suffix)] for p in AGENTS_SRC.glob("*.md.jinja")}
+
+
+def _dispatched_agent_names() -> set[str]:
+    names: set[str] = set()
+    for jinja in SKILLS_SRC.rglob("*.jinja"):
+        names.update(_DISPATCH_RE.findall(jinja.read_text(encoding="utf-8")))
+    return names
+
+
+def test_agent_and_dispatch_discovery_non_empty():
+    """Guard against a vacuous pass from a glob/path typo (silent empty discovery)."""
+    agents = _shipped_agent_names()
+    assert len(agents) >= 8, f"agent discovery looks empty/short: {sorted(agents)}"
+    dispatched = _dispatched_agent_names()
+    assert dispatched, "no subagent_type dispatch sites discovered — glob/path typo?"
+
+
+def test_every_agent_is_dispatched_or_documented_optional():
+    """No agent may ship without a caller unless explicitly marked optional."""
+    agents = _shipped_agent_names()
+    dispatched = _dispatched_agent_names()
+    silent_orphans = sorted(
+        a
+        for a in agents
+        if a not in dispatched and a not in DOCUMENTED_OPTIONAL_AGENTS
+    )
+    assert not silent_orphans, (
+        f"Silent orphan agent(s) shipped with no dispatch site and not marked "
+        f"optional: {silent_orphans}. Per the Agent-Boundary Doctrine, either "
+        f"dispatch them from a skill, add them to DOCUMENTED_OPTIONAL_AGENTS with a "
+        f"'Dispatch status:' annotation, or remove them (see PR #240)."
+    )
+
+
+def test_documented_optional_agents_exist_and_are_annotated():
+    """Optional-agent registry must have no stale entries and each must self-declare."""
+    agents = _shipped_agent_names()
+    for name in DOCUMENTED_OPTIONAL_AGENTS:
+        assert name in agents, (
+            f"DOCUMENTED_OPTIONAL_AGENTS lists {name!r} but no template "
+            f"{name}.md.jinja exists — stale entry."
+        )
+        text = (AGENTS_SRC / f"{name}.md.jinja").read_text(encoding="utf-8")
+        assert "Dispatch status:" in text, (
+            f"{name}.md.jinja must carry a 'Dispatch status:' annotation so its "
+            f"undispatched state is deliberate and visible."
+        )
+
+
+def test_doctrine_documented_in_architecture():
+    """The doctrine itself must stay documented (issue #230 deliverable)."""
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+    assert "Agent-Boundary Doctrine" in text, (
+        "docs/ARCHITECTURE.md must document the Agent-Boundary Doctrine (issue #230)."
+    )


### PR DESCRIPTION
## What

Resolves #230 — writes down the **Agent-Boundary Doctrine** and audits every live agent hand-off `independent | relay`.

### Doctrine (in `docs/ARCHITECTURE.md` → "Agent-Boundary Doctrine")
> Keep a separate sub-agent **only** when it adds an *independent / adversarial* perspective; **collapse** any *pure-relay* hop (a context whose only job is to paraphrase a prior agent's output, emitting no new verdict) into its caller.

It is a **substance rule, not a wiring rule** — what matters is whether the agent emits an independent verdict, not how many skills call it.

### Audit (ground truth = `subagent_type="…"` dispatch sites in skill `*.jinja` sources, **not** docs)
All 9 shipped agents classified with `file:line` dispatch citations. The 8 pipeline-dispatched agents (task-decomposer, research-agent, actor, monitor, predictor, evaluator, final-verifier, reflector) each emit an independent verdict — **none is a relay**.

**No relay hops remain.** The only relay hops the doctrine condemns — the Self-MoA `synthesizer` (paraphrased 3× Actor/Monitor into one, no new verdict) and `debate-arbiter` — were already collapsed/removed in **PR #240** (`17c69bc`). That is the keep/collapse decision acceptance criterion 3 names for the Synthesizer hop: the decision was *collapse*, already executed (the agent no longer exists, so a fresh cost/approval delta is moot).

### Orphan resolved: `documentation-reviewer` → deliberate keep
Verified repo-wide: it has **zero** skill dispatch sites. But unlike the removed relays it is **not a relay** — it emits a unique docs-vs-source-architecture verdict (URL validation, completeness scoring, consistency). Under the substance rule it *passes* the doctrine; its missing caller is a discoverability gap, not redundancy. Retained as an **optional, user-dispatchable** agent (`Task(subagent_type="documentation-reviewer", …)`), now self-declaring a `Dispatch status:` annotation. Wiring it into a pipeline is deferred feature work, out of scope here.

> Disposition decided via llm-council (unanimous on "keep + annotate", not remove or wire-in), per the convention to consult the council on changes with documented eval risk.

### Enforcement
`tests/test_agent_dispatch_audit.py` makes the invariant a gate: any agent shipped with no dispatch site and not in `DOCUMENTED_OPTIONAL_AGENTS` (with a `Dispatch status:` annotation) fails — a silent orphan can't recur. Includes a non-empty discovery guard.

## Why

#240 removed two orphaned relay agents but never wrote down the *criterion* that justified it. This codifies that criterion so future agent-boundary decisions are principled, and pins the one remaining ambiguity (`documentation-reviewer`) as a deliberate, documented choice.

## Testing

- `make check` → **2572 passed, 3 skipped**, lint clean, `check-render` confirms generated trees match `templates_src` (agent annotation rendered to `.claude/agents/` + `templates/agents/`).
- New test negative-proofed: planting a dummy undispatched agent turns the guard **red** (`Silent orphan agent(s): ['zzz-orphan-probe']`); removing it restores green.

## Scope notes

- Doc-and-audit change only. No runtime behavior change.
- Historical docs (e.g. `docs/model-tier-trigger-experiment.md`) left intact as dated records; only source-of-truth `ARCHITECTURE.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)