### PR TITLE
fix #307: record_test_baseline timeout is fail-safe, not fail-open

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -11705,7 +11705,7 @@ def record_test_baseline(
     test_command: str = "",
     *,
     module_dir: str = "",
-    timeout_seconds: int = 120,
+    timeout_seconds: int = 600,
 ) -> dict[str, object]:
     """Record a pre-flight test baseline so subtasks can distinguish
     "this regression is mine" from "this was broken before I started".
@@ -11867,9 +11867,17 @@ def record_test_baseline(
         if m:
             failures.append(m.group(1))
 
+    if timed_out:
+        status = "timed_out"
+    elif returncode == 0:
+        status = "success"
+    else:
+        status = "baseline_failures"
+
     payload: dict[str, object] = {
         "branch": branch_name,
-        "status": "success" if returncode == 0 else "baseline_failures",
+        "status": status,
+        "baseline_complete": not timed_out,
         "command": cmd_str,
         "auto_detected": bool(auto_detected_command),
         "module_dir": detected_module_dir,
@@ -11907,14 +11915,26 @@ def list_baseline_failures(branch: str) -> dict[str, object]:
     failures = data.get("baseline_failures", [])
     if not isinstance(failures, list):
         failures = []
-    return {
+    baseline_complete = data.get("baseline_complete", not data.get("timed_out", False))
+    timed_out_flag = data.get("timed_out", False)
+    result: dict[str, object] = {
         "status": "success",
         "branch": branch_name,
         "command": data.get("command", ""),
         "returncode": data.get("returncode"),
+        "baseline_complete": baseline_complete,
+        "timed_out": timed_out_flag,
         "baseline_failures": failures,
         "recorded_at": data.get("recorded_at"),
     }
+    if timed_out_flag:
+        result["warning"] = (
+            "Baseline timed out — baseline_failures is empty because the suite "
+            "did not finish, not because there were no pre-existing failures. "
+            "Treat this baseline as UNKNOWN, not clean. Re-run record_test_baseline "
+            "with a longer --timeout or a faster --command."
+        )
+    return result
 
 
 def _acknowledged_diagnostics_path(branch: str) -> Path:
@@ -18578,7 +18598,7 @@ if __name__ == "__main__":
         baseline_branch = sys.argv[2]
         baseline_cmd = ""
         baseline_module_dir = ""
-        baseline_timeout = 120
+        baseline_timeout = 600
         if "--command" in sys.argv:
             c_idx = sys.argv.index("--command")
             if c_idx + 1 < len(sys.argv):

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -11705,7 +11705,7 @@ def record_test_baseline(
     test_command: str = "",
     *,
     module_dir: str = "",
-    timeout_seconds: int = 120,
+    timeout_seconds: int = 600,
 ) -> dict[str, object]:
     """Record a pre-flight test baseline so subtasks can distinguish
     "this regression is mine" from "this was broken before I started".
@@ -11867,9 +11867,17 @@ def record_test_baseline(
         if m:
             failures.append(m.group(1))
 
+    if timed_out:
+        status = "timed_out"
+    elif returncode == 0:
+        status = "success"
+    else:
+        status = "baseline_failures"
+
     payload: dict[str, object] = {
         "branch": branch_name,
-        "status": "success" if returncode == 0 else "baseline_failures",
+        "status": status,
+        "baseline_complete": not timed_out,
         "command": cmd_str,
         "auto_detected": bool(auto_detected_command),
         "module_dir": detected_module_dir,
@@ -11907,14 +11915,26 @@ def list_baseline_failures(branch: str) -> dict[str, object]:
     failures = data.get("baseline_failures", [])
     if not isinstance(failures, list):
         failures = []
-    return {
+    baseline_complete = data.get("baseline_complete", not data.get("timed_out", False))
+    timed_out_flag = data.get("timed_out", False)
+    result: dict[str, object] = {
         "status": "success",
         "branch": branch_name,
         "command": data.get("command", ""),
         "returncode": data.get("returncode"),
+        "baseline_complete": baseline_complete,
+        "timed_out": timed_out_flag,
         "baseline_failures": failures,
         "recorded_at": data.get("recorded_at"),
     }
+    if timed_out_flag:
+        result["warning"] = (
+            "Baseline timed out — baseline_failures is empty because the suite "
+            "did not finish, not because there were no pre-existing failures. "
+            "Treat this baseline as UNKNOWN, not clean. Re-run record_test_baseline "
+            "with a longer --timeout or a faster --command."
+        )
+    return result
 
 
 def _acknowledged_diagnostics_path(branch: str) -> Path:
@@ -18578,7 +18598,7 @@ if __name__ == "__main__":
         baseline_branch = sys.argv[2]
         baseline_cmd = ""
         baseline_module_dir = ""
-        baseline_timeout = 120
+        baseline_timeout = 600
         if "--command" in sys.argv:
             c_idx = sys.argv.index("--command")
             if c_idx + 1 < len(sys.argv):

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -11705,7 +11705,7 @@ def record_test_baseline(
     test_command: str = "",
     *,
     module_dir: str = "",
-    timeout_seconds: int = 120,
+    timeout_seconds: int = 600,
 ) -> dict[str, object]:
     """Record a pre-flight test baseline so subtasks can distinguish
     "this regression is mine" from "this was broken before I started".
@@ -11867,9 +11867,17 @@ def record_test_baseline(
         if m:
             failures.append(m.group(1))
 
+    if timed_out:
+        status = "timed_out"
+    elif returncode == 0:
+        status = "success"
+    else:
+        status = "baseline_failures"
+
     payload: dict[str, object] = {
         "branch": branch_name,
-        "status": "success" if returncode == 0 else "baseline_failures",
+        "status": status,
+        "baseline_complete": not timed_out,
         "command": cmd_str,
         "auto_detected": bool(auto_detected_command),
         "module_dir": detected_module_dir,
@@ -11907,14 +11915,26 @@ def list_baseline_failures(branch: str) -> dict[str, object]:
     failures = data.get("baseline_failures", [])
     if not isinstance(failures, list):
         failures = []
-    return {
+    baseline_complete = data.get("baseline_complete", not data.get("timed_out", False))
+    timed_out_flag = data.get("timed_out", False)
+    result: dict[str, object] = {
         "status": "success",
         "branch": branch_name,
         "command": data.get("command", ""),
         "returncode": data.get("returncode"),
+        "baseline_complete": baseline_complete,
+        "timed_out": timed_out_flag,
         "baseline_failures": failures,
         "recorded_at": data.get("recorded_at"),
     }
+    if timed_out_flag:
+        result["warning"] = (
+            "Baseline timed out — baseline_failures is empty because the suite "
+            "did not finish, not because there were no pre-existing failures. "
+            "Treat this baseline as UNKNOWN, not clean. Re-run record_test_baseline "
+            "with a longer --timeout or a faster --command."
+        )
+    return result
 
 
 def _acknowledged_diagnostics_path(branch: str) -> Path:
@@ -18578,7 +18598,7 @@ if __name__ == "__main__":
         baseline_branch = sys.argv[2]
         baseline_cmd = ""
         baseline_module_dir = ""
-        baseline_timeout = 120
+        baseline_timeout = 600
         if "--command" in sys.argv:
             c_idx = sys.argv.index("--command")
             if c_idx + 1 < len(sys.argv):

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -5943,6 +5943,62 @@ class TestRecordTestBaseline:
         assert report["status"] == "no_baseline"
         assert report["baseline_failures"] == []
 
+    def test_baseline_timeout_is_unknown_not_clean(
+        self, branch_workspace, monkeypatch
+    ):
+        """Regression #307: a timed-out baseline must NOT look like a clean run.
+
+        When the suite exceeds the timeout the subprocess never finishes, so
+        baseline_failures is always [] — indistinguishable from a genuinely
+        green suite unless the caller checks baseline_complete / timed_out.
+        This test verifies that both record_test_baseline and list_baseline_failures
+        surface the timeout as an explicit 'unknown' signal, not a clean pass.
+        """
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+
+        import subprocess as _subprocess
+
+        def fake_run_timeout(cmd, **kwargs):
+            raise _subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 1))
+
+        monkeypatch.setattr(map_step_runner.subprocess, "run", fake_run_timeout)
+
+        report = map_step_runner.record_test_baseline(
+            "test-branch", "pytest", timeout_seconds=1
+        )
+        # Must NOT report as success or baseline_failures with empty list
+        assert report["status"] == "timed_out", (
+            f"Expected 'timed_out' status, got {report['status']!r}"
+        )
+        assert report["baseline_complete"] is False
+        assert report["timed_out"] is True
+        assert report["baseline_failures"] == []
+
+        # list_baseline_failures must propagate the incomplete-baseline signal
+        listed = map_step_runner.list_baseline_failures("test-branch")
+        assert listed["status"] == "success"
+        assert listed["baseline_complete"] is False
+        assert listed["timed_out"] is True
+        assert "warning" in listed, "list_baseline_failures must emit a warning on timed-out baseline"
+        assert listed["baseline_failures"] == []
+
+    def test_baseline_complete_true_on_normal_run(
+        self, branch_workspace, monkeypatch
+    ):
+        """baseline_complete is True when the suite runs to completion (#307)."""
+        repo = branch_workspace.parents[1]
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        report = map_step_runner.record_test_baseline("test-branch", "true")
+        assert report["status"] == "success"
+        assert report["baseline_complete"] is True
+        assert report["timed_out"] is False
+
+        listed = map_step_runner.list_baseline_failures("test-branch")
+        assert listed["baseline_complete"] is True
+        assert listed["timed_out"] is False
+        assert "warning" not in listed
+
 
 class TestRecordSubtaskResultFilesSeparatorParsing:
     """Fix #2 (2026-05-26): CLI must accept --files with comma OR


### PR DESCRIPTION
## Summary

Fixes #307.

`record_test_baseline` defaulted to a 120 s subprocess timeout. On any repo whose full suite takes longer, the process was killed and the function returned `{"status":"baseline_failures","baseline_failures":[]}` — an empty failures list that was indistinguishable from a genuinely clean run. Any pre-existing failure was silently treated as "not pre-existing", making the regression-vs-pre-existing gate unreliable.

## Changes

**`record_test_baseline`**
- `status` is now `"timed_out"` (instead of `"baseline_failures"`) when the subprocess is killed by the timeout, giving callers a distinct value to branch on.
- New `baseline_complete: bool` field — `false` when the run timed out, `true` otherwise. Downstream code should check this before trusting an empty `baseline_failures` list.
- Default `timeout_seconds` raised from **120 → 600** (10 min) so most test suites complete in time; the `--timeout` CLI flag still accepts an explicit override.

**`list_baseline_failures`**
- Propagates `baseline_complete` and `timed_out` from the stored JSON.
- Adds a `"warning"` key (human-readable explanation) when the stored baseline is incomplete, so callers that log the full report surface the problem automatically.

**Tests** (`tests/test_map_step_runner.py`)
- `test_baseline_timeout_is_unknown_not_clean` — monkeypatches `subprocess.run` to raise `TimeoutExpired`, verifies `status=="timed_out"`, `baseline_complete==False`, and that `list_baseline_failures` propagates the warning.
- `test_baseline_complete_true_on_normal_run` — verifies `baseline_complete==True` and no `warning` key on a successful run.

All 3 225 existing tests pass; `ruff`, `pyright`, and `make check-render` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ncF4ESXM8YoxbH4U9VyYY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the baseline test timeout to give long-running suites more time to finish.
  * Improved baseline reporting to clearly distinguish between a timeout and actual test failures.
  * Added clearer warnings when baseline results are incomplete, so empty failure lists are not mistaken for a clean run.
  * Baseline results now include completion and timeout status for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->