### PR TITLE
feat: scope learned rules by path_glob — filter before Actor context and personal-rules injection

### DIFF
--- a/.claude/hooks/workflow-context-injector.py
+++ b/.claude/hooks/workflow-context-injector.py
@@ -22,6 +22,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from pathlib import Path
 
 # Keep in sync with map_step_runner.py GOAL_HEADING_RE
@@ -708,12 +709,70 @@ def _sanitize_fence_content(text: str) -> str:
     return text
 
 
-def _load_personal_rules(project_dir: Path) -> tuple[int, str]:
+def _parse_rule_paths(content: str) -> list[str]:
+    """Extract optional ``paths:`` frontmatter globs from a rule markdown file."""
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return []
+
+    paths: list[str] = []
+    in_paths = False
+    for raw_line in lines[1:]:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped == "paths:":
+            in_paths = True
+            continue
+        if not in_paths:
+            continue
+        if stripped.startswith("- "):
+            candidate = stripped[2:].strip().strip("\"'")
+            if candidate:
+                paths.append(candidate)
+            continue
+        if stripped:
+            in_paths = False
+    return paths
+
+
+def _paths_match_file(rule_paths: list[str], file_path: str) -> bool:
+    """Return True when *file_path* matches at least one glob in *rule_paths*."""
+    for pattern in rule_paths:
+        if fnmatch(file_path, pattern) or fnmatch(f"./{file_path}", pattern):
+            return True
+    return False
+
+
+def _extract_target_file(tool_name: str, tool_input: dict) -> str:
+    """Extract the target file path from a tool invocation.
+
+    For Edit/Write/MultiEdit, reads ``file_path`` directly.
+    For Bash, returns empty — we cannot reliably determine which files
+    a command operates on without parsing arbitrary shell syntax.
+    """
+    if tool_name in ("Edit", "Write", "MultiEdit"):
+        file_path = tool_input.get("file_path", "")
+        if isinstance(file_path, str) and file_path.strip():
+            return file_path.strip()
+    return ""
+
+
+def _load_personal_rules(
+    project_dir: Path, target_file: str = ""
+) -> tuple[int, str]:
     """Load personal learned rules from ``.map/personal/rules/learned/``.
 
     Reads every ``*.md`` file under the directory in sorted order,
     sanitises each file's content through ``_sanitize_fence_content``,
     and returns a tuple of ``(count, joined_content)``.
+
+    When *target_file* is non-empty, files with ``paths:`` frontmatter that
+    do not match *target_file* are skipped — only unconditional rules and
+    matching scoped rules are loaded.  When *target_file* is empty, all
+    files are loaded (no filtering — we cannot determine relevance without
+    a target).
 
     Returns ``(0, "")`` when the directory does not exist or contains
     no readable ``.md`` files.
@@ -743,6 +802,11 @@ def _load_personal_rules(project_dir: Path) -> tuple[int, str]:
             content = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+
+        if target_file:
+            rule_paths = _parse_rule_paths(content)
+            if rule_paths and not _paths_match_file(rule_paths, target_file):
+                continue
 
         sanitized_parts.append(_sanitize_fence_content(content))
 
@@ -906,7 +970,8 @@ def main() -> None:
         if conflict_context:
             context_parts.append(conflict_context)
         base_context = PERSONAL_RULES_SEPARATOR.join(context_parts)
-        personal_count, personal_content = _load_personal_rules(project_dir)
+        target_file = _extract_target_file(tool_name, tool_input)
+        personal_count, personal_content = _load_personal_rules(project_dir, target_file)
         personal_limit = max(
             0,
             PERSONAL_BLOCK_BUDGET_TOTAL - len(base_context) - len(PERSONAL_RULES_SEPARATOR),

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -2317,6 +2317,53 @@ def _load_learned_rules() -> list[dict[str, object]]:
     return rules
 
 
+def _filter_learned_rules_by_files(
+    learned_rules: list[dict[str, object]], affected_files: list[str]
+) -> list[dict[str, object]]:
+    """Filter learned rules to those applicable to the given affected files.
+
+    Rules without ``paths:`` frontmatter are always included (unconditional).
+    Rules with ``paths:`` are included only when at least one affected file
+    matches at least one path glob.  When *affected_files* is empty (the
+    subtask has no declared file targets), all rules are included — we cannot
+    safely exclude scoped rules without file context.
+    """
+    if not affected_files:
+        return learned_rules
+
+    filtered: list[dict[str, object]] = []
+    for rule in learned_rules:
+        rule_paths = cast(list[object], rule.get("paths", []))
+        str_paths: list[str] = [
+            str(p) for p in rule_paths if isinstance(p, str) and p.strip()
+        ]
+        if not str_paths:
+            filtered.append(rule)
+            continue
+        if _paths_match_rule_scope(str_paths, affected_files):
+            filtered.append(rule)
+    return filtered
+
+
+def _format_learned_rules_block(rules: list[dict[str, object]]) -> str:
+    """Format applicable learned rules as a compact context block."""
+    if not rules:
+        return ""
+
+    lines = [
+        "<learned_rules>",
+        f"[learned-rules: {len(rules)} applicable rules]",
+    ]
+    for rule in rules:
+        title = str(rule.get("title", ""))
+        body = str(rule.get("body", ""))
+        rule_file = str(rule.get("file", ""))
+        file_name = Path(rule_file).name if rule_file else "unknown"
+        lines.append(f"- **{title}** ({file_name}): {body}")
+    lines.append("</learned_rules>")
+    return "\n".join(lines)
+
+
 def _normalize_section_title(title: str) -> str:
     """Normalize markdown section headings for comparison."""
     return re.sub(r"\s+", " ", (title or "").strip().lower())
@@ -13003,6 +13050,22 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
                     parts.append(_consumption_contract)
                 break
     except (ValueError, OSError):
+        pass
+
+    # Path-scoped learned rules: load all rules, then filter to those whose
+    # paths: frontmatter intersects the current subtask's affected_files.
+    # Rules without paths: are always included (unconditional learned
+    # knowledge).  Rules with paths: that don't match any affected file are
+    # excluded — they don't apply to this subtask's files and would waste
+    # context budget.
+    try:
+        _all_rules = _load_learned_rules()
+        _applicable_rules = _filter_learned_rules_by_files(_all_rules, files)
+        _rules_block = _format_learned_rules_block(_applicable_rules)
+        if _rules_block:
+            parts.append("")
+            parts.append(_rules_block)
+    except Exception:
         pass
 
     parts.append("")

--- a/src/mapify_cli/templates/hooks/workflow-context-injector.py
+++ b/src/mapify_cli/templates/hooks/workflow-context-injector.py
@@ -22,6 +22,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from pathlib import Path
 
 # Keep in sync with map_step_runner.py GOAL_HEADING_RE
@@ -708,12 +709,70 @@ def _sanitize_fence_content(text: str) -> str:
     return text
 
 
-def _load_personal_rules(project_dir: Path) -> tuple[int, str]:
+def _parse_rule_paths(content: str) -> list[str]:
+    """Extract optional ``paths:`` frontmatter globs from a rule markdown file."""
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return []
+
+    paths: list[str] = []
+    in_paths = False
+    for raw_line in lines[1:]:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped == "paths:":
+            in_paths = True
+            continue
+        if not in_paths:
+            continue
+        if stripped.startswith("- "):
+            candidate = stripped[2:].strip().strip("\"'")
+            if candidate:
+                paths.append(candidate)
+            continue
+        if stripped:
+            in_paths = False
+    return paths
+
+
+def _paths_match_file(rule_paths: list[str], file_path: str) -> bool:
+    """Return True when *file_path* matches at least one glob in *rule_paths*."""
+    for pattern in rule_paths:
+        if fnmatch(file_path, pattern) or fnmatch(f"./{file_path}", pattern):
+            return True
+    return False
+
+
+def _extract_target_file(tool_name: str, tool_input: dict) -> str:
+    """Extract the target file path from a tool invocation.
+
+    For Edit/Write/MultiEdit, reads ``file_path`` directly.
+    For Bash, returns empty — we cannot reliably determine which files
+    a command operates on without parsing arbitrary shell syntax.
+    """
+    if tool_name in ("Edit", "Write", "MultiEdit"):
+        file_path = tool_input.get("file_path", "")
+        if isinstance(file_path, str) and file_path.strip():
+            return file_path.strip()
+    return ""
+
+
+def _load_personal_rules(
+    project_dir: Path, target_file: str = ""
+) -> tuple[int, str]:
     """Load personal learned rules from ``.map/personal/rules/learned/``.
 
     Reads every ``*.md`` file under the directory in sorted order,
     sanitises each file's content through ``_sanitize_fence_content``,
     and returns a tuple of ``(count, joined_content)``.
+
+    When *target_file* is non-empty, files with ``paths:`` frontmatter that
+    do not match *target_file* are skipped — only unconditional rules and
+    matching scoped rules are loaded.  When *target_file* is empty, all
+    files are loaded (no filtering — we cannot determine relevance without
+    a target).
 
     Returns ``(0, "")`` when the directory does not exist or contains
     no readable ``.md`` files.
@@ -743,6 +802,11 @@ def _load_personal_rules(project_dir: Path) -> tuple[int, str]:
             content = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+
+        if target_file:
+            rule_paths = _parse_rule_paths(content)
+            if rule_paths and not _paths_match_file(rule_paths, target_file):
+                continue
 
         sanitized_parts.append(_sanitize_fence_content(content))
 
@@ -906,7 +970,8 @@ def main() -> None:
         if conflict_context:
             context_parts.append(conflict_context)
         base_context = PERSONAL_RULES_SEPARATOR.join(context_parts)
-        personal_count, personal_content = _load_personal_rules(project_dir)
+        target_file = _extract_target_file(tool_name, tool_input)
+        personal_count, personal_content = _load_personal_rules(project_dir, target_file)
         personal_limit = max(
             0,
             PERSONAL_BLOCK_BUDGET_TOTAL - len(base_context) - len(PERSONAL_RULES_SEPARATOR),

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -2317,6 +2317,53 @@ def _load_learned_rules() -> list[dict[str, object]]:
     return rules
 
 
+def _filter_learned_rules_by_files(
+    learned_rules: list[dict[str, object]], affected_files: list[str]
+) -> list[dict[str, object]]:
+    """Filter learned rules to those applicable to the given affected files.
+
+    Rules without ``paths:`` frontmatter are always included (unconditional).
+    Rules with ``paths:`` are included only when at least one affected file
+    matches at least one path glob.  When *affected_files* is empty (the
+    subtask has no declared file targets), all rules are included — we cannot
+    safely exclude scoped rules without file context.
+    """
+    if not affected_files:
+        return learned_rules
+
+    filtered: list[dict[str, object]] = []
+    for rule in learned_rules:
+        rule_paths = cast(list[object], rule.get("paths", []))
+        str_paths: list[str] = [
+            str(p) for p in rule_paths if isinstance(p, str) and p.strip()
+        ]
+        if not str_paths:
+            filtered.append(rule)
+            continue
+        if _paths_match_rule_scope(str_paths, affected_files):
+            filtered.append(rule)
+    return filtered
+
+
+def _format_learned_rules_block(rules: list[dict[str, object]]) -> str:
+    """Format applicable learned rules as a compact context block."""
+    if not rules:
+        return ""
+
+    lines = [
+        "<learned_rules>",
+        f"[learned-rules: {len(rules)} applicable rules]",
+    ]
+    for rule in rules:
+        title = str(rule.get("title", ""))
+        body = str(rule.get("body", ""))
+        rule_file = str(rule.get("file", ""))
+        file_name = Path(rule_file).name if rule_file else "unknown"
+        lines.append(f"- **{title}** ({file_name}): {body}")
+    lines.append("</learned_rules>")
+    return "\n".join(lines)
+
+
 def _normalize_section_title(title: str) -> str:
     """Normalize markdown section headings for comparison."""
     return re.sub(r"\s+", " ", (title or "").strip().lower())
@@ -13003,6 +13050,22 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
                     parts.append(_consumption_contract)
                 break
     except (ValueError, OSError):
+        pass
+
+    # Path-scoped learned rules: load all rules, then filter to those whose
+    # paths: frontmatter intersects the current subtask's affected_files.
+    # Rules without paths: are always included (unconditional learned
+    # knowledge).  Rules with paths: that don't match any affected file are
+    # excluded — they don't apply to this subtask's files and would waste
+    # context budget.
+    try:
+        _all_rules = _load_learned_rules()
+        _applicable_rules = _filter_learned_rules_by_files(_all_rules, files)
+        _rules_block = _format_learned_rules_block(_applicable_rules)
+        if _rules_block:
+            parts.append("")
+            parts.append(_rules_block)
+    except Exception:
         pass
 
     parts.append("")

--- a/src/mapify_cli/templates_src/hooks/workflow-context-injector.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/workflow-context-injector.py.jinja
@@ -22,6 +22,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from pathlib import Path
 
 # Keep in sync with map_step_runner.py GOAL_HEADING_RE
@@ -708,12 +709,70 @@ def _sanitize_fence_content(text: str) -> str:
     return text
 
 
-def _load_personal_rules(project_dir: Path) -> tuple[int, str]:
+def _parse_rule_paths(content: str) -> list[str]:
+    """Extract optional ``paths:`` frontmatter globs from a rule markdown file."""
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return []
+
+    paths: list[str] = []
+    in_paths = False
+    for raw_line in lines[1:]:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped == "paths:":
+            in_paths = True
+            continue
+        if not in_paths:
+            continue
+        if stripped.startswith("- "):
+            candidate = stripped[2:].strip().strip("\"'")
+            if candidate:
+                paths.append(candidate)
+            continue
+        if stripped:
+            in_paths = False
+    return paths
+
+
+def _paths_match_file(rule_paths: list[str], file_path: str) -> bool:
+    """Return True when *file_path* matches at least one glob in *rule_paths*."""
+    for pattern in rule_paths:
+        if fnmatch(file_path, pattern) or fnmatch(f"./{file_path}", pattern):
+            return True
+    return False
+
+
+def _extract_target_file(tool_name: str, tool_input: dict) -> str:
+    """Extract the target file path from a tool invocation.
+
+    For Edit/Write/MultiEdit, reads ``file_path`` directly.
+    For Bash, returns empty — we cannot reliably determine which files
+    a command operates on without parsing arbitrary shell syntax.
+    """
+    if tool_name in ("Edit", "Write", "MultiEdit"):
+        file_path = tool_input.get("file_path", "")
+        if isinstance(file_path, str) and file_path.strip():
+            return file_path.strip()
+    return ""
+
+
+def _load_personal_rules(
+    project_dir: Path, target_file: str = ""
+) -> tuple[int, str]:
     """Load personal learned rules from ``.map/personal/rules/learned/``.
 
     Reads every ``*.md`` file under the directory in sorted order,
     sanitises each file's content through ``_sanitize_fence_content``,
     and returns a tuple of ``(count, joined_content)``.
+
+    When *target_file* is non-empty, files with ``paths:`` frontmatter that
+    do not match *target_file* are skipped — only unconditional rules and
+    matching scoped rules are loaded.  When *target_file* is empty, all
+    files are loaded (no filtering — we cannot determine relevance without
+    a target).
 
     Returns ``(0, "")`` when the directory does not exist or contains
     no readable ``.md`` files.
@@ -743,6 +802,11 @@ def _load_personal_rules(project_dir: Path) -> tuple[int, str]:
             content = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+
+        if target_file:
+            rule_paths = _parse_rule_paths(content)
+            if rule_paths and not _paths_match_file(rule_paths, target_file):
+                continue
 
         sanitized_parts.append(_sanitize_fence_content(content))
 
@@ -906,7 +970,8 @@ def main() -> None:
         if conflict_context:
             context_parts.append(conflict_context)
         base_context = PERSONAL_RULES_SEPARATOR.join(context_parts)
-        personal_count, personal_content = _load_personal_rules(project_dir)
+        target_file = _extract_target_file(tool_name, tool_input)
+        personal_count, personal_content = _load_personal_rules(project_dir, target_file)
         personal_limit = max(
             0,
             PERSONAL_BLOCK_BUDGET_TOTAL - len(base_context) - len(PERSONAL_RULES_SEPARATOR),

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -2317,6 +2317,53 @@ def _load_learned_rules() -> list[dict[str, object]]:
     return rules
 
 
+def _filter_learned_rules_by_files(
+    learned_rules: list[dict[str, object]], affected_files: list[str]
+) -> list[dict[str, object]]:
+    """Filter learned rules to those applicable to the given affected files.
+
+    Rules without ``paths:`` frontmatter are always included (unconditional).
+    Rules with ``paths:`` are included only when at least one affected file
+    matches at least one path glob.  When *affected_files* is empty (the
+    subtask has no declared file targets), all rules are included — we cannot
+    safely exclude scoped rules without file context.
+    """
+    if not affected_files:
+        return learned_rules
+
+    filtered: list[dict[str, object]] = []
+    for rule in learned_rules:
+        rule_paths = cast(list[object], rule.get("paths", []))
+        str_paths: list[str] = [
+            str(p) for p in rule_paths if isinstance(p, str) and p.strip()
+        ]
+        if not str_paths:
+            filtered.append(rule)
+            continue
+        if _paths_match_rule_scope(str_paths, affected_files):
+            filtered.append(rule)
+    return filtered
+
+
+def _format_learned_rules_block(rules: list[dict[str, object]]) -> str:
+    """Format applicable learned rules as a compact context block."""
+    if not rules:
+        return ""
+
+    lines = [
+        "<learned_rules>",
+        f"[learned-rules: {len(rules)} applicable rules]",
+    ]
+    for rule in rules:
+        title = str(rule.get("title", ""))
+        body = str(rule.get("body", ""))
+        rule_file = str(rule.get("file", ""))
+        file_name = Path(rule_file).name if rule_file else "unknown"
+        lines.append(f"- **{title}** ({file_name}): {body}")
+    lines.append("</learned_rules>")
+    return "\n".join(lines)
+
+
 def _normalize_section_title(title: str) -> str:
     """Normalize markdown section headings for comparison."""
     return re.sub(r"\s+", " ", (title or "").strip().lower())
@@ -13003,6 +13050,22 @@ def build_context_block(branch: str, current_subtask_id: str) -> str:
                     parts.append(_consumption_contract)
                 break
     except (ValueError, OSError):
+        pass
+
+    # Path-scoped learned rules: load all rules, then filter to those whose
+    # paths: frontmatter intersects the current subtask's affected_files.
+    # Rules without paths: are always included (unconditional learned
+    # knowledge).  Rules with paths: that don't match any affected file are
+    # excluded — they don't apply to this subtask's files and would waste
+    # context budget.
+    try:
+        _all_rules = _load_learned_rules()
+        _applicable_rules = _filter_learned_rules_by_files(_all_rules, files)
+        _rules_block = _format_learned_rules_block(_applicable_rules)
+        if _rules_block:
+            parts.append("")
+            parts.append(_rules_block)
+    except Exception:
         pass
 
     parts.append("")


### PR DESCRIPTION
## What changed

Path-scoped filtering for learned rules — rules with `paths:` frontmatter are now only loaded when the agent is working on matching files. This saves context budget and prevents irrelevant rules from leaking into unrelated modules.

### 1. `build_context_block()` in `map_step_runner.py`
- Added `_filter_learned_rules_by_files()` — rules with `paths:` frontmatter are only included when the subtask `affected_files` match at least one path glob. Rules without `paths:` are always included (unconditional).
- Added `_format_learned_rules_block()` — compact `<learned_rules>` XML block injected into `<map_context>` for Actor consumption.
- Empty `affected_files` → all rules included (cannot safely exclude without file context).

### 2. `workflow-context-injector.py` (personal rules)
- Added `_parse_rule_paths()` + `_paths_match_file()` + `_extract_target_file()` — personal rules from `.map/personal/rules/learned/` are filtered by `paths:` frontmatter against the current tool target file (Edit/Write/MultiEdit).
- Unconditional rules (no `paths:`) are always loaded. Bash commands skip filtering (cannot reliably determine target files).

## Why

Aligns MAP with Claude Code `.claude/rules/` path-scoped behavior and the industry-standard hierarchical rule loading pattern (Stripe, Anthropic, IBM).

## How tested

- `make check`: pyright 0, ruff clean, mypy clean, hook lint clean, render check passes
- 2843 tests passed, 0 failures

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)