### PR TITLE
fix(codex): merge hooks.json without managed metadata

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -258,6 +258,10 @@ This creates a Codex layout instead of `.claude/`:
 - `.codex/hooks.json` + `.codex/hooks/workflow-gate.py` — edit gate enforcement
 - `.map/scripts/` — shared orchestrator scripts (same as Claude provider)
 
+On reinstall or upgrade, MAP merges its `PreToolUse`/`Bash` workflow gate into
+an existing `.codex/hooks.json` instead of replacing project hook registrations.
+The installed `hooks.json` keeps Codex's strict top-level schema: only `hooks`.
+
 ### Using MAP with Codex
 
 ```bash

--- a/src/mapify_cli/delivery/codex_copier.py
+++ b/src/mapify_cli/delivery/codex_copier.py
@@ -8,8 +8,11 @@ Never touches .claude/.
 
 from __future__ import annotations
 
+import json
 import shutil
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 from mapify_cli.delivery.file_copier import (
     _extract_requires_block,
@@ -20,7 +23,11 @@ from mapify_cli.delivery.file_copier import (
     _warn_requires_skills,
     get_templates_dir,
 )
-from mapify_cli.delivery.managed_file_copier import copy_managed_file
+from mapify_cli.delivery.managed_file_copier import (
+    _assert_safe_dest,
+    _atomic_write,
+    copy_managed_file,
+)
 
 
 def _install_managed_file(
@@ -81,6 +88,129 @@ def _copy_tree(
 
 
 _EXEC_SUFFIXES = frozenset((".py", ".sh"))
+_CODEX_WORKFLOW_GATE_PATH = ".codex/hooks/workflow-gate.py"
+
+
+def _is_codex_workflow_gate_hook(hook: Any) -> bool:
+    """Return True for MAP's managed Codex workflow-gate command hook."""
+    if not isinstance(hook, dict):
+        return False
+    command = hook.get("command")
+    return isinstance(command, str) and _CODEX_WORKFLOW_GATE_PATH in command
+
+
+def _merge_codex_hook_entries(
+    existing_entries: Any,
+    template_entries: Any,
+) -> list[Any]:
+    """Merge MAP hook entries into existing Codex hook entries.
+
+    Existing project hooks are preserved. MAP-owned workflow-gate command hooks
+    are refreshed from the template and de-duplicated.
+    """
+    merged_entries: list[Any] = []
+    if isinstance(existing_entries, list):
+        for raw_entry in deepcopy(existing_entries):
+            if not isinstance(raw_entry, dict):
+                merged_entries.append(raw_entry)
+                continue
+
+            raw_hooks = raw_entry.get("hooks")
+            if not isinstance(raw_hooks, list):
+                merged_entries.append(raw_entry)
+                continue
+
+            cleaned_hooks = [
+                hook for hook in raw_hooks if not _is_codex_workflow_gate_hook(hook)
+            ]
+            if not cleaned_hooks and len(cleaned_hooks) != len(raw_hooks):
+                continue
+
+            raw_entry["hooks"] = cleaned_hooks
+            merged_entries.append(raw_entry)
+
+    if not isinstance(template_entries, list):
+        return merged_entries
+
+    for template_entry in template_entries:
+        if not isinstance(template_entry, dict):
+            if template_entry not in merged_entries:
+                merged_entries.append(deepcopy(template_entry))
+            continue
+
+        matcher = template_entry.get("matcher")
+        template_hooks = template_entry.get("hooks")
+        target = None
+        if isinstance(matcher, str) and isinstance(template_hooks, list):
+            for entry in merged_entries:
+                if (
+                    isinstance(entry, dict)
+                    and entry.get("matcher") == matcher
+                    and isinstance(entry.get("hooks"), list)
+                ):
+                    target = entry
+                    break
+
+        if target is None:
+            if template_entry not in merged_entries:
+                merged_entries.append(deepcopy(template_entry))
+            continue
+
+        assert isinstance(template_hooks, list)
+        target_hooks = target["hooks"]
+        assert isinstance(target_hooks, list)
+        for hook in template_hooks:
+            if hook not in target_hooks:
+                target_hooks.append(deepcopy(hook))
+
+    return merged_entries
+
+
+def _merge_codex_hooks_json(
+    existing_data: dict[str, Any] | None,
+    template_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Return Codex-valid hooks.json containing only the top-level hooks key."""
+    existing_hooks = existing_data.get("hooks") if existing_data else None
+    template_hooks = template_data.get("hooks")
+
+    merged_hooks: dict[str, Any] = (
+        deepcopy(existing_hooks) if isinstance(existing_hooks, dict) else {}
+    )
+
+    if isinstance(template_hooks, dict):
+        for event_name, template_entries in template_hooks.items():
+            merged_hooks[event_name] = _merge_codex_hook_entries(
+                merged_hooks.get(event_name),
+                template_entries,
+            )
+
+    return {"hooks": merged_hooks}
+
+
+def _load_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _install_codex_hooks_json(src: Path, dst: Path) -> None:
+    """Install .codex/hooks.json without MAP metadata and merge project hooks."""
+    template_data = _load_json_object(src)
+    if template_data is None:
+        raise ValueError(f"Invalid Codex hooks template JSON: {src}")
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_data: dict[str, Any] | None = None
+    if dst.exists():
+        _assert_safe_dest(dst)
+        existing_data = _load_json_object(dst)
+
+    merged = _merge_codex_hooks_json(existing_data, template_data)
+    _atomic_write(dst, json.dumps(merged, indent=2, ensure_ascii=False) + "\n")
 
 
 def create_codex_files(project_path: Path) -> dict[str, int]:
@@ -96,8 +226,8 @@ def create_codex_files(project_path: Path) -> dict[str, int]:
 
     Watched files (skills, agents, config, AGENTS.md, hooks) are installed
     fence-aware so a re-install preserves any user content below the fence;
-    hooks.json is JSON (fully-managed via _map_managed); .map/scripts is
-    MAP-owned (fenced=False, skip-if-exists).
+    hooks.json is merged without MAP metadata because Codex validates top-level
+    keys strictly; .map/scripts is MAP-owned (fenced=False, skip-if-exists).
 
     Skips .map/scripts/ if the directory already exists.
     Never creates or modifies any .claude/ path.
@@ -186,12 +316,13 @@ def create_codex_files(project_path: Path) -> dict[str, int]:
 
     # ------------------------------------------------------------------
     # 4. Hooks (hooks.json + hooks/*.py)
-    #    hooks.json is JSON (fully-managed via _map_managed, no fence);
+    #    hooks.json must remain Codex-schema-valid, so install it with a
+    #    Codex-specific merge instead of the generic _map_managed JSON copier.
     #    hooks/*.py are watched (fence-aware) with exec bits preserved.
     # ------------------------------------------------------------------
     hooks_json_src = codex_templates / "hooks.json"
     if hooks_json_src.exists():
-        _install_managed_file(hooks_json_src, codex_dir / "hooks.json", version)
+        _install_codex_hooks_json(hooks_json_src, codex_dir / "hooks.json")
         counts["hooks"] += 1
 
     hooks_dir_src = codex_templates / "hooks"

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -1636,6 +1636,9 @@ class TestCodexProvider:
 
         # Verify hook command uses quoted git-root-resolved path
         hooks_data = _json.loads(hooks_json_path.read_text())
+        assert set(hooks_data) == {"hooks"}, (
+            ".codex/hooks.json must not include MAP-only top-level metadata"
+        )
         command = hooks_data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
         assert (
             "$(git rev-parse --show-toplevel)" in command
@@ -1737,6 +1740,116 @@ class TestCodexProvider:
         assert (
             "Bash" in matchers
         ), f"hooks.json PreToolUse must have a 'Bash' matcher, got: {matchers}"
+
+    def test_ac18b_hooks_json_merges_existing_project_hooks(self, tmp_path):
+        """AC-18b: Codex init preserves project hooks and removes legacy MAP metadata."""
+        project = tmp_path / "existing_codex_hooks"
+        project.mkdir()
+        hooks_json_path = project / ".codex" / "hooks.json"
+        hooks_json_path.parent.mkdir(parents=True)
+        hooks_json_path.write_text(
+            json.dumps(
+                {
+                    "_map_managed": {"generated_by": "mapify-cli"},
+                    "customTopLevel": "must be dropped for Codex schema",
+                    "hooks": {
+                        "SessionStart": [
+                            {"hooks": [{"type": "command", "command": "echo session"}]}
+                        ],
+                        "UserPromptSubmit": [
+                            {"hooks": [{"type": "command", "command": "echo prompt"}]}
+                        ],
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    {
+                                        "type": "command",
+                                        "command": "echo existing bash",
+                                        "timeout": 3,
+                                    },
+                                    {
+                                        "type": "command",
+                                        "command": "python3 old/.codex/hooks/workflow-gate.py",
+                                        "timeout": 1,
+                                    },
+                                ],
+                            },
+                            {
+                                "matcher": "Read",
+                                "hooks": [{"type": "command", "command": "echo read"}],
+                            },
+                        ],
+                        "PostToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [{"type": "command", "command": "echo post"}],
+                            }
+                        ],
+                        "Stop": [
+                            {"hooks": [{"type": "command", "command": "echo stop"}]}
+                        ],
+                    },
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        local_runner = CliRunner()
+        os.chdir(project)
+        result = local_runner.invoke(
+            app, ["init", ".", "--provider", "codex", "--no-git", "--force"]
+        )
+        assert result.exit_code == 0, f"init failed:\n{result.output}"
+
+        hooks_data = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+        assert set(hooks_data) == {"hooks"}
+        hooks = hooks_data["hooks"]
+        assert hooks["SessionStart"][0]["hooks"][0]["command"] == "echo session"
+        assert hooks["UserPromptSubmit"][0]["hooks"][0]["command"] == "echo prompt"
+        assert hooks["PostToolUse"][0]["hooks"][0]["command"] == "echo post"
+        assert hooks["Stop"][0]["hooks"][0]["command"] == "echo stop"
+
+        pre_tool_use = hooks["PreToolUse"]
+        bash_entries = [
+            entry
+            for entry in pre_tool_use
+            if isinstance(entry, dict) and entry.get("matcher") == "Bash"
+        ]
+        assert len(bash_entries) == 1
+        bash_hooks = bash_entries[0]["hooks"]
+        commands = [hook["command"] for hook in bash_hooks]
+        assert "echo existing bash" in commands
+        assert "python3 old/.codex/hooks/workflow-gate.py" not in commands
+        workflow_gate_commands = [
+            command for command in commands if ".codex/hooks/workflow-gate.py" in command
+        ]
+        assert len(workflow_gate_commands) == 1
+        assert any(
+            entry.get("matcher") == "Read"
+            and entry["hooks"][0]["command"] == "echo read"
+            for entry in pre_tool_use
+            if isinstance(entry, dict)
+        )
+
+        result = local_runner.invoke(
+            app, ["init", ".", "--provider", "codex", "--no-git", "--force"]
+        )
+        assert result.exit_code == 0, f"second init failed:\n{result.output}"
+        hooks_data = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+        all_commands = [
+            hook["command"]
+            for entry in hooks_data["hooks"]["PreToolUse"]
+            if isinstance(entry, dict)
+            for hook in entry.get("hooks", [])
+            if isinstance(hook, dict)
+        ]
+        assert (
+            sum(".codex/hooks/workflow-gate.py" in command for command in all_commands)
+            == 1
+        )
 
     # ------------------------------------------------------------------ #
     # AC-19: Discovery paths — skills/agents/config at expected locations #


### PR DESCRIPTION
## Summary
- install Codex hooks.json through a Codex-specific merge path instead of generic managed JSON metadata injection
- preserve existing project hook registrations while refreshing/deduplicating MAP's PreToolUse/Bash workflow-gate hook
- document the reinstall/upgrade merge behavior and add regression coverage

Fixes #270

## Verification
- uv run pytest tests/test_mapify_cli.py::TestCodexProvider::test_ac12_hooks_created tests/test_mapify_cli.py::TestCodexProvider::test_ac18_hooks_matcher_is_bash tests/test_mapify_cli.py::TestCodexProvider::test_ac18b_hooks_json_merges_existing_project_hooks -v
- uv run ruff check src/ tests/
- uv run mypy src/
- uv run pyright src/
- make check
- uv run mapify init /tmp/mapify-codex-hooks-smoke-270 --provider codex --no-git --force --mcp none
