### PR TITLE
feat: adversarial multi-perspective code review (map-review --adversarial)

### DIFF
--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Interactive 4-section code review using Monitor, Predictor, and Evaluator agents on current changes. Use when reviewing a diff, PR, or staged work before merge. Do NOT use to plan or implement; use map-plan or map-efficient.
 effort: high
 disable-model-invocation: true
-argument-hint: "[review focus] [--detached] [--ci] [--reverse-sections] [--shuffle-sections] [--seed <int>] [--compare-orderings]"
+argument-hint: "[review focus] [--detached] [--ci] [--reverse-sections] [--shuffle-sections] [--seed <int>] [--compare-orderings] [--adversarial] [--quick] [--show-raw-findings]"
 ---
 # MAP Review Workflow
 
@@ -33,6 +33,9 @@ parallel_tool_policy: single_review_fanout
 - `--shuffle-sections`: randomize section order with a branch+commit derived seed.
 - `--seed <int>`: override shuffle seed with a non-negative integer.
 - `--compare-orderings`: run default and reverse ordering reviews, then aggregate drift. Cannot be combined with `--shuffle-sections` (EC-1/EC-17).
+- `--adversarial`: run three independent adversarial reviewers (Blind Hunter, Edge Case Hunter, Acceptance Auditor) in parallel, then aggregate with deduplication and convergence analysis. Each reviewer operates in an isolated context with only its permitted inputs.
+- `--quick`: used with `--adversarial` to skip the Edge Case Hunter (Blind + Acceptance only). Reduces token cost for routine changes.
+- `--show-raw-findings`: used with `--adversarial` to include raw reviewer outputs in the report. Useful for debugging or verifying aggregation.
 
 ## Execution Rules
 
@@ -155,6 +158,19 @@ fi
 if [ "$COMPARE_FLAG" = "true" ] && [ "$SHUFFLE_FLAG" = "true" ]; then
   echo '{"status":"error","reason":"--compare-orderings always uses default+reverse; cannot combine with --shuffle-sections (EC-1/EC-17)"}'
   exit 1
+fi
+
+ADVERSARIAL_FLAG=false
+QUICK_FLAG=false
+SHOW_RAW_FLAG=false
+if echo "$ARGUMENTS" | grep -q -- '--adversarial'; then
+  ADVERSARIAL_FLAG=true
+fi
+if echo "$ARGUMENTS" | grep -q -- '--quick'; then
+  QUICK_FLAG=true
+fi
+if echo "$ARGUMENTS" | grep -q -- '--show-raw-findings'; then
+  SHOW_RAW_FLAG=true
 fi
 
 MODE_FLAG="default"
@@ -362,7 +378,24 @@ skip Phase B. Record `REVISE` or `BLOCK` as appropriate. Bare
 mode skips presentation) with a verification note instead of
 publishing the bare verdict.
 
-## Phase B: Interactive Presentation (4 Sections)
+## Phase B: Adversarial Review (--adversarial only)
+When `--adversarial` is set, skip the Monitor/Predictor/Evaluator fan-out and the 4-section interactive walkthrough. Instead run three independent adversarial reviewers with isolated contexts, then aggregate. See [adversarial-reference.md](adversarial-reference.md) for the detailed step-by-step commands.
+
+### Quick reference
+
+```text
+1. Build prompts:  python3 .map/scripts/map_step_runner.py build_adversarial_review_prompts [--quick]
+2. Fan-out:        Task(subagent_type="general", ...) for blind, edge_case, acceptance — parallel, then wait for all
+3. Validate:       Each must return valid JSON per adversarial finding schema; retry ONCE on failure
+4. Aggregate:      python3 .map/scripts/map_step_runner.py aggregate_adversarial_findings --blind <path> --edge-case <path> --acceptance <path>
+5. Present:        Unified report: CRITICAL/IMPORTANT/MINOR, convergence section, all-clear statements (--show-raw-findings for debug)
+6. Verdict:        BLOCK (corroborated CRITICAL or >2 CRITICAL), REVISE (any CRITICAL/IMPORTANT), PROCEED (MINOR only or all-clear)
+7. Skip to:        Final Verdict → Handoff Artifacts; do NOT run normal 4-section walkthrough
+```
+
+## Phase B: Interactive Presentation (4 Sections) — NORMAL MODE ONLY
+
+This phase runs ONLY when `ADVERSARIAL_FLAG=false`. Skip it entirely when `--adversarial` is set.
 
 ### Step B.0: Determine section presentation order
 

--- a/.claude/skills/map-review/adversarial-reference.md
+++ b/.claude/skills/map-review/adversarial-reference.md
@@ -1,0 +1,148 @@
+# Adversarial Review Reference
+
+Detailed workflow for `map-review --adversarial`. See [SKILL.md](SKILL.md) for context and integration points.
+
+## Overview
+
+Three reviewers run in parallel, each with only its permitted inputs:
+
+| Reviewer | Context | Finds |
+|----------|---------|-------|
+| **Blind Hunter** | diff only | Typos, dead code, logic errors visible in isolation |
+| **Edge Case Hunter** | diff + repo read access | Null handling, boundary conditions, error paths, codebase consistency |
+| **Acceptance Auditor** | diff + spec + plan + artifacts | Missed requirements, spec violations, AC gaps, extra/unplanned work |
+
+With `--quick`: skip Edge Case Hunter (Blind + Acceptance only).
+
+## Step B.adversarial.0: Build adversarial review prompts
+
+```bash
+QUICK_ARG=""
+if [ "$QUICK_FLAG" = "true" ]; then
+  QUICK_ARG="--quick"
+fi
+
+ADV_PROMPTS_JSON=$(python3 .map/scripts/map_step_runner.py build_adversarial_review_prompts $QUICK_ARG)
+
+BLIND_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("blind",{}).get("prompt",""))')
+BLIND_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("blind",{}).get("description",""))')
+
+EDGE_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("edge_case",{}).get("prompt",""))')
+EDGE_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("edge_case",{}).get("description",""))')
+
+ACCEPTANCE_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("acceptance",{}).get("prompt",""))')
+ACCEPTANCE_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("acceptance",{}).get("description",""))')
+```
+
+## Step B.adversarial.1: Launch all three in parallel (fan-out)
+
+```text
+# Launch all three adversarial reviewers in parallel — they are fully independent
+# with no shared context. Wait for all to complete before aggregation.
+
+Task(subagent_type="general", description=BLIND_DESC, prompt=BLIND_PROMPT)
+# Save output as BLIND_OUTPUT
+Task(subagent_type="general", description=EDGE_DESC, prompt=EDGE_PROMPT)
+# Save output as EDGE_OUTPUT  (skip if --quick)
+Task(subagent_type="general", description=ACCEPTANCE_DESC, prompt=ACCEPTANCE_PROMPT)
+# Save output as ACCEPTANCE_OUTPUT
+```
+
+## Step B.adversarial.2: Validate reviewer outputs
+
+Each reviewer must return valid JSON matching the adversarial finding schema. If any reviewer output is truncated or invalid JSON:
+- Log the failure
+- Re-invoke that specific reviewer ONCE with the same prompt
+- If still invalid, record the reviewer as `parse_error` and continue with remaining reviewers
+
+## Step B.adversarial.3: Aggregate findings
+
+Write each reviewer's raw JSON output to a temp file, then aggregate:
+
+```bash
+printf '%s' "$BLIND_OUTPUT" > .map/$BRANCH/adversarial-blind.json
+printf '%s' "$EDGE_OUTPUT" > .map/$BRANCH/adversarial-edge.json
+printf '%s' "$ACCEPTANCE_OUTPUT" > .map/$BRANCH/adversarial-acceptance.json
+
+BLIND_ARG=""
+EDGE_ARG=""
+ACCEPTANCE_ARG=""
+if [ -f .map/$BRANCH/adversarial-blind.json ]; then
+  BLIND_ARG="--blind .map/$BRANCH/adversarial-blind.json"
+fi
+if [ -f .map/$BRANCH/adversarial-edge.json ]; then
+  EDGE_ARG="--edge-case .map/$BRANCH/adversarial-edge.json"
+fi
+if [ -f .map/$BRANCH/adversarial-acceptance.json ]; then
+  ACCEPTANCE_ARG="--acceptance .map/$BRANCH/adversarial-acceptance.json"
+fi
+
+ADV_AGGREGATED=$(python3 .map/scripts/map_step_runner.py aggregate_adversarial_findings \
+  $BLIND_ARG $EDGE_ARG $ACCEPTANCE_ARG)
+```
+
+## Step B.adversarial.4: Present unified adversarial report
+
+Parse the aggregated JSON and present the report in this structure:
+
+```
+# Adversarial Review Report
+
+## Summary
+- Total findings: N (C CRITICAL, I IMPORTANT, M MINOR)
+- Corroborated (found by 2+ reviewers): K — highest confidence
+- Per-reviewer: Blind: B, Edge Case: E, Acceptance: A
+- All-clear: [reviewers who reported all_clear=true]
+
+## CRITICAL
+[per finding: severity, category, file:line, failure_mode, evidence, reported_by, corroborated flag]
+
+## IMPORTANT
+[per finding: same structure]
+
+## MINOR
+[per finding: same structure]
+
+## Cross-Reviewer Convergence
+[Highlight what multiple reviewers independently found — these are highest-confidence issues]
+
+## Reviewer All-Clear Statements
+[Per reviewer who said all_clear: what they checked and why it's clean]
+```
+
+When `--show-raw-findings` is set, also show the raw per-reviewer JSON files.
+
+## Step B.adversarial.5: Determine verdict
+
+Based on aggregated findings:
+- **BLOCK**: any CRITICAL finding with corroboration OR > 2 CRITICAL from any single reviewer
+- **REVISE**: any CRITICAL (uncorroborated) OR any IMPORTANT
+- **PROCEED**: only MINOR findings OR all all_clear
+
+## Step B.adversarial.6: Skip to Final Verdict
+
+After presenting the adversarial report, skip the normal 4-section interactive walkthrough and go directly to Final Verdict → Handoff Artifacts.
+
+## Flow summary for adversarial
+
+When `ADVERSARIAL_FLAG=true`, the workflow is:
+Phase A (all steps) → Phase B: Adversarial Review → Final Verdict → Handoff Artifacts.
+Do NOT run the normal Monitor/Predictor/Evaluator fan-out or the 4-section walkthrough.
+
+## Examples
+
+See [review-reference.md](review-reference.md#examples) for adversarial examples.
+
+## Troubleshooting
+
+### Reviewer returns invalid JSON
+
+Re-invoke that specific reviewer ONCE. If still invalid, record `parse_error` and continue — two valid reviewers are better than zero.
+
+### All three reviewers fail
+
+Stop with CLARIFICATION_NEEDED. The diff may be too large or the context too complex for adversarial review.
+
+### Edge Case Hunter runs out of context
+
+Edge Case Hunter has repo read access. If the repo is very large, limit its scope by pre-computing an impact graph of files importing/imported-by the changes plus relevant tests. Defer full implementation to v2.

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -8314,6 +8314,511 @@ def build_review_prompts(
     }
 
 
+ADVERSARIAL_REVIEWER_SPECS: dict[str, dict[str, str]] = {
+    "blind": {
+        "subagent_type": "general",
+        "description": "Blind diff-only review",
+        "task": """Review ONLY the git diff below. You have NO access to the project context, spec, architecture, or naming conventions. Your job is to find bugs, dead code, and obvious errors that are visible in the diff alone — without being biased by "what was intended."
+
+Be skeptical: assume nothing about intent. If something looks wrong in isolation, flag it.
+
+IMPORTANT: If the diff is correct and you find no issues, you MUST explicitly state that. A clean review is signal, not absence of output.""",
+        "instructions": """Find:
+- Typos, syntax errors, logic errors visible in isolation
+- Dead code, unreachable branches, unused variables
+- Obvious null-pointer / None-access risks
+- Missing imports or undefined references
+- Copy-paste errors
+- Inconsistent naming within the diff itself
+
+Do NOT speculate about:
+- Whether the code fits the project architecture (you cannot see it)
+- Whether a requirement is met (you cannot see the spec)
+- Whether edge cases are handled (that's the Edge Case reviewer's job)""",
+        "context_access": "diff_only",
+    },
+    "edge_case": {
+        "subagent_type": "general",
+        "description": "Edge case and codebase consistency review",
+        "task": """Review the git diff AND the full repository. You have read access to the codebase but NO access to the spec, requirements, or architecture documents. Your job is to find edge cases, error paths, and consistency issues through mechanical path tracing.
+
+Trace every changed function: who calls it, what can be null, where could it fail. Compare with existing patterns in the codebase.
+
+IMPORTANT: If you find no issues, explicitly state that the code is correct with reasoning.""",
+        "instructions": """Find:
+- Null handling gaps: trace every value that could be None/null
+- Boundary conditions: empty lists, zero values, max values
+- Error paths: are exceptions handled? Are error returns checked?
+- Consistency with existing codebase patterns
+- State lifecycle issues: initialization, cleanup, transitions
+- Race conditions or ordering dependencies
+- Missing validation on inputs from callers
+
+For each finding, include concrete evidence:
+- The line in the diff where the issue is
+- The caller path that triggers it (grep the repo)
+- What would fail and how""",
+        "context_access": "diff_plus_repo_read",
+    },
+    "acceptance": {
+        "subagent_type": "general",
+        "description": "Spec compliance and acceptance review",
+        "task": """Review the git diff against the specification and requirements. You have access to the diff, spec, plan, and all project artifacts. Your job is to verify every requirement is implemented and flag gaps.
+
+Take an adversarial stance toward COMPLACENCY, not the developer: "Has every stated requirement actually been met? Is there implemented code that serves no spec requirement?" 
+
+IMPORTANT: If all requirements are met, explicitly state that with reasoning. A clean review is signal.""",
+        "instructions": """Verify:
+- Every acceptance criterion / requirement has a corresponding implementation
+- Every requirement's implementation is correct (not just present)
+- No extra/unplanned work slipped in (implementation without spec requirement)
+- The implementation matches the spec's intent, not just its literal text
+- Spec contradictions or ambiguities exposed by the implementation
+- Edge cases mentioned in the spec are actually handled
+
+For each gap, cite:
+- The spec requirement ID and text
+- The file:line of the missing or incorrect implementation
+- The concrete failure scenario""",
+        "context_access": "diff_plus_spec_plus_artifacts",
+    },
+}
+
+ADVERSARIAL_FINDING_SCHEMA: dict[str, object] = {
+    "reviewer": "<'blind' | 'edge_case' | 'acceptance'>",
+    "all_clear": "<boolean — true if NO issues found; must be explicit>",
+    "all_clear_rationale": "<string — required when all_clear=true: what you checked and why it's clean>",
+    "findings": [
+        {
+            "id": "<F-<reviewer_prefix>-<NN> — e.g. F-B-01, F-E-01, F-A-01>",
+            "severity": "<'CRITICAL' | 'IMPORTANT' | 'MINOR'>",
+            "category": "<string — e.g. 'null_safety', 'spec_gap', 'logic_error', 'boundary', 'consistency', 'dead_code', 'typo'>",
+            "file_path": "<string | null — null for spec-level findings without a code location>",
+            "line_range": "<string | null>",
+            "symbol": "<string | null — affected function/class/variable>",
+            "failure_mode": "<string — concrete description of what goes wrong and when>",
+            "evidence": "<string — concrete trace: grep output, code path, spec requirement ID>",
+            "recommendation": "<string — actionable fix suggestion>",
+        }
+    ],
+    "checks_performed": ["<string — list what was actually checked>"],
+}
+
+
+def _render_adversarial_reviewer_prompt(
+    spec: dict[str, str],
+    git_diff: str,
+    repo_context: str = "",
+    spec_context: str = "",
+    layering: str = DEFAULT_PROMPT_LAYERING,
+) -> str:
+    """Render a self-contained prompt for one adversarial reviewer.
+
+    The reviewer receives only its permitted context, never the full bundle.
+    """
+    reviewer_id = spec.get("context_access", "unknown")
+    documents = ["<documents>"]
+
+    if reviewer_id == "diff_only":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+    elif reviewer_id == "diff_plus_repo_read":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+        if repo_context:
+            documents.extend(
+                [
+                    "  <document source='repo context' priority='secondary'>",
+                    "    <document_content>",
+                    repo_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+        documents.extend(
+            [
+                "  <document source='repo access note' priority='diagnostic'>",
+                "    <document_content>",
+                "You have READ access to the entire repository. Trace callers, "
+                "check existing patterns, and grep for related code. The repo "
+                "context above provides guidance on what to investigate.",
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+    elif reviewer_id == "diff_plus_spec_plus_artifacts":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+        if spec_context:
+            documents.extend(
+                [
+                    "  <document source='specification and requirements' priority='primary'>",
+                    "    <document_content>",
+                    spec_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+        if repo_context:
+            documents.extend(
+                [
+                    "  <document source='project artifacts' priority='secondary'>",
+                    "    <document_content>",
+                    repo_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+    else:
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+
+    documents.append("</documents>")
+
+    output_schema = json.dumps(ADVERSARIAL_FINDING_SCHEMA, indent=2)
+    format_rules = (
+        "Return exactly one JSON object matching the schema. "
+        "No markdown, no code fences, no prose before/after. "
+        "Every finding must include concrete evidence and a plausible failure_mode. "
+        "Prefer no finding over a weak finding. "
+        'Set all_clear=true when no issues found, with a rationale explaining what you checked.'
+    )
+
+    documents_section = "\n".join(documents)
+    stable_sections = [
+        f"<task>\n{spec['task']}\n</task>",
+        "<workflow_policy>\n"
+        "You are one of three independent adversarial reviewers. You have NO access "
+        "to other reviewers' output. Review only what is in your context documents. "
+        "Do NOT speculate about information you cannot see.\n"
+        "</workflow_policy>",
+        f"<instructions>\n{spec['instructions']}\n</instructions>",
+        "<expected_output>\n"
+        f"<output_schema>\n{output_schema}\n</output_schema>\n"
+        f"<format_rules>\n{format_rules}\n</format_rules>\n"
+        "</expected_output>",
+    ]
+    return _layer_prompt_sections(documents_section, stable_sections, layering)
+
+
+def build_adversarial_review_prompts(
+    branch: Optional[str] = None,
+    reviewers: Optional[list[str]] = None,
+    git_diff_text: Optional[str] = None,
+    spec_text: Optional[str] = None,
+) -> dict:
+    """Build isolated prompts for the three adversarial reviewers.
+
+    Args:
+        branch: Branch name for reading spec/plan artifacts.
+        reviewers: Which reviewers to build prompts for.
+                   Default all three. ['blind', 'acceptance'] for --quick.
+        git_diff_text: Preloaded diff (avoids redundant git calls).
+        spec_text: Preloaded spec text (avoids redundant file reads).
+
+    Returns dict with 'prompts' key mapping reviewer_id to {subagent_type, description, prompt}.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    reviewer_ids = reviewers or ["blind", "edge_case", "acceptance"]
+    layering = _load_prompt_layering(Path.cwd())
+
+    git_diff = git_diff_text if git_diff_text is not None else _read_git_diff_for_review()
+
+    spec_context = spec_text if spec_text is not None else _read_spec_for_review(branch_name)
+    repo_context = _read_repo_summary_for_review(branch_name)
+
+    prompts: dict[str, dict[str, object]] = {}
+    for reviewer_id in reviewer_ids:
+        spec_entry = ADVERSARIAL_REVIEWER_SPECS.get(reviewer_id)
+        if spec_entry is None:
+            continue
+        prompt = _render_adversarial_reviewer_prompt(
+            spec_entry,
+            git_diff=git_diff,
+            repo_context=repo_context,
+            spec_context=spec_context,
+            layering=layering,
+        )
+        prompts[reviewer_id] = {
+            "subagent_type": spec_entry["subagent_type"],
+            "description": spec_entry["description"],
+            "prompt": prompt,
+            "context_access": spec_entry["context_access"],
+        }
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "prompt_layering": layering,
+        "prompts": prompts,
+        "reviewers_requested": reviewer_ids,
+    }
+
+
+def _read_spec_for_review(branch_name: str) -> str:
+    """Read spec and plan artifacts for the acceptance reviewer."""
+    branch_dir = get_branch_dir(branch_name)
+    parts: list[str] = []
+
+    spec_path = branch_dir / f"spec_{branch_name}.md"
+    if spec_path.exists():
+        try:
+            parts.append(spec_path.read_text(encoding="utf-8"))
+        except OSError:
+            pass
+
+    plan_path = branch_dir / f"task_plan_{branch_name}.md"
+    if plan_path.exists():
+        try:
+            parts.append(plan_path.read_text(encoding="utf-8"))
+        except OSError:
+            pass
+
+    return "\n\n---\n\n".join(parts) if parts else "[no spec or plan artifacts found]"
+
+
+def _read_repo_summary_for_review(branch_name: str) -> str:
+    """Build a lightweight repo summary for edge_case and acceptance reviewers."""
+    branch_dir = get_branch_dir(branch_name)
+    parts: list[str] = []
+
+    review_bundle_path = branch_dir / "review-bundle.md"
+    if review_bundle_path.exists():
+        try:
+            content = review_bundle_path.read_text(encoding="utf-8")
+            if content.strip() and not content.strip().startswith("MISSING"):
+                parts.append(f"=== Review Bundle ===\n{content}")
+        except OSError:
+            pass
+
+    return "\n\n".join(parts) if parts else "[no review bundle; use git history and repo structure for context]"
+
+
+def _cluster_adversarial_findings(
+    findings_by_reviewer: dict[str, list[dict[str, object]]],
+) -> list[dict[str, object]]:
+    """Deterministic clustering: group findings by file+proximity or by category+symbol.
+
+    Returns list of clusters, each with merged findings from multiple reviewers.
+    """
+    all_findings: list[tuple[str, dict[str, object]]] = []
+    for reviewer_id, findings in findings_by_reviewer.items():
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            all_findings.append((reviewer_id, finding))
+
+    clusters: list[dict[str, object]] = []
+    used: set[int] = set()
+
+    for i, (rev_i, f_i) in enumerate(all_findings):
+        if i in used:
+            continue
+        cluster: dict[str, object] = {
+            "findings": [f_i],
+            "reviewers": [rev_i],
+        }
+        used.add(i)
+        fp_i = str(f_i.get("file_path") or "")
+        sym_i = str(f_i.get("symbol") or "")
+        cat_i = str(f_i.get("category") or "")
+
+        for j, (rev_j, f_j) in enumerate(all_findings):
+            if j in used:
+                continue
+            fp_j = str(f_j.get("file_path") or "")
+            sym_j = str(f_j.get("symbol") or "")
+            cat_j = str(f_j.get("category") or "")
+
+            same_file = fp_i and fp_j and fp_i == fp_j
+            same_symbol = sym_i and sym_j and sym_i == sym_j
+            same_category = cat_i and cat_j and cat_i == cat_j
+
+            if (same_file and same_category) or (same_symbol and same_category):
+                cluster["findings"].append(f_j)  # type: ignore[union-attr]
+                cluster["reviewers"].append(rev_j)  # type: ignore[union-attr]
+                used.add(j)
+
+        clusters.append(cluster)
+
+    return clusters
+
+
+def _dedup_cluster_via_llm_fallback(cluster: dict[str, object]) -> dict[str, object]:
+    """Return cluster as-is for v1 — deterministic clustering is sufficient.
+
+    LLM adjudication for ambiguous cases is deferred to v2.
+    """
+    return cluster
+
+
+def _severity_rank(severity: str) -> int:
+    return {"CRITICAL": 0, "IMPORTANT": 1, "MINOR": 2}.get(str(severity).upper(), 3)
+
+
+def aggregate_adversarial_findings(
+    blind_json: Optional[str] = None,
+    edge_case_json: Optional[str] = None,
+    acceptance_json: Optional[str] = None,
+) -> dict:
+    """Aggregate, deduplicate, and classify findings from adversarial reviewers.
+
+    Args:
+        blind_json: Raw JSON output from Blind Hunter reviewer.
+        edge_case_json: Raw JSON output from Edge Case Hunter reviewer.
+        acceptance_json: Raw JSON output from Acceptance Auditor reviewer.
+
+    Returns dict with unified report.
+    """
+    reviewer_data: dict[str, dict[str, object]] = {}
+    findings_by_reviewer: dict[str, list[dict[str, object]]] = {}
+
+    inputs = [
+        ("blind", blind_json),
+        ("edge_case", edge_case_json),
+        ("acceptance", acceptance_json),
+    ]
+
+    parse_errors: list[str] = []
+    for reviewer_id, raw_json in inputs:
+        if raw_json is None:
+            reviewer_data[reviewer_id] = {
+                "status": "not_run",
+                "error": "No output provided",
+            }
+            findings_by_reviewer[reviewer_id] = []
+            continue
+        try:
+            parsed = json.loads(raw_json)
+            if not isinstance(parsed, dict):
+                reviewer_data[reviewer_id] = {
+                    "status": "parse_error",
+                    "error": "Output is not a JSON object",
+                }
+                findings_by_reviewer[reviewer_id] = []
+                parse_errors.append(f"{reviewer_id}: output is not a JSON object")
+                continue
+            reviewer_data[reviewer_id] = {
+                "status": "ok",
+                "all_clear": parsed.get("all_clear"),
+                "all_clear_rationale": parsed.get("all_clear_rationale", ""),
+                "checks_performed": parsed.get("checks_performed", []),
+                "raw": parsed,
+            }
+            findings = parsed.get("findings", [])
+            if not isinstance(findings, list):
+                findings = []
+            findings_by_reviewer[reviewer_id] = findings
+        except (json.JSONDecodeError, ValueError) as e:
+            reviewer_data[reviewer_id] = {
+                "status": "parse_error",
+                "error": str(e),
+            }
+            findings_by_reviewer[reviewer_id] = []
+            parse_errors.append(f"{reviewer_id}: {e}")
+
+    clusters = _cluster_adversarial_findings(findings_by_reviewer)
+
+    merged_findings: list[dict[str, object]] = []
+    for cluster in clusters:
+        cluster_findings = cluster.get("findings", [])
+        cluster_reviewers = cluster.get("reviewers", [])
+        if not isinstance(cluster_findings, list) or not cluster_findings:
+            continue
+
+        primary = cluster_findings[0] if isinstance(cluster_findings[0], dict) else {}
+        corroborated = len(set(str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else []))) > 1
+
+        severities = [
+            _severity_rank(str(f.get("severity", "MINOR")))
+            for f in cluster_findings
+            if isinstance(f, dict)
+        ]
+        max_sev = min(severities) if severities else 2
+        merged_severity = {0: "CRITICAL", 1: "IMPORTANT", 2: "MINOR"}[max_sev]
+
+        merged: dict[str, object] = {
+            "severity": merged_severity,
+            "category": primary.get("category", "unknown"),
+            "file_path": primary.get("file_path"),
+            "line_range": primary.get("line_range"),
+            "symbol": primary.get("symbol"),
+            "failure_mode": primary.get("failure_mode", ""),
+            "evidence": primary.get("evidence", ""),
+            "recommendation": primary.get("recommendation", ""),
+            "reported_by": sorted(set(
+                str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else [])
+            )),
+            "corroborated": corroborated,
+            "corroboration_note": (
+                f"Found independently by {len(set(str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else [])))} reviewers — high confidence"
+                if corroborated
+                else ""
+            ),
+            "raw_findings": cluster_findings,
+        }
+        merged_findings.append(merged)
+
+    merged_findings.sort(key=lambda f: _severity_rank(str(f.get("severity", "MINOR"))))
+
+    critical_count = sum(1 for f in merged_findings if f.get("severity") == "CRITICAL")
+    important_count = sum(1 for f in merged_findings if f.get("severity") == "IMPORTANT")
+    minor_count = sum(1 for f in merged_findings if f.get("severity") == "MINOR")
+    corroborated_count = sum(1 for f in merged_findings if f.get("corroborated"))
+
+    per_reviewer_counts = {}
+    for reviewer_id, findings in findings_by_reviewer.items():
+        per_reviewer_counts[reviewer_id] = len(findings)
+
+    all_clear_by_reviewer = {}
+    for reviewer_id, data in reviewer_data.items():
+        all_clear_by_reviewer[reviewer_id] = data.get("all_clear")
+
+    return {
+        "status": "success",
+        "summary": {
+            "total_findings": len(merged_findings),
+            "critical": critical_count,
+            "important": important_count,
+            "minor": minor_count,
+            "corroborated": corroborated_count,
+            "per_reviewer_counts": per_reviewer_counts,
+            "all_clear_by_reviewer": all_clear_by_reviewer,
+        },
+        "findings": merged_findings,
+        "reviewer_status": reviewer_data,
+        "parse_errors": parse_errors,
+    }
+
+
 def write_learning_handoff(
     workflow: str,
     task_title: str = "",
@@ -14466,6 +14971,62 @@ if __name__ == "__main__":
             branch=_args.branch,
             review_preferences=_args.review_preferences,
             budget_tokens=_args.budget_tokens,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "build_adversarial_review_prompts":
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py build_adversarial_review_prompts")
+        _p.add_argument("--branch", default=None)
+        _p.add_argument("--reviewers", default=None, help="Comma-separated: blind,edge_case,acceptance")
+        _p.add_argument("--quick", action="store_true", default=False, help="Skip edge_case reviewer")
+        _args = _p.parse_args(sys.argv[2:])
+        reviewer_ids = None
+        if _args.reviewers:
+            reviewer_ids = [r.strip() for r in _args.reviewers.split(",") if r.strip()]
+        elif _args.quick:
+            reviewer_ids = ["blind", "acceptance"]
+        result = build_adversarial_review_prompts(
+            branch=_args.branch,
+            reviewers=reviewer_ids,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "aggregate_adversarial_findings":
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py aggregate_adversarial_findings")
+        _p.add_argument("--blind", default=None, help="Path to blind reviewer JSON output")
+        _p.add_argument("--edge-case", default=None, help="Path to edge_case reviewer JSON output")
+        _p.add_argument("--acceptance", default=None, help="Path to acceptance reviewer JSON output")
+        _args = _p.parse_args(sys.argv[2:])
+
+        blind_json = None
+        edge_case_json = None
+        acceptance_json = None
+        for arg_path, key in [
+            (_args.blind, "blind"),
+            (_args.edge_case, "edge_case"),
+            (_args.acceptance, "acceptance"),
+        ]:
+            if arg_path:
+                try:
+                    text = Path(arg_path).read_text(encoding="utf-8")
+                    if key == "blind":
+                        blind_json = text
+                    elif key == "edge_case":
+                        edge_case_json = text
+                    elif key == "acceptance":
+                        acceptance_json = text
+                except OSError as e:
+                    print(json.dumps({"status": "error", "reason": f"Cannot read {arg_path}: {e}"}))
+                    sys.exit(1)
+
+        result = aggregate_adversarial_findings(
+            blind_json=blind_json,
+            edge_case_json=edge_case_json,
+            acceptance_json=acceptance_json,
         )
         print(json.dumps(result, indent=2, ensure_ascii=True))
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -8314,6 +8314,511 @@ def build_review_prompts(
     }
 
 
+ADVERSARIAL_REVIEWER_SPECS: dict[str, dict[str, str]] = {
+    "blind": {
+        "subagent_type": "general",
+        "description": "Blind diff-only review",
+        "task": """Review ONLY the git diff below. You have NO access to the project context, spec, architecture, or naming conventions. Your job is to find bugs, dead code, and obvious errors that are visible in the diff alone — without being biased by "what was intended."
+
+Be skeptical: assume nothing about intent. If something looks wrong in isolation, flag it.
+
+IMPORTANT: If the diff is correct and you find no issues, you MUST explicitly state that. A clean review is signal, not absence of output.""",
+        "instructions": """Find:
+- Typos, syntax errors, logic errors visible in isolation
+- Dead code, unreachable branches, unused variables
+- Obvious null-pointer / None-access risks
+- Missing imports or undefined references
+- Copy-paste errors
+- Inconsistent naming within the diff itself
+
+Do NOT speculate about:
+- Whether the code fits the project architecture (you cannot see it)
+- Whether a requirement is met (you cannot see the spec)
+- Whether edge cases are handled (that's the Edge Case reviewer's job)""",
+        "context_access": "diff_only",
+    },
+    "edge_case": {
+        "subagent_type": "general",
+        "description": "Edge case and codebase consistency review",
+        "task": """Review the git diff AND the full repository. You have read access to the codebase but NO access to the spec, requirements, or architecture documents. Your job is to find edge cases, error paths, and consistency issues through mechanical path tracing.
+
+Trace every changed function: who calls it, what can be null, where could it fail. Compare with existing patterns in the codebase.
+
+IMPORTANT: If you find no issues, explicitly state that the code is correct with reasoning.""",
+        "instructions": """Find:
+- Null handling gaps: trace every value that could be None/null
+- Boundary conditions: empty lists, zero values, max values
+- Error paths: are exceptions handled? Are error returns checked?
+- Consistency with existing codebase patterns
+- State lifecycle issues: initialization, cleanup, transitions
+- Race conditions or ordering dependencies
+- Missing validation on inputs from callers
+
+For each finding, include concrete evidence:
+- The line in the diff where the issue is
+- The caller path that triggers it (grep the repo)
+- What would fail and how""",
+        "context_access": "diff_plus_repo_read",
+    },
+    "acceptance": {
+        "subagent_type": "general",
+        "description": "Spec compliance and acceptance review",
+        "task": """Review the git diff against the specification and requirements. You have access to the diff, spec, plan, and all project artifacts. Your job is to verify every requirement is implemented and flag gaps.
+
+Take an adversarial stance toward COMPLACENCY, not the developer: "Has every stated requirement actually been met? Is there implemented code that serves no spec requirement?" 
+
+IMPORTANT: If all requirements are met, explicitly state that with reasoning. A clean review is signal.""",
+        "instructions": """Verify:
+- Every acceptance criterion / requirement has a corresponding implementation
+- Every requirement's implementation is correct (not just present)
+- No extra/unplanned work slipped in (implementation without spec requirement)
+- The implementation matches the spec's intent, not just its literal text
+- Spec contradictions or ambiguities exposed by the implementation
+- Edge cases mentioned in the spec are actually handled
+
+For each gap, cite:
+- The spec requirement ID and text
+- The file:line of the missing or incorrect implementation
+- The concrete failure scenario""",
+        "context_access": "diff_plus_spec_plus_artifacts",
+    },
+}
+
+ADVERSARIAL_FINDING_SCHEMA: dict[str, object] = {
+    "reviewer": "<'blind' | 'edge_case' | 'acceptance'>",
+    "all_clear": "<boolean — true if NO issues found; must be explicit>",
+    "all_clear_rationale": "<string — required when all_clear=true: what you checked and why it's clean>",
+    "findings": [
+        {
+            "id": "<F-<reviewer_prefix>-<NN> — e.g. F-B-01, F-E-01, F-A-01>",
+            "severity": "<'CRITICAL' | 'IMPORTANT' | 'MINOR'>",
+            "category": "<string — e.g. 'null_safety', 'spec_gap', 'logic_error', 'boundary', 'consistency', 'dead_code', 'typo'>",
+            "file_path": "<string | null — null for spec-level findings without a code location>",
+            "line_range": "<string | null>",
+            "symbol": "<string | null — affected function/class/variable>",
+            "failure_mode": "<string — concrete description of what goes wrong and when>",
+            "evidence": "<string — concrete trace: grep output, code path, spec requirement ID>",
+            "recommendation": "<string — actionable fix suggestion>",
+        }
+    ],
+    "checks_performed": ["<string — list what was actually checked>"],
+}
+
+
+def _render_adversarial_reviewer_prompt(
+    spec: dict[str, str],
+    git_diff: str,
+    repo_context: str = "",
+    spec_context: str = "",
+    layering: str = DEFAULT_PROMPT_LAYERING,
+) -> str:
+    """Render a self-contained prompt for one adversarial reviewer.
+
+    The reviewer receives only its permitted context, never the full bundle.
+    """
+    reviewer_id = spec.get("context_access", "unknown")
+    documents = ["<documents>"]
+
+    if reviewer_id == "diff_only":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+    elif reviewer_id == "diff_plus_repo_read":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+        if repo_context:
+            documents.extend(
+                [
+                    "  <document source='repo context' priority='secondary'>",
+                    "    <document_content>",
+                    repo_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+        documents.extend(
+            [
+                "  <document source='repo access note' priority='diagnostic'>",
+                "    <document_content>",
+                "You have READ access to the entire repository. Trace callers, "
+                "check existing patterns, and grep for related code. The repo "
+                "context above provides guidance on what to investigate.",
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+    elif reviewer_id == "diff_plus_spec_plus_artifacts":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+        if spec_context:
+            documents.extend(
+                [
+                    "  <document source='specification and requirements' priority='primary'>",
+                    "    <document_content>",
+                    spec_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+        if repo_context:
+            documents.extend(
+                [
+                    "  <document source='project artifacts' priority='secondary'>",
+                    "    <document_content>",
+                    repo_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+    else:
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+
+    documents.append("</documents>")
+
+    output_schema = json.dumps(ADVERSARIAL_FINDING_SCHEMA, indent=2)
+    format_rules = (
+        "Return exactly one JSON object matching the schema. "
+        "No markdown, no code fences, no prose before/after. "
+        "Every finding must include concrete evidence and a plausible failure_mode. "
+        "Prefer no finding over a weak finding. "
+        'Set all_clear=true when no issues found, with a rationale explaining what you checked.'
+    )
+
+    documents_section = "\n".join(documents)
+    stable_sections = [
+        f"<task>\n{spec['task']}\n</task>",
+        "<workflow_policy>\n"
+        "You are one of three independent adversarial reviewers. You have NO access "
+        "to other reviewers' output. Review only what is in your context documents. "
+        "Do NOT speculate about information you cannot see.\n"
+        "</workflow_policy>",
+        f"<instructions>\n{spec['instructions']}\n</instructions>",
+        "<expected_output>\n"
+        f"<output_schema>\n{output_schema}\n</output_schema>\n"
+        f"<format_rules>\n{format_rules}\n</format_rules>\n"
+        "</expected_output>",
+    ]
+    return _layer_prompt_sections(documents_section, stable_sections, layering)
+
+
+def build_adversarial_review_prompts(
+    branch: Optional[str] = None,
+    reviewers: Optional[list[str]] = None,
+    git_diff_text: Optional[str] = None,
+    spec_text: Optional[str] = None,
+) -> dict:
+    """Build isolated prompts for the three adversarial reviewers.
+
+    Args:
+        branch: Branch name for reading spec/plan artifacts.
+        reviewers: Which reviewers to build prompts for.
+                   Default all three. ['blind', 'acceptance'] for --quick.
+        git_diff_text: Preloaded diff (avoids redundant git calls).
+        spec_text: Preloaded spec text (avoids redundant file reads).
+
+    Returns dict with 'prompts' key mapping reviewer_id to {subagent_type, description, prompt}.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    reviewer_ids = reviewers or ["blind", "edge_case", "acceptance"]
+    layering = _load_prompt_layering(Path.cwd())
+
+    git_diff = git_diff_text if git_diff_text is not None else _read_git_diff_for_review()
+
+    spec_context = spec_text if spec_text is not None else _read_spec_for_review(branch_name)
+    repo_context = _read_repo_summary_for_review(branch_name)
+
+    prompts: dict[str, dict[str, object]] = {}
+    for reviewer_id in reviewer_ids:
+        spec_entry = ADVERSARIAL_REVIEWER_SPECS.get(reviewer_id)
+        if spec_entry is None:
+            continue
+        prompt = _render_adversarial_reviewer_prompt(
+            spec_entry,
+            git_diff=git_diff,
+            repo_context=repo_context,
+            spec_context=spec_context,
+            layering=layering,
+        )
+        prompts[reviewer_id] = {
+            "subagent_type": spec_entry["subagent_type"],
+            "description": spec_entry["description"],
+            "prompt": prompt,
+            "context_access": spec_entry["context_access"],
+        }
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "prompt_layering": layering,
+        "prompts": prompts,
+        "reviewers_requested": reviewer_ids,
+    }
+
+
+def _read_spec_for_review(branch_name: str) -> str:
+    """Read spec and plan artifacts for the acceptance reviewer."""
+    branch_dir = get_branch_dir(branch_name)
+    parts: list[str] = []
+
+    spec_path = branch_dir / f"spec_{branch_name}.md"
+    if spec_path.exists():
+        try:
+            parts.append(spec_path.read_text(encoding="utf-8"))
+        except OSError:
+            pass
+
+    plan_path = branch_dir / f"task_plan_{branch_name}.md"
+    if plan_path.exists():
+        try:
+            parts.append(plan_path.read_text(encoding="utf-8"))
+        except OSError:
+            pass
+
+    return "\n\n---\n\n".join(parts) if parts else "[no spec or plan artifacts found]"
+
+
+def _read_repo_summary_for_review(branch_name: str) -> str:
+    """Build a lightweight repo summary for edge_case and acceptance reviewers."""
+    branch_dir = get_branch_dir(branch_name)
+    parts: list[str] = []
+
+    review_bundle_path = branch_dir / "review-bundle.md"
+    if review_bundle_path.exists():
+        try:
+            content = review_bundle_path.read_text(encoding="utf-8")
+            if content.strip() and not content.strip().startswith("MISSING"):
+                parts.append(f"=== Review Bundle ===\n{content}")
+        except OSError:
+            pass
+
+    return "\n\n".join(parts) if parts else "[no review bundle; use git history and repo structure for context]"
+
+
+def _cluster_adversarial_findings(
+    findings_by_reviewer: dict[str, list[dict[str, object]]],
+) -> list[dict[str, object]]:
+    """Deterministic clustering: group findings by file+proximity or by category+symbol.
+
+    Returns list of clusters, each with merged findings from multiple reviewers.
+    """
+    all_findings: list[tuple[str, dict[str, object]]] = []
+    for reviewer_id, findings in findings_by_reviewer.items():
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            all_findings.append((reviewer_id, finding))
+
+    clusters: list[dict[str, object]] = []
+    used: set[int] = set()
+
+    for i, (rev_i, f_i) in enumerate(all_findings):
+        if i in used:
+            continue
+        cluster: dict[str, object] = {
+            "findings": [f_i],
+            "reviewers": [rev_i],
+        }
+        used.add(i)
+        fp_i = str(f_i.get("file_path") or "")
+        sym_i = str(f_i.get("symbol") or "")
+        cat_i = str(f_i.get("category") or "")
+
+        for j, (rev_j, f_j) in enumerate(all_findings):
+            if j in used:
+                continue
+            fp_j = str(f_j.get("file_path") or "")
+            sym_j = str(f_j.get("symbol") or "")
+            cat_j = str(f_j.get("category") or "")
+
+            same_file = fp_i and fp_j and fp_i == fp_j
+            same_symbol = sym_i and sym_j and sym_i == sym_j
+            same_category = cat_i and cat_j and cat_i == cat_j
+
+            if (same_file and same_category) or (same_symbol and same_category):
+                cluster["findings"].append(f_j)  # type: ignore[union-attr]
+                cluster["reviewers"].append(rev_j)  # type: ignore[union-attr]
+                used.add(j)
+
+        clusters.append(cluster)
+
+    return clusters
+
+
+def _dedup_cluster_via_llm_fallback(cluster: dict[str, object]) -> dict[str, object]:
+    """Return cluster as-is for v1 — deterministic clustering is sufficient.
+
+    LLM adjudication for ambiguous cases is deferred to v2.
+    """
+    return cluster
+
+
+def _severity_rank(severity: str) -> int:
+    return {"CRITICAL": 0, "IMPORTANT": 1, "MINOR": 2}.get(str(severity).upper(), 3)
+
+
+def aggregate_adversarial_findings(
+    blind_json: Optional[str] = None,
+    edge_case_json: Optional[str] = None,
+    acceptance_json: Optional[str] = None,
+) -> dict:
+    """Aggregate, deduplicate, and classify findings from adversarial reviewers.
+
+    Args:
+        blind_json: Raw JSON output from Blind Hunter reviewer.
+        edge_case_json: Raw JSON output from Edge Case Hunter reviewer.
+        acceptance_json: Raw JSON output from Acceptance Auditor reviewer.
+
+    Returns dict with unified report.
+    """
+    reviewer_data: dict[str, dict[str, object]] = {}
+    findings_by_reviewer: dict[str, list[dict[str, object]]] = {}
+
+    inputs = [
+        ("blind", blind_json),
+        ("edge_case", edge_case_json),
+        ("acceptance", acceptance_json),
+    ]
+
+    parse_errors: list[str] = []
+    for reviewer_id, raw_json in inputs:
+        if raw_json is None:
+            reviewer_data[reviewer_id] = {
+                "status": "not_run",
+                "error": "No output provided",
+            }
+            findings_by_reviewer[reviewer_id] = []
+            continue
+        try:
+            parsed = json.loads(raw_json)
+            if not isinstance(parsed, dict):
+                reviewer_data[reviewer_id] = {
+                    "status": "parse_error",
+                    "error": "Output is not a JSON object",
+                }
+                findings_by_reviewer[reviewer_id] = []
+                parse_errors.append(f"{reviewer_id}: output is not a JSON object")
+                continue
+            reviewer_data[reviewer_id] = {
+                "status": "ok",
+                "all_clear": parsed.get("all_clear"),
+                "all_clear_rationale": parsed.get("all_clear_rationale", ""),
+                "checks_performed": parsed.get("checks_performed", []),
+                "raw": parsed,
+            }
+            findings = parsed.get("findings", [])
+            if not isinstance(findings, list):
+                findings = []
+            findings_by_reviewer[reviewer_id] = findings
+        except (json.JSONDecodeError, ValueError) as e:
+            reviewer_data[reviewer_id] = {
+                "status": "parse_error",
+                "error": str(e),
+            }
+            findings_by_reviewer[reviewer_id] = []
+            parse_errors.append(f"{reviewer_id}: {e}")
+
+    clusters = _cluster_adversarial_findings(findings_by_reviewer)
+
+    merged_findings: list[dict[str, object]] = []
+    for cluster in clusters:
+        cluster_findings = cluster.get("findings", [])
+        cluster_reviewers = cluster.get("reviewers", [])
+        if not isinstance(cluster_findings, list) or not cluster_findings:
+            continue
+
+        primary = cluster_findings[0] if isinstance(cluster_findings[0], dict) else {}
+        corroborated = len(set(str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else []))) > 1
+
+        severities = [
+            _severity_rank(str(f.get("severity", "MINOR")))
+            for f in cluster_findings
+            if isinstance(f, dict)
+        ]
+        max_sev = min(severities) if severities else 2
+        merged_severity = {0: "CRITICAL", 1: "IMPORTANT", 2: "MINOR"}[max_sev]
+
+        merged: dict[str, object] = {
+            "severity": merged_severity,
+            "category": primary.get("category", "unknown"),
+            "file_path": primary.get("file_path"),
+            "line_range": primary.get("line_range"),
+            "symbol": primary.get("symbol"),
+            "failure_mode": primary.get("failure_mode", ""),
+            "evidence": primary.get("evidence", ""),
+            "recommendation": primary.get("recommendation", ""),
+            "reported_by": sorted(set(
+                str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else [])
+            )),
+            "corroborated": corroborated,
+            "corroboration_note": (
+                f"Found independently by {len(set(str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else [])))} reviewers — high confidence"
+                if corroborated
+                else ""
+            ),
+            "raw_findings": cluster_findings,
+        }
+        merged_findings.append(merged)
+
+    merged_findings.sort(key=lambda f: _severity_rank(str(f.get("severity", "MINOR"))))
+
+    critical_count = sum(1 for f in merged_findings if f.get("severity") == "CRITICAL")
+    important_count = sum(1 for f in merged_findings if f.get("severity") == "IMPORTANT")
+    minor_count = sum(1 for f in merged_findings if f.get("severity") == "MINOR")
+    corroborated_count = sum(1 for f in merged_findings if f.get("corroborated"))
+
+    per_reviewer_counts = {}
+    for reviewer_id, findings in findings_by_reviewer.items():
+        per_reviewer_counts[reviewer_id] = len(findings)
+
+    all_clear_by_reviewer = {}
+    for reviewer_id, data in reviewer_data.items():
+        all_clear_by_reviewer[reviewer_id] = data.get("all_clear")
+
+    return {
+        "status": "success",
+        "summary": {
+            "total_findings": len(merged_findings),
+            "critical": critical_count,
+            "important": important_count,
+            "minor": minor_count,
+            "corroborated": corroborated_count,
+            "per_reviewer_counts": per_reviewer_counts,
+            "all_clear_by_reviewer": all_clear_by_reviewer,
+        },
+        "findings": merged_findings,
+        "reviewer_status": reviewer_data,
+        "parse_errors": parse_errors,
+    }
+
+
 def write_learning_handoff(
     workflow: str,
     task_title: str = "",
@@ -14466,6 +14971,62 @@ if __name__ == "__main__":
             branch=_args.branch,
             review_preferences=_args.review_preferences,
             budget_tokens=_args.budget_tokens,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "build_adversarial_review_prompts":
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py build_adversarial_review_prompts")
+        _p.add_argument("--branch", default=None)
+        _p.add_argument("--reviewers", default=None, help="Comma-separated: blind,edge_case,acceptance")
+        _p.add_argument("--quick", action="store_true", default=False, help="Skip edge_case reviewer")
+        _args = _p.parse_args(sys.argv[2:])
+        reviewer_ids = None
+        if _args.reviewers:
+            reviewer_ids = [r.strip() for r in _args.reviewers.split(",") if r.strip()]
+        elif _args.quick:
+            reviewer_ids = ["blind", "acceptance"]
+        result = build_adversarial_review_prompts(
+            branch=_args.branch,
+            reviewers=reviewer_ids,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "aggregate_adversarial_findings":
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py aggregate_adversarial_findings")
+        _p.add_argument("--blind", default=None, help="Path to blind reviewer JSON output")
+        _p.add_argument("--edge-case", default=None, help="Path to edge_case reviewer JSON output")
+        _p.add_argument("--acceptance", default=None, help="Path to acceptance reviewer JSON output")
+        _args = _p.parse_args(sys.argv[2:])
+
+        blind_json = None
+        edge_case_json = None
+        acceptance_json = None
+        for arg_path, key in [
+            (_args.blind, "blind"),
+            (_args.edge_case, "edge_case"),
+            (_args.acceptance, "acceptance"),
+        ]:
+            if arg_path:
+                try:
+                    text = Path(arg_path).read_text(encoding="utf-8")
+                    if key == "blind":
+                        blind_json = text
+                    elif key == "edge_case":
+                        edge_case_json = text
+                    elif key == "acceptance":
+                        acceptance_json = text
+                except OSError as e:
+                    print(json.dumps({"status": "error", "reason": f"Cannot read {arg_path}: {e}"}))
+                    sys.exit(1)
+
+        result = aggregate_adversarial_findings(
+            blind_json=blind_json,
+            edge_case_json=edge_case_json,
+            acceptance_json=acceptance_json,
         )
         print(json.dumps(result, indent=2, ensure_ascii=True))
 

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Interactive 4-section code review using Monitor, Predictor, and Evaluator agents on current changes. Use when reviewing a diff, PR, or staged work before merge. Do NOT use to plan or implement; use map-plan or map-efficient.
 effort: high
 disable-model-invocation: true
-argument-hint: "[review focus] [--detached] [--ci] [--reverse-sections] [--shuffle-sections] [--seed <int>] [--compare-orderings]"
+argument-hint: "[review focus] [--detached] [--ci] [--reverse-sections] [--shuffle-sections] [--seed <int>] [--compare-orderings] [--adversarial] [--quick] [--show-raw-findings]"
 ---
 # MAP Review Workflow
 
@@ -33,6 +33,9 @@ parallel_tool_policy: single_review_fanout
 - `--shuffle-sections`: randomize section order with a branch+commit derived seed.
 - `--seed <int>`: override shuffle seed with a non-negative integer.
 - `--compare-orderings`: run default and reverse ordering reviews, then aggregate drift. Cannot be combined with `--shuffle-sections` (EC-1/EC-17).
+- `--adversarial`: run three independent adversarial reviewers (Blind Hunter, Edge Case Hunter, Acceptance Auditor) in parallel, then aggregate with deduplication and convergence analysis. Each reviewer operates in an isolated context with only its permitted inputs.
+- `--quick`: used with `--adversarial` to skip the Edge Case Hunter (Blind + Acceptance only). Reduces token cost for routine changes.
+- `--show-raw-findings`: used with `--adversarial` to include raw reviewer outputs in the report. Useful for debugging or verifying aggregation.
 
 ## Execution Rules
 
@@ -155,6 +158,19 @@ fi
 if [ "$COMPARE_FLAG" = "true" ] && [ "$SHUFFLE_FLAG" = "true" ]; then
   echo '{"status":"error","reason":"--compare-orderings always uses default+reverse; cannot combine with --shuffle-sections (EC-1/EC-17)"}'
   exit 1
+fi
+
+ADVERSARIAL_FLAG=false
+QUICK_FLAG=false
+SHOW_RAW_FLAG=false
+if echo "$ARGUMENTS" | grep -q -- '--adversarial'; then
+  ADVERSARIAL_FLAG=true
+fi
+if echo "$ARGUMENTS" | grep -q -- '--quick'; then
+  QUICK_FLAG=true
+fi
+if echo "$ARGUMENTS" | grep -q -- '--show-raw-findings'; then
+  SHOW_RAW_FLAG=true
 fi
 
 MODE_FLAG="default"
@@ -362,7 +378,24 @@ skip Phase B. Record `REVISE` or `BLOCK` as appropriate. Bare
 mode skips presentation) with a verification note instead of
 publishing the bare verdict.
 
-## Phase B: Interactive Presentation (4 Sections)
+## Phase B: Adversarial Review (--adversarial only)
+When `--adversarial` is set, skip the Monitor/Predictor/Evaluator fan-out and the 4-section interactive walkthrough. Instead run three independent adversarial reviewers with isolated contexts, then aggregate. See [adversarial-reference.md](adversarial-reference.md) for the detailed step-by-step commands.
+
+### Quick reference
+
+```text
+1. Build prompts:  python3 .map/scripts/map_step_runner.py build_adversarial_review_prompts [--quick]
+2. Fan-out:        Task(subagent_type="general", ...) for blind, edge_case, acceptance — parallel, then wait for all
+3. Validate:       Each must return valid JSON per adversarial finding schema; retry ONCE on failure
+4. Aggregate:      python3 .map/scripts/map_step_runner.py aggregate_adversarial_findings --blind <path> --edge-case <path> --acceptance <path>
+5. Present:        Unified report: CRITICAL/IMPORTANT/MINOR, convergence section, all-clear statements (--show-raw-findings for debug)
+6. Verdict:        BLOCK (corroborated CRITICAL or >2 CRITICAL), REVISE (any CRITICAL/IMPORTANT), PROCEED (MINOR only or all-clear)
+7. Skip to:        Final Verdict → Handoff Artifacts; do NOT run normal 4-section walkthrough
+```
+
+## Phase B: Interactive Presentation (4 Sections) — NORMAL MODE ONLY
+
+This phase runs ONLY when `ADVERSARIAL_FLAG=false`. Skip it entirely when `--adversarial` is set.
 
 ### Step B.0: Determine section presentation order
 

--- a/src/mapify_cli/templates/skills/map-review/adversarial-reference.md
+++ b/src/mapify_cli/templates/skills/map-review/adversarial-reference.md
@@ -1,0 +1,148 @@
+# Adversarial Review Reference
+
+Detailed workflow for `map-review --adversarial`. See [SKILL.md](SKILL.md) for context and integration points.
+
+## Overview
+
+Three reviewers run in parallel, each with only its permitted inputs:
+
+| Reviewer | Context | Finds |
+|----------|---------|-------|
+| **Blind Hunter** | diff only | Typos, dead code, logic errors visible in isolation |
+| **Edge Case Hunter** | diff + repo read access | Null handling, boundary conditions, error paths, codebase consistency |
+| **Acceptance Auditor** | diff + spec + plan + artifacts | Missed requirements, spec violations, AC gaps, extra/unplanned work |
+
+With `--quick`: skip Edge Case Hunter (Blind + Acceptance only).
+
+## Step B.adversarial.0: Build adversarial review prompts
+
+```bash
+QUICK_ARG=""
+if [ "$QUICK_FLAG" = "true" ]; then
+  QUICK_ARG="--quick"
+fi
+
+ADV_PROMPTS_JSON=$(python3 .map/scripts/map_step_runner.py build_adversarial_review_prompts $QUICK_ARG)
+
+BLIND_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("blind",{}).get("prompt",""))')
+BLIND_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("blind",{}).get("description",""))')
+
+EDGE_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("edge_case",{}).get("prompt",""))')
+EDGE_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("edge_case",{}).get("description",""))')
+
+ACCEPTANCE_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("acceptance",{}).get("prompt",""))')
+ACCEPTANCE_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("acceptance",{}).get("description",""))')
+```
+
+## Step B.adversarial.1: Launch all three in parallel (fan-out)
+
+```text
+# Launch all three adversarial reviewers in parallel — they are fully independent
+# with no shared context. Wait for all to complete before aggregation.
+
+Task(subagent_type="general", description=BLIND_DESC, prompt=BLIND_PROMPT)
+# Save output as BLIND_OUTPUT
+Task(subagent_type="general", description=EDGE_DESC, prompt=EDGE_PROMPT)
+# Save output as EDGE_OUTPUT  (skip if --quick)
+Task(subagent_type="general", description=ACCEPTANCE_DESC, prompt=ACCEPTANCE_PROMPT)
+# Save output as ACCEPTANCE_OUTPUT
+```
+
+## Step B.adversarial.2: Validate reviewer outputs
+
+Each reviewer must return valid JSON matching the adversarial finding schema. If any reviewer output is truncated or invalid JSON:
+- Log the failure
+- Re-invoke that specific reviewer ONCE with the same prompt
+- If still invalid, record the reviewer as `parse_error` and continue with remaining reviewers
+
+## Step B.adversarial.3: Aggregate findings
+
+Write each reviewer's raw JSON output to a temp file, then aggregate:
+
+```bash
+printf '%s' "$BLIND_OUTPUT" > .map/$BRANCH/adversarial-blind.json
+printf '%s' "$EDGE_OUTPUT" > .map/$BRANCH/adversarial-edge.json
+printf '%s' "$ACCEPTANCE_OUTPUT" > .map/$BRANCH/adversarial-acceptance.json
+
+BLIND_ARG=""
+EDGE_ARG=""
+ACCEPTANCE_ARG=""
+if [ -f .map/$BRANCH/adversarial-blind.json ]; then
+  BLIND_ARG="--blind .map/$BRANCH/adversarial-blind.json"
+fi
+if [ -f .map/$BRANCH/adversarial-edge.json ]; then
+  EDGE_ARG="--edge-case .map/$BRANCH/adversarial-edge.json"
+fi
+if [ -f .map/$BRANCH/adversarial-acceptance.json ]; then
+  ACCEPTANCE_ARG="--acceptance .map/$BRANCH/adversarial-acceptance.json"
+fi
+
+ADV_AGGREGATED=$(python3 .map/scripts/map_step_runner.py aggregate_adversarial_findings \
+  $BLIND_ARG $EDGE_ARG $ACCEPTANCE_ARG)
+```
+
+## Step B.adversarial.4: Present unified adversarial report
+
+Parse the aggregated JSON and present the report in this structure:
+
+```
+# Adversarial Review Report
+
+## Summary
+- Total findings: N (C CRITICAL, I IMPORTANT, M MINOR)
+- Corroborated (found by 2+ reviewers): K — highest confidence
+- Per-reviewer: Blind: B, Edge Case: E, Acceptance: A
+- All-clear: [reviewers who reported all_clear=true]
+
+## CRITICAL
+[per finding: severity, category, file:line, failure_mode, evidence, reported_by, corroborated flag]
+
+## IMPORTANT
+[per finding: same structure]
+
+## MINOR
+[per finding: same structure]
+
+## Cross-Reviewer Convergence
+[Highlight what multiple reviewers independently found — these are highest-confidence issues]
+
+## Reviewer All-Clear Statements
+[Per reviewer who said all_clear: what they checked and why it's clean]
+```
+
+When `--show-raw-findings` is set, also show the raw per-reviewer JSON files.
+
+## Step B.adversarial.5: Determine verdict
+
+Based on aggregated findings:
+- **BLOCK**: any CRITICAL finding with corroboration OR > 2 CRITICAL from any single reviewer
+- **REVISE**: any CRITICAL (uncorroborated) OR any IMPORTANT
+- **PROCEED**: only MINOR findings OR all all_clear
+
+## Step B.adversarial.6: Skip to Final Verdict
+
+After presenting the adversarial report, skip the normal 4-section interactive walkthrough and go directly to Final Verdict → Handoff Artifacts.
+
+## Flow summary for adversarial
+
+When `ADVERSARIAL_FLAG=true`, the workflow is:
+Phase A (all steps) → Phase B: Adversarial Review → Final Verdict → Handoff Artifacts.
+Do NOT run the normal Monitor/Predictor/Evaluator fan-out or the 4-section walkthrough.
+
+## Examples
+
+See [review-reference.md](review-reference.md#examples) for adversarial examples.
+
+## Troubleshooting
+
+### Reviewer returns invalid JSON
+
+Re-invoke that specific reviewer ONCE. If still invalid, record `parse_error` and continue — two valid reviewers are better than zero.
+
+### All three reviewers fail
+
+Stop with CLARIFICATION_NEEDED. The diff may be too large or the context too complex for adversarial review.
+
+### Edge Case Hunter runs out of context
+
+Edge Case Hunter has repo read access. If the repo is very large, limit its scope by pre-computing an impact graph of files importing/imported-by the changes plus relevant tests. Defer full implementation to v2.

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -8314,6 +8314,511 @@ def build_review_prompts(
     }
 
 
+ADVERSARIAL_REVIEWER_SPECS: dict[str, dict[str, str]] = {
+    "blind": {
+        "subagent_type": "general",
+        "description": "Blind diff-only review",
+        "task": """Review ONLY the git diff below. You have NO access to the project context, spec, architecture, or naming conventions. Your job is to find bugs, dead code, and obvious errors that are visible in the diff alone — without being biased by "what was intended."
+
+Be skeptical: assume nothing about intent. If something looks wrong in isolation, flag it.
+
+IMPORTANT: If the diff is correct and you find no issues, you MUST explicitly state that. A clean review is signal, not absence of output.""",
+        "instructions": """Find:
+- Typos, syntax errors, logic errors visible in isolation
+- Dead code, unreachable branches, unused variables
+- Obvious null-pointer / None-access risks
+- Missing imports or undefined references
+- Copy-paste errors
+- Inconsistent naming within the diff itself
+
+Do NOT speculate about:
+- Whether the code fits the project architecture (you cannot see it)
+- Whether a requirement is met (you cannot see the spec)
+- Whether edge cases are handled (that's the Edge Case reviewer's job)""",
+        "context_access": "diff_only",
+    },
+    "edge_case": {
+        "subagent_type": "general",
+        "description": "Edge case and codebase consistency review",
+        "task": """Review the git diff AND the full repository. You have read access to the codebase but NO access to the spec, requirements, or architecture documents. Your job is to find edge cases, error paths, and consistency issues through mechanical path tracing.
+
+Trace every changed function: who calls it, what can be null, where could it fail. Compare with existing patterns in the codebase.
+
+IMPORTANT: If you find no issues, explicitly state that the code is correct with reasoning.""",
+        "instructions": """Find:
+- Null handling gaps: trace every value that could be None/null
+- Boundary conditions: empty lists, zero values, max values
+- Error paths: are exceptions handled? Are error returns checked?
+- Consistency with existing codebase patterns
+- State lifecycle issues: initialization, cleanup, transitions
+- Race conditions or ordering dependencies
+- Missing validation on inputs from callers
+
+For each finding, include concrete evidence:
+- The line in the diff where the issue is
+- The caller path that triggers it (grep the repo)
+- What would fail and how""",
+        "context_access": "diff_plus_repo_read",
+    },
+    "acceptance": {
+        "subagent_type": "general",
+        "description": "Spec compliance and acceptance review",
+        "task": """Review the git diff against the specification and requirements. You have access to the diff, spec, plan, and all project artifacts. Your job is to verify every requirement is implemented and flag gaps.
+
+Take an adversarial stance toward COMPLACENCY, not the developer: "Has every stated requirement actually been met? Is there implemented code that serves no spec requirement?" 
+
+IMPORTANT: If all requirements are met, explicitly state that with reasoning. A clean review is signal.""",
+        "instructions": """Verify:
+- Every acceptance criterion / requirement has a corresponding implementation
+- Every requirement's implementation is correct (not just present)
+- No extra/unplanned work slipped in (implementation without spec requirement)
+- The implementation matches the spec's intent, not just its literal text
+- Spec contradictions or ambiguities exposed by the implementation
+- Edge cases mentioned in the spec are actually handled
+
+For each gap, cite:
+- The spec requirement ID and text
+- The file:line of the missing or incorrect implementation
+- The concrete failure scenario""",
+        "context_access": "diff_plus_spec_plus_artifacts",
+    },
+}
+
+ADVERSARIAL_FINDING_SCHEMA: dict[str, object] = {
+    "reviewer": "<'blind' | 'edge_case' | 'acceptance'>",
+    "all_clear": "<boolean — true if NO issues found; must be explicit>",
+    "all_clear_rationale": "<string — required when all_clear=true: what you checked and why it's clean>",
+    "findings": [
+        {
+            "id": "<F-<reviewer_prefix>-<NN> — e.g. F-B-01, F-E-01, F-A-01>",
+            "severity": "<'CRITICAL' | 'IMPORTANT' | 'MINOR'>",
+            "category": "<string — e.g. 'null_safety', 'spec_gap', 'logic_error', 'boundary', 'consistency', 'dead_code', 'typo'>",
+            "file_path": "<string | null — null for spec-level findings without a code location>",
+            "line_range": "<string | null>",
+            "symbol": "<string | null — affected function/class/variable>",
+            "failure_mode": "<string — concrete description of what goes wrong and when>",
+            "evidence": "<string — concrete trace: grep output, code path, spec requirement ID>",
+            "recommendation": "<string — actionable fix suggestion>",
+        }
+    ],
+    "checks_performed": ["<string — list what was actually checked>"],
+}
+
+
+def _render_adversarial_reviewer_prompt(
+    spec: dict[str, str],
+    git_diff: str,
+    repo_context: str = "",
+    spec_context: str = "",
+    layering: str = DEFAULT_PROMPT_LAYERING,
+) -> str:
+    """Render a self-contained prompt for one adversarial reviewer.
+
+    The reviewer receives only its permitted context, never the full bundle.
+    """
+    reviewer_id = spec.get("context_access", "unknown")
+    documents = ["<documents>"]
+
+    if reviewer_id == "diff_only":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+    elif reviewer_id == "diff_plus_repo_read":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+        if repo_context:
+            documents.extend(
+                [
+                    "  <document source='repo context' priority='secondary'>",
+                    "    <document_content>",
+                    repo_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+        documents.extend(
+            [
+                "  <document source='repo access note' priority='diagnostic'>",
+                "    <document_content>",
+                "You have READ access to the entire repository. Trace callers, "
+                "check existing patterns, and grep for related code. The repo "
+                "context above provides guidance on what to investigate.",
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+    elif reviewer_id == "diff_plus_spec_plus_artifacts":
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+        if spec_context:
+            documents.extend(
+                [
+                    "  <document source='specification and requirements' priority='primary'>",
+                    "    <document_content>",
+                    spec_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+        if repo_context:
+            documents.extend(
+                [
+                    "  <document source='project artifacts' priority='secondary'>",
+                    "    <document_content>",
+                    repo_context,
+                    "    </document_content>",
+                    "  </document>",
+                ]
+            )
+    else:
+        documents.extend(
+            [
+                "  <document source='git diff' priority='primary'>",
+                "    <document_content>",
+                git_diff,
+                "    </document_content>",
+                "  </document>",
+            ]
+        )
+
+    documents.append("</documents>")
+
+    output_schema = json.dumps(ADVERSARIAL_FINDING_SCHEMA, indent=2)
+    format_rules = (
+        "Return exactly one JSON object matching the schema. "
+        "No markdown, no code fences, no prose before/after. "
+        "Every finding must include concrete evidence and a plausible failure_mode. "
+        "Prefer no finding over a weak finding. "
+        'Set all_clear=true when no issues found, with a rationale explaining what you checked.'
+    )
+
+    documents_section = "\n".join(documents)
+    stable_sections = [
+        f"<task>\n{spec['task']}\n</task>",
+        "<workflow_policy>\n"
+        "You are one of three independent adversarial reviewers. You have NO access "
+        "to other reviewers' output. Review only what is in your context documents. "
+        "Do NOT speculate about information you cannot see.\n"
+        "</workflow_policy>",
+        f"<instructions>\n{spec['instructions']}\n</instructions>",
+        "<expected_output>\n"
+        f"<output_schema>\n{output_schema}\n</output_schema>\n"
+        f"<format_rules>\n{format_rules}\n</format_rules>\n"
+        "</expected_output>",
+    ]
+    return _layer_prompt_sections(documents_section, stable_sections, layering)
+
+
+def build_adversarial_review_prompts(
+    branch: Optional[str] = None,
+    reviewers: Optional[list[str]] = None,
+    git_diff_text: Optional[str] = None,
+    spec_text: Optional[str] = None,
+) -> dict:
+    """Build isolated prompts for the three adversarial reviewers.
+
+    Args:
+        branch: Branch name for reading spec/plan artifacts.
+        reviewers: Which reviewers to build prompts for.
+                   Default all three. ['blind', 'acceptance'] for --quick.
+        git_diff_text: Preloaded diff (avoids redundant git calls).
+        spec_text: Preloaded spec text (avoids redundant file reads).
+
+    Returns dict with 'prompts' key mapping reviewer_id to {subagent_type, description, prompt}.
+    """
+    branch_name = _sanitize_branch(branch) if branch else get_branch_name()
+    reviewer_ids = reviewers or ["blind", "edge_case", "acceptance"]
+    layering = _load_prompt_layering(Path.cwd())
+
+    git_diff = git_diff_text if git_diff_text is not None else _read_git_diff_for_review()
+
+    spec_context = spec_text if spec_text is not None else _read_spec_for_review(branch_name)
+    repo_context = _read_repo_summary_for_review(branch_name)
+
+    prompts: dict[str, dict[str, object]] = {}
+    for reviewer_id in reviewer_ids:
+        spec_entry = ADVERSARIAL_REVIEWER_SPECS.get(reviewer_id)
+        if spec_entry is None:
+            continue
+        prompt = _render_adversarial_reviewer_prompt(
+            spec_entry,
+            git_diff=git_diff,
+            repo_context=repo_context,
+            spec_context=spec_context,
+            layering=layering,
+        )
+        prompts[reviewer_id] = {
+            "subagent_type": spec_entry["subagent_type"],
+            "description": spec_entry["description"],
+            "prompt": prompt,
+            "context_access": spec_entry["context_access"],
+        }
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "prompt_layering": layering,
+        "prompts": prompts,
+        "reviewers_requested": reviewer_ids,
+    }
+
+
+def _read_spec_for_review(branch_name: str) -> str:
+    """Read spec and plan artifacts for the acceptance reviewer."""
+    branch_dir = get_branch_dir(branch_name)
+    parts: list[str] = []
+
+    spec_path = branch_dir / f"spec_{branch_name}.md"
+    if spec_path.exists():
+        try:
+            parts.append(spec_path.read_text(encoding="utf-8"))
+        except OSError:
+            pass
+
+    plan_path = branch_dir / f"task_plan_{branch_name}.md"
+    if plan_path.exists():
+        try:
+            parts.append(plan_path.read_text(encoding="utf-8"))
+        except OSError:
+            pass
+
+    return "\n\n---\n\n".join(parts) if parts else "[no spec or plan artifacts found]"
+
+
+def _read_repo_summary_for_review(branch_name: str) -> str:
+    """Build a lightweight repo summary for edge_case and acceptance reviewers."""
+    branch_dir = get_branch_dir(branch_name)
+    parts: list[str] = []
+
+    review_bundle_path = branch_dir / "review-bundle.md"
+    if review_bundle_path.exists():
+        try:
+            content = review_bundle_path.read_text(encoding="utf-8")
+            if content.strip() and not content.strip().startswith("MISSING"):
+                parts.append(f"=== Review Bundle ===\n{content}")
+        except OSError:
+            pass
+
+    return "\n\n".join(parts) if parts else "[no review bundle; use git history and repo structure for context]"
+
+
+def _cluster_adversarial_findings(
+    findings_by_reviewer: dict[str, list[dict[str, object]]],
+) -> list[dict[str, object]]:
+    """Deterministic clustering: group findings by file+proximity or by category+symbol.
+
+    Returns list of clusters, each with merged findings from multiple reviewers.
+    """
+    all_findings: list[tuple[str, dict[str, object]]] = []
+    for reviewer_id, findings in findings_by_reviewer.items():
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            all_findings.append((reviewer_id, finding))
+
+    clusters: list[dict[str, object]] = []
+    used: set[int] = set()
+
+    for i, (rev_i, f_i) in enumerate(all_findings):
+        if i in used:
+            continue
+        cluster: dict[str, object] = {
+            "findings": [f_i],
+            "reviewers": [rev_i],
+        }
+        used.add(i)
+        fp_i = str(f_i.get("file_path") or "")
+        sym_i = str(f_i.get("symbol") or "")
+        cat_i = str(f_i.get("category") or "")
+
+        for j, (rev_j, f_j) in enumerate(all_findings):
+            if j in used:
+                continue
+            fp_j = str(f_j.get("file_path") or "")
+            sym_j = str(f_j.get("symbol") or "")
+            cat_j = str(f_j.get("category") or "")
+
+            same_file = fp_i and fp_j and fp_i == fp_j
+            same_symbol = sym_i and sym_j and sym_i == sym_j
+            same_category = cat_i and cat_j and cat_i == cat_j
+
+            if (same_file and same_category) or (same_symbol and same_category):
+                cluster["findings"].append(f_j)  # type: ignore[union-attr]
+                cluster["reviewers"].append(rev_j)  # type: ignore[union-attr]
+                used.add(j)
+
+        clusters.append(cluster)
+
+    return clusters
+
+
+def _dedup_cluster_via_llm_fallback(cluster: dict[str, object]) -> dict[str, object]:
+    """Return cluster as-is for v1 — deterministic clustering is sufficient.
+
+    LLM adjudication for ambiguous cases is deferred to v2.
+    """
+    return cluster
+
+
+def _severity_rank(severity: str) -> int:
+    return {"CRITICAL": 0, "IMPORTANT": 1, "MINOR": 2}.get(str(severity).upper(), 3)
+
+
+def aggregate_adversarial_findings(
+    blind_json: Optional[str] = None,
+    edge_case_json: Optional[str] = None,
+    acceptance_json: Optional[str] = None,
+) -> dict:
+    """Aggregate, deduplicate, and classify findings from adversarial reviewers.
+
+    Args:
+        blind_json: Raw JSON output from Blind Hunter reviewer.
+        edge_case_json: Raw JSON output from Edge Case Hunter reviewer.
+        acceptance_json: Raw JSON output from Acceptance Auditor reviewer.
+
+    Returns dict with unified report.
+    """
+    reviewer_data: dict[str, dict[str, object]] = {}
+    findings_by_reviewer: dict[str, list[dict[str, object]]] = {}
+
+    inputs = [
+        ("blind", blind_json),
+        ("edge_case", edge_case_json),
+        ("acceptance", acceptance_json),
+    ]
+
+    parse_errors: list[str] = []
+    for reviewer_id, raw_json in inputs:
+        if raw_json is None:
+            reviewer_data[reviewer_id] = {
+                "status": "not_run",
+                "error": "No output provided",
+            }
+            findings_by_reviewer[reviewer_id] = []
+            continue
+        try:
+            parsed = json.loads(raw_json)
+            if not isinstance(parsed, dict):
+                reviewer_data[reviewer_id] = {
+                    "status": "parse_error",
+                    "error": "Output is not a JSON object",
+                }
+                findings_by_reviewer[reviewer_id] = []
+                parse_errors.append(f"{reviewer_id}: output is not a JSON object")
+                continue
+            reviewer_data[reviewer_id] = {
+                "status": "ok",
+                "all_clear": parsed.get("all_clear"),
+                "all_clear_rationale": parsed.get("all_clear_rationale", ""),
+                "checks_performed": parsed.get("checks_performed", []),
+                "raw": parsed,
+            }
+            findings = parsed.get("findings", [])
+            if not isinstance(findings, list):
+                findings = []
+            findings_by_reviewer[reviewer_id] = findings
+        except (json.JSONDecodeError, ValueError) as e:
+            reviewer_data[reviewer_id] = {
+                "status": "parse_error",
+                "error": str(e),
+            }
+            findings_by_reviewer[reviewer_id] = []
+            parse_errors.append(f"{reviewer_id}: {e}")
+
+    clusters = _cluster_adversarial_findings(findings_by_reviewer)
+
+    merged_findings: list[dict[str, object]] = []
+    for cluster in clusters:
+        cluster_findings = cluster.get("findings", [])
+        cluster_reviewers = cluster.get("reviewers", [])
+        if not isinstance(cluster_findings, list) or not cluster_findings:
+            continue
+
+        primary = cluster_findings[0] if isinstance(cluster_findings[0], dict) else {}
+        corroborated = len(set(str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else []))) > 1
+
+        severities = [
+            _severity_rank(str(f.get("severity", "MINOR")))
+            for f in cluster_findings
+            if isinstance(f, dict)
+        ]
+        max_sev = min(severities) if severities else 2
+        merged_severity = {0: "CRITICAL", 1: "IMPORTANT", 2: "MINOR"}[max_sev]
+
+        merged: dict[str, object] = {
+            "severity": merged_severity,
+            "category": primary.get("category", "unknown"),
+            "file_path": primary.get("file_path"),
+            "line_range": primary.get("line_range"),
+            "symbol": primary.get("symbol"),
+            "failure_mode": primary.get("failure_mode", ""),
+            "evidence": primary.get("evidence", ""),
+            "recommendation": primary.get("recommendation", ""),
+            "reported_by": sorted(set(
+                str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else [])
+            )),
+            "corroborated": corroborated,
+            "corroboration_note": (
+                f"Found independently by {len(set(str(r) for r in (cluster_reviewers if isinstance(cluster_reviewers, list) else [])))} reviewers — high confidence"
+                if corroborated
+                else ""
+            ),
+            "raw_findings": cluster_findings,
+        }
+        merged_findings.append(merged)
+
+    merged_findings.sort(key=lambda f: _severity_rank(str(f.get("severity", "MINOR"))))
+
+    critical_count = sum(1 for f in merged_findings if f.get("severity") == "CRITICAL")
+    important_count = sum(1 for f in merged_findings if f.get("severity") == "IMPORTANT")
+    minor_count = sum(1 for f in merged_findings if f.get("severity") == "MINOR")
+    corroborated_count = sum(1 for f in merged_findings if f.get("corroborated"))
+
+    per_reviewer_counts = {}
+    for reviewer_id, findings in findings_by_reviewer.items():
+        per_reviewer_counts[reviewer_id] = len(findings)
+
+    all_clear_by_reviewer = {}
+    for reviewer_id, data in reviewer_data.items():
+        all_clear_by_reviewer[reviewer_id] = data.get("all_clear")
+
+    return {
+        "status": "success",
+        "summary": {
+            "total_findings": len(merged_findings),
+            "critical": critical_count,
+            "important": important_count,
+            "minor": minor_count,
+            "corroborated": corroborated_count,
+            "per_reviewer_counts": per_reviewer_counts,
+            "all_clear_by_reviewer": all_clear_by_reviewer,
+        },
+        "findings": merged_findings,
+        "reviewer_status": reviewer_data,
+        "parse_errors": parse_errors,
+    }
+
+
 def write_learning_handoff(
     workflow: str,
     task_title: str = "",
@@ -14466,6 +14971,62 @@ if __name__ == "__main__":
             branch=_args.branch,
             review_preferences=_args.review_preferences,
             budget_tokens=_args.budget_tokens,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "build_adversarial_review_prompts":
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py build_adversarial_review_prompts")
+        _p.add_argument("--branch", default=None)
+        _p.add_argument("--reviewers", default=None, help="Comma-separated: blind,edge_case,acceptance")
+        _p.add_argument("--quick", action="store_true", default=False, help="Skip edge_case reviewer")
+        _args = _p.parse_args(sys.argv[2:])
+        reviewer_ids = None
+        if _args.reviewers:
+            reviewer_ids = [r.strip() for r in _args.reviewers.split(",") if r.strip()]
+        elif _args.quick:
+            reviewer_ids = ["blind", "acceptance"]
+        result = build_adversarial_review_prompts(
+            branch=_args.branch,
+            reviewers=reviewer_ids,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "aggregate_adversarial_findings":
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py aggregate_adversarial_findings")
+        _p.add_argument("--blind", default=None, help="Path to blind reviewer JSON output")
+        _p.add_argument("--edge-case", default=None, help="Path to edge_case reviewer JSON output")
+        _p.add_argument("--acceptance", default=None, help="Path to acceptance reviewer JSON output")
+        _args = _p.parse_args(sys.argv[2:])
+
+        blind_json = None
+        edge_case_json = None
+        acceptance_json = None
+        for arg_path, key in [
+            (_args.blind, "blind"),
+            (_args.edge_case, "edge_case"),
+            (_args.acceptance, "acceptance"),
+        ]:
+            if arg_path:
+                try:
+                    text = Path(arg_path).read_text(encoding="utf-8")
+                    if key == "blind":
+                        blind_json = text
+                    elif key == "edge_case":
+                        edge_case_json = text
+                    elif key == "acceptance":
+                        acceptance_json = text
+                except OSError as e:
+                    print(json.dumps({"status": "error", "reason": f"Cannot read {arg_path}: {e}"}))
+                    sys.exit(1)
+
+        result = aggregate_adversarial_findings(
+            blind_json=blind_json,
+            edge_case_json=edge_case_json,
+            acceptance_json=acceptance_json,
         )
         print(json.dumps(result, indent=2, ensure_ascii=True))
 

--- a/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
@@ -4,7 +4,7 @@ description: |
   Interactive 4-section code review using Monitor, Predictor, and Evaluator agents on current changes. Use when reviewing a diff, PR, or staged work before merge. Do NOT use to plan or implement; use map-plan or map-efficient.
 effort: high
 disable-model-invocation: true
-argument-hint: "[review focus] [--detached] [--ci] [--reverse-sections] [--shuffle-sections] [--seed <int>] [--compare-orderings]"
+argument-hint: "[review focus] [--detached] [--ci] [--reverse-sections] [--shuffle-sections] [--seed <int>] [--compare-orderings] [--adversarial] [--quick] [--show-raw-findings]"
 ---
 # MAP Review Workflow
 
@@ -33,6 +33,9 @@ parallel_tool_policy: single_review_fanout
 - `--shuffle-sections`: randomize section order with a branch+commit derived seed.
 - `--seed <int>`: override shuffle seed with a non-negative integer.
 - `--compare-orderings`: run default and reverse ordering reviews, then aggregate drift. Cannot be combined with `--shuffle-sections` (EC-1/EC-17).
+- `--adversarial`: run three independent adversarial reviewers (Blind Hunter, Edge Case Hunter, Acceptance Auditor) in parallel, then aggregate with deduplication and convergence analysis. Each reviewer operates in an isolated context with only its permitted inputs.
+- `--quick`: used with `--adversarial` to skip the Edge Case Hunter (Blind + Acceptance only). Reduces token cost for routine changes.
+- `--show-raw-findings`: used with `--adversarial` to include raw reviewer outputs in the report. Useful for debugging or verifying aggregation.
 
 ## Execution Rules
 
@@ -155,6 +158,19 @@ fi
 if [ "$COMPARE_FLAG" = "true" ] && [ "$SHUFFLE_FLAG" = "true" ]; then
   echo '{"status":"error","reason":"--compare-orderings always uses default+reverse; cannot combine with --shuffle-sections (EC-1/EC-17)"}'
   exit 1
+fi
+
+ADVERSARIAL_FLAG=false
+QUICK_FLAG=false
+SHOW_RAW_FLAG=false
+if echo "$ARGUMENTS" | grep -q -- '--adversarial'; then
+  ADVERSARIAL_FLAG=true
+fi
+if echo "$ARGUMENTS" | grep -q -- '--quick'; then
+  QUICK_FLAG=true
+fi
+if echo "$ARGUMENTS" | grep -q -- '--show-raw-findings'; then
+  SHOW_RAW_FLAG=true
 fi
 
 MODE_FLAG="default"
@@ -362,7 +378,24 @@ skip Phase B. Record `REVISE` or `BLOCK` as appropriate. Bare
 mode skips presentation) with a verification note instead of
 publishing the bare verdict.
 
-## Phase B: Interactive Presentation (4 Sections)
+## Phase B: Adversarial Review (--adversarial only)
+When `--adversarial` is set, skip the Monitor/Predictor/Evaluator fan-out and the 4-section interactive walkthrough. Instead run three independent adversarial reviewers with isolated contexts, then aggregate. See [adversarial-reference.md](adversarial-reference.md) for the detailed step-by-step commands.
+
+### Quick reference
+
+```text
+1. Build prompts:  python3 .map/scripts/map_step_runner.py build_adversarial_review_prompts [--quick]
+2. Fan-out:        Task(subagent_type="general", ...) for blind, edge_case, acceptance — parallel, then wait for all
+3. Validate:       Each must return valid JSON per adversarial finding schema; retry ONCE on failure
+4. Aggregate:      python3 .map/scripts/map_step_runner.py aggregate_adversarial_findings --blind <path> --edge-case <path> --acceptance <path>
+5. Present:        Unified report: CRITICAL/IMPORTANT/MINOR, convergence section, all-clear statements (--show-raw-findings for debug)
+6. Verdict:        BLOCK (corroborated CRITICAL or >2 CRITICAL), REVISE (any CRITICAL/IMPORTANT), PROCEED (MINOR only or all-clear)
+7. Skip to:        Final Verdict → Handoff Artifacts; do NOT run normal 4-section walkthrough
+```
+
+## Phase B: Interactive Presentation (4 Sections) — NORMAL MODE ONLY
+
+This phase runs ONLY when `ADVERSARIAL_FLAG=false`. Skip it entirely when `--adversarial` is set.
 
 ### Step B.0: Determine section presentation order
 

--- a/src/mapify_cli/templates_src/skills/map-review/adversarial-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-review/adversarial-reference.md.jinja
@@ -1,0 +1,148 @@
+# Adversarial Review Reference
+
+Detailed workflow for `map-review --adversarial`. See [SKILL.md](SKILL.md) for context and integration points.
+
+## Overview
+
+Three reviewers run in parallel, each with only its permitted inputs:
+
+| Reviewer | Context | Finds |
+|----------|---------|-------|
+| **Blind Hunter** | diff only | Typos, dead code, logic errors visible in isolation |
+| **Edge Case Hunter** | diff + repo read access | Null handling, boundary conditions, error paths, codebase consistency |
+| **Acceptance Auditor** | diff + spec + plan + artifacts | Missed requirements, spec violations, AC gaps, extra/unplanned work |
+
+With `--quick`: skip Edge Case Hunter (Blind + Acceptance only).
+
+## Step B.adversarial.0: Build adversarial review prompts
+
+```bash
+QUICK_ARG=""
+if [ "$QUICK_FLAG" = "true" ]; then
+  QUICK_ARG="--quick"
+fi
+
+ADV_PROMPTS_JSON=$(python3 .map/scripts/map_step_runner.py build_adversarial_review_prompts $QUICK_ARG)
+
+BLIND_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("blind",{}).get("prompt",""))')
+BLIND_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("blind",{}).get("description",""))')
+
+EDGE_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("edge_case",{}).get("prompt",""))')
+EDGE_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("edge_case",{}).get("description",""))')
+
+ACCEPTANCE_PROMPT=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("acceptance",{}).get("prompt",""))')
+ACCEPTANCE_DESC=$(printf '%s' "$ADV_PROMPTS_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("prompts",{}).get("acceptance",{}).get("description",""))')
+```
+
+## Step B.adversarial.1: Launch all three in parallel (fan-out)
+
+```text
+# Launch all three adversarial reviewers in parallel — they are fully independent
+# with no shared context. Wait for all to complete before aggregation.
+
+Task(subagent_type="general", description=BLIND_DESC, prompt=BLIND_PROMPT)
+# Save output as BLIND_OUTPUT
+Task(subagent_type="general", description=EDGE_DESC, prompt=EDGE_PROMPT)
+# Save output as EDGE_OUTPUT  (skip if --quick)
+Task(subagent_type="general", description=ACCEPTANCE_DESC, prompt=ACCEPTANCE_PROMPT)
+# Save output as ACCEPTANCE_OUTPUT
+```
+
+## Step B.adversarial.2: Validate reviewer outputs
+
+Each reviewer must return valid JSON matching the adversarial finding schema. If any reviewer output is truncated or invalid JSON:
+- Log the failure
+- Re-invoke that specific reviewer ONCE with the same prompt
+- If still invalid, record the reviewer as `parse_error` and continue with remaining reviewers
+
+## Step B.adversarial.3: Aggregate findings
+
+Write each reviewer's raw JSON output to a temp file, then aggregate:
+
+```bash
+printf '%s' "$BLIND_OUTPUT" > .map/$BRANCH/adversarial-blind.json
+printf '%s' "$EDGE_OUTPUT" > .map/$BRANCH/adversarial-edge.json
+printf '%s' "$ACCEPTANCE_OUTPUT" > .map/$BRANCH/adversarial-acceptance.json
+
+BLIND_ARG=""
+EDGE_ARG=""
+ACCEPTANCE_ARG=""
+if [ -f .map/$BRANCH/adversarial-blind.json ]; then
+  BLIND_ARG="--blind .map/$BRANCH/adversarial-blind.json"
+fi
+if [ -f .map/$BRANCH/adversarial-edge.json ]; then
+  EDGE_ARG="--edge-case .map/$BRANCH/adversarial-edge.json"
+fi
+if [ -f .map/$BRANCH/adversarial-acceptance.json ]; then
+  ACCEPTANCE_ARG="--acceptance .map/$BRANCH/adversarial-acceptance.json"
+fi
+
+ADV_AGGREGATED=$(python3 .map/scripts/map_step_runner.py aggregate_adversarial_findings \
+  $BLIND_ARG $EDGE_ARG $ACCEPTANCE_ARG)
+```
+
+## Step B.adversarial.4: Present unified adversarial report
+
+Parse the aggregated JSON and present the report in this structure:
+
+```
+# Adversarial Review Report
+
+## Summary
+- Total findings: N (C CRITICAL, I IMPORTANT, M MINOR)
+- Corroborated (found by 2+ reviewers): K — highest confidence
+- Per-reviewer: Blind: B, Edge Case: E, Acceptance: A
+- All-clear: [reviewers who reported all_clear=true]
+
+## CRITICAL
+[per finding: severity, category, file:line, failure_mode, evidence, reported_by, corroborated flag]
+
+## IMPORTANT
+[per finding: same structure]
+
+## MINOR
+[per finding: same structure]
+
+## Cross-Reviewer Convergence
+[Highlight what multiple reviewers independently found — these are highest-confidence issues]
+
+## Reviewer All-Clear Statements
+[Per reviewer who said all_clear: what they checked and why it's clean]
+```
+
+When `--show-raw-findings` is set, also show the raw per-reviewer JSON files.
+
+## Step B.adversarial.5: Determine verdict
+
+Based on aggregated findings:
+- **BLOCK**: any CRITICAL finding with corroboration OR > 2 CRITICAL from any single reviewer
+- **REVISE**: any CRITICAL (uncorroborated) OR any IMPORTANT
+- **PROCEED**: only MINOR findings OR all all_clear
+
+## Step B.adversarial.6: Skip to Final Verdict
+
+After presenting the adversarial report, skip the normal 4-section interactive walkthrough and go directly to Final Verdict → Handoff Artifacts.
+
+## Flow summary for adversarial
+
+When `ADVERSARIAL_FLAG=true`, the workflow is:
+Phase A (all steps) → Phase B: Adversarial Review → Final Verdict → Handoff Artifacts.
+Do NOT run the normal Monitor/Predictor/Evaluator fan-out or the 4-section walkthrough.
+
+## Examples
+
+See [review-reference.md](review-reference.md#examples) for adversarial examples.
+
+## Troubleshooting
+
+### Reviewer returns invalid JSON
+
+Re-invoke that specific reviewer ONCE. If still invalid, record `parse_error` and continue — two valid reviewers are better than zero.
+
+### All three reviewers fail
+
+Stop with CLARIFICATION_NEEDED. The diff may be too large or the context too complex for adversarial review.
+
+### Edge Case Hunter runs out of context
+
+Edge Case Hunter has repo read access. If the repo is very large, limit its scope by pre-computing an impact graph of files importing/imported-by the changes plus relevant tests. Defer full implementation to v2.


### PR DESCRIPTION
Adds `map-review --adversarial` — three parallel independent reviewers with isolated contexts for cross-perspective triangulation of code changes.

Three reviewers run in parallel, each with only its permitted inputs:

| Reviewer | Context | Finds |
|----------|---------|-------|
| Blind Hunter | diff only | Typos, dead code, logic errors visible in isolation |
| Edge Case Hunter | diff + repo read | Null handling, boundary conditions, error paths, consistency |
| Acceptance Auditor | diff + spec + artifacts | Missed requirements, spec violations, AC gaps |

Features:
- `map-review --adversarial` — launch all three reviewers in parallel
- `--quick` — skip Edge Case Hunter (Blind + Acceptance only)
- `--show-raw-findings` — show raw reviewer outputs for debugging
- Structured finding schema with severity/category/evidence/failure_mode
- Deterministic clustering deduplication with corroboration signals
- Unified report: CRITICAL/IMPORTANT/MINOR + convergence section + all-clear statements
- `build_adversarial_review_prompts()` and `aggregate_adversarial_findings()` in map_step_runner
- `adversarial-reference.md` with detailed workflow steps

Design per llm-council:
- Parallel dispatch (unanimous): all three run simultaneously, no gating
- Standalone flag in v1: not automatic per-subtask
- Skeptical but evidence-gated tone: not theatrical "DO NOT trust them"
- All three reviewers in v1: Edge Case Hunter catches runtime bugs others miss
- Corroboration as signal: when 2+ reviewers find same issue, elevated confidence
- Deferred to v2: per-subtask automatic gate, model tiering, risk classifier

Tested: 2843 tests pass, lint clean, check-render matches.