### PR TITLE
fix: resume_from_plan parses ST-XXX from table rows

### DIFF
--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -3450,10 +3450,11 @@ def resume_from_plan(branch: str) -> dict:
         }
 
     # Extract subtask IDs from plan file (ST-XXX pattern)
+    # Matches heading style (### ST-001), table rows (| ST-001 | ...), and plain references
     import re
 
     plan_content = plan_file.read_text(encoding="utf-8")
-    subtask_ids = re.findall(r"###\s+(ST-\d+)", plan_content)
+    subtask_ids = re.findall(r"\bST-\d+\b", plan_content)
 
     if not subtask_ids:
         return {

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -3450,10 +3450,11 @@ def resume_from_plan(branch: str) -> dict:
         }
 
     # Extract subtask IDs from plan file (ST-XXX pattern)
+    # Matches heading style (### ST-001), table rows (| ST-001 | ...), and plain references
     import re
 
     plan_content = plan_file.read_text(encoding="utf-8")
-    subtask_ids = re.findall(r"###\s+(ST-\d+)", plan_content)
+    subtask_ids = re.findall(r"\bST-\d+\b", plan_content)
 
     if not subtask_ids:
         return {

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -3450,10 +3450,11 @@ def resume_from_plan(branch: str) -> dict:
         }
 
     # Extract subtask IDs from plan file (ST-XXX pattern)
+    # Matches heading style (### ST-001), table rows (| ST-001 | ...), and plain references
     import re
 
     plan_content = plan_file.read_text(encoding="utf-8")
-    subtask_ids = re.findall(r"###\s+(ST-\d+)", plan_content)
+    subtask_ids = re.findall(r"\bST-\d+\b", plan_content)
 
     if not subtask_ids:
         return {


### PR DESCRIPTION
## Summary

Fixes `resume_from_plan` failing to parse ST-XXX subtask IDs from markdown table rows generated by `/map-plan`.

**Root cause:** The regex `r"###\s+(ST-\d+)"` only matched heading-style entries (`### ST-001`) but the `/map-plan` template renders subtasks as a markdown table:

```
| ID | Title | concern | diff | risk | one-step | deps |
|----|-------|---------|------|------|----------|------|
| ST-001 | Migration 108 | data | small | medium | yes | — |
```

**Fix:** Broadened the regex to `r"\bST-\d+\b"` which matches ST-XXX IDs in any format — headings, table rows, or plain references.

## Testing

### Before (old regex — fails on table format)
```python
>>> re.findall(r"###\s+(ST-\d+)", "| ST-001 | foo |\n| ST-002 | bar |")
[]
```

### After (new regex — all formats)
```python
>>> re.findall(r"\bST-\d+\b", "### ST-001\n| ST-002 | foo |\n### ST-003\nST-004")
['ST-001', 'ST-002', 'ST-003', 'ST-004']
```

### Ruff
```bash
$ uv run ruff check src/ tests/
All checks passed!
```

### Template render
```bash
$ make render-templates
✅ Templates rendered
```

Closes #264
