### PR TITLE
fix: validate MAP-only declared artifacts by filesystem, not git diff (closes #277)

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -11506,6 +11506,39 @@ def _is_test_path(path: str) -> bool:
     return False
 
 
+# Framework-managed artifact trees. These are gitignored (or otherwise stripped
+# from the diff surface), so a git-diff-based change detector can never witness
+# them. The mutation-boundary direction strips them as non-scope-creep; the
+# declared-but-not-written direction must instead validate them by filesystem
+# existence (see ``_map_artifact_written``).
+_MAP_INTERNAL_ARTIFACT_PREFIXES = (".map/", ".codex/", ".agents/")
+
+
+def _is_map_internal_artifact(path: str) -> bool:
+    """True when ``path`` lives under a framework-managed artifact tree.
+
+    Such paths are gitignored, so ``git diff``/``git status`` never surface them
+    and ``_current_subtask_changed_files`` strips them — a diff-based "was it
+    written?" check would false-positive every MAP-only subtask as truncated.
+    """
+    return path.startswith(_MAP_INTERNAL_ARTIFACT_PREFIXES)
+
+
+def _map_artifact_written(path: str, project_dir: Path) -> bool:
+    """True when a declared MAP-internal artifact exists on disk with content.
+
+    "Written" for a gitignored artifact means the file exists and is non-empty.
+    An empty file is treated as *not* written — that is exactly the truncated /
+    incomplete-edit signal this detector exists to catch. Any ``OSError`` (e.g.
+    the path resolves to a directory) is treated as not written.
+    """
+    try:
+        artifact = project_dir / path
+        return artifact.is_file() and artifact.stat().st_size > 0
+    except OSError:
+        return False
+
+
 def _current_subtask_changed_files(
     branch_name: str, subtask_id: str, project_dir: Path
 ) -> Optional[set[str]]:
@@ -11570,12 +11603,7 @@ def _current_subtask_changed_files(
             if path:
                 changed.add(path)
 
-    changed = {
-        p for p in changed
-        if not p.startswith(".map/")
-        and not p.startswith(".codex/")
-        and not p.startswith(".agents/")
-    }
+    changed = {p for p in changed if not _is_map_internal_artifact(p)}
 
     baseline_path = _subtask_baseline_path(branch_name, subtask_id, project_dir)
     if baseline_path.exists():
@@ -11735,6 +11763,15 @@ def detect_actor_files_changed_mismatch(
     - THIS function checks *declared-but-not-written* only.  The load-bearing
       field is ``declared_not_written``.
 
+    Declared files are validated in two ways depending on their tree:
+    - **git-tracked files** are validated against the git diff (``actual``).
+    - **MAP-internal artifacts** (``.map/``, ``.codex/``, ``.agents/``) are
+      gitignored and stripped from the diff surface, so they are validated by
+      filesystem existence + non-empty content instead. Without this split a
+      subtask whose only declared artifact is e.g.
+      ``.map/<branch>/verification-summary.md`` would always false-positive as
+      truncated even though the file exists (see issue #277).
+
     Returns::
 
         {
@@ -11755,52 +11792,83 @@ def detect_actor_files_changed_mismatch(
     branch_name = _sanitize_branch(branch)
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
 
-    actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
-    if actual_set is None:
-        # Intent: fail safe to mismatch so the gate cannot pass blindly.
-        declared_sorted = sorted(d.strip() for d in (declared_files or []) if d.strip())
-        return {
-            "status": "unknown",
-            "subtask_id": subtask_id,
-            "declared": declared_sorted,
-            "actual": [],
-            "declared_not_written": declared_sorted,
-            "status_mismatch": True,
-            "recovery_instruction": (
-                "git diff unavailable (fail-safe — actual changes were NOT "
-                f"consulted): treating all declared files as unwritten: {declared_sorted}. "
-                "Re-invoke the Actor to finish any truncated edits and re-run this "
-                "check once git is available; do NOT record the subtask until "
-                "git diff --name-only covers every declared file."
-            ),
-            "reason": (
-                "could not compute the actual diff (git unavailable) — "
-                "assuming mismatch as a fail-safe."
-            ),
-        }
-
     declared = [d.strip() for d in (declared_files or []) if d.strip()]
-    declared_not_written = sorted(d for d in declared if d not in actual_set)
+    map_declared = [d for d in declared if _is_map_internal_artifact(d)]
+    git_declared = [d for d in declared if not _is_map_internal_artifact(d)]
+
+    # MAP-internal artifacts are gitignored, so the diff surface can never
+    # witness them. Validate them by filesystem existence + non-empty content
+    # instead — independent of git availability (fixes issue #277).
+    map_not_written = sorted(
+        d for d in map_declared if not _map_artifact_written(d, project_dir)
+    )
+
+    status = "ok"
+    reason = ""
+    actual_list: list[str] = []
+    git_not_written: list[str] = []
+
+    # Only consult git when there are git-tracked declared files to validate.
+    # A MAP-only subtask needs no diff, so a git error must not force it into a
+    # false mismatch.
+    if git_declared:
+        actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+        if actual_set is None:
+            # Intent: fail safe to mismatch so the gate cannot pass blindly on a
+            # git error — but only for the git-tracked files. MAP artifacts were
+            # already validated against the filesystem above.
+            status = "unknown"
+            reason = (
+                "could not compute the actual diff (git unavailable) — "
+                "assuming the git-tracked declared files are unwritten as a "
+                "fail-safe."
+            )
+            git_not_written = sorted(git_declared)
+        else:
+            actual_list = sorted(actual_set)
+            git_not_written = sorted(d for d in git_declared if d not in actual_set)
+
+    declared_not_written = sorted([*git_not_written, *map_not_written])
     status_mismatch = bool(declared_not_written)
 
     recovery_instruction = ""
     if status_mismatch:
-        recovery_instruction = (
-            f"Actor declared files it did not write: {declared_not_written}. "
-            "Its previous response was likely truncated mid-edit — re-invoke "
-            "the Actor to finish those files; do NOT record the subtask until "
-            "git diff --name-only covers every declared file."
+        parts: list[str] = []
+        if git_not_written:
+            if status == "unknown":
+                parts.append(
+                    "git diff unavailable (fail-safe — actual changes were NOT "
+                    "consulted): treating git-tracked declared files as "
+                    f"unwritten: {git_not_written}."
+                )
+            else:
+                parts.append(
+                    "Actor declared git-tracked files it did not write: "
+                    f"{git_not_written}. Its previous response was likely "
+                    "truncated mid-edit — re-invoke the Actor to finish those "
+                    "files."
+                )
+        if map_not_written:
+            parts.append(
+                "Declared MAP artifacts are missing or empty on disk: "
+                f"{map_not_written}. Re-invoke the Actor to write them."
+            )
+        parts.append(
+            "Do NOT record the subtask until every declared file is written "
+            "(git diff --name-only covers git-tracked files; MAP artifacts must "
+            "exist on disk with content)."
         )
+        recovery_instruction = " ".join(parts)
 
     return {
-        "status": "ok",
+        "status": status,
         "subtask_id": subtask_id,
         "declared": sorted(declared),
-        "actual": sorted(actual_set),
+        "actual": actual_list,
         "declared_not_written": declared_not_written,
         "status_mismatch": status_mismatch,
         "recovery_instruction": recovery_instruction,
-        "reason": "",
+        "reason": reason,
     }
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`detect_actor_files_changed_mismatch` no longer false-positives on MAP-only subtask artifacts (closes #277).** The actor files-changed gate validated every declared file against `_current_subtask_changed_files`, which derives from `git diff`/`git status` and strips the gitignored framework trees (`.map/`, `.codex/`, `.agents/`). A subtask whose only declared `affected_files` entry was a MAP artifact (e.g. `.map/<branch>/verification-summary.md`) therefore always reported `status_mismatch=true` with a false "Actor declared files it did not write" recovery instruction, making MAP-only documentation/verification subtasks look like truncated actor edits. The detector now partitions declared files: git-tracked files keep the diff check, while MAP-internal artifacts are validated by filesystem existence + non-empty content (a missing or empty artifact is still a real mismatch). MAP-artifact validation is independent of git availability, so a MAP-only subtask is never forced into a false mismatch by a git error. A new shared `_is_map_internal_artifact` helper de-duplicates the framework-tree prefix list used by both the strip filter and the new validation path.
+
 ## [3.20.0] - 2026-06-26
 
 ### Added

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -11506,6 +11506,39 @@ def _is_test_path(path: str) -> bool:
     return False
 
 
+# Framework-managed artifact trees. These are gitignored (or otherwise stripped
+# from the diff surface), so a git-diff-based change detector can never witness
+# them. The mutation-boundary direction strips them as non-scope-creep; the
+# declared-but-not-written direction must instead validate them by filesystem
+# existence (see ``_map_artifact_written``).
+_MAP_INTERNAL_ARTIFACT_PREFIXES = (".map/", ".codex/", ".agents/")
+
+
+def _is_map_internal_artifact(path: str) -> bool:
+    """True when ``path`` lives under a framework-managed artifact tree.
+
+    Such paths are gitignored, so ``git diff``/``git status`` never surface them
+    and ``_current_subtask_changed_files`` strips them — a diff-based "was it
+    written?" check would false-positive every MAP-only subtask as truncated.
+    """
+    return path.startswith(_MAP_INTERNAL_ARTIFACT_PREFIXES)
+
+
+def _map_artifact_written(path: str, project_dir: Path) -> bool:
+    """True when a declared MAP-internal artifact exists on disk with content.
+
+    "Written" for a gitignored artifact means the file exists and is non-empty.
+    An empty file is treated as *not* written — that is exactly the truncated /
+    incomplete-edit signal this detector exists to catch. Any ``OSError`` (e.g.
+    the path resolves to a directory) is treated as not written.
+    """
+    try:
+        artifact = project_dir / path
+        return artifact.is_file() and artifact.stat().st_size > 0
+    except OSError:
+        return False
+
+
 def _current_subtask_changed_files(
     branch_name: str, subtask_id: str, project_dir: Path
 ) -> Optional[set[str]]:
@@ -11570,12 +11603,7 @@ def _current_subtask_changed_files(
             if path:
                 changed.add(path)
 
-    changed = {
-        p for p in changed
-        if not p.startswith(".map/")
-        and not p.startswith(".codex/")
-        and not p.startswith(".agents/")
-    }
+    changed = {p for p in changed if not _is_map_internal_artifact(p)}
 
     baseline_path = _subtask_baseline_path(branch_name, subtask_id, project_dir)
     if baseline_path.exists():
@@ -11735,6 +11763,15 @@ def detect_actor_files_changed_mismatch(
     - THIS function checks *declared-but-not-written* only.  The load-bearing
       field is ``declared_not_written``.
 
+    Declared files are validated in two ways depending on their tree:
+    - **git-tracked files** are validated against the git diff (``actual``).
+    - **MAP-internal artifacts** (``.map/``, ``.codex/``, ``.agents/``) are
+      gitignored and stripped from the diff surface, so they are validated by
+      filesystem existence + non-empty content instead. Without this split a
+      subtask whose only declared artifact is e.g.
+      ``.map/<branch>/verification-summary.md`` would always false-positive as
+      truncated even though the file exists (see issue #277).
+
     Returns::
 
         {
@@ -11755,52 +11792,83 @@ def detect_actor_files_changed_mismatch(
     branch_name = _sanitize_branch(branch)
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
 
-    actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
-    if actual_set is None:
-        # Intent: fail safe to mismatch so the gate cannot pass blindly.
-        declared_sorted = sorted(d.strip() for d in (declared_files or []) if d.strip())
-        return {
-            "status": "unknown",
-            "subtask_id": subtask_id,
-            "declared": declared_sorted,
-            "actual": [],
-            "declared_not_written": declared_sorted,
-            "status_mismatch": True,
-            "recovery_instruction": (
-                "git diff unavailable (fail-safe — actual changes were NOT "
-                f"consulted): treating all declared files as unwritten: {declared_sorted}. "
-                "Re-invoke the Actor to finish any truncated edits and re-run this "
-                "check once git is available; do NOT record the subtask until "
-                "git diff --name-only covers every declared file."
-            ),
-            "reason": (
-                "could not compute the actual diff (git unavailable) — "
-                "assuming mismatch as a fail-safe."
-            ),
-        }
-
     declared = [d.strip() for d in (declared_files or []) if d.strip()]
-    declared_not_written = sorted(d for d in declared if d not in actual_set)
+    map_declared = [d for d in declared if _is_map_internal_artifact(d)]
+    git_declared = [d for d in declared if not _is_map_internal_artifact(d)]
+
+    # MAP-internal artifacts are gitignored, so the diff surface can never
+    # witness them. Validate them by filesystem existence + non-empty content
+    # instead — independent of git availability (fixes issue #277).
+    map_not_written = sorted(
+        d for d in map_declared if not _map_artifact_written(d, project_dir)
+    )
+
+    status = "ok"
+    reason = ""
+    actual_list: list[str] = []
+    git_not_written: list[str] = []
+
+    # Only consult git when there are git-tracked declared files to validate.
+    # A MAP-only subtask needs no diff, so a git error must not force it into a
+    # false mismatch.
+    if git_declared:
+        actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+        if actual_set is None:
+            # Intent: fail safe to mismatch so the gate cannot pass blindly on a
+            # git error — but only for the git-tracked files. MAP artifacts were
+            # already validated against the filesystem above.
+            status = "unknown"
+            reason = (
+                "could not compute the actual diff (git unavailable) — "
+                "assuming the git-tracked declared files are unwritten as a "
+                "fail-safe."
+            )
+            git_not_written = sorted(git_declared)
+        else:
+            actual_list = sorted(actual_set)
+            git_not_written = sorted(d for d in git_declared if d not in actual_set)
+
+    declared_not_written = sorted([*git_not_written, *map_not_written])
     status_mismatch = bool(declared_not_written)
 
     recovery_instruction = ""
     if status_mismatch:
-        recovery_instruction = (
-            f"Actor declared files it did not write: {declared_not_written}. "
-            "Its previous response was likely truncated mid-edit — re-invoke "
-            "the Actor to finish those files; do NOT record the subtask until "
-            "git diff --name-only covers every declared file."
+        parts: list[str] = []
+        if git_not_written:
+            if status == "unknown":
+                parts.append(
+                    "git diff unavailable (fail-safe — actual changes were NOT "
+                    "consulted): treating git-tracked declared files as "
+                    f"unwritten: {git_not_written}."
+                )
+            else:
+                parts.append(
+                    "Actor declared git-tracked files it did not write: "
+                    f"{git_not_written}. Its previous response was likely "
+                    "truncated mid-edit — re-invoke the Actor to finish those "
+                    "files."
+                )
+        if map_not_written:
+            parts.append(
+                "Declared MAP artifacts are missing or empty on disk: "
+                f"{map_not_written}. Re-invoke the Actor to write them."
+            )
+        parts.append(
+            "Do NOT record the subtask until every declared file is written "
+            "(git diff --name-only covers git-tracked files; MAP artifacts must "
+            "exist on disk with content)."
         )
+        recovery_instruction = " ".join(parts)
 
     return {
-        "status": "ok",
+        "status": status,
         "subtask_id": subtask_id,
         "declared": sorted(declared),
-        "actual": sorted(actual_set),
+        "actual": actual_list,
         "declared_not_written": declared_not_written,
         "status_mismatch": status_mismatch,
         "recovery_instruction": recovery_instruction,
-        "reason": "",
+        "reason": reason,
     }
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -11506,6 +11506,39 @@ def _is_test_path(path: str) -> bool:
     return False
 
 
+# Framework-managed artifact trees. These are gitignored (or otherwise stripped
+# from the diff surface), so a git-diff-based change detector can never witness
+# them. The mutation-boundary direction strips them as non-scope-creep; the
+# declared-but-not-written direction must instead validate them by filesystem
+# existence (see ``_map_artifact_written``).
+_MAP_INTERNAL_ARTIFACT_PREFIXES = (".map/", ".codex/", ".agents/")
+
+
+def _is_map_internal_artifact(path: str) -> bool:
+    """True when ``path`` lives under a framework-managed artifact tree.
+
+    Such paths are gitignored, so ``git diff``/``git status`` never surface them
+    and ``_current_subtask_changed_files`` strips them — a diff-based "was it
+    written?" check would false-positive every MAP-only subtask as truncated.
+    """
+    return path.startswith(_MAP_INTERNAL_ARTIFACT_PREFIXES)
+
+
+def _map_artifact_written(path: str, project_dir: Path) -> bool:
+    """True when a declared MAP-internal artifact exists on disk with content.
+
+    "Written" for a gitignored artifact means the file exists and is non-empty.
+    An empty file is treated as *not* written — that is exactly the truncated /
+    incomplete-edit signal this detector exists to catch. Any ``OSError`` (e.g.
+    the path resolves to a directory) is treated as not written.
+    """
+    try:
+        artifact = project_dir / path
+        return artifact.is_file() and artifact.stat().st_size > 0
+    except OSError:
+        return False
+
+
 def _current_subtask_changed_files(
     branch_name: str, subtask_id: str, project_dir: Path
 ) -> Optional[set[str]]:
@@ -11570,12 +11603,7 @@ def _current_subtask_changed_files(
             if path:
                 changed.add(path)
 
-    changed = {
-        p for p in changed
-        if not p.startswith(".map/")
-        and not p.startswith(".codex/")
-        and not p.startswith(".agents/")
-    }
+    changed = {p for p in changed if not _is_map_internal_artifact(p)}
 
     baseline_path = _subtask_baseline_path(branch_name, subtask_id, project_dir)
     if baseline_path.exists():
@@ -11735,6 +11763,15 @@ def detect_actor_files_changed_mismatch(
     - THIS function checks *declared-but-not-written* only.  The load-bearing
       field is ``declared_not_written``.
 
+    Declared files are validated in two ways depending on their tree:
+    - **git-tracked files** are validated against the git diff (``actual``).
+    - **MAP-internal artifacts** (``.map/``, ``.codex/``, ``.agents/``) are
+      gitignored and stripped from the diff surface, so they are validated by
+      filesystem existence + non-empty content instead. Without this split a
+      subtask whose only declared artifact is e.g.
+      ``.map/<branch>/verification-summary.md`` would always false-positive as
+      truncated even though the file exists (see issue #277).
+
     Returns::
 
         {
@@ -11755,52 +11792,83 @@ def detect_actor_files_changed_mismatch(
     branch_name = _sanitize_branch(branch)
     project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
 
-    actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
-    if actual_set is None:
-        # Intent: fail safe to mismatch so the gate cannot pass blindly.
-        declared_sorted = sorted(d.strip() for d in (declared_files or []) if d.strip())
-        return {
-            "status": "unknown",
-            "subtask_id": subtask_id,
-            "declared": declared_sorted,
-            "actual": [],
-            "declared_not_written": declared_sorted,
-            "status_mismatch": True,
-            "recovery_instruction": (
-                "git diff unavailable (fail-safe — actual changes were NOT "
-                f"consulted): treating all declared files as unwritten: {declared_sorted}. "
-                "Re-invoke the Actor to finish any truncated edits and re-run this "
-                "check once git is available; do NOT record the subtask until "
-                "git diff --name-only covers every declared file."
-            ),
-            "reason": (
-                "could not compute the actual diff (git unavailable) — "
-                "assuming mismatch as a fail-safe."
-            ),
-        }
-
     declared = [d.strip() for d in (declared_files or []) if d.strip()]
-    declared_not_written = sorted(d for d in declared if d not in actual_set)
+    map_declared = [d for d in declared if _is_map_internal_artifact(d)]
+    git_declared = [d for d in declared if not _is_map_internal_artifact(d)]
+
+    # MAP-internal artifacts are gitignored, so the diff surface can never
+    # witness them. Validate them by filesystem existence + non-empty content
+    # instead — independent of git availability (fixes issue #277).
+    map_not_written = sorted(
+        d for d in map_declared if not _map_artifact_written(d, project_dir)
+    )
+
+    status = "ok"
+    reason = ""
+    actual_list: list[str] = []
+    git_not_written: list[str] = []
+
+    # Only consult git when there are git-tracked declared files to validate.
+    # A MAP-only subtask needs no diff, so a git error must not force it into a
+    # false mismatch.
+    if git_declared:
+        actual_set = _current_subtask_changed_files(branch_name, subtask_id, project_dir)
+        if actual_set is None:
+            # Intent: fail safe to mismatch so the gate cannot pass blindly on a
+            # git error — but only for the git-tracked files. MAP artifacts were
+            # already validated against the filesystem above.
+            status = "unknown"
+            reason = (
+                "could not compute the actual diff (git unavailable) — "
+                "assuming the git-tracked declared files are unwritten as a "
+                "fail-safe."
+            )
+            git_not_written = sorted(git_declared)
+        else:
+            actual_list = sorted(actual_set)
+            git_not_written = sorted(d for d in git_declared if d not in actual_set)
+
+    declared_not_written = sorted([*git_not_written, *map_not_written])
     status_mismatch = bool(declared_not_written)
 
     recovery_instruction = ""
     if status_mismatch:
-        recovery_instruction = (
-            f"Actor declared files it did not write: {declared_not_written}. "
-            "Its previous response was likely truncated mid-edit — re-invoke "
-            "the Actor to finish those files; do NOT record the subtask until "
-            "git diff --name-only covers every declared file."
+        parts: list[str] = []
+        if git_not_written:
+            if status == "unknown":
+                parts.append(
+                    "git diff unavailable (fail-safe — actual changes were NOT "
+                    "consulted): treating git-tracked declared files as "
+                    f"unwritten: {git_not_written}."
+                )
+            else:
+                parts.append(
+                    "Actor declared git-tracked files it did not write: "
+                    f"{git_not_written}. Its previous response was likely "
+                    "truncated mid-edit — re-invoke the Actor to finish those "
+                    "files."
+                )
+        if map_not_written:
+            parts.append(
+                "Declared MAP artifacts are missing or empty on disk: "
+                f"{map_not_written}. Re-invoke the Actor to write them."
+            )
+        parts.append(
+            "Do NOT record the subtask until every declared file is written "
+            "(git diff --name-only covers git-tracked files; MAP artifacts must "
+            "exist on disk with content)."
         )
+        recovery_instruction = " ".join(parts)
 
     return {
-        "status": "ok",
+        "status": status,
         "subtask_id": subtask_id,
         "declared": sorted(declared),
-        "actual": sorted(actual_set),
+        "actual": actual_list,
         "declared_not_written": declared_not_written,
         "status_mismatch": status_mismatch,
         "recovery_instruction": recovery_instruction,
-        "reason": "",
+        "reason": reason,
     }
 
 

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -561,7 +561,7 @@ def test_run_flaky_test_triage_uses_shell_false(branch_workspace):
 
     def fake_run(command: list[str], **kwargs: object) -> types.SimpleNamespace:
         calls.append({"command": command, **kwargs})
-        stdout = kwargs["stdout"]
+        stdout = cast(Any, kwargs["stdout"])
         assert hasattr(stdout, "write")
         stdout.write(b"ok")
         return types.SimpleNamespace(returncode=0)
@@ -10153,6 +10153,117 @@ class TestDetectActorFilesChangedMismatch:
         assert result.returncode == 0, result.stderr
         parsed = json.loads(result.stdout)
         assert "status_mismatch" in parsed
+
+    # ── #277: MAP-only artifacts validated by filesystem, not git diff ──────
+
+    def test_map_only_artifact_exists_no_mismatch(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression #277: a subtask whose only declared file is a MAP artifact
+        that EXISTS on disk must NOT be flagged as truncated.
+
+        ``.map/`` is gitignored and stripped from the diff surface, so the old
+        diff-only detector reported a false ``status_mismatch`` for a real file.
+        """
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        artifact = branch_workspace / "verification-summary.md"
+        artifact.write_text("# Verification Summary\n\nAll VCs pass.\n")
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-007",
+            [".map/test-branch/verification-summary.md"],
+        )
+
+        assert report["status"] == "ok", report
+        assert report["status_mismatch"] is False, report
+        assert report["declared_not_written"] == [], report
+        assert report["recovery_instruction"] == "", report
+
+    def test_map_only_artifact_missing_is_mismatch(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A declared MAP artifact that does NOT exist is a real mismatch."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        declared = [".map/test-branch/verification-summary.md"]
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-007", declared
+        )
+
+        assert report["status_mismatch"] is True, report
+        assert report["declared_not_written"] == declared, report
+        assert report["recovery_instruction"] != "", report
+
+    def test_map_only_artifact_empty_is_mismatch(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty declared MAP artifact counts as not-written (truncation)."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        (branch_workspace / "verification-summary.md").write_text("")
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        declared = [".map/test-branch/verification-summary.md"]
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-007", declared
+        )
+
+        assert report["status_mismatch"] is True, report
+        assert report["declared_not_written"] == declared, report
+
+    def test_mixed_git_and_map_artifacts_validated_independently(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A git file (written) + a MAP artifact (exists) → no mismatch; each
+        surface is validated by its own mechanism."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        (repo / "a.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+        (branch_workspace / "verification-summary.md").write_text("done\n")
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-007",
+            ["a.py", ".map/test-branch/verification-summary.md"],
+        )
+
+        assert report["status_mismatch"] is False, report
+        assert report["declared_not_written"] == [], report
+
+    def test_mixed_git_written_map_missing_flags_only_map(
+        self, branch_workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """git file written, MAP artifact missing → only the MAP artifact is
+        flagged; the written git file is not a false positive."""
+        repo = branch_workspace.parents[1]
+        self._init_git(repo)
+        self._write_state(branch_workspace)
+
+        (repo / "a.py").write_text("x = 1\n")
+        subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.detect_actor_files_changed_mismatch(
+            "test-branch", "ST-007",
+            ["a.py", ".map/test-branch/verification-summary.md"],
+        )
+
+        assert report["declared_not_written"] == [
+            ".map/test-branch/verification-summary.md"
+        ], report
+        assert report["status_mismatch"] is True, report
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`detect_actor_files_changed_mismatch` (the actor "declared-but-not-written" gate) reported a false `status_mismatch=true` for any subtask whose declared `affected_files` are MAP-only artifacts (e.g. `.map/<branch>/verification-summary.md`).

## Why

The detector validated every declared file against `_current_subtask_changed_files`, which derives from `git diff` / `git status` and explicitly strips the gitignored framework trees (`.map/`, `.codex/`, `.agents/`). Those paths can never appear in the diff surface, so a real, existing `.map/` artifact was always reported as unwritten with a misleading "Actor declared files it did not write" recovery instruction — making MAP-only documentation/verification subtasks look like truncated actor edits (see #277).

## How

- Partition declared files in `detect_actor_files_changed_mismatch`:
  - **git-tracked files** keep the existing `git diff` check.
  - **MAP-internal artifacts** (`.map/`, `.codex/`, `.agents/`) are validated by filesystem existence + non-empty content. A missing or empty artifact is still a real mismatch (genuine truncation signal).
- MAP-artifact validation runs independently of git availability, so a MAP-only subtask is never forced into a false mismatch by a git error; git is only consulted when there are git-tracked declared files.
- New shared `_is_map_internal_artifact` helper de-duplicates the framework-tree prefix list (now `_MAP_INTERNAL_ARTIFACT_PREFIXES`) used by both the strip filter in `_current_subtask_changed_files` and the new validation path (DRY).
- Edited the single-source `.jinja` and re-rendered (`make render-templates`); generated trees match.

## Tests

5 new regression tests in `TestDetectActorFilesChangedMismatch`:
- MAP-only artifact exists → no mismatch (the #277 repro; **fails without the fix**, verified via negative-proof run against `origin/main`).
- MAP-only artifact missing / empty → mismatch.
- Mixed git+MAP (both present) → no mismatch.
- Mixed git written + MAP missing → only the MAP artifact flagged.

Also fixed a pre-existing pyright error surfaced in the touched test file (`.write` on `object`).

Gate: `make check` green — ruff, mypy, pyright (`src/`), **2835 passed, 3 skipped**, `check-render` clean.

Closes #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)