### PR TITLE
fix: declare pyyaml as a hard runtime dependency (closes #245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **PyYAML promoted to a hard runtime dependency (closes #245).** `pyyaml` was
+  declared only in the `test`/`dev` optional groups, so a normal install
+  (`uv tool install` / `pipx` / `pip install mapify-cli` without extras) shipped
+  without PyYAML. `project_config.load_map_config` then hit `ImportError`, warned
+  once, and **silently fell back to default config** — the user's entire
+  `.map/config.yaml` (`minimality`, `profile`, `compression_policy`, thresholds,
+  `language`, `prompt_layering`, …) was ignored by every config-dependent CLI path
+  (`minimality-report`, `mapify init` compression/sofa overrides). CI never caught
+  it because the dev/test groups *do* include `pyyaml`. Fix adds `pyyaml>=6.0.0` to
+  `[project].dependencies` in `pyproject.toml`. (The `.map/scripts/map_step_runner.py`
+  runner was unaffected — it reads config via a stdlib-only scalar parser — which is
+  why the defect hid.) Regression tests assert `pyyaml` is in the runtime dependency
+  table and that a non-default `.map/config.yaml` value actually loads.
+
 ### Changed
 - **Global `minimality` default flipped `off` → `lite` (Phase 3, closes #183).**
   The promotion gate (`mapify minimality-report`) reached `candidate` and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ dependencies = [
     "jinja2>=3.1,<4",
     "platformdirs>=4.0.0",
     "readchar>=4.0.0",
-    "questionary>=2.0.0"
+    "questionary>=2.0.0",
+    # mapify is a config-driven CLI: project_config.py loads .map/config.yaml via
+    # PyYAML on every config-dependent path (minimality-report, init overrides).
+    # It MUST be a hard runtime dep — a normal install (uv tool / pipx / pip
+    # without dev/test extras) otherwise ships without yaml, hits ImportError,
+    # and silently falls back to default config, ignoring the user's settings (#245).
+    "pyyaml>=6.0.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_pyyaml_dep.py
+++ b/tests/test_pyyaml_dep.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Regression tests for #245: PyYAML must be a hard runtime dependency.
+
+`mapify` is a config-driven CLI: ``project_config.load_map_config`` parses
+``.map/config.yaml`` via PyYAML on every config-dependent path. If PyYAML is
+declared only in the ``test``/``dev`` optional groups (as it was before #245),
+a normal install (``uv tool install`` / ``pipx`` / ``pip install mapify-cli``
+without extras) ships without yaml, hits ``ImportError``, and silently falls
+back to default config — the user's ``.map/config.yaml`` is ignored.
+
+CI never caught this because the dev/test groups *do* include pyyaml, so the
+guarding test here asserts on the declared dependency table, not on the import.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+from mapify_cli.config.project_config import load_map_config
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _runtime_dependencies() -> list[str]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    return list(data["project"]["dependencies"])
+
+
+def test_pyyaml_is_a_runtime_dependency() -> None:
+    """pyyaml must be in [project].dependencies, not only the dev/test extras.
+
+    Fails before #245 (pyyaml only in optional-dependencies); passes after.
+    """
+    runtime = _runtime_dependencies()
+    assert any(
+        req.lower().replace("_", "-").startswith("pyyaml") for req in runtime
+    ), (
+        "pyyaml missing from [project].dependencies — a normal install would "
+        f"ship without PyYAML and silently ignore .map/config.yaml (#245). "
+        f"Declared runtime deps: {runtime}"
+    )
+
+
+def test_pyyaml_importable_and_version_floor() -> None:
+    """PyYAML is installed and meets the >=6.0 floor declared in pyproject."""
+    assert tuple(int(x) for x in yaml.__version__.split(".")[:2]) >= (6, 0)
+
+
+def test_load_map_config_reads_non_default_value(tmp_path: Path) -> None:
+    """With PyYAML present, a non-default config value is actually loaded.
+
+    This is the behavioral half of #245: proves the config-driven CLI path
+    reads ``.map/config.yaml`` instead of degrading to defaults. The default
+    profile is ``full``; assert an explicit override round-trips.
+    """
+    map_dir = tmp_path / ".map"
+    map_dir.mkdir()
+    (map_dir / "config.yaml").write_text(
+        "profile: core\nminimality: full\n", encoding="utf-8"
+    )
+
+    cfg = load_map_config(tmp_path)
+
+    assert cfg.profile == "core"
+    assert cfg.minimality == "full"
+
+
+def test_load_map_config_falls_back_when_yaml_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The ImportError fallback path is intact: yaml=None -> defaults.
+
+    Simulates the broken-install state (no PyYAML) to lock in the documented
+    degradation: a missing yaml module yields defaults rather than crashing.
+    This guards the warn-and-default branch the runtime dep is meant to avoid
+    in production.
+    """
+    map_dir = tmp_path / ".map"
+    map_dir.mkdir()
+    (map_dir / "config.yaml").write_text("profile: core\n", encoding="utf-8")
+
+    monkeypatch.setattr("mapify_cli.config.project_config.yaml", None)
+
+    cfg = load_map_config(tmp_path)
+
+    # yaml unavailable -> default profile, config silently ignored
+    assert cfg.profile == "full"
+
+
+if __name__ == "__main__":  # pragma: no cover - manual debugging convenience
+    sys.exit(__import__("pytest").main([__file__, "-v"]))


### PR DESCRIPTION
## What changed
`pyyaml>=6.0.0` is now a hard runtime dependency in `[project].dependencies` (previously declared only in the `test`/`dev` optional groups).

## Why
`mapify` is a config-driven CLI: `project_config.load_map_config` parses `.map/config.yaml` via PyYAML on every config-dependent path. A normal install (`uv tool install` / `pipx` / `pip install mapify-cli` without extras) shipped **without** PyYAML, so `load_map_config` hit `ImportError`, warned once, and **silently fell back to default config** — the user's entire `.map/config.yaml` (`minimality`, `profile`, `compression_policy`, thresholds, `language`, `prompt_layering`, …) was ignored by `minimality-report` and `mapify init` compression/sofa overrides.

CI never caught it because the `dev`/`test` groups *do* include `pyyaml`. The `.map/scripts/map_step_runner.py` runner was unaffected (it reads config via a stdlib-only scalar parser), which is why the defect hid in CLI-only paths.

## How it was tested
- New `tests/test_pyyaml_dep.py`:
  - `test_pyyaml_is_a_runtime_dependency` — parses `pyproject.toml` `[project].dependencies` and asserts `pyyaml` is present. **Proven to fail without the fix** (negative-proof: stripping the line → red; restoring → green) and pass with it.
  - `test_pyyaml_importable_and_version_floor` — `>=6.0` floor.
  - `test_load_map_config_reads_non_default_value` — behavioral: a non-default `.map/config.yaml` (`profile: core`, `minimality: full`) actually loads.
  - `test_load_map_config_falls_back_when_yaml_missing` — locks in the `yaml=None` → defaults degradation.
- Full gate green: `make check` (2607 passed, 3 skipped) + `make lint` (ruff ✅, mypy ✅, pyright 0/0/0, hooks-lint ✅) + `make check-render` ✅.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)