### PR TITLE
fix: flaky git-mutation-check test false-positives on pytest tmp paths

### DIFF
--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -8111,11 +8111,13 @@ class TestPrepareDetachedReview:
 
         # "worktree add" is the one permitted mutation (creates a new worktree entry).
         # All other staging/checkout/destructive git subcommands must never appear.
+        # Check individual argv tokens, not a joined string — a joined-string substring
+        # check false-positives when an unrelated argument (e.g. a pytest tmp_path
+        # component) happens to contain "rm" or another mutating-command substring.
         mutating = ("checkout", "stash", "reset", "restore", "commit", "rm")
         for call in recorded_calls:
-            joined = " ".join(call)
             for bad in mutating:
-                assert bad not in joined, (
+                assert bad not in call, (
                     f"mutating git command {bad!r} found in call: {call}"
                 )
             # bare "git add <path>" (staging) must not appear; "worktree add" is fine


### PR DESCRIPTION
## Summary
- `test_prepare_detached_review_never_calls_mutating_git_commands` checked mutating-command substrings (`checkout`, `stash`, `reset`, `restore`, `commit`, `rm`) against a joined argv string instead of individual tokens.
- On macOS CI this false-positived when pytest's random tmp_path component happened to contain `rm` as a substring (e.g. `.../cx43xdqhzy2rmp6tqr.../`), failing `test (macos-latest, 3.11)` on main after #322 merged and cascading a cancellation of `test (macos-latest, 3.12)`.
- Fixed by checking individual argv tokens (`bad not in call`) rather than the joined string, matching the existing bare-`git add` check just below it in the same test.

## Test plan
- [x] `pytest tests/test_map_step_runner.py -k test_prepare_detached_review_never_calls_mutating_git_commands` passes
- [x] `make check` passes (3236 passed, 3 skipped, render-parity check clean)