### PR TITLE
[codex] Fix plan resume low-overlap mismatch

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -52,11 +52,13 @@ GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
 # preflight diverts a brand-new request to `goal_mismatch` (instead of falsely
 # reporting "plan complete" / silently clobbering the prior plan) ONLY on strong
 # evidence: both the existing goal and the incoming request must carry at least
-# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and their containment (shared
-# tokens / smaller significant-token set) must fall below
-# RESUME_GOAL_MISMATCH_CONTAINMENT. Conservative by design so a legitimate resume
-# with a shorter paraphrase is never falsely diverted.
+# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and either containment
+# (shared tokens / smaller significant-token set) or Jaccard overlap must fall
+# below the mismatch floor. Conservative by design so a legitimate resume with a
+# shorter paraphrase is rarely diverted, but a few generic shared domain terms
+# cannot falsely resume an unrelated completed plan.
 RESUME_GOAL_MISMATCH_CONTAINMENT = 0.25
+RESUME_GOAL_MISMATCH_OVERLAP = 0.10
 RESUME_MIN_TOKENS_FOR_MISMATCH = 2
 
 
@@ -10966,8 +10968,9 @@ def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
       before planning the new goal, with operator confirmation.
 
     Goal comparison is a deterministic token-overlap heuristic (see
-    RESUME_GOAL_MISMATCH_CONTAINMENT) — intentionally conservative so a real
-    resume with a shorter paraphrase is never falsely diverted.
+    RESUME_GOAL_MISMATCH_CONTAINMENT / RESUME_GOAL_MISMATCH_OVERLAP) —
+    intentionally conservative so a real resume with a shorter paraphrase is
+    rarely diverted.
     """
     branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
@@ -11034,15 +11037,24 @@ def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
         and min_len >= RESUME_MIN_TOKENS_FOR_MISMATCH
     )
 
+    mismatch_reasons = []
     if comparable and containment < RESUME_GOAL_MISMATCH_CONTAINMENT:
+        mismatch_reasons.append(
+            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}"
+        )
+    if comparable and overlap < RESUME_GOAL_MISMATCH_OVERLAP:
+        mismatch_reasons.append(
+            f"goal-overlap {overlap} < {RESUME_GOAL_MISMATCH_OVERLAP}"
+        )
+
+    if mismatch_reasons:
         verdict = "goal_mismatch"
         snippet = " ".join(existing_goal.split())
         if len(snippet) > 160:
             snippet = snippet[:157].rstrip() + "..."
         recommendation = (
             f"The existing plan on branch '{branch_name}' targets a DIFFERENT "
-            f"goal than the current request (goal-overlap {overlap}, "
-            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}). "
+            f"goal than the current request ({', '.join(mismatch_reasons)}). "
             f'Existing goal: "{snippet}". Do NOT report "plan complete" / STOP. '
             f"Archive or rename the prior .map/{branch_name}/ artifacts (or run "
             "/map-plan on a fresh branch) so the completed plan is preserved, "

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -52,11 +52,13 @@ GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
 # preflight diverts a brand-new request to `goal_mismatch` (instead of falsely
 # reporting "plan complete" / silently clobbering the prior plan) ONLY on strong
 # evidence: both the existing goal and the incoming request must carry at least
-# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and their containment (shared
-# tokens / smaller significant-token set) must fall below
-# RESUME_GOAL_MISMATCH_CONTAINMENT. Conservative by design so a legitimate resume
-# with a shorter paraphrase is never falsely diverted.
+# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and either containment
+# (shared tokens / smaller significant-token set) or Jaccard overlap must fall
+# below the mismatch floor. Conservative by design so a legitimate resume with a
+# shorter paraphrase is rarely diverted, but a few generic shared domain terms
+# cannot falsely resume an unrelated completed plan.
 RESUME_GOAL_MISMATCH_CONTAINMENT = 0.25
+RESUME_GOAL_MISMATCH_OVERLAP = 0.10
 RESUME_MIN_TOKENS_FOR_MISMATCH = 2
 
 
@@ -10966,8 +10968,9 @@ def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
       before planning the new goal, with operator confirmation.
 
     Goal comparison is a deterministic token-overlap heuristic (see
-    RESUME_GOAL_MISMATCH_CONTAINMENT) — intentionally conservative so a real
-    resume with a shorter paraphrase is never falsely diverted.
+    RESUME_GOAL_MISMATCH_CONTAINMENT / RESUME_GOAL_MISMATCH_OVERLAP) —
+    intentionally conservative so a real resume with a shorter paraphrase is
+    rarely diverted.
     """
     branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
@@ -11034,15 +11037,24 @@ def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
         and min_len >= RESUME_MIN_TOKENS_FOR_MISMATCH
     )
 
+    mismatch_reasons = []
     if comparable and containment < RESUME_GOAL_MISMATCH_CONTAINMENT:
+        mismatch_reasons.append(
+            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}"
+        )
+    if comparable and overlap < RESUME_GOAL_MISMATCH_OVERLAP:
+        mismatch_reasons.append(
+            f"goal-overlap {overlap} < {RESUME_GOAL_MISMATCH_OVERLAP}"
+        )
+
+    if mismatch_reasons:
         verdict = "goal_mismatch"
         snippet = " ".join(existing_goal.split())
         if len(snippet) > 160:
             snippet = snippet[:157].rstrip() + "..."
         recommendation = (
             f"The existing plan on branch '{branch_name}' targets a DIFFERENT "
-            f"goal than the current request (goal-overlap {overlap}, "
-            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}). "
+            f"goal than the current request ({', '.join(mismatch_reasons)}). "
             f'Existing goal: "{snippet}". Do NOT report "plan complete" / STOP. '
             f"Archive or rename the prior .map/{branch_name}/ artifacts (or run "
             "/map-plan on a fresh branch) so the completed plan is preserved, "

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -52,11 +52,13 @@ GOAL_HEADING_RE = r"## (?:Goal|Overview)\n(.*?)(?=\n##|\Z)"
 # preflight diverts a brand-new request to `goal_mismatch` (instead of falsely
 # reporting "plan complete" / silently clobbering the prior plan) ONLY on strong
 # evidence: both the existing goal and the incoming request must carry at least
-# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and their containment (shared
-# tokens / smaller significant-token set) must fall below
-# RESUME_GOAL_MISMATCH_CONTAINMENT. Conservative by design so a legitimate resume
-# with a shorter paraphrase is never falsely diverted.
+# RESUME_MIN_TOKENS_FOR_MISMATCH significant tokens, and either containment
+# (shared tokens / smaller significant-token set) or Jaccard overlap must fall
+# below the mismatch floor. Conservative by design so a legitimate resume with a
+# shorter paraphrase is rarely diverted, but a few generic shared domain terms
+# cannot falsely resume an unrelated completed plan.
 RESUME_GOAL_MISMATCH_CONTAINMENT = 0.25
+RESUME_GOAL_MISMATCH_OVERLAP = 0.10
 RESUME_MIN_TOKENS_FOR_MISMATCH = 2
 
 
@@ -10966,8 +10968,9 @@ def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
       before planning the new goal, with operator confirmation.
 
     Goal comparison is a deterministic token-overlap heuristic (see
-    RESUME_GOAL_MISMATCH_CONTAINMENT) — intentionally conservative so a real
-    resume with a shorter paraphrase is never falsely diverted.
+    RESUME_GOAL_MISMATCH_CONTAINMENT / RESUME_GOAL_MISMATCH_OVERLAP) —
+    intentionally conservative so a real resume with a shorter paraphrase is
+    rarely diverted.
     """
     branch_name = _sanitize_branch(branch) if branch else get_branch_name()
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
@@ -11034,15 +11037,24 @@ def check_plan_resume(request: str = "", branch: Optional[str] = None) -> dict:
         and min_len >= RESUME_MIN_TOKENS_FOR_MISMATCH
     )
 
+    mismatch_reasons = []
     if comparable and containment < RESUME_GOAL_MISMATCH_CONTAINMENT:
+        mismatch_reasons.append(
+            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}"
+        )
+    if comparable and overlap < RESUME_GOAL_MISMATCH_OVERLAP:
+        mismatch_reasons.append(
+            f"goal-overlap {overlap} < {RESUME_GOAL_MISMATCH_OVERLAP}"
+        )
+
+    if mismatch_reasons:
         verdict = "goal_mismatch"
         snippet = " ".join(existing_goal.split())
         if len(snippet) > 160:
             snippet = snippet[:157].rstrip() + "..."
         recommendation = (
             f"The existing plan on branch '{branch_name}' targets a DIFFERENT "
-            f"goal than the current request (goal-overlap {overlap}, "
-            f"containment {containment} < {RESUME_GOAL_MISMATCH_CONTAINMENT}). "
+            f"goal than the current request ({', '.join(mismatch_reasons)}). "
             f'Existing goal: "{snippet}". Do NOT report "plan complete" / STOP. '
             f"Archive or rename the prior .map/{branch_name}/ artifacts (or run "
             "/map-plan on a fresh branch) so the completed plan is preserved, "

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -1513,6 +1513,29 @@ def test_check_plan_resume_goal_mismatch_issue_166(branch_workspace):
     assert "Analysis" in result["recommendation"]
 
 
+def test_check_plan_resume_goal_mismatch_issue_274_low_overlap(branch_workspace):
+    # Repro of issue #274: a few generic branch-wide domain terms can inflate
+    # containment on a short request, but near-zero Jaccard overlap still means
+    # this is a different goal and must not be resumed as "plan complete".
+    _write_completed_plan(
+        branch_workspace,
+        "Address actionable reviewer comments on yc quantum PR 3184 "
+        "IngressConfig restructure contour nginx ingress validation gateway "
+        "route listener source cluster patch cleanup tests docs followup "
+        "cert-manager annotations rollout ordering",
+    )
+
+    result = map_step_runner.check_plan_resume(
+        "contour nginx ingress fresh install version cutover helper default"
+    )
+
+    assert result["verdict"] == "goal_mismatch"
+    assert result["containment"] >= map_step_runner.RESUME_GOAL_MISMATCH_CONTAINMENT
+    assert result["overlap"] < map_step_runner.RESUME_GOAL_MISMATCH_OVERLAP
+    assert {"contour", "nginx"}.issubset(set(result["shared_terms"]))
+    assert "goal-overlap" in result["recommendation"]
+
+
 def test_check_plan_resume_empty_request_defaults_to_resume(branch_workspace):
     # A bare `/map-plan` resume (no request text) must preserve the prior
     # "step_state => complete" behavior — never divert to goal_mismatch.


### PR DESCRIPTION
## Summary

- add a low Jaccard overlap floor to check_plan_resume so generic shared domain tokens cannot falsely return resume
- report the concrete mismatch reason in the recommendation
- add a regression test for #274 and render generated templates

Fixes #274

## Validation

- uv run pytest tests/test_map_step_runner.py -k check_plan_resume -v
- uv run pytest tests/test_map_step_runner.py tests/test_template_render.py -v
- make check