### PR TITLE
fix: resolve bare-basename citations (#301) and research-agent full report (#300)

### DIFF
--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -107,17 +107,23 @@ Task(
 <documents>
   <document source="user-request"><document_content>$ARGUMENTS</document_content></document>
 </documents>
-<task>Locate relevant code and return verified existing files, new files confirmed absent, patterns, risks, and unknowns. Also determine, with `file:line` evidence, which parts of the request are ALREADY IMPLEMENTED in the codebase (whole feature, or specific behaviors/acceptance criteria) versus genuinely missing. Do not assume absence — search for existing implementations before reporting a part as missing.</task>
-<expected_output>Markdown sections: Already Implemented (each entry cites the feature part + `file:line` proof), Existing Files, Files to Create, Patterns Found, Risks / Unknowns. If nothing matching the request exists, write "Already Implemented: none found (searched: <queries>)".</expected_output>
+<task>Locate relevant code and return verified existing files, new files confirmed absent, patterns, risks, and unknowns. Also determine, with `file:line` evidence, which parts of the request are ALREADY IMPLEMENTED in the codebase (whole feature, or specific behaviors/acceptance criteria) versus genuinely missing. Do not assume absence — search for existing implementations before reporting a part as missing.
+
+**MANDATORY artifact write:** When your research is complete, write the FULL detailed report (not a summary) directly to `.map/$BRANCH/research/plan__discovery.md` using the Write tool. Every `file:line` reference you found must appear in that file — downstream steps (Step 0.5 and Step 2a.5) read this file directly and will fail if it contains only a summary. After writing, confirm: "Written full discovery report to .map/$BRANCH/research/plan__discovery.md".</task>
+<expected_output>Write `.map/$BRANCH/research/plan__discovery.md` containing Markdown sections: Already Implemented (each entry cites the feature part + `file:line` proof), Existing Files, Files to Create, Patterns Found, Risks / Unknowns. If nothing matching the request exists, write "Already Implemented: none found (searched: &lt;queries&gt;)". Then return a brief confirmation to the parent (not a re-summary — the file is the canonical artifact).</expected_output>
 """
 )
 ```
 
-Save discovery to `.map/<branch>/research/plan__discovery.md` with the shared research API by feeding the researcher output on stdin:
+**Note on continuation:** If you need the research agent to elaborate on its findings after the Task returns, use `SendMessage` to the agent's task id — do NOT spawn a new `Agent` call, which starts with no prior context and will produce a hallucinated unrelated report.
+
+After the Task returns, verify the artifact was written directly (preferred path). Fall back to saving the returned text only if the agent did not write the file:
 
 ```bash
-printf '%s' "$PLAN_DISCOVERY" | \
-  python3 .map/scripts/map_step_runner.py save_research "$BRANCH" plan discovery
+if [ ! -f ".map/$BRANCH/research/plan__discovery.md" ]; then
+  printf '%s' "$PLAN_DISCOVERY" | \
+    python3 .map/scripts/map_step_runner.py save_research "$BRANCH" plan discovery
+fi
 ```
 
 ### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)

--- a/.map/scripts/validate_spec_citations.py
+++ b/.map/scripts/validate_spec_citations.py
@@ -51,6 +51,27 @@ _IDENT_RE = re.compile(r"`([A-Za-z_][\w./\-]{1,79})`")
 # Citations whose path looks like one of these are skipped (not in-repo).
 _SKIP_PREFIXES = ("http://", "https://", "/Users/", "/home/", "~/", "$HOME")
 
+# Directories excluded from bare-basename searches to avoid false positives.
+_SKIP_DIRS = frozenset({
+    ".git", "__pycache__", "node_modules", ".tox", ".venv", "venv", ".mypy_cache",
+})
+
+
+def _find_by_basename(repo_root: Path, basename: str) -> list[Path]:
+    """Return regular files whose name equals ``basename`` under ``repo_root``.
+
+    Common non-source directories are skipped so results only reflect actual
+    project files and the search stays fast on large repos.
+    """
+    results = []
+    for p in repo_root.rglob(basename):
+        if not p.is_file():
+            continue
+        if any(part in _SKIP_DIRS for part in p.relative_to(repo_root).parts):
+            continue
+        results.append(p)
+    return results
+
 
 def _branch_slug() -> str:
     try:
@@ -110,13 +131,47 @@ def _check_citation(
             "reason": "resolved path escapes repo root",
         }
 
+    resolved_from_basename: str | None = None
     if not target.is_file():
-        return {
-            "path": raw_path,
-            "line": line_no,
-            "status": "error",
-            "reason": f"file does not exist at {target.relative_to(repo_root)}",
-        }
+        # Bare filename (no path separator): try repo-wide basename search so a
+        # citation like `api.ts:80` resolves to `web-review/src/api.ts:80` when
+        # that is the only file with that name.  Full paths that simply don't
+        # exist keep the original "file does not exist" error.
+        is_bare = "/" not in raw_path and "\\" not in raw_path
+        if is_bare:
+            matches = _find_by_basename(repo_root, raw_path)
+            if len(matches) == 1:
+                target = matches[0]
+                resolved_from_basename = str(target.relative_to(repo_root))
+            elif len(matches) > 1:
+                shown = sorted(str(m.relative_to(repo_root)) for m in matches)
+                preview = ", ".join(shown[:3]) + (" …" if len(shown) > 3 else "")
+                return {
+                    "path": raw_path,
+                    "line": line_no,
+                    "status": "warning",
+                    "reason": (
+                        f"ambiguous bare basename: {len(matches)} files match "
+                        f"({preview}) — use a repo-root-relative path"
+                    ),
+                }
+            else:
+                return {
+                    "path": raw_path,
+                    "line": line_no,
+                    "status": "error",
+                    "reason": (
+                        f"file does not exist: {raw_path!r} not found anywhere in the repo "
+                        "(consider a repo-root-relative path)"
+                    ),
+                }
+        else:
+            return {
+                "path": raw_path,
+                "line": line_no,
+                "status": "error",
+                "reason": f"file does not exist at {raw_path}",
+            }
 
     try:
         lines = target.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -153,6 +208,9 @@ def _check_citation(
         }
 
     ident = _nearest_identifier(spec_text, match.start())
+    _extra: dict[str, object] = (
+        {"resolved_to": resolved_from_basename} if resolved_from_basename else {}
+    )
     if ident is None:
         return {
             "path": raw_path,
@@ -160,6 +218,7 @@ def _check_citation(
             "end_line": end_no,
             "status": "ok-no-identifier",
             "reason": "path/line valid; no adjacent identifier to cross-check",
+            **_extra,
         }
 
     cited_block = "\n".join(lines[line_no - 1 : end_no])
@@ -170,6 +229,7 @@ def _check_citation(
             "end_line": end_no,
             "identifier": ident,
             "status": "ok",
+            **_extra,
         }
 
     return {
@@ -183,6 +243,7 @@ def _check_citation(
             + (f"-{end_no}" if end_no != line_no else "")
             + "; cited block does not contain it"
         ),
+        **_extra,
     }
 
 
@@ -192,11 +253,13 @@ def validate_spec(spec_path: Path, repo_root: Path) -> dict[str, object]:
         _check_citation(repo_root, text, m) for m in _CITATION_RE.finditer(text)
     ]
     failures = [r for r in results if r["status"] in ("error", "stale-citation")]
+    warnings = [r for r in results if r["status"] == "warning"]
     return {
         "spec_path": str(spec_path),
         "repo_root": str(repo_root),
         "total_citations": len(results),
         "failures": failures,
+        "warnings": warnings,
         "passed": len(failures) == 0,
         "details": results,
     }

--- a/src/mapify_cli/templates/map/scripts/validate_spec_citations.py
+++ b/src/mapify_cli/templates/map/scripts/validate_spec_citations.py
@@ -51,6 +51,27 @@ _IDENT_RE = re.compile(r"`([A-Za-z_][\w./\-]{1,79})`")
 # Citations whose path looks like one of these are skipped (not in-repo).
 _SKIP_PREFIXES = ("http://", "https://", "/Users/", "/home/", "~/", "$HOME")
 
+# Directories excluded from bare-basename searches to avoid false positives.
+_SKIP_DIRS = frozenset({
+    ".git", "__pycache__", "node_modules", ".tox", ".venv", "venv", ".mypy_cache",
+})
+
+
+def _find_by_basename(repo_root: Path, basename: str) -> list[Path]:
+    """Return regular files whose name equals ``basename`` under ``repo_root``.
+
+    Common non-source directories are skipped so results only reflect actual
+    project files and the search stays fast on large repos.
+    """
+    results = []
+    for p in repo_root.rglob(basename):
+        if not p.is_file():
+            continue
+        if any(part in _SKIP_DIRS for part in p.relative_to(repo_root).parts):
+            continue
+        results.append(p)
+    return results
+
 
 def _branch_slug() -> str:
     try:
@@ -110,13 +131,47 @@ def _check_citation(
             "reason": "resolved path escapes repo root",
         }
 
+    resolved_from_basename: str | None = None
     if not target.is_file():
-        return {
-            "path": raw_path,
-            "line": line_no,
-            "status": "error",
-            "reason": f"file does not exist at {target.relative_to(repo_root)}",
-        }
+        # Bare filename (no path separator): try repo-wide basename search so a
+        # citation like `api.ts:80` resolves to `web-review/src/api.ts:80` when
+        # that is the only file with that name.  Full paths that simply don't
+        # exist keep the original "file does not exist" error.
+        is_bare = "/" not in raw_path and "\\" not in raw_path
+        if is_bare:
+            matches = _find_by_basename(repo_root, raw_path)
+            if len(matches) == 1:
+                target = matches[0]
+                resolved_from_basename = str(target.relative_to(repo_root))
+            elif len(matches) > 1:
+                shown = sorted(str(m.relative_to(repo_root)) for m in matches)
+                preview = ", ".join(shown[:3]) + (" …" if len(shown) > 3 else "")
+                return {
+                    "path": raw_path,
+                    "line": line_no,
+                    "status": "warning",
+                    "reason": (
+                        f"ambiguous bare basename: {len(matches)} files match "
+                        f"({preview}) — use a repo-root-relative path"
+                    ),
+                }
+            else:
+                return {
+                    "path": raw_path,
+                    "line": line_no,
+                    "status": "error",
+                    "reason": (
+                        f"file does not exist: {raw_path!r} not found anywhere in the repo "
+                        "(consider a repo-root-relative path)"
+                    ),
+                }
+        else:
+            return {
+                "path": raw_path,
+                "line": line_no,
+                "status": "error",
+                "reason": f"file does not exist at {raw_path}",
+            }
 
     try:
         lines = target.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -153,6 +208,9 @@ def _check_citation(
         }
 
     ident = _nearest_identifier(spec_text, match.start())
+    _extra: dict[str, object] = (
+        {"resolved_to": resolved_from_basename} if resolved_from_basename else {}
+    )
     if ident is None:
         return {
             "path": raw_path,
@@ -160,6 +218,7 @@ def _check_citation(
             "end_line": end_no,
             "status": "ok-no-identifier",
             "reason": "path/line valid; no adjacent identifier to cross-check",
+            **_extra,
         }
 
     cited_block = "\n".join(lines[line_no - 1 : end_no])
@@ -170,6 +229,7 @@ def _check_citation(
             "end_line": end_no,
             "identifier": ident,
             "status": "ok",
+            **_extra,
         }
 
     return {
@@ -183,6 +243,7 @@ def _check_citation(
             + (f"-{end_no}" if end_no != line_no else "")
             + "; cited block does not contain it"
         ),
+        **_extra,
     }
 
 
@@ -192,11 +253,13 @@ def validate_spec(spec_path: Path, repo_root: Path) -> dict[str, object]:
         _check_citation(repo_root, text, m) for m in _CITATION_RE.finditer(text)
     ]
     failures = [r for r in results if r["status"] in ("error", "stale-citation")]
+    warnings = [r for r in results if r["status"] == "warning"]
     return {
         "spec_path": str(spec_path),
         "repo_root": str(repo_root),
         "total_citations": len(results),
         "failures": failures,
+        "warnings": warnings,
         "passed": len(failures) == 0,
         "details": results,
     }

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -107,17 +107,23 @@ Task(
 <documents>
   <document source="user-request"><document_content>$ARGUMENTS</document_content></document>
 </documents>
-<task>Locate relevant code and return verified existing files, new files confirmed absent, patterns, risks, and unknowns. Also determine, with `file:line` evidence, which parts of the request are ALREADY IMPLEMENTED in the codebase (whole feature, or specific behaviors/acceptance criteria) versus genuinely missing. Do not assume absence — search for existing implementations before reporting a part as missing.</task>
-<expected_output>Markdown sections: Already Implemented (each entry cites the feature part + `file:line` proof), Existing Files, Files to Create, Patterns Found, Risks / Unknowns. If nothing matching the request exists, write "Already Implemented: none found (searched: <queries>)".</expected_output>
+<task>Locate relevant code and return verified existing files, new files confirmed absent, patterns, risks, and unknowns. Also determine, with `file:line` evidence, which parts of the request are ALREADY IMPLEMENTED in the codebase (whole feature, or specific behaviors/acceptance criteria) versus genuinely missing. Do not assume absence — search for existing implementations before reporting a part as missing.
+
+**MANDATORY artifact write:** When your research is complete, write the FULL detailed report (not a summary) directly to `.map/$BRANCH/research/plan__discovery.md` using the Write tool. Every `file:line` reference you found must appear in that file — downstream steps (Step 0.5 and Step 2a.5) read this file directly and will fail if it contains only a summary. After writing, confirm: "Written full discovery report to .map/$BRANCH/research/plan__discovery.md".</task>
+<expected_output>Write `.map/$BRANCH/research/plan__discovery.md` containing Markdown sections: Already Implemented (each entry cites the feature part + `file:line` proof), Existing Files, Files to Create, Patterns Found, Risks / Unknowns. If nothing matching the request exists, write "Already Implemented: none found (searched: &lt;queries&gt;)". Then return a brief confirmation to the parent (not a re-summary — the file is the canonical artifact).</expected_output>
 """
 )
 ```
 
-Save discovery to `.map/<branch>/research/plan__discovery.md` with the shared research API by feeding the researcher output on stdin:
+**Note on continuation:** If you need the research agent to elaborate on its findings after the Task returns, use `SendMessage` to the agent's task id — do NOT spawn a new `Agent` call, which starts with no prior context and will produce a hallucinated unrelated report.
+
+After the Task returns, verify the artifact was written directly (preferred path). Fall back to saving the returned text only if the agent did not write the file:
 
 ```bash
-printf '%s' "$PLAN_DISCOVERY" | \
-  python3 .map/scripts/map_step_runner.py save_research "$BRANCH" plan discovery
+if [ ! -f ".map/$BRANCH/research/plan__discovery.md" ]; then
+  printf '%s' "$PLAN_DISCOVERY" | \
+    python3 .map/scripts/map_step_runner.py save_research "$BRANCH" plan discovery
+fi
 ```
 
 ### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)

--- a/src/mapify_cli/templates_src/map/scripts/validate_spec_citations.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/validate_spec_citations.py.jinja
@@ -51,6 +51,27 @@ _IDENT_RE = re.compile(r"`([A-Za-z_][\w./\-]{1,79})`")
 # Citations whose path looks like one of these are skipped (not in-repo).
 _SKIP_PREFIXES = ("http://", "https://", "/Users/", "/home/", "~/", "$HOME")
 
+# Directories excluded from bare-basename searches to avoid false positives.
+_SKIP_DIRS = frozenset({
+    ".git", "__pycache__", "node_modules", ".tox", ".venv", "venv", ".mypy_cache",
+})
+
+
+def _find_by_basename(repo_root: Path, basename: str) -> list[Path]:
+    """Return regular files whose name equals ``basename`` under ``repo_root``.
+
+    Common non-source directories are skipped so results only reflect actual
+    project files and the search stays fast on large repos.
+    """
+    results = []
+    for p in repo_root.rglob(basename):
+        if not p.is_file():
+            continue
+        if any(part in _SKIP_DIRS for part in p.relative_to(repo_root).parts):
+            continue
+        results.append(p)
+    return results
+
 
 def _branch_slug() -> str:
     try:
@@ -110,13 +131,47 @@ def _check_citation(
             "reason": "resolved path escapes repo root",
         }
 
+    resolved_from_basename: str | None = None
     if not target.is_file():
-        return {
-            "path": raw_path,
-            "line": line_no,
-            "status": "error",
-            "reason": f"file does not exist at {target.relative_to(repo_root)}",
-        }
+        # Bare filename (no path separator): try repo-wide basename search so a
+        # citation like `api.ts:80` resolves to `web-review/src/api.ts:80` when
+        # that is the only file with that name.  Full paths that simply don't
+        # exist keep the original "file does not exist" error.
+        is_bare = "/" not in raw_path and "\\" not in raw_path
+        if is_bare:
+            matches = _find_by_basename(repo_root, raw_path)
+            if len(matches) == 1:
+                target = matches[0]
+                resolved_from_basename = str(target.relative_to(repo_root))
+            elif len(matches) > 1:
+                shown = sorted(str(m.relative_to(repo_root)) for m in matches)
+                preview = ", ".join(shown[:3]) + (" …" if len(shown) > 3 else "")
+                return {
+                    "path": raw_path,
+                    "line": line_no,
+                    "status": "warning",
+                    "reason": (
+                        f"ambiguous bare basename: {len(matches)} files match "
+                        f"({preview}) — use a repo-root-relative path"
+                    ),
+                }
+            else:
+                return {
+                    "path": raw_path,
+                    "line": line_no,
+                    "status": "error",
+                    "reason": (
+                        f"file does not exist: {raw_path!r} not found anywhere in the repo "
+                        "(consider a repo-root-relative path)"
+                    ),
+                }
+        else:
+            return {
+                "path": raw_path,
+                "line": line_no,
+                "status": "error",
+                "reason": f"file does not exist at {raw_path}",
+            }
 
     try:
         lines = target.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -153,6 +208,9 @@ def _check_citation(
         }
 
     ident = _nearest_identifier(spec_text, match.start())
+    _extra: dict[str, object] = (
+        {"resolved_to": resolved_from_basename} if resolved_from_basename else {}
+    )
     if ident is None:
         return {
             "path": raw_path,
@@ -160,6 +218,7 @@ def _check_citation(
             "end_line": end_no,
             "status": "ok-no-identifier",
             "reason": "path/line valid; no adjacent identifier to cross-check",
+            **_extra,
         }
 
     cited_block = "\n".join(lines[line_no - 1 : end_no])
@@ -170,6 +229,7 @@ def _check_citation(
             "end_line": end_no,
             "identifier": ident,
             "status": "ok",
+            **_extra,
         }
 
     return {
@@ -183,6 +243,7 @@ def _check_citation(
             + (f"-{end_no}" if end_no != line_no else "")
             + "; cited block does not contain it"
         ),
+        **_extra,
     }
 
 
@@ -192,11 +253,13 @@ def validate_spec(spec_path: Path, repo_root: Path) -> dict[str, object]:
         _check_citation(repo_root, text, m) for m in _CITATION_RE.finditer(text)
     ]
     failures = [r for r in results if r["status"] in ("error", "stale-citation")]
+    warnings = [r for r in results if r["status"] == "warning"]
     return {
         "spec_path": str(spec_path),
         "repo_root": str(repo_root),
         "total_citations": len(results),
         "failures": failures,
+        "warnings": warnings,
         "passed": len(failures) == 0,
         "details": results,
     }

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -107,17 +107,23 @@ Task(
 <documents>
   <document source="user-request"><document_content>$ARGUMENTS</document_content></document>
 </documents>
-<task>Locate relevant code and return verified existing files, new files confirmed absent, patterns, risks, and unknowns. Also determine, with `file:line` evidence, which parts of the request are ALREADY IMPLEMENTED in the codebase (whole feature, or specific behaviors/acceptance criteria) versus genuinely missing. Do not assume absence — search for existing implementations before reporting a part as missing.</task>
-<expected_output>Markdown sections: Already Implemented (each entry cites the feature part + `file:line` proof), Existing Files, Files to Create, Patterns Found, Risks / Unknowns. If nothing matching the request exists, write "Already Implemented: none found (searched: <queries>)".</expected_output>
+<task>Locate relevant code and return verified existing files, new files confirmed absent, patterns, risks, and unknowns. Also determine, with `file:line` evidence, which parts of the request are ALREADY IMPLEMENTED in the codebase (whole feature, or specific behaviors/acceptance criteria) versus genuinely missing. Do not assume absence — search for existing implementations before reporting a part as missing.
+
+**MANDATORY artifact write:** When your research is complete, write the FULL detailed report (not a summary) directly to `.map/$BRANCH/research/plan__discovery.md` using the Write tool. Every `file:line` reference you found must appear in that file — downstream steps (Step 0.5 and Step 2a.5) read this file directly and will fail if it contains only a summary. After writing, confirm: "Written full discovery report to .map/$BRANCH/research/plan__discovery.md".</task>
+<expected_output>Write `.map/$BRANCH/research/plan__discovery.md` containing Markdown sections: Already Implemented (each entry cites the feature part + `file:line` proof), Existing Files, Files to Create, Patterns Found, Risks / Unknowns. If nothing matching the request exists, write "Already Implemented: none found (searched: &lt;queries&gt;)". Then return a brief confirmation to the parent (not a re-summary — the file is the canonical artifact).</expected_output>
 """
 )
 ```
 
-Save discovery to `.map/<branch>/research/plan__discovery.md` with the shared research API by feeding the researcher output on stdin:
+**Note on continuation:** If you need the research agent to elaborate on its findings after the Task returns, use `SendMessage` to the agent's task id — do NOT spawn a new `Agent` call, which starts with no prior context and will produce a hallucinated unrelated report.
+
+After the Task returns, verify the artifact was written directly (preferred path). Fall back to saving the returned text only if the agent did not write the file:
 
 ```bash
-printf '%s' "$PLAN_DISCOVERY" | \
-  python3 .map/scripts/map_step_runner.py save_research "$BRANCH" plan discovery
+if [ ! -f ".map/$BRANCH/research/plan__discovery.md" ]; then
+  printf '%s' "$PLAN_DISCOVERY" | \
+    python3 .map/scripts/map_step_runner.py save_research "$BRANCH" plan discovery
+fi
 ```
 
 ### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)

--- a/tests/test_validate_spec_citations.py
+++ b/tests/test_validate_spec_citations.py
@@ -197,3 +197,103 @@ def test_picks_nearest_backticked_identifier_on_left(validator, tmp_path: Path):
     by_path = {d["path"]: d for d in result["details"]}
     assert by_path["b.py"]["identifier"] == "BETA"
     assert by_path["a.py"]["identifier"] == "ALPHA"
+
+
+# ---------------------------------------------------------------------------
+# Bare-basename resolution (#301)
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_unique_bare_basename_no_identifier(validator, tmp_path: Path):
+    """A bare filename that is unique in the repo resolves to the full path."""
+    repo = _seed_repo(tmp_path, {"sub/pkg/mod.py": "line1\nline2\nline3\n"})
+    spec = _write_spec(repo, "See mod.py:2 for context.")
+    result = validator.validate_spec(spec, repo)
+    assert result["passed"] is True
+    detail = result["details"][0]
+    assert detail["status"] == "ok-no-identifier"
+    assert detail["path"] == "mod.py"
+    assert detail["resolved_to"] == "sub/pkg/mod.py"
+
+
+def test_resolves_unique_bare_basename_with_identifier(validator, tmp_path: Path):
+    """Bare-basename resolution still validates the identifier in the cited line."""
+    repo = _seed_repo(tmp_path, {"deep/api.ts": "first\nMY_SYMBOL = 1\nthird\n"})
+    spec = _write_spec(repo, "The `MY_SYMBOL` binding lives at `api.ts:2`.")
+    result = validator.validate_spec(spec, repo)
+    assert result["passed"] is True
+    detail = result["details"][0]
+    assert detail["status"] == "ok"
+    assert detail["resolved_to"] == "deep/api.ts"
+
+
+def test_bare_basename_stale_identifier_still_fails(validator, tmp_path: Path):
+    """Resolved bare basename that fails identifier check is stale-citation."""
+    repo = _seed_repo(tmp_path, {"deep/api.ts": "first\nOTHER = 1\nthird\n"})
+    # MY_SYMBOL doesn't appear at line 2
+    spec = _write_spec(repo, "The `MY_SYMBOL` binding lives at `api.ts:2`.")
+    result = validator.validate_spec(spec, repo)
+    assert result["passed"] is False
+    detail = result["failures"][0]
+    assert detail["status"] == "stale-citation"
+    assert detail["resolved_to"] == "deep/api.ts"
+
+
+def test_warns_on_ambiguous_bare_basename(validator, tmp_path: Path):
+    """A bare filename that matches multiple files in the repo → warning, not error."""
+    repo = _seed_repo(
+        tmp_path,
+        {
+            "pkg_a/utils.py": "line1\nline2\n",
+            "pkg_b/utils.py": "lineA\nlineB\n",
+        },
+    )
+    spec = _write_spec(repo, "See utils.py:1 for the helper.")
+    result = validator.validate_spec(spec, repo)
+    # Ambiguous basename: should NOT hard-fail the plan
+    assert result["passed"] is True
+    detail = result["details"][0]
+    assert detail["status"] == "warning"
+    assert "ambiguous" in detail["reason"]
+    # warnings list carries it
+    assert len(result["warnings"]) == 1
+
+
+def test_bare_basename_not_in_repo_is_error(validator, tmp_path: Path):
+    """A bare filename that doesn't exist anywhere in the repo → error."""
+    spec = _write_spec(tmp_path, "See phantom.py:1 for reference.")
+    result = validator.validate_spec(spec, tmp_path)
+    assert result["passed"] is False
+    detail = result["failures"][0]
+    assert detail["status"] == "error"
+    # Error message should not say misleadingly "file does not exist at phantom.py"
+    assert "phantom.py" in detail["reason"]
+
+
+def test_full_path_missing_is_still_error(validator, tmp_path: Path):
+    """An explicit repo-root-relative path that doesn't exist is a hard error."""
+    spec = _write_spec(tmp_path, "See `TOKEN` at `src/does/not/exist.py:5`.")
+    result = validator.validate_spec(spec, tmp_path)
+    assert result["passed"] is False
+    assert result["failures"][0]["status"] == "error"
+    assert "does not exist" in result["failures"][0]["reason"]
+
+
+def test_warnings_field_present_even_when_empty(validator, tmp_path: Path):
+    """validate_spec always includes 'warnings' in output."""
+    repo = _seed_repo(tmp_path, {"src/a.py": "x\n"})
+    spec = _write_spec(repo, "See `x` at `src/a.py:1`.")
+    result = validator.validate_spec(spec, repo)
+    assert "warnings" in result
+    assert result["warnings"] == []
+
+
+def test_skip_dirs_excluded_from_basename_search(validator, tmp_path: Path):
+    """Files inside .git / __pycache__ / node_modules are excluded from basename search."""
+    # Put the real file inside a skip dir only — should not resolve
+    repo = _seed_repo(tmp_path, {"node_modules/api.ts": "line1\nline2\n"})
+    spec = _write_spec(repo, "See api.ts:1 here.")
+    result = validator.validate_spec(spec, repo)
+    # The only match is in node_modules → treated as not found → error
+    assert result["passed"] is False
+    assert result["failures"][0]["status"] == "error"


### PR DESCRIPTION
## Summary

- **#301** `validate_spec_citations.py`: bare-filename citations like `api.ts:80` now resolve automatically when the file is unique in the repo, instead of hard-failing with "file does not exist"
- **#300** `map-plan` Step 0: research-agent is instructed to write its full report directly to the discovery artifact on disk; fallback to the pipe is kept for backward compatibility

## Bug fixes

### #301 — Bare-basename citation resolution

`validate_spec_citations.py` previously reported `"file does not exist at api.ts"` even when exactly one `api.ts` existed deeper in the repo (`web-review/src/api.ts`). The validator treated bare filenames identically to full paths.

**Fix:**
- When a citation has no path separator and the direct path doesn't exist, search the repo for files matching that basename (skipping `.git`, `__pycache__`, `node_modules`, etc.)
- Exactly 1 match → resolve and validate normally; result includes `"resolved_to": "<full-path>"` so authors can optionally tighten the citation
- Multiple matches → non-blocking `"status": "warning"` (plan is not gated on a path-format ambiguity)
- No match → error with a clearer message ("not found anywhere in the repo")
- `validate_spec` output now includes a `"warnings"` list alongside `"failures"`

### #300 — research-agent full report

`research-agent` is designed to return compressed output. This meant Step 0 saved a summary to the discovery artifact, losing the `file:line` evidence that Step 0.5 and Step 2a.5 require.

**Fix:**
- Step 0 prompt now explicitly requires the agent to **Write** the complete report directly to `.map/$BRANCH/research/plan__discovery.md` before returning
- The save step checks whether the file was written (primary path) and falls back to the pipe only when the agent didn't write it
- Added note: continuation after a Task returns must use `SendMessage` to the agent's id — a new `Agent()` call starts fresh and hallucinated a different answer in the original bug report

## Test plan

- [x] `pytest tests/test_validate_spec_citations.py` — 21 tests pass (8 new tests covering all new paths: unique resolve, ambiguous warning, not-found error, skip-dirs exclusion, warnings field)
- [x] `make check-render` — generated trees match `templates_src` byte-for-byte
- [x] `pytest` (full suite) — 2968 passed, 1 pre-existing failure (`test_write_project_mcp_json_permission_error` — runs as root in CI container, permission never raised; predates this PR)

Closes #301, closes #300

---
_Generated by [Claude Code](https://claude.ai/code/session_018JeRJPx7rF1jHQJ2gCb4Dq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Citation checks now handle bare filenames more intelligently, resolving unique matches automatically and showing the resolved file path when helpful.
  * Discovery steps now require a full saved report, improving consistency for follow-up workflow steps.

* **Bug Fixes**
  * Ambiguous filename citations now generate warnings instead of hard failures.
  * Missing or stale citations continue to fail clearly, with improved error reporting.

* **Documentation**
  * Updated workflow guidance to make research handoff and report creation more explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->