### PR TITLE
feat(tokenreport): dashboard, history, estimate, JSON/CSV export modes

### DIFF
--- a/.claude/skills/map-tokenreport/SKILL.md
+++ b/.claude/skills/map-tokenreport/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: map-tokenreport
 description: |
-  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
+  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Supports --dashboard (box-drawing visual), --history (trends), --estimate (cost projection), --json / --csv export, and --finalize (record session snapshot). Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
 effort: low
 disable-model-invocation: true
-argument-hint: "[branch]"
+argument-hint: "[branch] [--dashboard|--history|--estimate|--json|--csv|--finalize]"
 ---
 # /map-tokenreport - Token Accounting Report
 
@@ -41,6 +41,20 @@ appends attributed rows to `.map/<branch>/token_log.jsonl`, rolled up into
   with downstream Actor/Monitor tokens, so users can see whether delegated
   exploration paid for itself.
 
+## Modes
+
+The skill supports several modes via CLI flags:
+
+| Flag | Effect |
+|---|---|
+| _(default)_ | Classic text table: per-subtask rows, by-agent section, research ROI, cache-hit + cost |
+| `--dashboard` | Box-drawing visual dashboard: subtask bar chart, per-agent + per-model breakdowns, vs-previous comparison |
+| `--history [N]` | Trend table over last N recorded sessions (default 10) with cost delta and cache-hit trend |
+| `--estimate` | Cost projection from weighted historical average, with range, median, and remaining estimate |
+| `--json` | Export `token_accounting.json` as formatted JSON |
+| `--csv` | Export as CSV (one row per dimension key: aggregate, subtask, agent, phase) |
+| `--finalize` | Record current `token_accounting.json` as a snapshot in `token_history.jsonl` for trend tracking |
+
 ## Steps
 
 ### Step 1: Resolve the branch
@@ -54,14 +68,38 @@ one.
 
 ### Step 2: Render the report
 
+Choose the right command for the user's intent:
+
+**Default (classic table):**
 ```bash
 python3 .map/scripts/map_step_runner.py token_report "$BRANCH"
 ```
 
-`token_report` re-reads `token_log.jsonl`, rebuilds `token_accounting.json`,
-and prints a per-subtask table, a per-agent table, research ROI, and a TOTAL
-line with the cache-hit ratio and estimated cost. It is idempotent and read-only
-against your code.
+**Dashboard (visual):**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --dashboard
+```
+
+**History (trends):**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --history
+```
+
+**Estimate:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --estimate
+```
+
+**JSON / CSV export:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --json
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --csv
+```
+
+**Record snapshot for history:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --finalize
+```
 
 ### Step 3: Optional — inspect the raw rollup
 
@@ -93,24 +131,93 @@ Report token usage for the current branch:
 /map-tokenreport
 ```
 
-Report for a specific branch:
+Visual dashboard:
 
 ```text
-/map-tokenreport feat/add-multiply
+/map-tokenreport --dashboard
 ```
 
-Typical output:
+Trend over last 5 sessions:
 
 ```text
-Token accounting — feat-add-multiply (93 assistant turns)
+/map-tokenreport --history 5
+```
 
-subtask              input      output     cache_rd    cache_cr     $cost
--------------------------------------------------------------------------
-ST-001                 183     150,879   14,085,841     792,780     47.31
--------------------------------------------------------------------------
-TOTAL                  183     150,879   14,085,841     792,780     47.31
+Cost estimate before starting:
 
-cache hit ratio: 100.0%   est cost: $47.31
+```text
+/map-tokenreport --estimate
+```
+
+Export for CI pipeline:
+
+```text
+/map-tokenreport --json > .map/token_report.json
+```
+
+Record a snapshot (typically called automatically by the Stop hook):
+
+```text
+/map-tokenreport --finalize
+```
+
+Typical dashboard output:
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  MAP Token Report — feat-oauth2                                 │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  Session: $ 3.42     Cache-hit: 67%  │ vs prev: ↑12%            │
+│  Turns: 93  │                                                   │
+├─────────────────────────────────────────────────────────────────┤
+│  Per-subtask                                                    │
+│                                                                 │
+│  ST-001       $   0.87  █████████████████████████████░░░░ 28%   │
+│  ST-002       $   1.23  ██████████████████████████████████████  │
+│  ST-003       $   0.65  █████████████████████░░░░░░░░░░░░ 21%   │
+│  ST-004       $   0.67  ██████████████████████░░░░░░░░░░░ 22%   │
+├─────────────────────────────────────────────────────────────────┤
+│  By agent                                                        │
+│    actor                       $   1.89 (55%)                    │
+│    monitor                     $   0.67 (20%)                    │
+│    evaluator                   $   0.44 (13%)                    │
+│    predictor                   $   0.42 (12%)                    │
+├─────────────────────────────────────────────────────────────────┤
+│  By model                                                        │
+│    claude-sonnet-4-6           $   2.10 (61%)                    │
+│    claude-haiku-4-5            $   1.32 (39%)                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Typical history output:
+
+```text
+Token history — feat-oauth2 (last 3 of 3 sessions)
+
+  #  timestamp              turns     cost   cache%  vs prev
+-------------------------------------------------------------------
+  1  2026-06-24T10:15:00       45  $   2.87    58%        —
+  2  2026-06-25T14:22:00       72  $   3.15    62%      +10%
+  3  2026-06-26T09:30:00       93  $   3.42    67%       +9%
+
+Trend (3 sessions):
+  Cost:     $ 2.87 → $ 3.42  ↑ 19%
+  Cache:    58% → 67%  ↑ 9pp
+  Avg cost: $ 3.15 / session
+```
+
+Typical estimate output:
+
+```text
+Cost estimate — feat-oauth2
+
+  Based on 3 historical sessions (last 3 weighted):
+  Weighted avg:  $ 3.22
+  Range:         $ 2.87 — $ 3.42
+  Median:        $ 3.15
+  Spent so far:  $ 1.20
+  Remaining est: $ 2.02
 ```
 
 ## Troubleshooting
@@ -132,3 +239,9 @@ cache hit ratio: 100.0%   est cost: $47.31
 - **Unknown model in cost estimate.** `MODEL_TOKEN_PRICES` falls back to the
   default model price for unrecognized model ids; update that table in
   `map_step_runner.py` when a new model ships.
+- **`--history` / `--estimate` show no data.** No snapshots have been recorded.
+  Run `/map-tokenreport --finalize` at the end of each session, or set up the
+  Stop hook to call `record_session_snapshot` automatically.
+- **Dashboard layout looks wrong in narrow terminals.** The dashboard uses
+  a fixed 67-character width. Pipe the output to a file and view it in a wider
+  terminal, or use `--json` for programmatic consumption.

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -748,6 +748,7 @@ def record_token_budget_decision(
 
 TOKEN_LOG_NAME = "token_log.jsonl"
 TOKEN_ACCOUNTING_NAME = "token_accounting.json"
+TOKEN_HISTORY_NAME = "token_history.jsonl"
 TOKEN_METER_CACHE_NAME = ".token-meter-cache.json"
 _SEEN_ID_CACHE_LIMIT = 5000
 
@@ -1383,6 +1384,359 @@ def token_report(branch: Optional[str] = None) -> str:
         f"cache hit ratio: {ratio:.1f}%   "
         f"est cost: ${float(aggregate.get('est_cost_usd', 0.0)):.2f}"
     )
+    return "\n".join(rows) + "\n"
+
+
+def record_session_snapshot(branch: Optional[str] = None) -> dict[str, object]:
+    """Append the current token_accounting.json to token_history.jsonl.
+
+    Called once per session (typically from the Stop hook or /map-tokenreport
+    --finalize). Records timestamp, branch, aggregate, by_subtask, by_agent,
+    by_model, cache_hit_ratio, and est_cost_usd so history queries can show
+    trends across sessions without re-reading every token_log.jsonl.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+
+    by_model: dict[str, dict[str, float]] = {}
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    if log_path.is_file():
+        try:
+            for raw in log_path.read_text(encoding="utf-8").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                model = str(row.get("model") or "unknown")
+                usage = {field: _coerce_token_int(row.get(field, 0)) for field in _TOKEN_FIELDS}
+                cost = _token_cost(usage, model)
+                bucket = by_model.setdefault(model, {**_empty_token_bucket(), "est_cost_usd": 0.0})
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(bucket.get("est_cost_usd", 0.0) + cost, 6)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    snapshot: dict[str, object] = {
+        "ts": _utc_timestamp(),
+        "branch": branch_name,
+        "event_count": payload.get("event_count", 0),
+        "aggregate": aggregate,
+        "by_subtask": {k: v for k, v in by_subtask.items()},
+        "by_agent": {k: v for k, v in by_agent.items()},
+        "by_model": {k: v for k, v in by_model.items()},
+    }
+    history_path = get_branch_dir(branch_name) / TOKEN_HISTORY_NAME
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with history_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(snapshot) + "\n")
+    except OSError as exc:
+        return {"status": "error", "reason": str(exc)}
+    return {"status": "success", "recorded": 1}
+
+
+def _load_token_history(branch: str) -> list[dict[str, object]]:
+    """Load all snapshots from token_history.jsonl for a branch."""
+    history_path = get_branch_dir(branch) / TOKEN_HISTORY_NAME
+    entries: list[dict[str, object]] = []
+    if not history_path.is_file():
+        return entries
+    try:
+        for raw in history_path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+                if isinstance(row, dict):
+                    entries.append(cast(dict[str, object], row))
+            except json.JSONDecodeError:
+                continue
+    except (OSError, UnicodeDecodeError):
+        pass
+    return entries
+
+
+def token_report_json(branch: Optional[str] = None) -> str:
+    """Export token_accounting.json as formatted JSON."""
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    return json.dumps(payload, indent=2)
+
+
+def token_report_csv(branch: Optional[str] = None) -> str:
+    """Export token_accounting as CSV (one row per accounting bucket)."""
+    import csv as _csv
+    import io as _io
+
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+    by_phase = cast(dict[str, dict[str, float]], payload.get("by_phase", {}))
+
+    buf = _io.StringIO()
+    writer = _csv.writer(buf)
+    header = ["dimension", "key", "input", "output", "cache_read", "cache_creation", "est_cost_usd", "cache_hit_ratio"]
+    writer.writerow(header)
+
+    def _write_rows(dim: str, bucket: dict[str, dict[str, float]]) -> None:
+        for key in sorted(bucket):
+            b = bucket[key]
+            cacheable = b.get("input", 0.0) + b.get("cache_read", 0.0)
+            ratio = round(b.get("cache_read", 0.0) / cacheable, 4) if cacheable else 0.0
+            writer.writerow([
+                dim, key,
+                int(b.get("input", 0)), int(b.get("output", 0)),
+                int(b.get("cache_read", 0)), int(b.get("cache_creation", 0)),
+                round(b.get("est_cost_usd", 0.0), 4), ratio,
+            ])
+
+    cacheable = aggregate.get("input", 0.0) + aggregate.get("cache_read", 0.0)
+    agg_ratio = round(aggregate.get("cache_read", 0.0) / cacheable, 4) if cacheable else 0.0
+    writer.writerow([
+        "aggregate", branch_name,
+        int(aggregate.get("input", 0)), int(aggregate.get("output", 0)),
+        int(aggregate.get("cache_read", 0)), int(aggregate.get("cache_creation", 0)),
+        round(aggregate.get("est_cost_usd", 0.0), 4), agg_ratio,
+    ])
+    _write_rows("subtask", by_subtask)
+    _write_rows("agent", by_agent)
+    _write_rows("phase", by_phase)
+    return buf.getvalue()
+
+
+def token_report_dashboard(branch: Optional[str] = None) -> str:
+    """Render a visual dashboard with box-drawing characters.
+
+    Shows session summary, per-subtask bar chart, per-agent/per-model
+    breakdowns, and vs-previous-session comparison when history exists.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+
+    total_cost = aggregate.get("est_cost_usd", 0.0)
+    cache_ratio = float(aggregate.get("cache_hit_ratio", 0.0)) * 100
+    event_count = _coerce_token_int(payload.get("event_count", 0))
+
+    rows: list[str] = []
+    W = 67
+
+    def _box_row(content):
+        rows.append("│  " + content.ljust(W - 5) + " │")
+
+    rows.append("┌" + "─" * (W - 2) + "┐")
+    rows.append("│  MAP Token Report — " + branch_name.ljust(W - 24) + " │")
+    rows.append("│" + " " * (W - 2) + "│")
+    rows.append("├" + "─" * (W - 2) + "┤")
+
+    # ---- summary ----
+    history = _load_token_history(branch_name)
+    vs_prev = ""
+    if len(history) >= 2:
+        prev = cast(dict[str, float], history[-2].get("aggregate", {}))
+        prev_cost = prev.get("est_cost_usd", 0.0)
+        if prev_cost > 0:
+            delta = ((total_cost - prev_cost) / prev_cost) * 100
+            arrow = "\u25b2" if delta > 0 else "\u25bc"
+            vs_prev = " | vs prev: {}{:+.0f}%".format(arrow, delta)
+
+    _box_row("Session: ${:.2f}  |  Cache-hit: {:.0f}%{}".format(
+        total_cost, cache_ratio, vs_prev))
+    _box_row("Turns: {}".format(event_count))
+
+    # ---- per-subtask bar chart ----
+    if by_subtask:
+        rows.append("├" + "─" * (W - 2) + "┤")
+        _box_row("Per-subtask:")
+        rows.append("│  " + " " * (W - 5) + " │")
+
+        max_cost = max((b.get("est_cost_usd", 0.0) for b in by_subtask.values()), default=0.01)
+        bar_max = W - 24
+        for sid in sorted(by_subtask):
+            b = by_subtask[sid]
+            scost = b.get("est_cost_usd", 0.0)
+            ratio_pct = (scost / total_cost * 100) if total_cost > 0 else 0
+            bar_len = int((scost / max_cost) * bar_max) if max_cost > 0 else 0
+            bar = "\u2588" * bar_len + "\u2591" * (bar_max - bar_len)
+            rows.append("│  {:12s} $ {:>7.2f}  {} {:>3.0f}% │".format(
+                sid, scost, bar, ratio_pct))
+
+    # ---- by agent ----
+    if by_agent:
+        rows.append("├" + "─" * (W - 2) + "┤")
+        _box_row("By agent:")
+        agent_cost_total = sum(b.get("est_cost_usd", 0.0) for b in by_agent.values())
+        for agent in sorted(by_agent, key=lambda a: by_agent[a].get("est_cost_usd", 0.0), reverse=True):
+            b = by_agent[agent]
+            acost = b.get("est_cost_usd", 0.0)
+            pct = (acost / agent_cost_total * 100) if agent_cost_total > 0 else 0
+            pad = max(0, W - 5 - 26 - 11 - 7)
+            rows.append("│    {:26s} $ {:>7.2f} ({:>3.0f}%){:s} │".format(
+                agent, acost, pct, " " * pad))
+
+    # ---- by model ----
+    rows.append("├" + "─" * (W - 2) + "┤")
+    _box_row("By model:")
+    by_model: dict[str, dict[str, float]] = {}
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    if log_path.is_file():
+        try:
+            for raw in log_path.read_text(encoding="utf-8").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                model = str(row.get("model") or "unknown")
+                usage = {field: _coerce_token_int(row.get(field, 0)) for field in _TOKEN_FIELDS}
+                cost = _token_cost(usage, model)
+                bucket = by_model.setdefault(model, {**_empty_token_bucket(), "est_cost_usd": 0.0})
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(bucket.get("est_cost_usd", 0.0) + cost, 6)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    if by_model:
+        model_cost_total = sum(b.get("est_cost_usd", 0.0) for b in by_model.values())
+        for model in sorted(by_model, key=lambda m: by_model[m].get("est_cost_usd", 0.0), reverse=True):
+            b = by_model[model]
+            mcost = b.get("est_cost_usd", 0.0)
+            pct = (mcost / model_cost_total * 100) if model_cost_total > 0 else 0
+            model_short = model[:30] if len(model) > 30 else model
+            pad = max(0, W - 5 - 32 - 11 - 7)
+            rows.append("│    {:32s} $ {:>7.2f} ({:>3.0f}%){:s} │".format(
+                model_short, mcost, pct, " " * pad))
+
+    rows.append("└" + "─" * (W - 2) + "┘")
+    return "\n".join(rows) + "\n"
+
+
+def token_report_history(branch: Optional[str] = None, n: int = 10) -> str:
+    """Show token cost trends across the last N recorded sessions."""
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    entries = _load_token_history(branch_name)
+    if not entries:
+        return "No session history recorded yet. Run /map-tokenreport to record a snapshot.\n"
+
+    shown = entries[-n:]
+    rows: list[str] = []
+    rows.append(f"Token history — {branch_name} (last {len(shown)} of {len(entries)} sessions)")
+    rows.append("")
+    header = f"{'#':>3}  {'timestamp':<20}  {'turns':>7}  {'cost':>9}  {'cache%':>7}  {'vs prev':>8}"
+    rows.append(header)
+    rows.append("-" * len(header))
+
+    prev_cost: Optional[float] = None
+    for i, entry in enumerate(shown):
+        idx = len(entries) - len(shown) + i + 1
+        agg = cast(dict[str, float], entry.get("aggregate", {}))
+        ts = str(entry.get("ts", ""))[:19]
+        turns = _coerce_token_int(entry.get("event_count", 0))
+        cost = agg.get("est_cost_usd", 0.0)
+        cache = float(agg.get("cache_hit_ratio", 0.0)) * 100
+
+        vs_str = ""
+        if prev_cost is not None and prev_cost > 0:
+            delta = ((cost - prev_cost) / prev_cost) * 100
+            vs_str = f"{delta:+.0f}%"
+        else:
+            vs_str = "—"
+
+        rows.append(f"{idx:>3}  {ts:<20}  {turns:>7,}  $ {cost:>7.2f}  {cache:>5.0f}%  {vs_str:>8}")
+        prev_cost = cost
+
+    if len(shown) >= 2:
+        first = cast(dict[str, float], shown[0].get("aggregate", {}))
+        last = cast(dict[str, float], shown[-1].get("aggregate", {}))
+        first_cost = first.get("est_cost_usd", 0.0)
+        last_cost = last.get("est_cost_usd", 0.0)
+        first_cache = float(first.get("cache_hit_ratio", 0.0)) * 100
+        last_cache = float(last.get("cache_hit_ratio", 0.0)) * 100
+        rows.append("")
+        rows.append(f"Trend ({len(shown)} sessions):")
+        rows.append(f"  Cost:     $ {first_cost:.2f} → $ {last_cost:.2f}  "
+                     f"({'↑' if last_cost > first_cost else '↓' if last_cost < first_cost else '→'} "
+                     f"{abs(((last_cost - first_cost) / first_cost * 100) if first_cost > 0 else 0):.0f}%)")
+        rows.append(f"  Cache:    {first_cache:.0f}% → {last_cache:.0f}%  "
+                     f"({'↑' if last_cache > first_cache else '↓' if last_cache < first_cache else '→'} "
+                     f"{abs(last_cache - first_cache):.0f}pp)")
+        avg_cost = sum(
+            float(cast(dict[str, float], e.get("aggregate", {})).get("est_cost_usd", 0.0))
+            for e in shown
+        ) / len(shown)
+        rows.append(f"  Avg cost: $ {avg_cost:.2f} / session")
+
+    return "\n".join(rows) + "\n"
+
+
+def token_report_estimate(branch: Optional[str] = None) -> str:
+    """Estimate session cost from history data.
+
+    Uses weighted average of past sessions, with recent sessions weighted
+    more heavily. Falls back to worst-case estimate when no history exists.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    spent_so_far = aggregate.get("est_cost_usd", 0.0)
+
+    entries = _load_token_history(branch_name)
+    history_costs = [
+        float(cast(dict[str, float], e.get("aggregate", {})).get("est_cost_usd", 0.0))
+        for e in entries
+    ]
+
+    rows: list[str] = []
+    if not history_costs:
+        rows.append(f"Cost estimate — {branch_name}")
+        rows.append("")
+        rows.append("  No session history available.")
+        rows.append(f"  Spent so far: $ {spent_so_far:.2f}")
+        rows.append("  A typical MAP session (1-3 subtasks) costs $0.50–$5.00")
+        rows.append("  with default models, depending on codebase size and task complexity.")
+        return "\n".join(rows) + "\n"
+
+    weighted_sum = 0.0
+    weight_sum = 0.0
+    for i, cost in enumerate(history_costs[-10:]):
+        weight = i + 1
+        weighted_sum += cost * weight
+        weight_sum += weight
+    weighted_avg = weighted_sum / weight_sum if weight_sum > 0 else 0.0
+
+    sorted_costs = sorted(history_costs[-10:])
+    median = sorted_costs[len(sorted_costs) // 2]
+    lo = sorted_costs[0]
+    hi = sorted_costs[-1]
+
+    rows.append(f"Cost estimate — {branch_name}")
+    rows.append("")
+    rows.append(f"  Based on {len(history_costs)} historical sessions (last {min(len(history_costs), 10)} weighted):")
+    rows.append(f"  Weighted avg:  $ {weighted_avg:.2f}")
+    rows.append(f"  Range:         $ {lo:.2f} — $ {hi:.2f}")
+    rows.append(f"  Median:        $ {median:.2f}")
+    rows.append(f"  Spent so far:  $ {spent_so_far:.2f}")
+    remaining = max(0.0, weighted_avg - spent_so_far)
+    rows.append(f"  Remaining est: $ {remaining:.2f}")
     return "\n".join(rows) + "\n"
 
 
@@ -14221,9 +14575,36 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
 
     elif func_name == "token_report":
-        # CLI: token_report [branch]
-        tok_branch = sys.argv[2] if len(sys.argv) >= 3 else None
-        print(token_report(tok_branch))
+        # CLI: token_report [branch] [--dashboard] [--json] [--csv]
+        #       [--history [N]] [--estimate] [--finalize]
+        args = sys.argv[2:]
+        branch_arg: Optional[str] = None
+        if args and not args[0].startswith("--"):
+            branch_arg = args[0]
+            args = args[1:]
+
+        if "--json" in args:
+            print(token_report_json(branch_arg))
+        elif "--csv" in args:
+            print(token_report_csv(branch_arg))
+        elif "--history" in args:
+            n = 10
+            try:
+                idx = args.index("--history")
+                if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                    n = int(args[idx + 1])
+            except (ValueError, IndexError):
+                pass
+            print(token_report_history(branch_arg, n))
+        elif "--estimate" in args:
+            print(token_report_estimate(branch_arg))
+        elif "--dashboard" in args:
+            print(token_report_dashboard(branch_arg))
+        elif "--finalize" in args:
+            result = record_session_snapshot(branch_arg)
+            print(json.dumps(result, indent=2))
+        else:
+            print(token_report(branch_arg))
 
     elif func_name == "detect_cross_subtask_regression_risk" and len(sys.argv) >= 4:
         # CLI: detect_cross_subtask_regression_risk <branch> <subtask_id>

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -748,6 +748,7 @@ def record_token_budget_decision(
 
 TOKEN_LOG_NAME = "token_log.jsonl"
 TOKEN_ACCOUNTING_NAME = "token_accounting.json"
+TOKEN_HISTORY_NAME = "token_history.jsonl"
 TOKEN_METER_CACHE_NAME = ".token-meter-cache.json"
 _SEEN_ID_CACHE_LIMIT = 5000
 
@@ -1383,6 +1384,359 @@ def token_report(branch: Optional[str] = None) -> str:
         f"cache hit ratio: {ratio:.1f}%   "
         f"est cost: ${float(aggregate.get('est_cost_usd', 0.0)):.2f}"
     )
+    return "\n".join(rows) + "\n"
+
+
+def record_session_snapshot(branch: Optional[str] = None) -> dict[str, object]:
+    """Append the current token_accounting.json to token_history.jsonl.
+
+    Called once per session (typically from the Stop hook or /map-tokenreport
+    --finalize). Records timestamp, branch, aggregate, by_subtask, by_agent,
+    by_model, cache_hit_ratio, and est_cost_usd so history queries can show
+    trends across sessions without re-reading every token_log.jsonl.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+
+    by_model: dict[str, dict[str, float]] = {}
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    if log_path.is_file():
+        try:
+            for raw in log_path.read_text(encoding="utf-8").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                model = str(row.get("model") or "unknown")
+                usage = {field: _coerce_token_int(row.get(field, 0)) for field in _TOKEN_FIELDS}
+                cost = _token_cost(usage, model)
+                bucket = by_model.setdefault(model, {**_empty_token_bucket(), "est_cost_usd": 0.0})
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(bucket.get("est_cost_usd", 0.0) + cost, 6)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    snapshot: dict[str, object] = {
+        "ts": _utc_timestamp(),
+        "branch": branch_name,
+        "event_count": payload.get("event_count", 0),
+        "aggregate": aggregate,
+        "by_subtask": {k: v for k, v in by_subtask.items()},
+        "by_agent": {k: v for k, v in by_agent.items()},
+        "by_model": {k: v for k, v in by_model.items()},
+    }
+    history_path = get_branch_dir(branch_name) / TOKEN_HISTORY_NAME
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with history_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(snapshot) + "\n")
+    except OSError as exc:
+        return {"status": "error", "reason": str(exc)}
+    return {"status": "success", "recorded": 1}
+
+
+def _load_token_history(branch: str) -> list[dict[str, object]]:
+    """Load all snapshots from token_history.jsonl for a branch."""
+    history_path = get_branch_dir(branch) / TOKEN_HISTORY_NAME
+    entries: list[dict[str, object]] = []
+    if not history_path.is_file():
+        return entries
+    try:
+        for raw in history_path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+                if isinstance(row, dict):
+                    entries.append(cast(dict[str, object], row))
+            except json.JSONDecodeError:
+                continue
+    except (OSError, UnicodeDecodeError):
+        pass
+    return entries
+
+
+def token_report_json(branch: Optional[str] = None) -> str:
+    """Export token_accounting.json as formatted JSON."""
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    return json.dumps(payload, indent=2)
+
+
+def token_report_csv(branch: Optional[str] = None) -> str:
+    """Export token_accounting as CSV (one row per accounting bucket)."""
+    import csv as _csv
+    import io as _io
+
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+    by_phase = cast(dict[str, dict[str, float]], payload.get("by_phase", {}))
+
+    buf = _io.StringIO()
+    writer = _csv.writer(buf)
+    header = ["dimension", "key", "input", "output", "cache_read", "cache_creation", "est_cost_usd", "cache_hit_ratio"]
+    writer.writerow(header)
+
+    def _write_rows(dim: str, bucket: dict[str, dict[str, float]]) -> None:
+        for key in sorted(bucket):
+            b = bucket[key]
+            cacheable = b.get("input", 0.0) + b.get("cache_read", 0.0)
+            ratio = round(b.get("cache_read", 0.0) / cacheable, 4) if cacheable else 0.0
+            writer.writerow([
+                dim, key,
+                int(b.get("input", 0)), int(b.get("output", 0)),
+                int(b.get("cache_read", 0)), int(b.get("cache_creation", 0)),
+                round(b.get("est_cost_usd", 0.0), 4), ratio,
+            ])
+
+    cacheable = aggregate.get("input", 0.0) + aggregate.get("cache_read", 0.0)
+    agg_ratio = round(aggregate.get("cache_read", 0.0) / cacheable, 4) if cacheable else 0.0
+    writer.writerow([
+        "aggregate", branch_name,
+        int(aggregate.get("input", 0)), int(aggregate.get("output", 0)),
+        int(aggregate.get("cache_read", 0)), int(aggregate.get("cache_creation", 0)),
+        round(aggregate.get("est_cost_usd", 0.0), 4), agg_ratio,
+    ])
+    _write_rows("subtask", by_subtask)
+    _write_rows("agent", by_agent)
+    _write_rows("phase", by_phase)
+    return buf.getvalue()
+
+
+def token_report_dashboard(branch: Optional[str] = None) -> str:
+    """Render a visual dashboard with box-drawing characters.
+
+    Shows session summary, per-subtask bar chart, per-agent/per-model
+    breakdowns, and vs-previous-session comparison when history exists.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+
+    total_cost = aggregate.get("est_cost_usd", 0.0)
+    cache_ratio = float(aggregate.get("cache_hit_ratio", 0.0)) * 100
+    event_count = _coerce_token_int(payload.get("event_count", 0))
+
+    rows: list[str] = []
+    W = 67
+
+    def _box_row(content):
+        rows.append("│  " + content.ljust(W - 5) + " │")
+
+    rows.append("┌" + "─" * (W - 2) + "┐")
+    rows.append("│  MAP Token Report — " + branch_name.ljust(W - 24) + " │")
+    rows.append("│" + " " * (W - 2) + "│")
+    rows.append("├" + "─" * (W - 2) + "┤")
+
+    # ---- summary ----
+    history = _load_token_history(branch_name)
+    vs_prev = ""
+    if len(history) >= 2:
+        prev = cast(dict[str, float], history[-2].get("aggregate", {}))
+        prev_cost = prev.get("est_cost_usd", 0.0)
+        if prev_cost > 0:
+            delta = ((total_cost - prev_cost) / prev_cost) * 100
+            arrow = "\u25b2" if delta > 0 else "\u25bc"
+            vs_prev = " | vs prev: {}{:+.0f}%".format(arrow, delta)
+
+    _box_row("Session: ${:.2f}  |  Cache-hit: {:.0f}%{}".format(
+        total_cost, cache_ratio, vs_prev))
+    _box_row("Turns: {}".format(event_count))
+
+    # ---- per-subtask bar chart ----
+    if by_subtask:
+        rows.append("├" + "─" * (W - 2) + "┤")
+        _box_row("Per-subtask:")
+        rows.append("│  " + " " * (W - 5) + " │")
+
+        max_cost = max((b.get("est_cost_usd", 0.0) for b in by_subtask.values()), default=0.01)
+        bar_max = W - 24
+        for sid in sorted(by_subtask):
+            b = by_subtask[sid]
+            scost = b.get("est_cost_usd", 0.0)
+            ratio_pct = (scost / total_cost * 100) if total_cost > 0 else 0
+            bar_len = int((scost / max_cost) * bar_max) if max_cost > 0 else 0
+            bar = "\u2588" * bar_len + "\u2591" * (bar_max - bar_len)
+            rows.append("│  {:12s} $ {:>7.2f}  {} {:>3.0f}% │".format(
+                sid, scost, bar, ratio_pct))
+
+    # ---- by agent ----
+    if by_agent:
+        rows.append("├" + "─" * (W - 2) + "┤")
+        _box_row("By agent:")
+        agent_cost_total = sum(b.get("est_cost_usd", 0.0) for b in by_agent.values())
+        for agent in sorted(by_agent, key=lambda a: by_agent[a].get("est_cost_usd", 0.0), reverse=True):
+            b = by_agent[agent]
+            acost = b.get("est_cost_usd", 0.0)
+            pct = (acost / agent_cost_total * 100) if agent_cost_total > 0 else 0
+            pad = max(0, W - 5 - 26 - 11 - 7)
+            rows.append("│    {:26s} $ {:>7.2f} ({:>3.0f}%){:s} │".format(
+                agent, acost, pct, " " * pad))
+
+    # ---- by model ----
+    rows.append("├" + "─" * (W - 2) + "┤")
+    _box_row("By model:")
+    by_model: dict[str, dict[str, float]] = {}
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    if log_path.is_file():
+        try:
+            for raw in log_path.read_text(encoding="utf-8").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                model = str(row.get("model") or "unknown")
+                usage = {field: _coerce_token_int(row.get(field, 0)) for field in _TOKEN_FIELDS}
+                cost = _token_cost(usage, model)
+                bucket = by_model.setdefault(model, {**_empty_token_bucket(), "est_cost_usd": 0.0})
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(bucket.get("est_cost_usd", 0.0) + cost, 6)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    if by_model:
+        model_cost_total = sum(b.get("est_cost_usd", 0.0) for b in by_model.values())
+        for model in sorted(by_model, key=lambda m: by_model[m].get("est_cost_usd", 0.0), reverse=True):
+            b = by_model[model]
+            mcost = b.get("est_cost_usd", 0.0)
+            pct = (mcost / model_cost_total * 100) if model_cost_total > 0 else 0
+            model_short = model[:30] if len(model) > 30 else model
+            pad = max(0, W - 5 - 32 - 11 - 7)
+            rows.append("│    {:32s} $ {:>7.2f} ({:>3.0f}%){:s} │".format(
+                model_short, mcost, pct, " " * pad))
+
+    rows.append("└" + "─" * (W - 2) + "┘")
+    return "\n".join(rows) + "\n"
+
+
+def token_report_history(branch: Optional[str] = None, n: int = 10) -> str:
+    """Show token cost trends across the last N recorded sessions."""
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    entries = _load_token_history(branch_name)
+    if not entries:
+        return "No session history recorded yet. Run /map-tokenreport to record a snapshot.\n"
+
+    shown = entries[-n:]
+    rows: list[str] = []
+    rows.append(f"Token history — {branch_name} (last {len(shown)} of {len(entries)} sessions)")
+    rows.append("")
+    header = f"{'#':>3}  {'timestamp':<20}  {'turns':>7}  {'cost':>9}  {'cache%':>7}  {'vs prev':>8}"
+    rows.append(header)
+    rows.append("-" * len(header))
+
+    prev_cost: Optional[float] = None
+    for i, entry in enumerate(shown):
+        idx = len(entries) - len(shown) + i + 1
+        agg = cast(dict[str, float], entry.get("aggregate", {}))
+        ts = str(entry.get("ts", ""))[:19]
+        turns = _coerce_token_int(entry.get("event_count", 0))
+        cost = agg.get("est_cost_usd", 0.0)
+        cache = float(agg.get("cache_hit_ratio", 0.0)) * 100
+
+        vs_str = ""
+        if prev_cost is not None and prev_cost > 0:
+            delta = ((cost - prev_cost) / prev_cost) * 100
+            vs_str = f"{delta:+.0f}%"
+        else:
+            vs_str = "—"
+
+        rows.append(f"{idx:>3}  {ts:<20}  {turns:>7,}  $ {cost:>7.2f}  {cache:>5.0f}%  {vs_str:>8}")
+        prev_cost = cost
+
+    if len(shown) >= 2:
+        first = cast(dict[str, float], shown[0].get("aggregate", {}))
+        last = cast(dict[str, float], shown[-1].get("aggregate", {}))
+        first_cost = first.get("est_cost_usd", 0.0)
+        last_cost = last.get("est_cost_usd", 0.0)
+        first_cache = float(first.get("cache_hit_ratio", 0.0)) * 100
+        last_cache = float(last.get("cache_hit_ratio", 0.0)) * 100
+        rows.append("")
+        rows.append(f"Trend ({len(shown)} sessions):")
+        rows.append(f"  Cost:     $ {first_cost:.2f} → $ {last_cost:.2f}  "
+                     f"({'↑' if last_cost > first_cost else '↓' if last_cost < first_cost else '→'} "
+                     f"{abs(((last_cost - first_cost) / first_cost * 100) if first_cost > 0 else 0):.0f}%)")
+        rows.append(f"  Cache:    {first_cache:.0f}% → {last_cache:.0f}%  "
+                     f"({'↑' if last_cache > first_cache else '↓' if last_cache < first_cache else '→'} "
+                     f"{abs(last_cache - first_cache):.0f}pp)")
+        avg_cost = sum(
+            float(cast(dict[str, float], e.get("aggregate", {})).get("est_cost_usd", 0.0))
+            for e in shown
+        ) / len(shown)
+        rows.append(f"  Avg cost: $ {avg_cost:.2f} / session")
+
+    return "\n".join(rows) + "\n"
+
+
+def token_report_estimate(branch: Optional[str] = None) -> str:
+    """Estimate session cost from history data.
+
+    Uses weighted average of past sessions, with recent sessions weighted
+    more heavily. Falls back to worst-case estimate when no history exists.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    spent_so_far = aggregate.get("est_cost_usd", 0.0)
+
+    entries = _load_token_history(branch_name)
+    history_costs = [
+        float(cast(dict[str, float], e.get("aggregate", {})).get("est_cost_usd", 0.0))
+        for e in entries
+    ]
+
+    rows: list[str] = []
+    if not history_costs:
+        rows.append(f"Cost estimate — {branch_name}")
+        rows.append("")
+        rows.append("  No session history available.")
+        rows.append(f"  Spent so far: $ {spent_so_far:.2f}")
+        rows.append("  A typical MAP session (1-3 subtasks) costs $0.50–$5.00")
+        rows.append("  with default models, depending on codebase size and task complexity.")
+        return "\n".join(rows) + "\n"
+
+    weighted_sum = 0.0
+    weight_sum = 0.0
+    for i, cost in enumerate(history_costs[-10:]):
+        weight = i + 1
+        weighted_sum += cost * weight
+        weight_sum += weight
+    weighted_avg = weighted_sum / weight_sum if weight_sum > 0 else 0.0
+
+    sorted_costs = sorted(history_costs[-10:])
+    median = sorted_costs[len(sorted_costs) // 2]
+    lo = sorted_costs[0]
+    hi = sorted_costs[-1]
+
+    rows.append(f"Cost estimate — {branch_name}")
+    rows.append("")
+    rows.append(f"  Based on {len(history_costs)} historical sessions (last {min(len(history_costs), 10)} weighted):")
+    rows.append(f"  Weighted avg:  $ {weighted_avg:.2f}")
+    rows.append(f"  Range:         $ {lo:.2f} — $ {hi:.2f}")
+    rows.append(f"  Median:        $ {median:.2f}")
+    rows.append(f"  Spent so far:  $ {spent_so_far:.2f}")
+    remaining = max(0.0, weighted_avg - spent_so_far)
+    rows.append(f"  Remaining est: $ {remaining:.2f}")
     return "\n".join(rows) + "\n"
 
 
@@ -14221,9 +14575,36 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
 
     elif func_name == "token_report":
-        # CLI: token_report [branch]
-        tok_branch = sys.argv[2] if len(sys.argv) >= 3 else None
-        print(token_report(tok_branch))
+        # CLI: token_report [branch] [--dashboard] [--json] [--csv]
+        #       [--history [N]] [--estimate] [--finalize]
+        args = sys.argv[2:]
+        branch_arg: Optional[str] = None
+        if args and not args[0].startswith("--"):
+            branch_arg = args[0]
+            args = args[1:]
+
+        if "--json" in args:
+            print(token_report_json(branch_arg))
+        elif "--csv" in args:
+            print(token_report_csv(branch_arg))
+        elif "--history" in args:
+            n = 10
+            try:
+                idx = args.index("--history")
+                if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                    n = int(args[idx + 1])
+            except (ValueError, IndexError):
+                pass
+            print(token_report_history(branch_arg, n))
+        elif "--estimate" in args:
+            print(token_report_estimate(branch_arg))
+        elif "--dashboard" in args:
+            print(token_report_dashboard(branch_arg))
+        elif "--finalize" in args:
+            result = record_session_snapshot(branch_arg)
+            print(json.dumps(result, indent=2))
+        else:
+            print(token_report(branch_arg))
 
     elif func_name == "detect_cross_subtask_regression_risk" and len(sys.argv) >= 4:
         # CLI: detect_cross_subtask_regression_risk <branch> <subtask_id>

--- a/src/mapify_cli/templates/skills/map-tokenreport/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-tokenreport/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: map-tokenreport
 description: |
-  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
+  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Supports --dashboard (box-drawing visual), --history (trends), --estimate (cost projection), --json / --csv export, and --finalize (record session snapshot). Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
 effort: low
 disable-model-invocation: true
-argument-hint: "[branch]"
+argument-hint: "[branch] [--dashboard|--history|--estimate|--json|--csv|--finalize]"
 ---
 # /map-tokenreport - Token Accounting Report
 
@@ -41,6 +41,20 @@ appends attributed rows to `.map/<branch>/token_log.jsonl`, rolled up into
   with downstream Actor/Monitor tokens, so users can see whether delegated
   exploration paid for itself.
 
+## Modes
+
+The skill supports several modes via CLI flags:
+
+| Flag | Effect |
+|---|---|
+| _(default)_ | Classic text table: per-subtask rows, by-agent section, research ROI, cache-hit + cost |
+| `--dashboard` | Box-drawing visual dashboard: subtask bar chart, per-agent + per-model breakdowns, vs-previous comparison |
+| `--history [N]` | Trend table over last N recorded sessions (default 10) with cost delta and cache-hit trend |
+| `--estimate` | Cost projection from weighted historical average, with range, median, and remaining estimate |
+| `--json` | Export `token_accounting.json` as formatted JSON |
+| `--csv` | Export as CSV (one row per dimension key: aggregate, subtask, agent, phase) |
+| `--finalize` | Record current `token_accounting.json` as a snapshot in `token_history.jsonl` for trend tracking |
+
 ## Steps
 
 ### Step 1: Resolve the branch
@@ -54,14 +68,38 @@ one.
 
 ### Step 2: Render the report
 
+Choose the right command for the user's intent:
+
+**Default (classic table):**
 ```bash
 python3 .map/scripts/map_step_runner.py token_report "$BRANCH"
 ```
 
-`token_report` re-reads `token_log.jsonl`, rebuilds `token_accounting.json`,
-and prints a per-subtask table, a per-agent table, research ROI, and a TOTAL
-line with the cache-hit ratio and estimated cost. It is idempotent and read-only
-against your code.
+**Dashboard (visual):**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --dashboard
+```
+
+**History (trends):**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --history
+```
+
+**Estimate:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --estimate
+```
+
+**JSON / CSV export:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --json
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --csv
+```
+
+**Record snapshot for history:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --finalize
+```
 
 ### Step 3: Optional — inspect the raw rollup
 
@@ -93,24 +131,93 @@ Report token usage for the current branch:
 /map-tokenreport
 ```
 
-Report for a specific branch:
+Visual dashboard:
 
 ```text
-/map-tokenreport feat/add-multiply
+/map-tokenreport --dashboard
 ```
 
-Typical output:
+Trend over last 5 sessions:
 
 ```text
-Token accounting — feat-add-multiply (93 assistant turns)
+/map-tokenreport --history 5
+```
 
-subtask              input      output     cache_rd    cache_cr     $cost
--------------------------------------------------------------------------
-ST-001                 183     150,879   14,085,841     792,780     47.31
--------------------------------------------------------------------------
-TOTAL                  183     150,879   14,085,841     792,780     47.31
+Cost estimate before starting:
 
-cache hit ratio: 100.0%   est cost: $47.31
+```text
+/map-tokenreport --estimate
+```
+
+Export for CI pipeline:
+
+```text
+/map-tokenreport --json > .map/token_report.json
+```
+
+Record a snapshot (typically called automatically by the Stop hook):
+
+```text
+/map-tokenreport --finalize
+```
+
+Typical dashboard output:
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  MAP Token Report — feat-oauth2                                 │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  Session: $ 3.42     Cache-hit: 67%  │ vs prev: ↑12%            │
+│  Turns: 93  │                                                   │
+├─────────────────────────────────────────────────────────────────┤
+│  Per-subtask                                                    │
+│                                                                 │
+│  ST-001       $   0.87  █████████████████████████████░░░░ 28%   │
+│  ST-002       $   1.23  ██████████████████████████████████████  │
+│  ST-003       $   0.65  █████████████████████░░░░░░░░░░░░ 21%   │
+│  ST-004       $   0.67  ██████████████████████░░░░░░░░░░░ 22%   │
+├─────────────────────────────────────────────────────────────────┤
+│  By agent                                                        │
+│    actor                       $   1.89 (55%)                    │
+│    monitor                     $   0.67 (20%)                    │
+│    evaluator                   $   0.44 (13%)                    │
+│    predictor                   $   0.42 (12%)                    │
+├─────────────────────────────────────────────────────────────────┤
+│  By model                                                        │
+│    claude-sonnet-4-6           $   2.10 (61%)                    │
+│    claude-haiku-4-5            $   1.32 (39%)                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Typical history output:
+
+```text
+Token history — feat-oauth2 (last 3 of 3 sessions)
+
+  #  timestamp              turns     cost   cache%  vs prev
+-------------------------------------------------------------------
+  1  2026-06-24T10:15:00       45  $   2.87    58%        —
+  2  2026-06-25T14:22:00       72  $   3.15    62%      +10%
+  3  2026-06-26T09:30:00       93  $   3.42    67%       +9%
+
+Trend (3 sessions):
+  Cost:     $ 2.87 → $ 3.42  ↑ 19%
+  Cache:    58% → 67%  ↑ 9pp
+  Avg cost: $ 3.15 / session
+```
+
+Typical estimate output:
+
+```text
+Cost estimate — feat-oauth2
+
+  Based on 3 historical sessions (last 3 weighted):
+  Weighted avg:  $ 3.22
+  Range:         $ 2.87 — $ 3.42
+  Median:        $ 3.15
+  Spent so far:  $ 1.20
+  Remaining est: $ 2.02
 ```
 
 ## Troubleshooting
@@ -132,3 +239,9 @@ cache hit ratio: 100.0%   est cost: $47.31
 - **Unknown model in cost estimate.** `MODEL_TOKEN_PRICES` falls back to the
   default model price for unrecognized model ids; update that table in
   `map_step_runner.py` when a new model ships.
+- **`--history` / `--estimate` show no data.** No snapshots have been recorded.
+  Run `/map-tokenreport --finalize` at the end of each session, or set up the
+  Stop hook to call `record_session_snapshot` automatically.
+- **Dashboard layout looks wrong in narrow terminals.** The dashboard uses
+  a fixed 67-character width. Pipe the output to a file and view it in a wider
+  terminal, or use `--json` for programmatic consumption.

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -748,6 +748,7 @@ def record_token_budget_decision(
 
 TOKEN_LOG_NAME = "token_log.jsonl"
 TOKEN_ACCOUNTING_NAME = "token_accounting.json"
+TOKEN_HISTORY_NAME = "token_history.jsonl"
 TOKEN_METER_CACHE_NAME = ".token-meter-cache.json"
 _SEEN_ID_CACHE_LIMIT = 5000
 
@@ -1383,6 +1384,359 @@ def token_report(branch: Optional[str] = None) -> str:
         f"cache hit ratio: {ratio:.1f}%   "
         f"est cost: ${float(aggregate.get('est_cost_usd', 0.0)):.2f}"
     )
+    return "\n".join(rows) + "\n"
+
+
+def record_session_snapshot(branch: Optional[str] = None) -> dict[str, object]:
+    """Append the current token_accounting.json to token_history.jsonl.
+
+    Called once per session (typically from the Stop hook or /map-tokenreport
+    --finalize). Records timestamp, branch, aggregate, by_subtask, by_agent,
+    by_model, cache_hit_ratio, and est_cost_usd so history queries can show
+    trends across sessions without re-reading every token_log.jsonl.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+
+    by_model: dict[str, dict[str, float]] = {}
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    if log_path.is_file():
+        try:
+            for raw in log_path.read_text(encoding="utf-8").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                model = str(row.get("model") or "unknown")
+                usage = {field: _coerce_token_int(row.get(field, 0)) for field in _TOKEN_FIELDS}
+                cost = _token_cost(usage, model)
+                bucket = by_model.setdefault(model, {**_empty_token_bucket(), "est_cost_usd": 0.0})
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(bucket.get("est_cost_usd", 0.0) + cost, 6)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    snapshot: dict[str, object] = {
+        "ts": _utc_timestamp(),
+        "branch": branch_name,
+        "event_count": payload.get("event_count", 0),
+        "aggregate": aggregate,
+        "by_subtask": {k: v for k, v in by_subtask.items()},
+        "by_agent": {k: v for k, v in by_agent.items()},
+        "by_model": {k: v for k, v in by_model.items()},
+    }
+    history_path = get_branch_dir(branch_name) / TOKEN_HISTORY_NAME
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with history_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(snapshot) + "\n")
+    except OSError as exc:
+        return {"status": "error", "reason": str(exc)}
+    return {"status": "success", "recorded": 1}
+
+
+def _load_token_history(branch: str) -> list[dict[str, object]]:
+    """Load all snapshots from token_history.jsonl for a branch."""
+    history_path = get_branch_dir(branch) / TOKEN_HISTORY_NAME
+    entries: list[dict[str, object]] = []
+    if not history_path.is_file():
+        return entries
+    try:
+        for raw in history_path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                row = json.loads(raw)
+                if isinstance(row, dict):
+                    entries.append(cast(dict[str, object], row))
+            except json.JSONDecodeError:
+                continue
+    except (OSError, UnicodeDecodeError):
+        pass
+    return entries
+
+
+def token_report_json(branch: Optional[str] = None) -> str:
+    """Export token_accounting.json as formatted JSON."""
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    return json.dumps(payload, indent=2)
+
+
+def token_report_csv(branch: Optional[str] = None) -> str:
+    """Export token_accounting as CSV (one row per accounting bucket)."""
+    import csv as _csv
+    import io as _io
+
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+    by_phase = cast(dict[str, dict[str, float]], payload.get("by_phase", {}))
+
+    buf = _io.StringIO()
+    writer = _csv.writer(buf)
+    header = ["dimension", "key", "input", "output", "cache_read", "cache_creation", "est_cost_usd", "cache_hit_ratio"]
+    writer.writerow(header)
+
+    def _write_rows(dim: str, bucket: dict[str, dict[str, float]]) -> None:
+        for key in sorted(bucket):
+            b = bucket[key]
+            cacheable = b.get("input", 0.0) + b.get("cache_read", 0.0)
+            ratio = round(b.get("cache_read", 0.0) / cacheable, 4) if cacheable else 0.0
+            writer.writerow([
+                dim, key,
+                int(b.get("input", 0)), int(b.get("output", 0)),
+                int(b.get("cache_read", 0)), int(b.get("cache_creation", 0)),
+                round(b.get("est_cost_usd", 0.0), 4), ratio,
+            ])
+
+    cacheable = aggregate.get("input", 0.0) + aggregate.get("cache_read", 0.0)
+    agg_ratio = round(aggregate.get("cache_read", 0.0) / cacheable, 4) if cacheable else 0.0
+    writer.writerow([
+        "aggregate", branch_name,
+        int(aggregate.get("input", 0)), int(aggregate.get("output", 0)),
+        int(aggregate.get("cache_read", 0)), int(aggregate.get("cache_creation", 0)),
+        round(aggregate.get("est_cost_usd", 0.0), 4), agg_ratio,
+    ])
+    _write_rows("subtask", by_subtask)
+    _write_rows("agent", by_agent)
+    _write_rows("phase", by_phase)
+    return buf.getvalue()
+
+
+def token_report_dashboard(branch: Optional[str] = None) -> str:
+    """Render a visual dashboard with box-drawing characters.
+
+    Shows session summary, per-subtask bar chart, per-agent/per-model
+    breakdowns, and vs-previous-session comparison when history exists.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    by_subtask = cast(dict[str, dict[str, float]], payload.get("by_subtask", {}))
+    by_agent = cast(dict[str, dict[str, float]], payload.get("by_agent", {}))
+
+    total_cost = aggregate.get("est_cost_usd", 0.0)
+    cache_ratio = float(aggregate.get("cache_hit_ratio", 0.0)) * 100
+    event_count = _coerce_token_int(payload.get("event_count", 0))
+
+    rows: list[str] = []
+    W = 67
+
+    def _box_row(content):
+        rows.append("│  " + content.ljust(W - 5) + " │")
+
+    rows.append("┌" + "─" * (W - 2) + "┐")
+    rows.append("│  MAP Token Report — " + branch_name.ljust(W - 24) + " │")
+    rows.append("│" + " " * (W - 2) + "│")
+    rows.append("├" + "─" * (W - 2) + "┤")
+
+    # ---- summary ----
+    history = _load_token_history(branch_name)
+    vs_prev = ""
+    if len(history) >= 2:
+        prev = cast(dict[str, float], history[-2].get("aggregate", {}))
+        prev_cost = prev.get("est_cost_usd", 0.0)
+        if prev_cost > 0:
+            delta = ((total_cost - prev_cost) / prev_cost) * 100
+            arrow = "\u25b2" if delta > 0 else "\u25bc"
+            vs_prev = " | vs prev: {}{:+.0f}%".format(arrow, delta)
+
+    _box_row("Session: ${:.2f}  |  Cache-hit: {:.0f}%{}".format(
+        total_cost, cache_ratio, vs_prev))
+    _box_row("Turns: {}".format(event_count))
+
+    # ---- per-subtask bar chart ----
+    if by_subtask:
+        rows.append("├" + "─" * (W - 2) + "┤")
+        _box_row("Per-subtask:")
+        rows.append("│  " + " " * (W - 5) + " │")
+
+        max_cost = max((b.get("est_cost_usd", 0.0) for b in by_subtask.values()), default=0.01)
+        bar_max = W - 24
+        for sid in sorted(by_subtask):
+            b = by_subtask[sid]
+            scost = b.get("est_cost_usd", 0.0)
+            ratio_pct = (scost / total_cost * 100) if total_cost > 0 else 0
+            bar_len = int((scost / max_cost) * bar_max) if max_cost > 0 else 0
+            bar = "\u2588" * bar_len + "\u2591" * (bar_max - bar_len)
+            rows.append("│  {:12s} $ {:>7.2f}  {} {:>3.0f}% │".format(
+                sid, scost, bar, ratio_pct))
+
+    # ---- by agent ----
+    if by_agent:
+        rows.append("├" + "─" * (W - 2) + "┤")
+        _box_row("By agent:")
+        agent_cost_total = sum(b.get("est_cost_usd", 0.0) for b in by_agent.values())
+        for agent in sorted(by_agent, key=lambda a: by_agent[a].get("est_cost_usd", 0.0), reverse=True):
+            b = by_agent[agent]
+            acost = b.get("est_cost_usd", 0.0)
+            pct = (acost / agent_cost_total * 100) if agent_cost_total > 0 else 0
+            pad = max(0, W - 5 - 26 - 11 - 7)
+            rows.append("│    {:26s} $ {:>7.2f} ({:>3.0f}%){:s} │".format(
+                agent, acost, pct, " " * pad))
+
+    # ---- by model ----
+    rows.append("├" + "─" * (W - 2) + "┤")
+    _box_row("By model:")
+    by_model: dict[str, dict[str, float]] = {}
+    log_path = get_branch_dir(branch_name) / TOKEN_LOG_NAME
+    if log_path.is_file():
+        try:
+            for raw in log_path.read_text(encoding="utf-8").splitlines():
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                model = str(row.get("model") or "unknown")
+                usage = {field: _coerce_token_int(row.get(field, 0)) for field in _TOKEN_FIELDS}
+                cost = _token_cost(usage, model)
+                bucket = by_model.setdefault(model, {**_empty_token_bucket(), "est_cost_usd": 0.0})
+                for field in _TOKEN_FIELDS:
+                    bucket[field] += usage[field]
+                bucket["est_cost_usd"] = round(bucket.get("est_cost_usd", 0.0) + cost, 6)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    if by_model:
+        model_cost_total = sum(b.get("est_cost_usd", 0.0) for b in by_model.values())
+        for model in sorted(by_model, key=lambda m: by_model[m].get("est_cost_usd", 0.0), reverse=True):
+            b = by_model[model]
+            mcost = b.get("est_cost_usd", 0.0)
+            pct = (mcost / model_cost_total * 100) if model_cost_total > 0 else 0
+            model_short = model[:30] if len(model) > 30 else model
+            pad = max(0, W - 5 - 32 - 11 - 7)
+            rows.append("│    {:32s} $ {:>7.2f} ({:>3.0f}%){:s} │".format(
+                model_short, mcost, pct, " " * pad))
+
+    rows.append("└" + "─" * (W - 2) + "┘")
+    return "\n".join(rows) + "\n"
+
+
+def token_report_history(branch: Optional[str] = None, n: int = 10) -> str:
+    """Show token cost trends across the last N recorded sessions."""
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    entries = _load_token_history(branch_name)
+    if not entries:
+        return "No session history recorded yet. Run /map-tokenreport to record a snapshot.\n"
+
+    shown = entries[-n:]
+    rows: list[str] = []
+    rows.append(f"Token history — {branch_name} (last {len(shown)} of {len(entries)} sessions)")
+    rows.append("")
+    header = f"{'#':>3}  {'timestamp':<20}  {'turns':>7}  {'cost':>9}  {'cache%':>7}  {'vs prev':>8}"
+    rows.append(header)
+    rows.append("-" * len(header))
+
+    prev_cost: Optional[float] = None
+    for i, entry in enumerate(shown):
+        idx = len(entries) - len(shown) + i + 1
+        agg = cast(dict[str, float], entry.get("aggregate", {}))
+        ts = str(entry.get("ts", ""))[:19]
+        turns = _coerce_token_int(entry.get("event_count", 0))
+        cost = agg.get("est_cost_usd", 0.0)
+        cache = float(agg.get("cache_hit_ratio", 0.0)) * 100
+
+        vs_str = ""
+        if prev_cost is not None and prev_cost > 0:
+            delta = ((cost - prev_cost) / prev_cost) * 100
+            vs_str = f"{delta:+.0f}%"
+        else:
+            vs_str = "—"
+
+        rows.append(f"{idx:>3}  {ts:<20}  {turns:>7,}  $ {cost:>7.2f}  {cache:>5.0f}%  {vs_str:>8}")
+        prev_cost = cost
+
+    if len(shown) >= 2:
+        first = cast(dict[str, float], shown[0].get("aggregate", {}))
+        last = cast(dict[str, float], shown[-1].get("aggregate", {}))
+        first_cost = first.get("est_cost_usd", 0.0)
+        last_cost = last.get("est_cost_usd", 0.0)
+        first_cache = float(first.get("cache_hit_ratio", 0.0)) * 100
+        last_cache = float(last.get("cache_hit_ratio", 0.0)) * 100
+        rows.append("")
+        rows.append(f"Trend ({len(shown)} sessions):")
+        rows.append(f"  Cost:     $ {first_cost:.2f} → $ {last_cost:.2f}  "
+                     f"({'↑' if last_cost > first_cost else '↓' if last_cost < first_cost else '→'} "
+                     f"{abs(((last_cost - first_cost) / first_cost * 100) if first_cost > 0 else 0):.0f}%)")
+        rows.append(f"  Cache:    {first_cache:.0f}% → {last_cache:.0f}%  "
+                     f"({'↑' if last_cache > first_cache else '↓' if last_cache < first_cache else '→'} "
+                     f"{abs(last_cache - first_cache):.0f}pp)")
+        avg_cost = sum(
+            float(cast(dict[str, float], e.get("aggregate", {})).get("est_cost_usd", 0.0))
+            for e in shown
+        ) / len(shown)
+        rows.append(f"  Avg cost: $ {avg_cost:.2f} / session")
+
+    return "\n".join(rows) + "\n"
+
+
+def token_report_estimate(branch: Optional[str] = None) -> str:
+    """Estimate session cost from history data.
+
+    Uses weighted average of past sessions, with recent sessions weighted
+    more heavily. Falls back to worst-case estimate when no history exists.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    payload = _rebuild_token_accounting(branch_name)
+    aggregate = cast(dict[str, float], payload.get("aggregate", {}))
+    spent_so_far = aggregate.get("est_cost_usd", 0.0)
+
+    entries = _load_token_history(branch_name)
+    history_costs = [
+        float(cast(dict[str, float], e.get("aggregate", {})).get("est_cost_usd", 0.0))
+        for e in entries
+    ]
+
+    rows: list[str] = []
+    if not history_costs:
+        rows.append(f"Cost estimate — {branch_name}")
+        rows.append("")
+        rows.append("  No session history available.")
+        rows.append(f"  Spent so far: $ {spent_so_far:.2f}")
+        rows.append("  A typical MAP session (1-3 subtasks) costs $0.50–$5.00")
+        rows.append("  with default models, depending on codebase size and task complexity.")
+        return "\n".join(rows) + "\n"
+
+    weighted_sum = 0.0
+    weight_sum = 0.0
+    for i, cost in enumerate(history_costs[-10:]):
+        weight = i + 1
+        weighted_sum += cost * weight
+        weight_sum += weight
+    weighted_avg = weighted_sum / weight_sum if weight_sum > 0 else 0.0
+
+    sorted_costs = sorted(history_costs[-10:])
+    median = sorted_costs[len(sorted_costs) // 2]
+    lo = sorted_costs[0]
+    hi = sorted_costs[-1]
+
+    rows.append(f"Cost estimate — {branch_name}")
+    rows.append("")
+    rows.append(f"  Based on {len(history_costs)} historical sessions (last {min(len(history_costs), 10)} weighted):")
+    rows.append(f"  Weighted avg:  $ {weighted_avg:.2f}")
+    rows.append(f"  Range:         $ {lo:.2f} — $ {hi:.2f}")
+    rows.append(f"  Median:        $ {median:.2f}")
+    rows.append(f"  Spent so far:  $ {spent_so_far:.2f}")
+    remaining = max(0.0, weighted_avg - spent_so_far)
+    rows.append(f"  Remaining est: $ {remaining:.2f}")
     return "\n".join(rows) + "\n"
 
 
@@ -14221,9 +14575,36 @@ if __name__ == "__main__":
         print(json.dumps(report, indent=2))
 
     elif func_name == "token_report":
-        # CLI: token_report [branch]
-        tok_branch = sys.argv[2] if len(sys.argv) >= 3 else None
-        print(token_report(tok_branch))
+        # CLI: token_report [branch] [--dashboard] [--json] [--csv]
+        #       [--history [N]] [--estimate] [--finalize]
+        args = sys.argv[2:]
+        branch_arg: Optional[str] = None
+        if args and not args[0].startswith("--"):
+            branch_arg = args[0]
+            args = args[1:]
+
+        if "--json" in args:
+            print(token_report_json(branch_arg))
+        elif "--csv" in args:
+            print(token_report_csv(branch_arg))
+        elif "--history" in args:
+            n = 10
+            try:
+                idx = args.index("--history")
+                if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                    n = int(args[idx + 1])
+            except (ValueError, IndexError):
+                pass
+            print(token_report_history(branch_arg, n))
+        elif "--estimate" in args:
+            print(token_report_estimate(branch_arg))
+        elif "--dashboard" in args:
+            print(token_report_dashboard(branch_arg))
+        elif "--finalize" in args:
+            result = record_session_snapshot(branch_arg)
+            print(json.dumps(result, indent=2))
+        else:
+            print(token_report(branch_arg))
 
     elif func_name == "detect_cross_subtask_regression_risk" and len(sys.argv) >= 4:
         # CLI: detect_cross_subtask_regression_risk <branch> <subtask_id>

--- a/src/mapify_cli/templates_src/skills/map-tokenreport/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-tokenreport/SKILL.md.jinja
@@ -1,10 +1,10 @@
 ---
 name: map-tokenreport
 description: |
-  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
+  Show per-subtask/agent token accounting (input, output, cache read/creation, cost, cache-hit ratio) for the current branch. Supports --dashboard (box-drawing visual), --history (trends), --estimate (cost projection), --json / --csv export, and --finalize (record session snapshot). Use when asked for token usage, run cost, or a token report. Do NOT use to plan or run work; use map-efficient.
 effort: low
 disable-model-invocation: true
-argument-hint: "[branch]"
+argument-hint: "[branch] [--dashboard|--history|--estimate|--json|--csv|--finalize]"
 ---
 # /map-tokenreport - Token Accounting Report
 
@@ -41,6 +41,20 @@ appends attributed rows to `.map/<branch>/token_log.jsonl`, rolled up into
   with downstream Actor/Monitor tokens, so users can see whether delegated
   exploration paid for itself.
 
+## Modes
+
+The skill supports several modes via CLI flags:
+
+| Flag | Effect |
+|---|---|
+| _(default)_ | Classic text table: per-subtask rows, by-agent section, research ROI, cache-hit + cost |
+| `--dashboard` | Box-drawing visual dashboard: subtask bar chart, per-agent + per-model breakdowns, vs-previous comparison |
+| `--history [N]` | Trend table over last N recorded sessions (default 10) with cost delta and cache-hit trend |
+| `--estimate` | Cost projection from weighted historical average, with range, median, and remaining estimate |
+| `--json` | Export `token_accounting.json` as formatted JSON |
+| `--csv` | Export as CSV (one row per dimension key: aggregate, subtask, agent, phase) |
+| `--finalize` | Record current `token_accounting.json` as a snapshot in `token_history.jsonl` for trend tracking |
+
 ## Steps
 
 ### Step 1: Resolve the branch
@@ -54,14 +68,38 @@ one.
 
 ### Step 2: Render the report
 
+Choose the right command for the user's intent:
+
+**Default (classic table):**
 ```bash
 python3 .map/scripts/map_step_runner.py token_report "$BRANCH"
 ```
 
-`token_report` re-reads `token_log.jsonl`, rebuilds `token_accounting.json`,
-and prints a per-subtask table, a per-agent table, research ROI, and a TOTAL
-line with the cache-hit ratio and estimated cost. It is idempotent and read-only
-against your code.
+**Dashboard (visual):**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --dashboard
+```
+
+**History (trends):**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --history
+```
+
+**Estimate:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --estimate
+```
+
+**JSON / CSV export:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --json
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --csv
+```
+
+**Record snapshot for history:**
+```bash
+python3 .map/scripts/map_step_runner.py token_report "$BRANCH" --finalize
+```
 
 ### Step 3: Optional — inspect the raw rollup
 
@@ -93,24 +131,93 @@ Report token usage for the current branch:
 /map-tokenreport
 ```
 
-Report for a specific branch:
+Visual dashboard:
 
 ```text
-/map-tokenreport feat/add-multiply
+/map-tokenreport --dashboard
 ```
 
-Typical output:
+Trend over last 5 sessions:
 
 ```text
-Token accounting — feat-add-multiply (93 assistant turns)
+/map-tokenreport --history 5
+```
 
-subtask              input      output     cache_rd    cache_cr     $cost
--------------------------------------------------------------------------
-ST-001                 183     150,879   14,085,841     792,780     47.31
--------------------------------------------------------------------------
-TOTAL                  183     150,879   14,085,841     792,780     47.31
+Cost estimate before starting:
 
-cache hit ratio: 100.0%   est cost: $47.31
+```text
+/map-tokenreport --estimate
+```
+
+Export for CI pipeline:
+
+```text
+/map-tokenreport --json > .map/token_report.json
+```
+
+Record a snapshot (typically called automatically by the Stop hook):
+
+```text
+/map-tokenreport --finalize
+```
+
+Typical dashboard output:
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  MAP Token Report — feat-oauth2                                 │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  Session: $ 3.42     Cache-hit: 67%  │ vs prev: ↑12%            │
+│  Turns: 93  │                                                   │
+├─────────────────────────────────────────────────────────────────┤
+│  Per-subtask                                                    │
+│                                                                 │
+│  ST-001       $   0.87  █████████████████████████████░░░░ 28%   │
+│  ST-002       $   1.23  ██████████████████████████████████████  │
+│  ST-003       $   0.65  █████████████████████░░░░░░░░░░░░ 21%   │
+│  ST-004       $   0.67  ██████████████████████░░░░░░░░░░░ 22%   │
+├─────────────────────────────────────────────────────────────────┤
+│  By agent                                                        │
+│    actor                       $   1.89 (55%)                    │
+│    monitor                     $   0.67 (20%)                    │
+│    evaluator                   $   0.44 (13%)                    │
+│    predictor                   $   0.42 (12%)                    │
+├─────────────────────────────────────────────────────────────────┤
+│  By model                                                        │
+│    claude-sonnet-4-6           $   2.10 (61%)                    │
+│    claude-haiku-4-5            $   1.32 (39%)                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Typical history output:
+
+```text
+Token history — feat-oauth2 (last 3 of 3 sessions)
+
+  #  timestamp              turns     cost   cache%  vs prev
+-------------------------------------------------------------------
+  1  2026-06-24T10:15:00       45  $   2.87    58%        —
+  2  2026-06-25T14:22:00       72  $   3.15    62%      +10%
+  3  2026-06-26T09:30:00       93  $   3.42    67%       +9%
+
+Trend (3 sessions):
+  Cost:     $ 2.87 → $ 3.42  ↑ 19%
+  Cache:    58% → 67%  ↑ 9pp
+  Avg cost: $ 3.15 / session
+```
+
+Typical estimate output:
+
+```text
+Cost estimate — feat-oauth2
+
+  Based on 3 historical sessions (last 3 weighted):
+  Weighted avg:  $ 3.22
+  Range:         $ 2.87 — $ 3.42
+  Median:        $ 3.15
+  Spent so far:  $ 1.20
+  Remaining est: $ 2.02
 ```
 
 ## Troubleshooting
@@ -132,3 +239,9 @@ cache hit ratio: 100.0%   est cost: $47.31
 - **Unknown model in cost estimate.** `MODEL_TOKEN_PRICES` falls back to the
   default model price for unrecognized model ids; update that table in
   `map_step_runner.py` when a new model ships.
+- **`--history` / `--estimate` show no data.** No snapshots have been recorded.
+  Run `/map-tokenreport --finalize` at the end of each session, or set up the
+  Stop hook to call `record_session_snapshot` automatically.
+- **Dashboard layout looks wrong in narrow terminals.** The dashboard uses
+  a fixed 67-character width. Pipe the output to a file and view it in a wider
+  terminal, or use `--json` for programmatic consumption.

--- a/tests/test_map_token_meter.py
+++ b/tests/test_map_token_meter.py
@@ -204,3 +204,210 @@ def test_repeated_msgid_keeps_most_complete_copy(tmp_path):
     agg = json.loads((branch_dir / "token_accounting.json").read_text())["aggregate"]
     assert agg["output"] == 200, "must keep the most complete copy, not the partial"
     assert agg["cache_read"] == 8000
+
+
+# ── token_report output mode tests ──
+
+
+def _setup_token_report_project(tmp_path: Path, branch: str) -> Path:
+    """Create a project with token accounting data and git branch."""
+    scripts_dir = tmp_path / ".map" / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy(SHIPPED_RUNNER, scripts_dir / "map_step_runner.py")
+    shutil.copy(SHIPPED_SCRIPTS / "map_utils.py", scripts_dir / "map_utils.py")
+    branch_dir = tmp_path / ".map" / branch
+    branch_dir.mkdir(parents=True)
+
+    # Write token_log.jsonl with two subtask entries
+    log = branch_dir / "token_log.jsonl"
+    log.write_text(
+        json.dumps({
+            "ts": "2026-06-26T10:00:00Z",
+            "subtask_id": "ST-001",
+            "phase": "ACTOR",
+            "agent": "actor",
+            "model": "claude-sonnet-4-6",
+            "msg_id": "msg_A",
+            "input": 5000,
+            "output": 2000,
+            "cache_creation": 1000,
+            "cache_read": 30000,
+        }) + "\n" +
+        json.dumps({
+            "ts": "2026-06-26T10:05:00Z",
+            "subtask_id": "ST-001",
+            "phase": "ACTOR",
+            "agent": "actor",
+            "model": "claude-sonnet-4-6",
+            "msg_id": "msg_B",
+            "input": 3000,
+            "output": 800,
+            "cache_creation": 0,
+            "cache_read": 15000,
+        }) + "\n" +
+        json.dumps({
+            "ts": "2026-06-26T10:10:00Z",
+            "subtask_id": "ST-002",
+            "phase": "MONITOR",
+            "agent": "monitor",
+            "model": "claude-haiku-4-5",
+            "msg_id": "msg_C",
+            "input": 1000,
+            "output": 400,
+            "cache_creation": 500,
+            "cache_read": 5000,
+        }) + "\n"
+    )
+
+    # Write step_state.json
+    (branch_dir / "step_state.json").write_text(
+        json.dumps({"current_subtask_id": "ST-002", "current_step_phase": "MONITOR"})
+    )
+    _init_git_branch(tmp_path, branch)
+    return branch_dir
+
+
+def _run_report_command(tmp_path: Path, branch: str, *flags: str) -> str:
+    """Run token_report via the shipped runner for a given branch and flags."""
+    r = subprocess.run(
+        [sys.executable, str(SHIPPED_RUNNER), "token_report", branch, *flags],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    return r.stdout
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_json_export(tmp_path):
+    """--json exports valid JSON with aggregate, by_subtask, by_agent."""
+    branch = "feat-json"
+    _setup_token_report_project(tmp_path, branch)
+    out = _run_report_command(tmp_path, branch, "--json")
+    payload = json.loads(out)
+    assert payload["branch"] == branch
+    assert payload["aggregate"]["input"] == 9000
+    assert "ST-001" in payload["by_subtask"]
+    assert "ST-002" in payload["by_subtask"]
+    assert "actor" in payload["by_agent"]
+    assert "monitor" in payload["by_agent"]
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_csv_export(tmp_path):
+    """--csv exports CSV with aggregate, subtask, agent, phase rows."""
+    branch = "feat-csv"
+    _setup_token_report_project(tmp_path, branch)
+    out = _run_report_command(tmp_path, branch, "--csv")
+    lines = out.strip().splitlines()
+    assert len(lines) >= 4  # header + aggregate + subtasks + agents
+    assert lines[0].startswith("dimension,key,")
+    assert any("aggregate" in line for line in lines)
+    assert any("ST-001" in line for line in lines)
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_dashboard(tmp_path):
+    """--dashboard renders box-drawing visual output."""
+    branch = "feat-dash"
+    _setup_token_report_project(tmp_path, branch)
+    out = _run_report_command(tmp_path, branch, "--dashboard")
+    assert "MAP Token Report" in out
+    assert "feat-dash" in out
+    assert "Per-subtask" in out
+    assert "By agent" in out
+    assert "By model" in out
+    assert "█" in out or "░" in out  # bar chart characters
+    assert "$" in out
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_history_no_snapshots(tmp_path):
+    """--history with no recorded snapshots shows guidance message."""
+    branch = "feat-hist-empty"
+    _setup_token_report_project(tmp_path, branch)
+    out = _run_report_command(tmp_path, branch, "--history")
+    assert "No session history" in out
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_snapshot_and_history(tmp_path):
+    """record_session_snapshot writes history; --history shows trends."""
+    branch = "feat-hist"
+    _setup_token_report_project(tmp_path, branch)
+
+    # Record two snapshots
+    r1 = subprocess.run(
+        [sys.executable, str(SHIPPED_RUNNER), "token_report", branch, "--finalize"],
+        capture_output=True, text=True,
+        cwd=str(tmp_path),
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    assert json.loads(r1.stdout)["status"] == "success"
+
+    r2 = subprocess.run(
+        [sys.executable, str(SHIPPED_RUNNER), "token_report", branch, "--finalize"],
+        capture_output=True, text=True,
+        cwd=str(tmp_path),
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    assert json.loads(r2.stdout)["status"] == "success"
+
+    # History file should have two lines
+    hist = tmp_path / ".map" / branch / "token_history.jsonl"
+    lines = [line for line in hist.read_text().splitlines() if line.strip()]
+    assert len(lines) == 2
+
+    out = _run_report_command(tmp_path, branch, "--history")
+    assert "Token history" in out
+    assert "feat-hist" in out
+    assert "—" in out  # vs-prev baseline marker
+    assert "Trend" in out
+    assert "Cost:" in out
+    assert "Cache:" in out
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_estimate_no_history(tmp_path):
+    """--estimate with no history shows fallback guidance."""
+    branch = "feat-est-empty"
+    _setup_token_report_project(tmp_path, branch)
+    out = _run_report_command(tmp_path, branch, "--estimate")
+    assert "No session history" in out
+    assert "Spent so far" in out
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_estimate_with_history(tmp_path):
+    """--estimate with history shows weighted avg, range, median, remaining."""
+    branch = "feat-est"
+    _setup_token_report_project(tmp_path, branch)
+
+    # Record one snapshot, then run estimate
+    subprocess.run(
+        [sys.executable, str(SHIPPED_RUNNER), "token_report", branch, "--finalize"],
+        capture_output=True, text=True,
+        cwd=str(tmp_path),
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    out = _run_report_command(tmp_path, branch, "--estimate")
+    assert "Cost estimate" in out
+    assert "Weighted avg" in out
+    assert "Range" in out
+    assert "Median" in out
+    assert "Spent so far" in out
+    assert "Remaining est" in out
+
+
+@pytest.mark.skipif(not SHIPPED_RUNNER.is_file(), reason="shipped runner missing")
+def test_token_report_default_still_works(tmp_path):
+    """Default mode (no flags) still renders classic text table."""
+    branch = "feat-default"
+    _setup_token_report_project(tmp_path, branch)
+    out = _run_report_command(tmp_path, branch)
+    assert "Token accounting" in out
+    assert "feat-default" in out
+    assert "subtask" in out or "ST-001" in out  # table header or subtask id
+    assert "cache hit ratio" in out.lower()
+    assert "est cost" in out.lower()


### PR DESCRIPTION
Closes #289

## Summary

Adds five new output modes to `/map-tokenreport`:

| Flag | Mode |
|---|---|
| `--dashboard` | Box-drawing visual dashboard: subtask bar chart, per-agent/model breakdowns, vs-previous comparison |
| `--history [N]` | Cost/cache-hit trend table over last N sessions |
| `--estimate` | Weighted cost projection from historical data with range/median/remaining |
| `--json` / `--csv` | Structured export for CI pipelines |
| `--finalize` | Record current snapshot to `.map/<branch>/token_history.jsonl` |

## Changes

- `map_step_runner.py.jinja`: +6 functions (`record_session_snapshot`, `token_report_json`, `token_report_csv`, `token_report_dashboard`, `token_report_history`, `token_report_estimate`), updated CLI dispatch
- `SKILL.md.jinja`: documented all new modes, examples, troubleshooting
- `test_map_token_meter.py`: +8 tests covering all new modes
- Rendered templates: `.claude/`, `.map/`, `src/mapify_cli/templates/`

## Verification

- `make check`: ruff ✅, mypy ✅, pyright ✅, 2838 passed ✅
- `make check-render`: generated trees match templates_src ✅