### PR TITLE
feat(#303): Slice 0 — worktree_isolation enum + execution_wave_mode scaffolding

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -15322,7 +15322,19 @@ def _wt_force_remove(path: Path, branch_ref: str) -> None:
 
 
 def _wt_isolation_enabled(project_dir: Path) -> bool:
-    return _parse_boolish(_map_config_str(project_dir, "worktree.isolation", "false"))
+    """Return True when worktree isolation is active for the current project.
+
+    Handles the enum migration (#303): the old boolean ``false``/``true`` raw
+    strings (YAML 1.1 booleans are written as ``false``/``true`` when read
+    line-by-line) still work.  New enum values:
+    - ``off``  -> False (disabled — default)
+    - ``auto`` -> False (Slice 0: sequential everywhere; parallel dispatch
+                  lands in Slice 5; the call site in create_subtask_worktree
+                  already degrades to sequential when this returns False)
+    - ``required`` -> True  (hard-fail on unavailability, same as old ``true``)
+    """
+    val = _map_config_str(project_dir, "worktree.isolation", "off").strip().lower()
+    return val in {"required", "true", "yes", "y", "1", "on"}
 
 
 def _wt_max_deletions(project_dir: Path) -> int:

--- a/src/mapify_cli/config/project_config.py
+++ b/src/mapify_cli/config/project_config.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 VALID_MINIMALITY = frozenset({"off", "lite", "full", "ultra"})
 VALID_PROMPT_LAYERING = frozenset({"docs_first", "stable_first"})
+VALID_WORKTREE_ISOLATION = frozenset({"off", "auto", "required"})
+VALID_WAVE_MODE = frozenset({"off", "auto", "on"})
 
 # Cross-AI peer review (#288): external AI CLI runtimes map-review can dispatch
 # to. Keep in sync with CROSS_AI_RUNTIMES in the rendered step runner
@@ -160,13 +162,37 @@ class MapConfig:
     # filesystem concern, deliberately NOT nested under review/sofa. Dotted YAML
     # key `worktree.isolation` aliases to this snake_case field (see
     # load_map_config). The step runner owns the lifecycle + safety guards.
-    worktree_isolation: bool = False
+    # Enum values:
+    #   "off"      — never create worktrees; sequential execution always (default).
+    #   "auto"     — create per-subtask worktrees when a parallel color-group
+    #                dispatches; degrade to sequential with a loud warning when git
+    #                worktrees are unavailable (non-git repo, shallow clone, etc.).
+    #   "required" — hard-fail before parallel dispatch if worktrees are unavailable.
+    # Backward compat: YAML boolean `false` migrates to `"off"`, `true` to
+    # `"required"` in load_map_config.
+    worktree_isolation: str = "off"
     # Bulk-deletion guard threshold: the per-subtask merge refuses when the
     # worktree branch deletes MORE than this many files vs the base commit
     # (catches `rm -rf` / hallucinated mass deletion before it reaches the
     # working branch). 0 disables the guard. Dotted YAML key
     # `worktree.max_deletions`.
     worktree_max_deletions: int = 50
+
+    # Parallel wave execution mode (#303, Slice 0 scaffolding — no behavior change
+    # until Slice 3/5 promote the wave-loop to default). Controls whether
+    # `/map-efficient` routes multi-subtask waves through the parallel wave
+    # coordinator or the sequential single-subtask walker.
+    # Enum values:
+    #   "auto" — (default) engage the wave-loop when the color-group has >=2
+    #             independent subtasks AND worktree.isolation != "off"; degrade to
+    #             sequential otherwise. Slice 0: behaves as sequential everywhere
+    #             (the wave-loop promotion and concurrent dispatch land in Slice 3/5).
+    #   "off"  — always sequential; the legacy walker; instant rollback escape hatch.
+    #   "on"   — always attempt parallel dispatch (reserved for Slice 5/6; same as
+    #             "auto" until the concurrent-dispatch step lands).
+    # Dotted YAML key `execution.wave_mode` aliases to this field. YAML 1.1 parses
+    # bare `off`/`on` as booleans — load_map_config migrates them to strings.
+    execution_wave_mode: str = "auto"
 
 
 def load_map_config(project_path: Path) -> MapConfig:
@@ -237,9 +263,23 @@ def load_map_config(project_path: Path) -> MapConfig:
             ("review.cross_ai.timeout_seconds", "review_cross_ai_timeout_seconds"),
             ("worktree.isolation", "worktree_isolation"),
             ("worktree.max_deletions", "worktree_max_deletions"),
+            ("execution.wave_mode", "execution_wave_mode"),
         ):
             if dotted in data and field_name not in data:
                 data[field_name] = data.pop(dotted)
+
+        # Backward compat: worktree_isolation was a bool field; YAML `false`/`true`
+        # (and YAML 1.1 `off`/`on`) arrive as Python booleans. Migrate to the new
+        # enum string before the type-check loop (which expects str).
+        if isinstance(data.get("worktree_isolation"), bool):
+            data["worktree_isolation"] = (
+                "required" if data["worktree_isolation"] else "off"
+            )
+
+        # YAML 1.1 parses bare `off`/`on` as booleans for execution.wave_mode too.
+        # Coerce back to strings: False->"off", True->"on".
+        if isinstance(data.get("execution_wave_mode"), bool):
+            data["execution_wave_mode"] = "on" if data["execution_wave_mode"] else "off"
 
         # YAML 1.1 parses bare ``off``/``on`` as booleans, so ``minimality: off``
         # — the documented opt-out from the lite default (#183) — arrives as bool
@@ -343,6 +383,26 @@ def load_map_config(project_path: Path) -> MapConfig:
                 cfg.worktree_max_deletions,
             )
             cfg.worktree_max_deletions = 50
+
+        if cfg.worktree_isolation not in VALID_WORKTREE_ISOLATION:
+            logger.warning(
+                "Invalid worktree_isolation %r in %s (expected one of %s). "
+                "Using default 'off'.",
+                cfg.worktree_isolation,
+                config_file,
+                ", ".join(sorted(VALID_WORKTREE_ISOLATION)),
+            )
+            cfg.worktree_isolation = "off"
+
+        if cfg.execution_wave_mode not in VALID_WAVE_MODE:
+            logger.warning(
+                "Invalid execution_wave_mode %r in %s (expected one of %s). "
+                "Using default 'auto'.",
+                cfg.execution_wave_mode,
+                config_file,
+                ", ".join(sorted(VALID_WAVE_MODE)),
+            )
+            cfg.execution_wave_mode = "auto"
 
         return cfg
 
@@ -484,15 +544,29 @@ minimality: lite
 # review.cross_ai.runtime: codex          # default target: claude|codex|gemini|opencode
 # review.cross_ai.timeout_seconds: 180
 
-# Per-subtask git worktree isolation (#284) — opt-in, OFF by default. When on,
-# `/map-efficient` runs each subtask's Actor in a dedicated git worktree (stored
-# out of the working tree, under the repo's .git common dir) and atomically
-# squash-merges it back into the working branch ONLY after `verification_checks`
-# pass IN the worktree (pre-merge gate). A rejected attempt (Monitor/Evaluator
-# fail) is discarded, so the working branch is never touched by a bad attempt.
-# Top-level filesystem concern; the step runner owns the lifecycle + guards.
-# worktree.isolation: false
+# Per-subtask git worktree isolation (#284). Controls filesystem isolation for
+# each Actor run in `/map-efficient`. Enum values:
+#   off      — never create worktrees; sequential execution always (default).
+#   auto     — create per-subtask worktrees when a parallel color-group dispatches;
+#              degrade to sequential with a warning when worktrees are unavailable.
+#   required — hard-fail before dispatch if worktrees are unavailable (first-party
+#              repos that must never degrade silently).
+# When on (auto/required), each Actor runs inside a dedicated git worktree stored
+# under the repo's .git common dir and is squash-merged back ONLY after
+# verification_checks pass. A rejected attempt is discarded — the working branch
+# is never touched by a bad Actor attempt.
+# Backward compat: the old boolean `false`/`true` still works (migrates to off/required).
+# worktree.isolation: off
 # worktree.max_deletions: 50   # refuse a merge deleting more than N files (0 = off)
+
+# Parallel wave execution mode (#303). Controls whether `/map-efficient` routes
+# multi-subtask waves through the parallel coordinator or the sequential walker.
+#   auto — (default) engage the wave-loop when >=2 independent subtasks AND
+#           worktree.isolation != off; otherwise sequential. Currently behaves as
+#           sequential everywhere (parallel dispatch lands in a later slice).
+#   off  — always sequential; instant rollback escape hatch.
+#   on   — always attempt parallel (reserved; same as auto until dispatch lands).
+# execution.wave_mode: auto
 
 # Strip MAP-internal workflow IDs (ST-/AC-/VC-/INV-/HC-) from the code a run
 # changed, at workflow completion (Stop hook). On by default; uncomment and set

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -15322,7 +15322,19 @@ def _wt_force_remove(path: Path, branch_ref: str) -> None:
 
 
 def _wt_isolation_enabled(project_dir: Path) -> bool:
-    return _parse_boolish(_map_config_str(project_dir, "worktree.isolation", "false"))
+    """Return True when worktree isolation is active for the current project.
+
+    Handles the enum migration (#303): the old boolean ``false``/``true`` raw
+    strings (YAML 1.1 booleans are written as ``false``/``true`` when read
+    line-by-line) still work.  New enum values:
+    - ``off``  -> False (disabled — default)
+    - ``auto`` -> False (Slice 0: sequential everywhere; parallel dispatch
+                  lands in Slice 5; the call site in create_subtask_worktree
+                  already degrades to sequential when this returns False)
+    - ``required`` -> True  (hard-fail on unavailability, same as old ``true``)
+    """
+    val = _map_config_str(project_dir, "worktree.isolation", "off").strip().lower()
+    return val in {"required", "true", "yes", "y", "1", "on"}
 
 
 def _wt_max_deletions(project_dir: Path) -> int:

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -15322,7 +15322,19 @@ def _wt_force_remove(path: Path, branch_ref: str) -> None:
 
 
 def _wt_isolation_enabled(project_dir: Path) -> bool:
-    return _parse_boolish(_map_config_str(project_dir, "worktree.isolation", "false"))
+    """Return True when worktree isolation is active for the current project.
+
+    Handles the enum migration (#303): the old boolean ``false``/``true`` raw
+    strings (YAML 1.1 booleans are written as ``false``/``true`` when read
+    line-by-line) still work.  New enum values:
+    - ``off``  -> False (disabled — default)
+    - ``auto`` -> False (Slice 0: sequential everywhere; parallel dispatch
+                  lands in Slice 5; the call site in create_subtask_worktree
+                  already degrades to sequential when this returns False)
+    - ``required`` -> True  (hard-fail on unavailability, same as old ``true``)
+    """
+    val = _map_config_str(project_dir, "worktree.isolation", "off").strip().lower()
+    return val in {"required", "true", "yes", "y", "1", "on"}
 
 
 def _wt_max_deletions(project_dir: Path) -> int:

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -1175,6 +1175,10 @@ class TestMcpJsonConfig:
         parsed = json.loads(content)
         assert parsed == config
 
+    @pytest.mark.skipif(
+        __import__("os").getuid() == 0,
+        reason="root bypasses file-permission enforcement; test is meaningless when running as root",
+    )
     def test_write_project_mcp_json_permission_error(self, tmp_path):
         """Test write_project_mcp_json raises OSError on permission denied."""
         mcp_file = tmp_path / ".mcp.json"
@@ -1183,11 +1187,12 @@ class TestMcpJsonConfig:
 
         config = {"mcpServers": {"test": {"command": "test"}}}
 
-        with pytest.raises(OSError):
-            write_project_mcp_json(mcp_file, config)
-
-        # Cleanup: restore permissions so tmp_path cleanup works
-        mcp_file.chmod(0o644)
+        try:
+            with pytest.raises(OSError):
+                write_project_mcp_json(mcp_file, config)
+        finally:
+            # Restore permissions so tmp_path cleanup works
+            mcp_file.chmod(0o644)
 
     def test_merge_mcp_json_preserves_existing(self):
         """Test that merge preserves existing servers."""

--- a/tests/test_worktree_isolation.py
+++ b/tests/test_worktree_isolation.py
@@ -1,8 +1,9 @@
-"""Per-subtask git worktree isolation (#284).
+"""Per-subtask git worktree isolation (#284) and parallel wave execution (#303).
 
 Two layers:
-- Config: the MapConfig fields, dotted-key YAML aliasing (`worktree.*` ->
-  snake_case), bounds-validation fallback, and the generated default-config doc.
+- Config: the MapConfig fields, dotted-key YAML aliasing (`worktree.*` /
+  `execution.*` -> snake_case), enum validation, backward-compat bool migration,
+  and the generated default-config doc.
 - Runtime: the step-runner lifecycle (create/merge/discard/status), the
   disabled no-op path, and every council-mandated safety guard, exercised
   against real throwaway git repos.
@@ -19,6 +20,8 @@ import pytest
 
 from mapify_cli.config.project_config import (
     MapConfig,
+    VALID_WAVE_MODE,
+    VALID_WORKTREE_ISOLATION,
     generate_default_config,
     load_map_config,
 )
@@ -47,20 +50,22 @@ def _write_config(tmp_path: Path, body: str) -> None:
 class TestWorktreeConfig:
     def test_defaults_off(self) -> None:
         cfg = MapConfig()
-        assert cfg.worktree_isolation is False
+        assert cfg.worktree_isolation == "off"
         assert cfg.worktree_max_deletions == 50
 
     def test_absent_config_uses_defaults(self, tmp_path: Path) -> None:
         cfg = load_map_config(tmp_path)
-        assert cfg.worktree_isolation is False
+        assert cfg.worktree_isolation == "off"
         assert cfg.worktree_max_deletions == 50
 
     def test_dotted_keys_alias_to_fields(self, tmp_path: Path) -> None:
+        # YAML `true` is a bool in Python; the backward-compat migration maps it
+        # to the enum string "required".
         _write_config(
             tmp_path, "worktree.isolation: true\nworktree.max_deletions: 7\n"
         )
         cfg = load_map_config(tmp_path)
-        assert cfg.worktree_isolation is True
+        assert cfg.worktree_isolation == "required"
         assert cfg.worktree_max_deletions == 7
 
     def test_negative_max_deletions_falls_back(self, tmp_path: Path) -> None:
@@ -75,14 +80,87 @@ class TestWorktreeConfig:
         assert cfg.worktree_max_deletions == 0
 
     def test_wrong_type_isolation_ignored(self, tmp_path: Path) -> None:
-        _write_config(tmp_path, "worktree.isolation: notabool\n")
+        # An unknown string is not a valid enum value -> falls back to "off".
+        _write_config(tmp_path, "worktree.isolation: notanenum\n")
         cfg = load_map_config(tmp_path)
-        assert cfg.worktree_isolation is False
+        assert cfg.worktree_isolation == "off"
 
     def test_generated_config_documents_keys(self) -> None:
         body = generate_default_config(include_comments=True)
-        assert "worktree.isolation: false" in body
+        assert "worktree.isolation: off" in body
         assert "worktree.max_deletions" in body
+
+    # ------------------------------------------------------------------ #
+    # Enum string values
+    # ------------------------------------------------------------------ #
+    @pytest.mark.parametrize("value", sorted(VALID_WORKTREE_ISOLATION))
+    def test_valid_isolation_enum_values_accepted(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        _write_config(tmp_path, f"worktree.isolation: {value}\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.worktree_isolation == value
+
+    # ------------------------------------------------------------------ #
+    # Backward-compat: YAML bool -> string migration
+    # ------------------------------------------------------------------ #
+    def test_bool_false_migrates_to_off(self, tmp_path: Path) -> None:
+        # YAML `false` is parsed as Python False by yaml.safe_load.
+        # load_map_config migrates it to the new enum string "off".
+        _write_config(tmp_path, "worktree.isolation: false\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.worktree_isolation == "off"
+
+    def test_bool_true_migrates_to_required(self, tmp_path: Path) -> None:
+        # YAML `true` is parsed as Python True by yaml.safe_load.
+        # load_map_config migrates it to "required" (the strict opt-in).
+        _write_config(tmp_path, "worktree.isolation: true\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.worktree_isolation == "required"
+
+
+# --------------------------------------------------------------------------- #
+# execution_wave_mode config (#303 Slice 0)
+# --------------------------------------------------------------------------- #
+class TestWaveModeConfig:
+    def test_default_is_auto(self) -> None:
+        cfg = MapConfig()
+        assert cfg.execution_wave_mode == "auto"
+
+    def test_absent_config_uses_default(self, tmp_path: Path) -> None:
+        cfg = load_map_config(tmp_path)
+        assert cfg.execution_wave_mode == "auto"
+
+    @pytest.mark.parametrize("value", sorted(VALID_WAVE_MODE))
+    def test_valid_wave_mode_values_accepted(
+        self, tmp_path: Path, value: str
+    ) -> None:
+        _write_config(tmp_path, f"execution.wave_mode: {value}\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.execution_wave_mode == value
+
+    def test_invalid_wave_mode_falls_back_to_auto(self, tmp_path: Path) -> None:
+        _write_config(tmp_path, "execution.wave_mode: superfast\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.execution_wave_mode == "auto"
+
+    def test_yaml11_off_bool_migrates_to_string(self, tmp_path: Path) -> None:
+        # YAML 1.1 parses bare `off` as Python False.  load_map_config must
+        # coerce it back to the string "off" before the type-check loop.
+        _write_config(tmp_path, "execution.wave_mode: off\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.execution_wave_mode == "off"
+
+    def test_yaml11_on_bool_migrates_to_string(self, tmp_path: Path) -> None:
+        # YAML 1.1 parses bare `on` as Python True.  load_map_config must
+        # coerce it to "on".
+        _write_config(tmp_path, "execution.wave_mode: on\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.execution_wave_mode == "on"
+
+    def test_generated_config_documents_wave_mode(self) -> None:
+        body = generate_default_config(include_comments=True)
+        assert "execution.wave_mode: auto" in body
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Slice 0 of the 7-slice parallel wave rollout (#303). Config scaffolding only — **no behavior change** in this slice.

- **`worktree_isolation`** migrated from `bool = False` to `str = "off"` (enum: `off` / `auto` / `required`). The old boolean `false`/`true` in existing YAML configs migrates automatically in `load_map_config`.
- **`execution_wave_mode`** new field (`str = "auto"`, enum: `off` / `auto` / `on`), aliased from dotted YAML key `execution.wave_mode`. YAML 1.1 bare `off`/`on` (parsed as Python booleans) coerced back to strings.
- **`_wt_isolation_enabled`** in step runner updated to treat `"required"` and `"on"` as truthy; `"auto"` remains falsy until Slice 3/5.
- **Tests**: `TestWorktreeConfig` updated to `== "off"` / `== "required"` assertions, new parametrized enum-coverage tests, backward-compat bool-migration tests; new `TestWaveModeConfig` class covering all `execution_wave_mode` paths including YAML 1.1 coercion.
- **Fix**: `test_write_project_mcp_json_permission_error` skipped when running as root (pre-existing failure — `chmod(0o444)` has no effect for root, so `OSError` is never raised).

## Test plan

- [x] `uv run pytest tests/test_worktree_isolation.py -v` — 56 passed
- [x] `uv run pytest --tb=short -q` — 2982 passed, 4 skipped
- [x] `uv run make check-render` — generated trees match templates_src
- [x] `uv run make check` (ruff, mypy, pyright, lint-hooks, pytest) — all green

Closes part of #303 (Slice 0 of 7).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiSdo3Y2J5BtLzGVy2n98C)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enum-style worktree isolation settings in project configuration, with clearer options for default, optional, and required behavior.
  * Added a new execution wave mode setting for configuring how work runs in parallel.

* **Bug Fixes**
  * Improved compatibility with older boolean-style settings so existing configurations continue to work.
  * Invalid configuration values now fall back to safe defaults instead of causing unexpected behavior.

* **Tests**
  * Expanded automated coverage for the new configuration options and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->