### PR TITLE
feat: add install manifest/lock for MAP-managed provider surfaces (#313)

### DIFF
--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -1003,6 +1003,22 @@ def init(
             else:
                 tracker.error("git", "failed")
 
+    # Write install manifest (.map/mapify.lock.json) — scan-based, after all files
+    # have been installed by both providers.
+    tracker.add("manifest", "Write install manifest")
+    tracker.start("manifest")
+    try:
+        from mapify_cli.install_manifest import build_manifest, write_manifest
+
+        manifest = build_manifest(project_path, provider, __version__)
+        manifest_path = write_manifest(project_path, manifest)
+        tracker.complete(
+            "manifest",
+            f"{len(manifest.entries)} entries → {manifest_path.relative_to(project_path)}",
+        )
+    except Exception as _manifest_exc:
+        tracker.error("manifest", f"skipped: {_manifest_exc}")
+
     tracker.add("finalize", "Finalize")
     tracker.complete("finalize", "project ready")
 
@@ -1569,6 +1585,80 @@ def upgrade():
         "[dim]To refresh this project's MAP files with the new templates, run "
         "[cyan]mapify init . --force[/cyan].[/dim]"
     )
+
+
+@app.command("check-installed")
+def check_installed(
+    project_path: Optional[Path] = typer.Argument(
+        None,
+        help="Project root directory (defaults to current directory).",
+    ),
+) -> None:
+    """Compare installed MAP files against .map/mapify.lock.json.
+
+    Reports missing files (in manifest but absent from disk), orphaned files
+    (MAP-managed on disk but not recorded in the manifest), and drifted files
+    (template hash differs from the manifest record).
+
+    Exit codes: 0 = all ok, 1 = issues found, 2 = no manifest.
+    """
+    from mapify_cli.install_manifest import check_installed as _check_installed
+    from mapify_cli.install_manifest import read_manifest
+
+    target = project_path or Path.cwd()
+
+    manifest = read_manifest(target)
+    if manifest is None:
+        console.print(
+            f"[yellow]No install manifest found at {target / '.map' / 'mapify.lock.json'}[/yellow]"
+        )
+        console.print(
+            "[dim]Run [cyan]mapify init .[/cyan] to generate the manifest.[/dim]"
+        )
+        raise typer.Exit(2)
+
+    console.print(
+        f"[bold]MAP install manifest[/bold] — provider: [cyan]{manifest.provider}[/cyan], "
+        f"version: [cyan]{manifest.mapify_version}[/cyan], "
+        f"installed: [dim]{manifest.installed_at}[/dim]"
+    )
+    console.print(f"[dim]{len(manifest.entries)} entries recorded[/dim]")
+    console.print()
+
+    result = _check_installed(target)
+
+    has_issues = False
+
+    if result.missing:
+        has_issues = True
+        console.print(f"[red]Missing ({len(result.missing)} files):[/red]")
+        for path in result.missing:
+            console.print(f"  [red]✗[/red] {path}")
+
+    if result.orphaned:
+        has_issues = True
+        console.print(f"[yellow]Orphaned ({len(result.orphaned)} files):[/yellow]")
+        for path in result.orphaned:
+            console.print(f"  [yellow]?[/yellow] {path}")
+
+    if result.drifted:
+        has_issues = True
+        console.print(f"[yellow]Drifted ({len(result.drifted)} files):[/yellow]")
+        for path in result.drifted:
+            console.print(f"  [yellow]~[/yellow] {path}")
+
+    if result.ok and not has_issues:
+        console.print(
+            f"[green]✅ All {len(result.ok)} managed files match the manifest.[/green]"
+        )
+    elif not has_issues:
+        console.print("[green]✅ No issues found.[/green]")
+    else:
+        console.print()
+        console.print(
+            "[dim]Run [cyan]mapify init . --force[/cyan] to refresh managed files.[/dim]"
+        )
+        raise typer.Exit(1)
 
 
 # Research localization eval commands

--- a/src/mapify_cli/install_manifest.py
+++ b/src/mapify_cli/install_manifest.py
@@ -1,0 +1,401 @@
+"""Install manifest/lock for MAP-managed provider surfaces.
+
+Writes .map/mapify.lock.json during ``mapify init`` and provides
+``check-installed`` comparison. The manifest records every MAP-managed
+file installed by the provider so the installed surface can be audited
+as a whole rather than file-by-file.
+
+Security invariants:
+- No absolute paths stored in the committed manifest.
+- Local-only files (statusline, machine-specific state) are excluded from
+  the committed manifest.
+- No secrets or credential paths are written here.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from mapify_cli.delivery.managed_file_copier import compute_hash, extract_metadata
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MANIFEST_FILENAME = "mapify.lock.json"
+
+# Relative paths (from project root) that are machine-local and should
+# NOT appear in the committed manifest.
+_LOCAL_ONLY_RELPATHS: frozenset[str] = frozenset({
+    ".claude/settings.local.json",
+})
+
+# Fence start tokens by extension (mirrors managed_file_copier._FENCE_TOKENS)
+_FENCE_START_BY_EXT: dict[str, str] = {
+    ".md": "<!-- map:start -->",
+    ".py": "# map:start",
+    ".sh": "# map:start",
+    ".bash": "# map:start",
+    ".toml": "# map:start",
+    ".yaml": "# map:start",
+    ".yml": "# map:start",
+}
+
+# Files installed WITHOUT MAP-MANAGED metadata (Codex hooks.json uses its own
+# merge strategy that is incompatible with the _map_managed root key).
+_HOOKS_MERGE_RELPATHS: frozenset[str] = frozenset({
+    ".codex/hooks.json",
+})
+
+# Directories to scan per provider (relative to project root).
+# Only the directories that each provider's install functions write to.
+_CLAUDE_SCAN_ROOTS: list[str] = [
+    ".claude/agents",
+    ".claude/skills",
+    ".claude/references",
+    ".claude/hooks",
+    ".claude/rules",
+    ".map/scripts",
+    ".map/static-analysis",
+]
+_CLAUDE_SINGLE_FILES: list[str] = [
+    ".claude/settings.json",
+    ".claude/ralph-loop-config.json",
+    ".claude/workflow-rules.json",
+]
+
+_CODEX_SCAN_ROOTS: list[str] = [
+    ".agents/skills",
+    ".codex/agents",
+    ".codex/hooks",
+    ".map/scripts",
+]
+_CODEX_SINGLE_FILES: list[str] = [
+    ".codex/config.toml",
+    ".codex/hooks.json",
+    "AGENTS.md",
+]
+
+# Ignored names/suffixes during directory scans (mirrors file_copier constants)
+_IGNORED_NAMES: frozenset[str] = frozenset({"__pycache__", ".DS_Store"})
+_IGNORED_SUFFIXES: frozenset[str] = frozenset({".pyc", ".pyo"})
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ManifestEntry:
+    """One MAP-managed file in the install manifest."""
+
+    dest: str             # relative path from project root (POSIX separators)
+    content_hash: str     # SHA-256 of file content with metadata stripped
+    template_hash: str    # SHA-256 of the template source at install time
+    management_mode: str  # "fenced" | "full" | "hooks-merge"
+    committed: bool       # True when this file should be committed to VCS
+    mapify_version: str   # mapify-cli version that installed this file
+    installed_at: str     # ISO 8601 UTC timestamp from the MAP-MANAGED header
+
+
+@dataclass
+class InstallManifest:
+    """Aggregate install lock for all MAP-managed provider surfaces."""
+
+    mapify_version: str
+    provider: str
+    installed_at: str     # manifest write timestamp
+    entries: list[ManifestEntry] = field(default_factory=list)
+
+
+@dataclass
+class CheckResult:
+    """Outcome of check_installed()."""
+
+    missing: list[str] = field(default_factory=list)   # in manifest, absent from disk
+    orphaned: list[str] = field(default_factory=list)  # MAP-managed on disk, not in manifest
+    drifted: list[str] = field(default_factory=list)   # template_hash differs vs manifest
+    ok: list[str] = field(default_factory=list)        # present and matching
+
+
+# ---------------------------------------------------------------------------
+# Management-mode inference
+# ---------------------------------------------------------------------------
+
+
+def _infer_management_mode(dest: Path, content: str, ext: str) -> str:
+    """Infer the management mode from the installed file's content."""
+    if ext == ".json":
+        # JSON files are always fully managed via _map_managed root key.
+        return "full"
+    fence_start = _FENCE_START_BY_EXT.get(ext)
+    if fence_start and fence_start in content:
+        return "fenced"
+    return "full"
+
+
+# ---------------------------------------------------------------------------
+# Single-file entry building
+# ---------------------------------------------------------------------------
+
+
+def _build_entry_from_file(
+    project_path: Path,
+    abs_path: Path,
+) -> Optional[ManifestEntry]:
+    """Build a ManifestEntry from an installed managed file.
+
+    Returns None when the file has no MAP-MANAGED metadata (unmanaged).
+    Skips symlinks to avoid following them (security invariant).
+    """
+    if abs_path.is_symlink():
+        return None  # AGENTS.md may be a symlink to CLAUDE.md
+
+    rel_str = abs_path.relative_to(project_path).as_posix()
+
+    # Local-only files are excluded from the committed manifest
+    if rel_str in _LOCAL_ONLY_RELPATHS:
+        return None
+
+    # Special case: hooks.json uses hooks-merge mode without MAP metadata
+    if rel_str in _HOOKS_MERGE_RELPATHS:
+        if abs_path.exists():
+            raw = abs_path.read_text(encoding="utf-8", errors="replace")
+            return ManifestEntry(
+                dest=rel_str,
+                content_hash=compute_hash(raw),
+                template_hash="",
+                management_mode="hooks-merge",
+                committed=True,
+                mapify_version="",
+                installed_at="",
+            )
+        return None
+
+    if not abs_path.is_file():
+        return None
+
+    try:
+        content = abs_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+
+    ext = abs_path.suffix.lower()
+    meta, clean_content = extract_metadata(content, ext)
+    if meta is None:
+        return None  # not a MAP-managed file
+
+    mode = _infer_management_mode(abs_path, content, ext)
+    return ManifestEntry(
+        dest=rel_str,
+        content_hash=compute_hash(clean_content),
+        template_hash=meta.get("template_hash", ""),
+        management_mode=mode,
+        committed=True,
+        mapify_version=meta.get("mapify_version", ""),
+        installed_at=meta.get("installed_at", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Directory scanning
+# ---------------------------------------------------------------------------
+
+
+def _scan_dir(project_path: Path, rel_dir: str) -> list[ManifestEntry]:
+    """Recursively scan a directory for MAP-managed files."""
+    entries: list[ManifestEntry] = []
+    abs_dir = project_path / rel_dir
+    if not abs_dir.is_dir():
+        return entries
+    for abs_path in sorted(abs_dir.rglob("*")):
+        if not abs_path.is_file():
+            continue
+        if abs_path.name in _IGNORED_NAMES or abs_path.suffix in _IGNORED_SUFFIXES:
+            continue
+        entry = _build_entry_from_file(project_path, abs_path)
+        if entry is not None:
+            entries.append(entry)
+    return entries
+
+
+def _scan_file(project_path: Path, rel_file: str) -> Optional[ManifestEntry]:
+    """Scan a single known file path."""
+    return _build_entry_from_file(project_path, project_path / rel_file)
+
+
+# ---------------------------------------------------------------------------
+# Manifest building
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(
+    project_path: Path,
+    provider: str,
+    version: str,
+) -> InstallManifest:
+    """Build an InstallManifest by scanning the installed provider surfaces.
+
+    Scans directories written by the given provider's install() method and
+    collects all files that carry MAP-MANAGED metadata. Local-only files and
+    symlinks are excluded from the committed manifest.
+    """
+    entries: list[ManifestEntry] = []
+
+    if provider == "claude":
+        for rel_dir in _CLAUDE_SCAN_ROOTS:
+            entries.extend(_scan_dir(project_path, rel_dir))
+        for rel_file in _CLAUDE_SINGLE_FILES:
+            entry = _scan_file(project_path, rel_file)
+            if entry is not None:
+                entries.append(entry)
+    elif provider == "codex":
+        for rel_dir in _CODEX_SCAN_ROOTS:
+            entries.extend(_scan_dir(project_path, rel_dir))
+        for rel_file in _CODEX_SINGLE_FILES:
+            entry = _scan_file(project_path, rel_file)
+            if entry is not None:
+                entries.append(entry)
+    # Unknown provider: no entries (still writes an empty manifest)
+
+    # Stable sort: alphabetical by dest path
+    entries.sort(key=lambda e: e.dest)
+
+    return InstallManifest(
+        mapify_version=version,
+        provider=provider,
+        installed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persist / load
+# ---------------------------------------------------------------------------
+
+
+def write_manifest(project_path: Path, manifest: InstallManifest) -> Path:
+    """Write the manifest to .map/mapify.lock.json and return the path."""
+    map_dir = project_path / ".map"
+    map_dir.mkdir(parents=True, exist_ok=True)
+    dest = map_dir / MANIFEST_FILENAME
+    data = asdict(manifest)
+    dest.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return dest
+
+
+def read_manifest(project_path: Path) -> Optional[InstallManifest]:
+    """Read and parse .map/mapify.lock.json.
+
+    Returns None when the manifest does not exist or cannot be parsed.
+    """
+    path = project_path / ".map" / MANIFEST_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        raw_entries = data.get("entries", [])
+        entries = [ManifestEntry(**e) for e in raw_entries if isinstance(e, dict)]
+        return InstallManifest(
+            mapify_version=data.get("mapify_version", ""),
+            provider=data.get("provider", ""),
+            installed_at=data.get("installed_at", ""),
+            entries=entries,
+        )
+    except (TypeError, KeyError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# check-installed comparison
+# ---------------------------------------------------------------------------
+
+
+def check_installed(project_path: Path) -> CheckResult:
+    """Compare the current installed surface against .map/mapify.lock.json.
+
+    For each manifest entry:
+    - missing: file does not exist on disk
+    - drifted: file exists but its MAP-MANAGED template_hash differs from the
+      manifest's recorded template_hash (template was updated)
+    - ok: file present and template_hash matches
+
+    Also scans the installed directories to detect orphaned MAP-managed files
+    (files that carry MAP-MANAGED metadata but are not recorded in the manifest).
+    """
+    result = CheckResult()
+    manifest = read_manifest(project_path)
+    if manifest is None:
+        return result
+
+    manifest_paths: set[str] = set()
+    for entry in manifest.entries:
+        manifest_paths.add(entry.dest)
+        abs_path = project_path / entry.dest
+
+        if entry.management_mode == "hooks-merge":
+            # hooks.json has no MAP metadata; just check existence
+            if abs_path.exists() and not abs_path.is_symlink():
+                result.ok.append(entry.dest)
+            else:
+                result.missing.append(entry.dest)
+            continue
+
+        if not abs_path.exists() or abs_path.is_symlink():
+            result.missing.append(entry.dest)
+            continue
+
+        try:
+            content = abs_path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            result.missing.append(entry.dest)
+            continue
+
+        ext = abs_path.suffix.lower()
+        meta, _ = extract_metadata(content, ext)
+
+        if meta is None:
+            # Metadata was stripped — treat as drifted
+            result.drifted.append(entry.dest)
+            continue
+
+        current_template_hash = meta.get("template_hash", "")
+        if current_template_hash != entry.template_hash:
+            result.drifted.append(entry.dest)
+        else:
+            result.ok.append(entry.dest)
+
+    # Orphan detection: scan directories for MAP-managed files not in manifest
+    provider = manifest.provider
+    scan_roots: list[str] = []
+    single_files: list[str] = []
+    if provider == "claude":
+        scan_roots = _CLAUDE_SCAN_ROOTS
+        single_files = _CLAUDE_SINGLE_FILES
+    elif provider == "codex":
+        scan_roots = _CODEX_SCAN_ROOTS
+        single_files = _CODEX_SINGLE_FILES
+
+    on_disk_managed: set[str] = set()
+    for rel_dir in scan_roots:
+        for entry in _scan_dir(project_path, rel_dir):
+            on_disk_managed.add(entry.dest)
+    for rel_file in single_files:
+        single_entry = _scan_file(project_path, rel_file)
+        if single_entry is not None:
+            on_disk_managed.add(single_entry.dest)
+
+    for rel in sorted(on_disk_managed - manifest_paths):
+        result.orphaned.append(rel)
+
+    return result

--- a/tests/test_install_manifest.py
+++ b/tests/test_install_manifest.py
@@ -1,0 +1,537 @@
+"""Tests for the install manifest/lock (issue #313).
+
+Covers:
+  VC1: Claude install writes manifest with correct entries.
+  VC2: Codex install writes manifest with correct entries.
+  VC3: Re-init (write twice) is idempotent — second manifest overwrites first.
+  VC4: check_installed detects missing files.
+  VC5: check_installed detects drifted files (template_hash changed).
+  VC6: check_installed detects orphaned files.
+  VC7: read_manifest returns None for missing/corrupt manifest.
+  VC8: management_mode is inferred correctly (fenced vs full vs hooks-merge).
+  VC9: Local-only paths are excluded from the committed manifest.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mapify_cli.delivery.managed_file_copier import (
+    compute_hash,
+    inject_metadata,
+)
+from mapify_cli.install_manifest import (
+    MANIFEST_FILENAME,
+    InstallManifest,
+    _build_entry_from_file,
+    _infer_management_mode,
+    build_manifest,
+    check_installed,
+    read_manifest,
+    write_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VERSION = "3.21.0"
+
+
+def _write_managed_file(
+    path: Path,
+    body: str,
+    *,
+    fenced: bool = True,
+    version: str = VERSION,
+    template_hash: str | None = None,
+) -> None:
+    """Write a minimal MAP-managed file at *path*.
+
+    If *template_hash* is not given, it is computed from *body*.
+    """
+    ext = path.suffix.lower()
+    th = template_hash if template_hash is not None else compute_hash(body)
+    injected = inject_metadata(body, ext, version, th)
+
+    if fenced and ext in (".md", ".py", ".sh", ".toml", ".yaml", ".yml"):
+        fence_tokens = {
+            ".md": ("<!-- map:start -->", "<!-- map:end -->"),
+            ".py": ("# map:start", "# map:end"),
+            ".sh": ("# map:start", "# map:end"),
+            ".toml": ("# map:start", "# map:end"),
+            ".yaml": ("# map:start", "# map:end"),
+            ".yml": ("# map:start", "# map:end"),
+        }
+        start, end = fence_tokens[ext]
+        # Find the metadata line end in injected
+        meta_line_end = injected.index("\n") + 1
+        meta_line = injected[:meta_line_end]
+        rest_body = injected[meta_line_end:]
+        content = meta_line + start + "\n" + rest_body + end + "\n"
+    else:
+        content = injected
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_json_managed(path: Path, body: dict[str, Any], version: str = VERSION) -> None:
+    """Write a MAP-managed JSON file at *path*."""
+    raw = json.dumps(body, indent=2)
+    managed = inject_metadata(raw, ".json", version, compute_hash(raw))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(managed, encoding="utf-8")
+
+
+def _setup_claude_install(project: Path) -> list[str]:
+    """Create a minimal Claude-provider install layout.
+
+    Returns list of relative paths that should appear in the manifest.
+    """
+    installed: list[str] = []
+
+    # .claude/agents/actor.md (fenced)
+    p = project / ".claude" / "agents" / "actor.md"
+    _write_managed_file(p, "# Actor\n\nAct.\n", fenced=True)
+    installed.append(".claude/agents/actor.md")
+
+    # .claude/skills/map-plan/SKILL.md (fenced)
+    p = project / ".claude" / "skills" / "map-plan" / "SKILL.md"
+    _write_managed_file(p, "# map-plan\n\nPlan.\n", fenced=True)
+    installed.append(".claude/skills/map-plan/SKILL.md")
+
+    # .claude/references/bash-guidelines.md (fenced)
+    p = project / ".claude" / "references" / "bash-guidelines.md"
+    _write_managed_file(p, "# Bash Guidelines\n\nContent.\n", fenced=True)
+    installed.append(".claude/references/bash-guidelines.md")
+
+    # .claude/hooks/workflow-gate.py (fenced)
+    p = project / ".claude" / "hooks" / "workflow-gate.py"
+    _write_managed_file(p, "# workflow-gate\npass\n", fenced=True)
+    installed.append(".claude/hooks/workflow-gate.py")
+
+    # .claude/settings.json (full JSON)
+    p = project / ".claude" / "settings.json"
+    _write_json_managed(p, {"theme": "dark"})
+    installed.append(".claude/settings.json")
+
+    # .map/scripts/map_step_runner.py (fenced=False, full mode)
+    p = project / ".map" / "scripts" / "map_step_runner.py"
+    _write_managed_file(p, "# runner\npass\n", fenced=False)
+    installed.append(".map/scripts/map_step_runner.py")
+
+    return sorted(installed)
+
+
+def _setup_codex_install(project: Path) -> list[str]:
+    """Create a minimal Codex-provider install layout.
+
+    Returns list of relative paths that should appear in the manifest.
+    """
+    installed: list[str] = []
+
+    # .agents/skills/map-plan/SKILL.md (fenced)
+    p = project / ".agents" / "skills" / "map-plan" / "SKILL.md"
+    _write_managed_file(p, "# map-plan\n\nPlan.\n", fenced=True)
+    installed.append(".agents/skills/map-plan/SKILL.md")
+
+    # .codex/agents/actor.toml (fenced)
+    p = project / ".codex" / "agents" / "actor.toml"
+    _write_managed_file(p, "[agent]\nname = \"actor\"\n", fenced=True)
+    installed.append(".codex/agents/actor.toml")
+
+    # .codex/config.toml (fenced)
+    p = project / ".codex" / "config.toml"
+    _write_managed_file(p, "[map]\nenabled = true\n", fenced=True)
+    installed.append(".codex/config.toml")
+
+    # .codex/hooks/workflow-gate.py (fenced)
+    p = project / ".codex" / "hooks" / "workflow-gate.py"
+    _write_managed_file(p, "# gate\npass\n", fenced=True)
+    installed.append(".codex/hooks/workflow-gate.py")
+
+    # .codex/hooks.json (hooks-merge, no MAP metadata)
+    p = project / ".codex" / "hooks.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"hooks": {}}, indent=2) + "\n", encoding="utf-8")
+    installed.append(".codex/hooks.json")
+
+    # .map/scripts/map_step_runner.py (fenced=False)
+    p = project / ".map" / "scripts" / "map_step_runner.py"
+    _write_managed_file(p, "# runner\npass\n", fenced=False)
+    installed.append(".map/scripts/map_step_runner.py")
+
+    return sorted(installed)
+
+
+# ---------------------------------------------------------------------------
+# VC1: Claude install writes manifest with correct entries
+# ---------------------------------------------------------------------------
+
+class TestVC1ClaudeManifest:
+    def test_build_manifest_claude_collects_all_managed_files(
+        self, tmp_path: Path
+    ) -> None:
+        expected = _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+
+        assert manifest.provider == "claude"
+        assert manifest.mapify_version == VERSION
+        assert manifest.installed_at != ""
+
+        actual_dests = sorted(e.dest for e in manifest.entries)
+        assert actual_dests == expected, (
+            f"Expected {expected}, got {actual_dests}"
+        )
+
+    def test_build_and_write_manifest_roundtrip(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        manifest_path = write_manifest(tmp_path, manifest)
+
+        assert manifest_path.exists()
+        assert manifest_path == tmp_path / ".map" / MANIFEST_FILENAME
+
+        loaded = read_manifest(tmp_path)
+        assert loaded is not None
+        assert loaded.provider == "claude"
+        assert len(loaded.entries) == len(manifest.entries)
+        loaded_dests = sorted(e.dest for e in loaded.entries)
+        written_dests = sorted(e.dest for e in manifest.entries)
+        assert loaded_dests == written_dests
+
+    def test_manifest_entries_have_hashes(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+
+        for entry in manifest.entries:
+            if entry.management_mode == "hooks-merge":
+                continue  # hooks-merge entries have empty template_hash
+            assert entry.template_hash != "", f"{entry.dest} missing template_hash"
+            assert entry.content_hash != "", f"{entry.dest} missing content_hash"
+
+    def test_manifest_entries_have_correct_management_mode(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+
+        by_dest = {e.dest: e for e in manifest.entries}
+
+        # Fenced .md file
+        agent = by_dest[".claude/agents/actor.md"]
+        assert agent.management_mode == "fenced"
+
+        # JSON file — always "full"
+        settings = by_dest[".claude/settings.json"]
+        assert settings.management_mode == "full"
+
+        # .py installed with fenced=False — should be "full" (no fence markers)
+        runner = by_dest[".map/scripts/map_step_runner.py"]
+        assert runner.management_mode == "full"
+
+
+# ---------------------------------------------------------------------------
+# VC2: Codex install writes manifest with correct entries
+# ---------------------------------------------------------------------------
+
+class TestVC2CodexManifest:
+    def test_build_manifest_codex_collects_all_managed_files(
+        self, tmp_path: Path
+    ) -> None:
+        expected = _setup_codex_install(tmp_path)
+        manifest = build_manifest(tmp_path, "codex", VERSION)
+
+        assert manifest.provider == "codex"
+        actual_dests = sorted(e.dest for e in manifest.entries)
+        assert actual_dests == expected, (
+            f"Expected {expected}, got {actual_dests}"
+        )
+
+    def test_codex_hooks_json_recorded_as_hooks_merge(self, tmp_path: Path) -> None:
+        _setup_codex_install(tmp_path)
+        manifest = build_manifest(tmp_path, "codex", VERSION)
+        by_dest = {e.dest: e for e in manifest.entries}
+
+        hooks_json = by_dest[".codex/hooks.json"]
+        assert hooks_json.management_mode == "hooks-merge"
+        assert hooks_json.committed is True
+
+    def test_codex_managed_toml_recorded_as_fenced(self, tmp_path: Path) -> None:
+        _setup_codex_install(tmp_path)
+        manifest = build_manifest(tmp_path, "codex", VERSION)
+        by_dest = {e.dest: e for e in manifest.entries}
+
+        config = by_dest[".codex/config.toml"]
+        assert config.management_mode == "fenced"
+        assert config.template_hash != ""
+
+
+# ---------------------------------------------------------------------------
+# VC3: Re-init idempotency — writing manifest twice overwrites the first
+# ---------------------------------------------------------------------------
+
+class TestVC3Idempotency:
+    def test_write_manifest_twice_overwrites(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+
+        manifest1 = build_manifest(tmp_path, "claude", "3.21.0")
+        write_manifest(tmp_path, manifest1)
+
+        # Simulate a file being removed (orphan after re-init)
+        (tmp_path / ".claude" / "agents" / "actor.md").unlink()
+
+        manifest2 = build_manifest(tmp_path, "claude", "3.22.0")
+        write_manifest(tmp_path, manifest2)
+
+        loaded = read_manifest(tmp_path)
+        assert loaded is not None
+        assert loaded.mapify_version == "3.22.0", (
+            "Second manifest write must overwrite the first"
+        )
+        # actor.md was removed, so manifest2 shouldn't contain it
+        dests2 = {e.dest for e in manifest2.entries}
+        assert ".claude/agents/actor.md" not in dests2
+
+
+# ---------------------------------------------------------------------------
+# VC4: check_installed detects missing files
+# ---------------------------------------------------------------------------
+
+class TestVC4MissingDetection:
+    def test_missing_file_is_reported(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        # Delete one managed file
+        (tmp_path / ".claude" / "agents" / "actor.md").unlink()
+
+        result = check_installed(tmp_path)
+        assert ".claude/agents/actor.md" in result.missing
+        assert ".claude/agents/actor.md" not in result.ok
+
+    def test_all_ok_when_no_files_missing(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        result = check_installed(tmp_path)
+        assert result.missing == []
+        assert result.drifted == []
+        assert result.orphaned == []
+        assert len(result.ok) == len(manifest.entries)
+
+    def test_missing_hooks_json_reported(self, tmp_path: Path) -> None:
+        _setup_codex_install(tmp_path)
+        manifest = build_manifest(tmp_path, "codex", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        (tmp_path / ".codex" / "hooks.json").unlink()
+
+        result = check_installed(tmp_path)
+        assert ".codex/hooks.json" in result.missing
+
+
+# ---------------------------------------------------------------------------
+# VC5: check_installed detects drifted files
+# ---------------------------------------------------------------------------
+
+class TestVC5DriftDetection:
+    def test_drifted_template_hash_reported(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        # Simulate template update by overwriting with a new template_hash
+        agent_path = tmp_path / ".claude" / "agents" / "actor.md"
+        new_body = "# Actor\n\nNew template content.\n"
+        _write_managed_file(
+            agent_path,
+            new_body,
+            fenced=True,
+            template_hash=compute_hash("new-template-body"),
+        )
+
+        result = check_installed(tmp_path)
+        assert ".claude/agents/actor.md" in result.drifted
+        assert ".claude/agents/actor.md" not in result.ok
+
+    def test_same_hash_is_ok(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        # Read the installed template_hash for actor.md
+        by_dest = {e.dest: e for e in manifest.entries}
+        recorded_hash = by_dest[".claude/agents/actor.md"].template_hash
+
+        # Reinstall with the SAME template_hash (same template, re-install)
+        _write_managed_file(
+            tmp_path / ".claude" / "agents" / "actor.md",
+            "# Actor\n\nAct.\n",
+            fenced=True,
+            template_hash=recorded_hash,
+        )
+
+        result = check_installed(tmp_path)
+        assert ".claude/agents/actor.md" not in result.drifted
+        assert ".claude/agents/actor.md" in result.ok
+
+    def test_stripped_metadata_reported_as_drifted(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        # User strips the MAP-MANAGED metadata from the file
+        agent_path = tmp_path / ".claude" / "agents" / "actor.md"
+        agent_path.write_text("# Actor\n\nAct.\n", encoding="utf-8")
+
+        result = check_installed(tmp_path)
+        assert ".claude/agents/actor.md" in result.drifted
+
+
+# ---------------------------------------------------------------------------
+# VC6: check_installed detects orphaned files
+# ---------------------------------------------------------------------------
+
+class TestVC6OrphanDetection:
+    def test_orphaned_file_detected_after_manifest_written_without_it(
+        self, tmp_path: Path
+    ) -> None:
+        # Write manifest before adding a new MAP-managed file
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        # A new MAP-managed file appears (e.g., from a new template that was
+        # installed manually but not re-manifested)
+        orphan_path = tmp_path / ".claude" / "agents" / "new-agent.md"
+        _write_managed_file(orphan_path, "# New Agent\n\nContent.\n", fenced=True)
+
+        result = check_installed(tmp_path)
+        assert ".claude/agents/new-agent.md" in result.orphaned
+
+    def test_no_orphans_when_manifest_is_current(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        write_manifest(tmp_path, manifest)
+
+        result = check_installed(tmp_path)
+        assert result.orphaned == []
+
+
+# ---------------------------------------------------------------------------
+# VC7: read_manifest returns None for missing/corrupt
+# ---------------------------------------------------------------------------
+
+class TestVC7ReadManifestEdgeCases:
+    def test_missing_manifest_returns_none(self, tmp_path: Path) -> None:
+        result = read_manifest(tmp_path)
+        assert result is None
+
+    def test_corrupt_json_returns_none(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / ".map" / MANIFEST_FILENAME
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("not valid json{{{", encoding="utf-8")
+
+        result = read_manifest(tmp_path)
+        assert result is None
+
+    def test_wrong_type_returns_none(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / ".map" / MANIFEST_FILENAME
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("[1, 2, 3]", encoding="utf-8")  # array, not object
+
+        result = read_manifest(tmp_path)
+        assert result is None
+
+    def test_empty_manifest_returns_empty_entries(self, tmp_path: Path) -> None:
+        manifest = InstallManifest(
+            mapify_version="3.21.0",
+            provider="claude",
+            installed_at="2026-07-05T00:00:00Z",
+            entries=[],
+        )
+        write_manifest(tmp_path, manifest)
+        loaded = read_manifest(tmp_path)
+        assert loaded is not None
+        assert loaded.entries == []
+
+
+# ---------------------------------------------------------------------------
+# VC8: management_mode inference
+# ---------------------------------------------------------------------------
+
+class TestVC8ManagementModeInference:
+    def test_md_with_fence_marker_is_fenced(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.md"
+        content = "<!-- MAP-MANAGED: {} -->\n<!-- map:start -->\nbody\n<!-- map:end -->\n"
+        assert _infer_management_mode(p, content, ".md") == "fenced"
+
+    def test_md_without_fence_marker_is_full(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.md"
+        content = "<!-- MAP-MANAGED: {} -->\nbody\n"
+        assert _infer_management_mode(p, content, ".md") == "full"
+
+    def test_py_with_fence_is_fenced(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.py"
+        content = "# MAP-MANAGED: {}\n# map:start\npass\n# map:end\n"
+        assert _infer_management_mode(p, content, ".py") == "fenced"
+
+    def test_json_is_always_full(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.json"
+        assert _infer_management_mode(p, "{}", ".json") == "full"
+
+    def test_toml_with_fence_is_fenced(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.toml"
+        content = "# MAP-MANAGED: {}\n# map:start\n[x]\n# map:end\n"
+        assert _infer_management_mode(p, content, ".toml") == "fenced"
+
+
+# ---------------------------------------------------------------------------
+# VC9: Local-only paths excluded from the committed manifest
+# ---------------------------------------------------------------------------
+
+class TestVC9LocalOnlyExclusion:
+    def test_settings_local_json_excluded(self, tmp_path: Path) -> None:
+        _setup_claude_install(tmp_path)
+
+        # Create a settings.local.json (machine-local, should be excluded)
+        local_settings = tmp_path / ".claude" / "settings.local.json"
+        _write_json_managed(local_settings, {"statusLine": {"type": "command", "command": "x"}})
+
+        manifest = build_manifest(tmp_path, "claude", VERSION)
+        dests = {e.dest for e in manifest.entries}
+        assert ".claude/settings.local.json" not in dests, (
+            "settings.local.json is machine-local and must not appear in the committed manifest"
+        )
+
+    def test_symlink_excluded(self, tmp_path: Path) -> None:
+        _setup_codex_install(tmp_path)
+
+        # Create a symlink at AGENTS.md (as the Codex provider does when CLAUDE.md exists)
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.symlink_to("CLAUDE.md")
+
+        entry = _build_entry_from_file(tmp_path, agents_md)
+        assert entry is None, "Symlinks must be excluded from the manifest"
+
+
+# ---------------------------------------------------------------------------
+# Integration: check_installed returns empty CheckResult when no manifest
+# ---------------------------------------------------------------------------
+
+class TestCheckInstalledNoManifest:
+    def test_no_manifest_returns_empty_check_result(self, tmp_path: Path) -> None:
+        result = check_installed(tmp_path)
+        assert result.missing == []
+        assert result.orphaned == []
+        assert result.drifted == []
+        assert result.ok == []


### PR DESCRIPTION
## Summary

Closes #313.

Implements a scan-based install manifest written to `.map/mapify.lock.json` during `mapify init` for both Claude and Codex providers. Adds a `mapify check-installed` command that compares the current installed tree against the manifest.

### What changed

**New module: `src/mapify_cli/install_manifest.py`**
- `ManifestEntry` dataclass: dest (relative POSIX path), content_hash, template_hash, management_mode (`fenced`/`full`/`hooks-merge`), committed, mapify_version, installed_at
- `InstallManifest` dataclass: mapify_version, provider, installed_at, entries
- `build_manifest(project_path, provider, version)` — scan-based: walks the provider's known install directories and collects all files carrying `MAP-MANAGED` metadata; no changes to existing install functions required
- `write_manifest` / `read_manifest` — persist and load `.map/mapify.lock.json`
- `check_installed(project_path)` → `CheckResult(missing, orphaned, drifted, ok)`

**`src/mapify_cli/__init__.py`**
- New `manifest` step in `init` command: writes the lock after all provider files are installed
- New `mapify check-installed [project_path]` command with exit codes 0 (ok), 1 (issues found), 2 (no manifest)

**`tests/test_install_manifest.py`** — 28 tests covering VC1–VC9:
- Claude install collects correct entries with correct management modes
- Codex install (including `hooks.json` → `hooks-merge` mode)
- Re-init idempotency (second write overwrites first)
- Missing, drifted (template_hash changed), and orphaned file detection
- `read_manifest` edge cases (missing/corrupt/wrong-type)
- Management mode inference (fenced vs full vs hooks-merge)
- Local-only exclusion (`.claude/settings.local.json`, symlinks)

### Design decisions

- **Scan-based, not instrumented**: manifest is built by scanning installed directories for `MAP-MANAGED` metadata after install completes. No changes to the 10+ `create_*` functions.
- **No absolute paths or secrets** in the committed manifest.
- **Local-only files excluded**: `settings.local.json` (statusline, machine-specific) is not recorded.
- **Symlinks excluded**: `AGENTS.md` symlink to `CLAUDE.md` is not followed.
- **`hooks.json` handled separately**: Codex hooks.json uses a custom merge without MAP metadata; recorded with `management_mode="hooks-merge"`.
- **Existing per-file drift/backup behavior unchanged**.

## Test plan

- [x] `uv run pytest tests/test_install_manifest.py -v` — 28/28 pass
- [x] `uv run make check` — all 3284 tests pass, ruff + mypy + check-render clean
- [x] `uv run python -m pyright src/mapify_cli/install_manifest.py src/mapify_cli/__init__.py` — 0 errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ3wHDow49xBGUwWFPH2mD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mapify check-installed` to verify whether installed files match the recorded state, with clear exit codes for success, missing setup, and detected issues.
  * `mapify init` now saves an install manifest after setup so installed files can be tracked later.

* **Bug Fixes**
  * Improved handling of partial or changed installs, including missing, drifted, and extra files.
  * Safer manifest loading now avoids failing on missing or invalid manifest data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->