### PR TITLE
fix: resolve project root from caller cwd git toplevel, not script anchor (#328)

### DIFF
--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -4771,38 +4771,66 @@ def main():
 
     args = parser.parse_args()
 
-    # Anchor cwd to the project root before any state lookup or branch
-    # detection. The script lives at ``<project>/.map/scripts/map_orchestrator.py``,
-    # so ``parents[2]`` is the project root regardless of how the script was
-    # invoked. Without this chdir, an absolute-path call from a different cwd
-    # silently reads ``.map/<branch>/`` from the caller's directory and
-    # returns misleading "step mismatch" errors.
-    script_anchored_root = Path(__file__).resolve().parents[2]
-    os.chdir(script_anchored_root)
+    # Resolve the project root before any state lookup or branch detection.
+    # Priority (highest first):
+    #   1. CLAUDE_PROJECT_DIR env var (explicit operator intent)
+    #   2. git rev-parse --show-toplevel from the *caller's* cwd (handles
+    #      git worktrees: the worktree root is the correct anchor, not the
+    #      main clone where the script file lives — issue #328)
+    #   3. Path(__file__).resolve().parents[2] — script-anchored fallback
+    #      (legacy behaviour for the normal case where the caller's cwd is
+    #      not a git repo, or git is unavailable)
+    import subprocess as _sp  # noqa: PLC0415 — local import keeps top clean
 
-    # Project-root sanity check: if CLAUDE_PROJECT_DIR is set and points
-    # somewhere other than the script-anchored root, the user almost
-    # certainly invoked the WRONG project's orchestrator. Common failure
-    # mode: `cd /tmp/sibling-repo && python3 .map/scripts/map_orchestrator.py`
-    # silently reads sibling-repo's state instead of the project the
-    # operator's session is bound to. We warn (to stderr, never block),
-    # so the deviation is loud but not fatal — the operator may have a
-    # legitimate reason.
+    script_anchored_root = Path(__file__).resolve().parents[2]
+    caller_cwd = Path.cwd()
+    project_root: Optional[Path] = None
+
+    # 1. CLAUDE_PROJECT_DIR
     env_project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
     if env_project_dir:
         try:
-            env_resolved = Path(env_project_dir).resolve()
+            candidate = Path(env_project_dir).resolve()
+            if candidate.is_dir():
+                project_root = candidate
+            else:
+                print(
+                    f"WARNING: CLAUDE_PROJECT_DIR={env_project_dir!r} is not a "
+                    "directory; falling back to git/script-anchored root resolution.",
+                    file=sys.stderr,
+                )
         except OSError:
-            env_resolved = None
-        if env_resolved and env_resolved != script_anchored_root:
-            print(
-                f"WARNING: orchestrator project mismatch. "
-                f"CLAUDE_PROJECT_DIR={env_resolved} but this script lives at "
-                f"{script_anchored_root}. Reading state from "
-                f"{script_anchored_root}/.map/ — if you meant the other "
-                "project, run that project's .map/scripts/map_orchestrator.py.",
-                file=sys.stderr,
+            pass
+
+    # 2. git toplevel from the caller's cwd
+    if project_root is None:
+        try:
+            _git = _sp.run(
+                ["git", "-C", str(caller_cwd), "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
+            if _git.returncode == 0:
+                project_root = Path(_git.stdout.strip()).resolve()
+        except Exception:
+            pass
+
+    # 3. Script-anchored fallback
+    if project_root is None:
+        project_root = script_anchored_root
+
+    # Inform (never block) when operating from a different root than where
+    # the script file lives — expected and correct for git worktrees.
+    if project_root != script_anchored_root:
+        print(
+            f"INFO: orchestrator resolved project root to {project_root} "
+            f"(script lives in {script_anchored_root}). "
+            "Operating on the resolved root — expected for git worktrees.",
+            file=sys.stderr,
+        )
+
+    os.chdir(project_root)
 
     # Get branch. ``--branch`` arrives unsanitized from the CLI; route it
     # through the same sanitiser used by ``get_branch_name()`` so the value

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -4771,38 +4771,66 @@ def main():
 
     args = parser.parse_args()
 
-    # Anchor cwd to the project root before any state lookup or branch
-    # detection. The script lives at ``<project>/.map/scripts/map_orchestrator.py``,
-    # so ``parents[2]`` is the project root regardless of how the script was
-    # invoked. Without this chdir, an absolute-path call from a different cwd
-    # silently reads ``.map/<branch>/`` from the caller's directory and
-    # returns misleading "step mismatch" errors.
-    script_anchored_root = Path(__file__).resolve().parents[2]
-    os.chdir(script_anchored_root)
+    # Resolve the project root before any state lookup or branch detection.
+    # Priority (highest first):
+    #   1. CLAUDE_PROJECT_DIR env var (explicit operator intent)
+    #   2. git rev-parse --show-toplevel from the *caller's* cwd (handles
+    #      git worktrees: the worktree root is the correct anchor, not the
+    #      main clone where the script file lives — issue #328)
+    #   3. Path(__file__).resolve().parents[2] — script-anchored fallback
+    #      (legacy behaviour for the normal case where the caller's cwd is
+    #      not a git repo, or git is unavailable)
+    import subprocess as _sp  # noqa: PLC0415 — local import keeps top clean
 
-    # Project-root sanity check: if CLAUDE_PROJECT_DIR is set and points
-    # somewhere other than the script-anchored root, the user almost
-    # certainly invoked the WRONG project's orchestrator. Common failure
-    # mode: `cd /tmp/sibling-repo && python3 .map/scripts/map_orchestrator.py`
-    # silently reads sibling-repo's state instead of the project the
-    # operator's session is bound to. We warn (to stderr, never block),
-    # so the deviation is loud but not fatal — the operator may have a
-    # legitimate reason.
+    script_anchored_root = Path(__file__).resolve().parents[2]
+    caller_cwd = Path.cwd()
+    project_root: Optional[Path] = None
+
+    # 1. CLAUDE_PROJECT_DIR
     env_project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
     if env_project_dir:
         try:
-            env_resolved = Path(env_project_dir).resolve()
+            candidate = Path(env_project_dir).resolve()
+            if candidate.is_dir():
+                project_root = candidate
+            else:
+                print(
+                    f"WARNING: CLAUDE_PROJECT_DIR={env_project_dir!r} is not a "
+                    "directory; falling back to git/script-anchored root resolution.",
+                    file=sys.stderr,
+                )
         except OSError:
-            env_resolved = None
-        if env_resolved and env_resolved != script_anchored_root:
-            print(
-                f"WARNING: orchestrator project mismatch. "
-                f"CLAUDE_PROJECT_DIR={env_resolved} but this script lives at "
-                f"{script_anchored_root}. Reading state from "
-                f"{script_anchored_root}/.map/ — if you meant the other "
-                "project, run that project's .map/scripts/map_orchestrator.py.",
-                file=sys.stderr,
+            pass
+
+    # 2. git toplevel from the caller's cwd
+    if project_root is None:
+        try:
+            _git = _sp.run(
+                ["git", "-C", str(caller_cwd), "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
+            if _git.returncode == 0:
+                project_root = Path(_git.stdout.strip()).resolve()
+        except Exception:
+            pass
+
+    # 3. Script-anchored fallback
+    if project_root is None:
+        project_root = script_anchored_root
+
+    # Inform (never block) when operating from a different root than where
+    # the script file lives — expected and correct for git worktrees.
+    if project_root != script_anchored_root:
+        print(
+            f"INFO: orchestrator resolved project root to {project_root} "
+            f"(script lives in {script_anchored_root}). "
+            "Operating on the resolved root — expected for git worktrees.",
+            file=sys.stderr,
+        )
+
+    os.chdir(project_root)
 
     # Get branch. ``--branch`` arrives unsanitized from the CLI; route it
     # through the same sanitiser used by ``get_branch_name()`` so the value

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -4771,38 +4771,66 @@ def main():
 
     args = parser.parse_args()
 
-    # Anchor cwd to the project root before any state lookup or branch
-    # detection. The script lives at ``<project>/.map/scripts/map_orchestrator.py``,
-    # so ``parents[2]`` is the project root regardless of how the script was
-    # invoked. Without this chdir, an absolute-path call from a different cwd
-    # silently reads ``.map/<branch>/`` from the caller's directory and
-    # returns misleading "step mismatch" errors.
-    script_anchored_root = Path(__file__).resolve().parents[2]
-    os.chdir(script_anchored_root)
+    # Resolve the project root before any state lookup or branch detection.
+    # Priority (highest first):
+    #   1. CLAUDE_PROJECT_DIR env var (explicit operator intent)
+    #   2. git rev-parse --show-toplevel from the *caller's* cwd (handles
+    #      git worktrees: the worktree root is the correct anchor, not the
+    #      main clone where the script file lives — issue #328)
+    #   3. Path(__file__).resolve().parents[2] — script-anchored fallback
+    #      (legacy behaviour for the normal case where the caller's cwd is
+    #      not a git repo, or git is unavailable)
+    import subprocess as _sp  # noqa: PLC0415 — local import keeps top clean
 
-    # Project-root sanity check: if CLAUDE_PROJECT_DIR is set and points
-    # somewhere other than the script-anchored root, the user almost
-    # certainly invoked the WRONG project's orchestrator. Common failure
-    # mode: `cd /tmp/sibling-repo && python3 .map/scripts/map_orchestrator.py`
-    # silently reads sibling-repo's state instead of the project the
-    # operator's session is bound to. We warn (to stderr, never block),
-    # so the deviation is loud but not fatal — the operator may have a
-    # legitimate reason.
+    script_anchored_root = Path(__file__).resolve().parents[2]
+    caller_cwd = Path.cwd()
+    project_root: Optional[Path] = None
+
+    # 1. CLAUDE_PROJECT_DIR
     env_project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
     if env_project_dir:
         try:
-            env_resolved = Path(env_project_dir).resolve()
+            candidate = Path(env_project_dir).resolve()
+            if candidate.is_dir():
+                project_root = candidate
+            else:
+                print(
+                    f"WARNING: CLAUDE_PROJECT_DIR={env_project_dir!r} is not a "
+                    "directory; falling back to git/script-anchored root resolution.",
+                    file=sys.stderr,
+                )
         except OSError:
-            env_resolved = None
-        if env_resolved and env_resolved != script_anchored_root:
-            print(
-                f"WARNING: orchestrator project mismatch. "
-                f"CLAUDE_PROJECT_DIR={env_resolved} but this script lives at "
-                f"{script_anchored_root}. Reading state from "
-                f"{script_anchored_root}/.map/ — if you meant the other "
-                "project, run that project's .map/scripts/map_orchestrator.py.",
-                file=sys.stderr,
+            pass
+
+    # 2. git toplevel from the caller's cwd
+    if project_root is None:
+        try:
+            _git = _sp.run(
+                ["git", "-C", str(caller_cwd), "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
+            if _git.returncode == 0:
+                project_root = Path(_git.stdout.strip()).resolve()
+        except Exception:
+            pass
+
+    # 3. Script-anchored fallback
+    if project_root is None:
+        project_root = script_anchored_root
+
+    # Inform (never block) when operating from a different root than where
+    # the script file lives — expected and correct for git worktrees.
+    if project_root != script_anchored_root:
+        print(
+            f"INFO: orchestrator resolved project root to {project_root} "
+            f"(script lives in {script_anchored_root}). "
+            "Operating on the resolved root — expected for git worktrees.",
+            file=sys.stderr,
+        )
+
+    os.chdir(project_root)
 
     # Get branch. ``--branch`` arrives unsanitized from the CLI; route it
     # through the same sanitiser used by ``get_branch_name()`` so the value

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -10,6 +10,7 @@ Validates:
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -4436,6 +4437,149 @@ class TestCwdIndependence:
         assert "ST-001" in flat and "ST-X" not in flat, (
             f"set_waves resolved blueprint relative to cwd (project_b) "
             f"instead of script project (project_a). got: {out}"
+        )
+
+    def test_claude_project_dir_takes_priority_over_script_anchor(
+        self, tmp_path
+    ):
+        """CLAUDE_PROJECT_DIR wins over the script-anchored root (issue #328).
+
+        project_a holds the script and is at COMPLETE state. project_b is at
+        step 1.0. With CLAUDE_PROJECT_DIR=project_b the orchestrator must read
+        project_b's state, not project_a's.
+        """
+        project_a = tmp_path / "project_a"
+        project_a.mkdir()
+        script = self._make_project(project_a)
+        self._seed_state(
+            project_a,
+            "test-branch",
+            current_step_id="2.4",
+            current_step_phase="MONITOR",
+            completed=["1.0", "1.5", "1.55", "1.56", "1.6", "2.2", "2.3"],
+            pending=[],
+        )
+
+        project_b = tmp_path / "project_b"
+        self._seed_state(
+            project_b,
+            "test-branch",
+            current_step_id="1.0",
+            current_step_phase="DECOMPOSE",
+            completed=[],
+            pending=["1.5", "1.55", "1.56", "1.6"],
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "get_next_step",
+                "--branch",
+                "test-branch",
+            ],
+            cwd=str(project_a),
+            capture_output=True,
+            text=True,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": str(project_b)},
+        )
+        assert result.returncode == 0, (
+            f"orchestrator failed: stdout={result.stdout!r} "
+            f"stderr={result.stderr!r}"
+        )
+        out = json.loads(result.stdout)
+        # CLAUDE_PROJECT_DIR wins → project_b state (pending step 1.5).
+        # If script-anchored root won instead → project_a state (COMPLETE /
+        # is_complete=True).
+        assert out.get("is_complete") is not True, (
+            f"orchestrator returned COMPLETE — it read project_a (script-anchored) "
+            f"instead of project_b (CLAUDE_PROJECT_DIR). got {out!r}. "
+            f"stderr: {result.stderr!r}"
+        )
+        assert out.get("step_id") == "1.5", (
+            f"orchestrator did not honour CLAUDE_PROJECT_DIR (expected "
+            f"step_id='1.5' from project_b, got {out!r}). "
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_git_toplevel_from_caller_cwd_takes_priority_over_script_anchor(
+        self, tmp_path
+    ):
+        """git rev-parse --show-toplevel from the caller's cwd wins over the
+        script-anchored root when no CLAUDE_PROJECT_DIR is set (issue #328).
+
+        This reproduces the worktree scenario: the script lives in project_a
+        (not a git repo), but the caller's cwd is project_b (a real git repo).
+        The orchestrator must resolve project_b as the project root and read
+        state from there instead of from project_a.
+        """
+        project_a = tmp_path / "project_a"
+        project_a.mkdir()
+        script = self._make_project(project_a)
+        # project_a: COMPLETE state (wrong answer if script-anchor wins)
+        self._seed_state(
+            project_a,
+            "test-branch",
+            current_step_id="2.4",
+            current_step_phase="MONITOR",
+            completed=["1.0", "1.5", "1.55", "1.56", "1.6", "2.2", "2.3"],
+            pending=[],
+        )
+
+        # project_b: a real git repo (simulates a git worktree checkout).
+        # git rev-parse --show-toplevel works after `git init` alone — no
+        # commit is required for toplevel detection.
+        project_b = tmp_path / "project_b"
+        project_b.mkdir()
+        subprocess.run(
+            ["git", "init", str(project_b)],
+            check=True,
+            capture_output=True,
+        )
+        # project_b: step 1.0 state (correct answer if git-toplevel wins)
+        self._seed_state(
+            project_b,
+            "test-branch",
+            current_step_id="1.0",
+            current_step_phase="DECOMPOSE",
+            completed=[],
+            pending=["1.5", "1.55", "1.56", "1.6"],
+        )
+
+        # Strip CLAUDE_PROJECT_DIR so only the git-toplevel path is exercised
+        env_no_cpd = {
+            k: v for k, v in os.environ.items() if k != "CLAUDE_PROJECT_DIR"
+        }
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "get_next_step",
+                "--branch",
+                "test-branch",
+            ],
+            cwd=str(project_b),  # caller's cwd IS a git repo
+            capture_output=True,
+            text=True,
+            env=env_no_cpd,
+        )
+        assert result.returncode == 0, (
+            f"orchestrator failed: stdout={result.stdout!r} "
+            f"stderr={result.stderr!r}"
+        )
+        out = json.loads(result.stdout)
+        # git-toplevel wins → project_b state (pending step 1.5).
+        # If script-anchored root won instead → project_a state (COMPLETE /
+        # is_complete=True).
+        assert out.get("is_complete") is not True, (
+            f"orchestrator returned COMPLETE — it read project_a (script-anchored) "
+            f"instead of project_b (git-toplevel). got {out!r}. "
+            f"stderr: {result.stderr!r}"
+        )
+        assert out.get("step_id") == "1.5", (
+            f"orchestrator did not resolve project root from caller's git repo "
+            f"(expected step_id='1.5' from project_b, got {out!r}). "
+            f"stderr: {result.stderr!r}"
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #328.

`map_orchestrator.py`'s `main()` previously anchored `cwd` exclusively to `Path(__file__).resolve().parents[2]`. When invoked via an absolute path from a git worktree that lacks its own `.map/scripts/` copy, this silently changed directory to the **main clone's root** — causing `get_branch_name()` to return the wrong branch and all `.map/<branch>/` reads/writes to operate on an unrelated workflow.

## Root cause

```python
# OLD — always uses the script file's location, ignores caller's cwd
script_anchored_root = Path(__file__).resolve().parents[2]
os.chdir(script_anchored_root)
```

## Fix

New resolution priority (highest first):

1. `CLAUDE_PROJECT_DIR` env var (explicit operator intent)
2. `git -C <caller_cwd> rev-parse --show-toplevel` — uses the **caller's actual cwd** so a worktree invocation anchors to the worktree root, not the main clone
3. `Path(__file__).resolve().parents[2]` — script-anchored fallback when caller's cwd is not a git repo (preserves the old non-worktree behaviour)

Emits an `INFO` message to stderr when the resolved root differs from the script anchor so cross-checkout usage is auditable but non-fatal.

## Tests

Two new regression tests added to `TestCwdIndependence`:

- `test_claude_project_dir_takes_priority_over_script_anchor` — `CLAUDE_PROJECT_DIR` wins over the script-anchored root
- `test_git_toplevel_from_caller_cwd_takes_priority_over_script_anchor` — git toplevel from the caller's cwd wins when `CLAUDE_PROJECT_DIR` is unset (the worktree scenario from the issue)

All 3 existing `TestCwdIndependence` tests continue to pass: they use a non-git `project_b`, so git resolution fails and the code correctly falls back to the script-anchored root.

---
_Generated by [Claude Code](https://claude.ai/code/session_015J78vXZPNJcBCwUKYHVEWi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project root detection so the tool now starts from the correct directory more reliably, including git worktrees and custom project paths.
  * The working directory is now set based on the resolved project root before state lookup, reducing path-related errors.
  * Added clearer informational output when the resolved root differs from the script location.

* **Tests**
  * Added coverage for project-root precedence and working-directory independence in subprocess-based scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->