### PR TITLE
feat: add deterministic boundary-quality eval for architecture plans (#316)

### DIFF
--- a/src/mapify_cli/boundary_quality_report.py
+++ b/src/mapify_cli/boundary_quality_report.py
@@ -1,0 +1,306 @@
+"""Deterministic boundary-quality evaluation for architecture-heavy MAP blueprints.
+
+Produces a boundary_quality_report from blueprint.json data alone — no network
+access, no external model calls, no structural code-map required.
+
+The report is ADVISORY by default: findings are warnings or informational, not
+hard errors.  Hard errors (hallucinated paths, duplicate IDs, cycle detection)
+remain in validate_blueprint_contract.
+
+Checks implemented
+------------------
+FILE_SHARED_ACROSS_BOUNDARIES (warn)
+    The same file appears in two subtasks that are not in a dependency
+    relationship.  Ownership is ambiguous; concurrent writes will conflict.
+
+CROSS_BOUNDARY_DEP_PRESSURE (warn)
+    Two high-risk or large-diff subtasks touch the same top-level module
+    directory but have no declared dependency between them.  Their order
+    of execution may matter even though the graph does not encode it.
+
+REFACTOR_WITHOUT_TEST_PAIR (info)
+    A subtask with concern_type=refactor has no test subtask that declares
+    it as a dependency.  Refactors without an explicit test gate are harder
+    to verify as behavior-preserving.
+
+LOW_COHESION_SUBTASK (info)
+    A subtask's affected_files span three or more distinct top-level module
+    directories without a concern_type that justifies cross-cutting changes
+    (refactor, docs, release, cross-repo, config).  Consider splitting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BoundaryFinding:
+    """A single boundary-quality finding."""
+
+    severity: str
+    code: str
+    message: str
+    subtask_ids: tuple[str, ...]
+    evidence: tuple[str, ...]
+
+
+@dataclass
+class BoundaryQualityReport:
+    """Aggregated boundary-quality report for one blueprint."""
+
+    is_architecture_heavy: bool
+    findings: list[BoundaryFinding] = field(default_factory=list)
+
+    @property
+    def summary(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for f in self.findings:
+            counts[f.severity] = counts.get(f.severity, 0) + 1
+        return counts
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "is_architecture_heavy": self.is_architecture_heavy,
+            "findings": [
+                {
+                    "severity": f.severity,
+                    "code": f.code,
+                    "message": f.message,
+                    "subtask_ids": list(f.subtask_ids),
+                    "evidence": list(f.evidence),
+                }
+                for f in self.findings
+            ],
+            "summary": self.summary,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Architecture-heavy detection
+# ---------------------------------------------------------------------------
+
+_ARCH_CONCERN_TYPES: frozenset[str] = frozenset({"refactor", "api", "data", "cross-repo"})
+_LARGE_DIFF_SIZES: frozenset[str] = frozenset({"medium", "large"})
+_PERMISSIVE_COHESION_TYPES: frozenset[str] = frozenset(
+    {"refactor", "docs", "release", "cross-repo", "config"}
+)
+
+
+def is_architecture_heavy(blueprint: dict[str, Any]) -> bool:
+    """Return True if the blueprint is architecture/refactor-heavy.
+
+    A blueprint is considered architecture-heavy when either:
+    - Any subtask combines concern_type=refactor with expected_diff_size=large, or
+    - Three or more subtasks have an architecture-oriented concern_type
+      (refactor, api, data, cross-repo).
+    """
+    subtasks: list[dict[str, Any]] = blueprint.get("subtasks", [])
+    arch_count = sum(
+        1 for st in subtasks if st.get("concern_type", "") in _ARCH_CONCERN_TYPES
+    )
+    has_heavy_refactor = any(
+        st.get("concern_type") == "refactor" and st.get("expected_diff_size") == "large"
+        for st in subtasks
+    )
+    return has_heavy_refactor or arch_count >= 3
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_dep_pairs(subtasks: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    """Return all (child_id, parent_id) dependency pairs from the blueprint."""
+    pairs: set[tuple[str, str]] = set()
+    for st in subtasks:
+        for dep in st.get("dependencies", []):
+            pairs.add((st["id"], dep))
+    return pairs
+
+
+def _are_related(a_id: str, b_id: str, dep_pairs: set[tuple[str, str]]) -> bool:
+    """True if a directly depends on b OR b directly depends on a."""
+    return (a_id, b_id) in dep_pairs or (b_id, a_id) in dep_pairs
+
+
+def _top_module(path: str) -> str:
+    """Return the top-two-segment module path (e.g. 'src/mapify_cli') for a file path."""
+    parts = PurePosixPath(path).parts
+    if len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}"
+    return parts[0] if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def _check_file_shared_across_boundaries(
+    subtasks: list[dict[str, Any]],
+    dep_pairs: set[tuple[str, str]],
+) -> list[BoundaryFinding]:
+    file_to_subtasks: dict[str, list[str]] = {}
+    for st in subtasks:
+        for f in st.get("affected_files", []):
+            file_to_subtasks.setdefault(f, []).append(st["id"])
+
+    findings: list[BoundaryFinding] = []
+    seen: set[tuple[str, str, str]] = set()
+    for file, owners in file_to_subtasks.items():
+        if len(owners) < 2:
+            continue
+        for i in range(len(owners)):
+            for j in range(i + 1, len(owners)):
+                a, b = owners[i], owners[j]
+                if _are_related(a, b, dep_pairs):
+                    continue
+                key = (min(a, b), max(a, b), file)
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(
+                    BoundaryFinding(
+                        severity="warn",
+                        code="FILE_SHARED_ACROSS_BOUNDARIES",
+                        message=(
+                            f"'{file}' appears in both {a} and {b}, which are not "
+                            "in a dependency relationship. Assign sole ownership "
+                            "to one subtask or add an explicit dependency."
+                        ),
+                        subtask_ids=(a, b),
+                        evidence=(file,),
+                    )
+                )
+    return findings
+
+
+def _check_cross_boundary_dep_pressure(
+    subtasks: list[dict[str, Any]],
+    dep_pairs: set[tuple[str, str]],
+) -> list[BoundaryFinding]:
+    heavy = [
+        st
+        for st in subtasks
+        if st.get("risk") == "high" or st.get("expected_diff_size") == "large"
+    ]
+
+    findings: list[BoundaryFinding] = []
+    for i in range(len(heavy)):
+        for j in range(i + 1, len(heavy)):
+            a, b = heavy[i], heavy[j]
+            if _are_related(a["id"], b["id"], dep_pairs):
+                continue
+            prefixes_a = {_top_module(f) for f in a.get("affected_files", [])}
+            prefixes_b = {_top_module(f) for f in b.get("affected_files", [])}
+            shared = prefixes_a & prefixes_b
+            if not shared:
+                continue
+            findings.append(
+                BoundaryFinding(
+                    severity="warn",
+                    code="CROSS_BOUNDARY_DEP_PRESSURE",
+                    message=(
+                        f"{a['id']} and {b['id']} both touch "
+                        f"{', '.join(sorted(shared))} but have no declared "
+                        "dependency. Verify they can execute in any order "
+                        "without write conflicts."
+                    ),
+                    subtask_ids=(a["id"], b["id"]),
+                    evidence=tuple(sorted(shared)),
+                )
+            )
+    return findings
+
+
+def _check_refactor_without_test_coverage(
+    subtasks: list[dict[str, Any]],
+    dep_pairs: set[tuple[str, str]],
+) -> list[BoundaryFinding]:
+    refactor_ids = {st["id"] for st in subtasks if st.get("concern_type") == "refactor"}
+    test_ids = {st["id"] for st in subtasks if st.get("concern_type") == "tests"}
+
+    findings: list[BoundaryFinding] = []
+    for r_id in sorted(refactor_ids):
+        covered = any((t_id, r_id) in dep_pairs for t_id in test_ids)
+        if not covered:
+            findings.append(
+                BoundaryFinding(
+                    severity="info",
+                    code="REFACTOR_WITHOUT_TEST_PAIR",
+                    message=(
+                        f"{r_id} has concern_type=refactor but no tests subtask "
+                        "declares it as a dependency. Add or pair a tests subtask "
+                        "to verify behavior is preserved."
+                    ),
+                    subtask_ids=(r_id,),
+                    evidence=(),
+                )
+            )
+    return findings
+
+
+def _check_low_cohesion(subtasks: list[dict[str, Any]]) -> list[BoundaryFinding]:
+    findings: list[BoundaryFinding] = []
+    for st in subtasks:
+        if st.get("concern_type") in _PERMISSIVE_COHESION_TYPES:
+            continue
+        prefixes = {_top_module(f) for f in st.get("affected_files", [])}
+        if len(prefixes) >= 3:
+            findings.append(
+                BoundaryFinding(
+                    severity="info",
+                    code="LOW_COHESION_SUBTASK",
+                    message=(
+                        f"{st['id']} touches {len(prefixes)} distinct top-level "
+                        f"directories ({', '.join(sorted(prefixes))}). Consider "
+                        "splitting along module boundaries."
+                    ),
+                    subtask_ids=(st["id"],),
+                    evidence=tuple(sorted(prefixes)),
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def report_boundary_quality(blueprint: dict[str, Any]) -> BoundaryQualityReport:
+    """Produce a deterministic boundary-quality report from blueprint.json data.
+
+    No network access, model calls, or external tools required.  The report
+    is advisory: findings are warn or info, never hard errors.
+
+    Args:
+        blueprint: Parsed blueprint.json dict.
+
+    Returns:
+        BoundaryQualityReport with is_architecture_heavy flag, findings list,
+        and a severity-count summary.
+    """
+    subtasks: list[dict[str, Any]] = blueprint.get("subtasks", [])
+    dep_pairs = _build_dep_pairs(subtasks)
+    heavy = is_architecture_heavy(blueprint)
+
+    findings: list[BoundaryFinding] = []
+    findings.extend(_check_file_shared_across_boundaries(subtasks, dep_pairs))
+    findings.extend(_check_cross_boundary_dep_pressure(subtasks, dep_pairs))
+    findings.extend(_check_refactor_without_test_coverage(subtasks, dep_pairs))
+    findings.extend(_check_low_cohesion(subtasks))
+
+    # Sort: warn before info, then by subtask_ids for determinism
+    findings.sort(key=lambda f: (0 if f.severity == "warn" else 1, f.subtask_ids))
+
+    return BoundaryQualityReport(is_architecture_heavy=heavy, findings=findings)

--- a/tests/test_boundary_quality_report.py
+++ b/tests/test_boundary_quality_report.py
@@ -1,0 +1,456 @@
+"""Tests for boundary_quality_report.py — deterministic boundary-quality eval.
+
+Verification criteria
+---------------------
+VC1  is_architecture_heavy returns True for refactor+large blueprint.
+VC2  is_architecture_heavy returns True when 3+ arch-concern subtasks present.
+VC3  is_architecture_heavy returns False for a simple low-risk blueprint.
+VC4  FILE_SHARED_ACROSS_BOUNDARIES fires when the same file appears in two
+     parallel (unrelated) subtasks.
+VC5  FILE_SHARED_ACROSS_BOUNDARIES is suppressed when subtasks are related
+     by a dependency edge.
+VC6  CROSS_BOUNDARY_DEP_PRESSURE fires for two high-risk subtasks that share
+     a directory prefix but have no declared dependency.
+VC7  CROSS_BOUNDARY_DEP_PRESSURE is suppressed when one subtask depends on
+     the other.
+VC8  REFACTOR_WITHOUT_TEST_PAIR fires when a refactor subtask has no test
+     subtask that declares it as a dependency.
+VC9  REFACTOR_WITHOUT_TEST_PAIR is suppressed when a tests subtask explicitly
+     depends on the refactor subtask.
+VC10 LOW_COHESION_SUBTASK fires when affected_files span 3+ top-level dirs
+     for a non-permissive concern_type.
+VC11 LOW_COHESION_SUBTASK is suppressed for concern_type=refactor even when
+     files span many directories (cross-cutting is expected for refactors).
+VC12 A clean blueprint (well-split, no shared files, clear ownership) produces
+     zero findings.
+VC13 report_boundary_quality returns a BoundaryQualityReport with the correct
+     is_architecture_heavy flag and a summary dict.
+VC14 as_dict() produces a JSON-serialisable structure with the expected keys.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mapify_cli.boundary_quality_report import (
+    BoundaryQualityReport,
+    is_architecture_heavy,
+    report_boundary_quality,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _subtask(
+    sid: str,
+    files: list[str],
+    concern_type: str = "runtime",
+    diff_size: str = "small",
+    risk: str = "low",
+    deps: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": sid,
+        "title": f"Task {sid}",
+        "aag_contract": f"Actor -> do_{sid}() -> done",
+        "dependencies": deps or [],
+        "affected_files": files,
+        "expected_diff_size": diff_size,
+        "concern_type": concern_type,
+        "risk": risk,
+        "one_logical_step": True,
+        "validation_criteria": [f"VC1 [AC-1]: {sid} works"],
+    }
+
+
+def _blueprint(*subtasks: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "hard_constraints": [{"id": "AC-1", "description": "It must work"}],
+        "soft_constraints": [],
+        "subtasks": list(subtasks),
+        "coverage_map": {"AC-1": subtasks[0]["id"] if subtasks else "ST-001"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# VC1-VC3  is_architecture_heavy
+# ---------------------------------------------------------------------------
+
+
+class TestVC1ArchitectureHeavyRefactorLarge:
+    def test_refactor_plus_large_is_heavy(self) -> None:
+        bp = _blueprint(_subtask("ST-001", ["src/x.py"], concern_type="refactor", diff_size="large"))
+        assert is_architecture_heavy(bp) is True
+
+    def test_refactor_small_is_not_heavy_alone(self) -> None:
+        bp = _blueprint(_subtask("ST-001", ["src/x.py"], concern_type="refactor", diff_size="small"))
+        assert is_architecture_heavy(bp) is False
+
+
+class TestVC2ArchitectureHeavyThreeArchConcerns:
+    def test_three_arch_concerns_is_heavy(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/a.py"], concern_type="api"),
+            _subtask("ST-002", ["src/b.py"], concern_type="data"),
+            _subtask("ST-003", ["src/c.py"], concern_type="refactor"),
+        )
+        assert is_architecture_heavy(bp) is True
+
+    def test_two_arch_concerns_not_heavy(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/a.py"], concern_type="api"),
+            _subtask("ST-002", ["src/b.py"], concern_type="data"),
+            _subtask("ST-003", ["src/c.py"], concern_type="runtime"),
+        )
+        assert is_architecture_heavy(bp) is False
+
+
+class TestVC3NotArchitectureHeavy:
+    def test_simple_blueprint_not_heavy(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/a.py"], concern_type="runtime"),
+            _subtask("ST-002", ["tests/test_a.py"], concern_type="tests"),
+        )
+        assert is_architecture_heavy(bp) is False
+
+
+# ---------------------------------------------------------------------------
+# VC4-VC5  FILE_SHARED_ACROSS_BOUNDARIES
+# ---------------------------------------------------------------------------
+
+
+class TestVC4FileSharedAcrossBoundaries:
+    def test_shared_file_in_parallel_subtasks_flagged(self) -> None:
+        shared = "src/mapify_cli/shared_model.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared, "src/mapify_cli/a.py"]),
+            _subtask("ST-002", [shared, "src/mapify_cli/b.py"]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "FILE_SHARED_ACROSS_BOUNDARIES" in codes
+
+    def test_finding_names_both_subtasks(self) -> None:
+        shared = "src/mapify_cli/shared_model.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared]),
+            _subtask("ST-002", [shared]),
+        )
+        report = report_boundary_quality(bp)
+        findings = [f for f in report.findings if f.code == "FILE_SHARED_ACROSS_BOUNDARIES"]
+        assert len(findings) == 1
+        assert set(findings[0].subtask_ids) == {"ST-001", "ST-002"}
+        assert shared in findings[0].evidence
+
+    def test_finding_is_warn_severity(self) -> None:
+        shared = "src/mapify_cli/shared_model.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared]),
+            _subtask("ST-002", [shared]),
+        )
+        report = report_boundary_quality(bp)
+        findings = [f for f in report.findings if f.code == "FILE_SHARED_ACROSS_BOUNDARIES"]
+        assert all(f.severity == "warn" for f in findings)
+
+
+class TestVC5FileSharedSuppressedByDependency:
+    def test_no_warning_when_st002_depends_on_st001(self) -> None:
+        shared = "src/mapify_cli/shared_model.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared]),
+            _subtask("ST-002", [shared], deps=["ST-001"]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "FILE_SHARED_ACROSS_BOUNDARIES" not in codes
+
+    def test_no_warning_when_st001_depends_on_st002(self) -> None:
+        shared = "src/mapify_cli/shared_model.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared], deps=["ST-002"]),
+            _subtask("ST-002", [shared]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "FILE_SHARED_ACROSS_BOUNDARIES" not in codes
+
+
+# ---------------------------------------------------------------------------
+# VC6-VC7  CROSS_BOUNDARY_DEP_PRESSURE
+# ---------------------------------------------------------------------------
+
+
+class TestVC6CrossBoundaryDepPressure:
+    def test_high_risk_subtasks_same_dir_no_dep_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"], risk="high"),
+            _subtask("ST-002", ["src/mapify_cli/b.py"], risk="high"),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "CROSS_BOUNDARY_DEP_PRESSURE" in codes
+
+    def test_large_diff_subtasks_same_dir_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"], diff_size="large"),
+            _subtask("ST-002", ["src/mapify_cli/b.py"], diff_size="large"),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "CROSS_BOUNDARY_DEP_PRESSURE" in codes
+
+    def test_finding_names_shared_directory(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"], risk="high"),
+            _subtask("ST-002", ["src/mapify_cli/b.py"], risk="high"),
+        )
+        report = report_boundary_quality(bp)
+        findings = [f for f in report.findings if f.code == "CROSS_BOUNDARY_DEP_PRESSURE"]
+        assert len(findings) == 1
+        assert "src/mapify_cli" in findings[0].evidence
+
+    def test_low_risk_different_dirs_no_pressure(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"]),
+            _subtask("ST-002", ["tests/test_b.py"]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "CROSS_BOUNDARY_DEP_PRESSURE" not in codes
+
+
+class TestVC7CrossBoundaryDepPressureSuppressed:
+    def test_suppressed_when_subtask_depends_on_other(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"], risk="high"),
+            _subtask("ST-002", ["src/mapify_cli/b.py"], risk="high", deps=["ST-001"]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "CROSS_BOUNDARY_DEP_PRESSURE" not in codes
+
+
+# ---------------------------------------------------------------------------
+# VC8-VC9  REFACTOR_WITHOUT_TEST_PAIR
+# ---------------------------------------------------------------------------
+
+
+class TestVC8RefactorWithoutTestPair:
+    def test_refactor_without_test_dep_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/x.py"], concern_type="refactor"),
+            _subtask("ST-002", ["tests/test_x.py"], concern_type="tests"),
+            # ST-002 does NOT depend on ST-001 — test doesn't gate the refactor
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "REFACTOR_WITHOUT_TEST_PAIR" in codes
+
+    def test_standalone_refactor_with_no_tests_subtask_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/x.py"], concern_type="refactor"),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "REFACTOR_WITHOUT_TEST_PAIR" in codes
+
+    def test_finding_is_info_severity(self) -> None:
+        bp = _blueprint(_subtask("ST-001", ["src/x.py"], concern_type="refactor"))
+        report = report_boundary_quality(bp)
+        findings = [f for f in report.findings if f.code == "REFACTOR_WITHOUT_TEST_PAIR"]
+        assert all(f.severity == "info" for f in findings)
+
+
+class TestVC9RefactorWithTestPairSuppressed:
+    def test_suppressed_when_test_depends_on_refactor(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/x.py"], concern_type="refactor"),
+            _subtask("ST-002", ["tests/test_x.py"], concern_type="tests", deps=["ST-001"]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "REFACTOR_WITHOUT_TEST_PAIR" not in codes
+
+
+# ---------------------------------------------------------------------------
+# VC10-VC11  LOW_COHESION_SUBTASK
+# ---------------------------------------------------------------------------
+
+
+class TestVC10LowCohesionSubtask:
+    def test_three_plus_dirs_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask(
+                "ST-001",
+                ["src/mapify_cli/a.py", "tests/test_a.py", "docs/README.md", ".claude/hooks/foo.py"],
+                concern_type="runtime",
+            )
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "LOW_COHESION_SUBTASK" in codes
+
+    def test_finding_names_directories(self) -> None:
+        bp = _blueprint(
+            _subtask(
+                "ST-001",
+                ["src/mapify_cli/a.py", "tests/test_a.py", "docs/README.md"],
+                concern_type="runtime",
+            )
+        )
+        report = report_boundary_quality(bp)
+        findings = [f for f in report.findings if f.code == "LOW_COHESION_SUBTASK"]
+        assert len(findings) == 1
+        assert ".claude" not in findings[0].evidence  # only 3 dirs here
+
+    def test_two_dirs_not_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py", "tests/test_a.py"], concern_type="runtime")
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "LOW_COHESION_SUBTASK" not in codes
+
+
+class TestVC11LowCohesionSuppressedForRefactor:
+    def test_refactor_with_many_dirs_not_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask(
+                "ST-001",
+                ["src/mapify_cli/a.py", "tests/test_a.py", "docs/arch.md"],
+                concern_type="refactor",
+            )
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "LOW_COHESION_SUBTASK" not in codes
+
+    def test_docs_concern_type_not_flagged(self) -> None:
+        bp = _blueprint(
+            _subtask(
+                "ST-001",
+                ["docs/a.md", "docs/b.md", "README.md", "src/x.py"],
+                concern_type="docs",
+            )
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "LOW_COHESION_SUBTASK" not in codes
+
+
+# ---------------------------------------------------------------------------
+# VC12  Clean blueprint produces zero findings
+# ---------------------------------------------------------------------------
+
+
+class TestVC12CleanBlueprintZeroFindings:
+    def test_well_split_blueprint_no_findings(self) -> None:
+        """A well-designed blueprint: distinct file ownership, test depends on impl."""
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"], concern_type="runtime", diff_size="small"),
+            _subtask("ST-002", ["src/mapify_cli/b.py"], concern_type="api", diff_size="small"),
+            _subtask(
+                "ST-003",
+                ["tests/test_a.py", "tests/test_b.py"],
+                concern_type="tests",
+                deps=["ST-001", "ST-002"],
+            ),
+        )
+        report = report_boundary_quality(bp)
+        assert report.findings == []
+
+    def test_good_refactor_with_test_no_findings(self) -> None:
+        bp = _blueprint(
+            _subtask("ST-001", ["src/mapify_cli/a.py"], concern_type="refactor"),
+            _subtask("ST-002", ["tests/test_a.py"], concern_type="tests", deps=["ST-001"]),
+        )
+        report = report_boundary_quality(bp)
+        codes = [f.code for f in report.findings]
+        assert "REFACTOR_WITHOUT_TEST_PAIR" not in codes
+        assert "FILE_SHARED_ACROSS_BOUNDARIES" not in codes
+
+
+# ---------------------------------------------------------------------------
+# VC13  report_boundary_quality contract
+# ---------------------------------------------------------------------------
+
+
+class TestVC13ReportBoundaryQualityContract:
+    def test_returns_boundary_quality_report(self) -> None:
+        bp = _blueprint(_subtask("ST-001", ["src/x.py"]))
+        result = report_boundary_quality(bp)
+        assert isinstance(result, BoundaryQualityReport)
+
+    def test_is_architecture_heavy_flag_set_correctly(self) -> None:
+        heavy = _blueprint(
+            _subtask("ST-001", ["src/x.py"], concern_type="refactor", diff_size="large")
+        )
+        light = _blueprint(_subtask("ST-001", ["src/x.py"]))
+        assert report_boundary_quality(heavy).is_architecture_heavy is True
+        assert report_boundary_quality(light).is_architecture_heavy is False
+
+    def test_summary_counts_by_severity(self) -> None:
+        shared = "src/mapify_cli/shared.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared]),
+            _subtask("ST-002", [shared]),
+            _subtask("ST-003", ["src/x.py"], concern_type="refactor"),
+        )
+        report = report_boundary_quality(bp)
+        summary = report.summary
+        assert summary.get("warn", 0) >= 1
+        assert summary.get("info", 0) >= 1
+
+    def test_empty_blueprint_no_crash(self) -> None:
+        bp: dict[str, Any] = {
+            "hard_constraints": [],
+            "soft_constraints": [],
+            "subtasks": [],
+            "coverage_map": {},
+        }
+        result = report_boundary_quality(bp)
+        assert isinstance(result, BoundaryQualityReport)
+        assert result.findings == []
+
+
+# ---------------------------------------------------------------------------
+# VC14  as_dict serialisability
+# ---------------------------------------------------------------------------
+
+
+class TestVC14AsDictSerializability:
+    def test_as_dict_has_expected_keys(self) -> None:
+        bp = _blueprint(_subtask("ST-001", ["src/x.py"]))
+        d = report_boundary_quality(bp).as_dict()
+        assert "is_architecture_heavy" in d
+        assert "findings" in d
+        assert "summary" in d
+
+    def test_as_dict_findings_have_expected_shape(self) -> None:
+        shared = "src/mapify_cli/shared.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared]),
+            _subtask("ST-002", [shared]),
+        )
+        d = report_boundary_quality(bp).as_dict()
+        assert len(d["findings"]) >= 1
+        finding = d["findings"][0]
+        for key in ("severity", "code", "message", "subtask_ids", "evidence"):
+            assert key in finding
+
+    def test_as_dict_is_json_serializable(self) -> None:
+        import json
+
+        shared = "src/mapify_cli/shared.py"
+        bp = _blueprint(
+            _subtask("ST-001", [shared]),
+            _subtask("ST-002", [shared]),
+        )
+        d = report_boundary_quality(bp).as_dict()
+        serialized = json.dumps(d)
+        assert isinstance(serialized, str)
+        parsed = json.loads(serialized)
+        assert parsed["findings"][0]["code"] == "FILE_SHARED_ACROSS_BOUNDARIES"


### PR DESCRIPTION
## Summary

Implements #316 — adds a deterministic `boundary_quality_report` module that evaluates architectural decomposition plans for boundary quality. Works from `blueprint.json` data alone: no network, no model calls, no optional structural code-map (#310) required.

## Changes

**`src/mapify_cli/boundary_quality_report.py`** (new module)
- `is_architecture_heavy(blueprint)` — detects refactor+large or 3+ arch-concern subtasks
- `report_boundary_quality(blueprint) -> BoundaryQualityReport` — runs all four advisory checks
- `BoundaryQualityReport.as_dict()` — JSON-serializable output

Four advisory checks (warn/info only — hard errors stay in `validate_blueprint_contract`):
- **FILE_SHARED_ACROSS_BOUNDARIES** (warn): same file in two unrelated subtasks — ownership ambiguous, concurrent writes will conflict
- **CROSS_BOUNDARY_DEP_PRESSURE** (warn): high-risk/large subtasks share a directory prefix but have no declared dependency
- **REFACTOR_WITHOUT_TEST_PAIR** (info): refactor subtask with no tests subtask that declares it as a dependency
- **LOW_COHESION_SUBTASK** (info): affected_files span 3+ top-level directories for non-permissive concern types (suppressed for refactor/docs/release/config)

Related subtasks (dependency edge in either direction) suppress FILE_SHARED and CROSS_BOUNDARY warnings.

**`tests/test_boundary_quality_report.py`** (new, 33 tests)
- VC1–VC3: architecture-heavy detection (True/False)
- VC4–VC5: FILE_SHARED_ACROSS_BOUNDARIES (fires + suppressed by dep)
- VC6–VC7: CROSS_BOUNDARY_DEP_PRESSURE (fires + suppressed by dep)
- VC8–VC9: REFACTOR_WITHOUT_TEST_PAIR (fires + suppressed by test dep)
- VC10–VC11: LOW_COHESION_SUBTASK (fires + suppressed for refactor/docs)
- VC12: clean blueprint → zero findings
- VC13: report contract (returns BoundaryQualityReport, summary dict, empty-blueprint safe)
- VC14: as_dict() JSON-serialisable

## Acceptance criteria

- ✅ Deterministic helper produces `boundary_quality_report` for fixture blueprints without network or model calls
- ✅ Report distinguishes hard grounding errors (out of scope, handled by existing gates) from advisory quality warnings
- ✅ Tests include good split (zero findings) and bad split (shared file, cross-boundary pressure)
- ✅ Works without #310 structural provider; integration with #310 is a future enhancement
- ✅ No template sources touched, no render-templates needed

## Test results

```
3342 passed, 4 skipped, 0 failures (full suite)
ruff: All checks passed
pyright: 0 errors, 0 warnings, 0 informations
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ3wHDow49xBGUwWFPH2mD)_