### PR TITLE
fix: add tdd.enforce to generate_default_config() and regression tests (#340)

### DIFF
--- a/src/mapify_cli/config/project_config.py
+++ b/src/mapify_cli/config/project_config.py
@@ -682,6 +682,13 @@ minimality: lite
 # changed, at workflow completion (Stop hook). On by default; uncomment and set
 # to false to keep the IDs the framework wrote into comments/strings/test names.
 # scrub_internal_ids: true
+
+# TDD enforcement (#285). When true, /map-efficient automatically routes each
+# subtask's Actor phase through the TEST_WRITER → TEST_FAIL_GATE → ACTOR sequence
+# (equivalent to always running /map-tdd). Code written before a failing test is
+# treated as a TDD_VIOLATION by Monitor; spec-compliance and code-quality reviewer
+# subagents run after each subtask. Default OFF — existing workflows are unaffected.
+# tdd.enforce: false
 """
 
 

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,6 +1,7 @@
 """ST-005: MapConfig fields max_actors + retry_degraded_once, and clamp helper.
 ST-000: MapConfig fields concurrent_dispatch + max_wave_retries (5b config).
 Issue #285: tdd_enforce config flag and template content.
+Issue #340: generate_default_config() must document all active config options.
 
 Covers:
   VC1 — dotted-key aliasing and field parsing from YAML
@@ -11,6 +12,7 @@ Covers:
   VC6 (ST-000) — concurrent_dispatch + max_wave_retries are ACTIVE in runner/orchestrator (Slice 5b)
   VC7 (#285) — tdd.enforce dotted-key alias and field defaults
   VC8 (#285) — map-tdd SKILL.md and monitor.md template content
+  VC9 (#340) — generate_default_config() documents every active config option
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from mapify_cli.config.project_config import (
     MapConfig,
     clamp_max_actors,
     clamp_max_wave_retries,
+    generate_default_config,
     load_map_config,
 )
 
@@ -583,4 +586,44 @@ class TestVc8TddTemplateContent:
         content = self._monitor_content()
         assert "Rationalization detection" in content or "rationalization" in content.lower(), (
             "monitor.md must include rationalization detection patterns (#285)"
+        )
+
+
+class TestVc9DefaultConfigCompleteness:
+    """VC9 (#340): generate_default_config() must document every active config option.
+
+    Regression guard: any new MapConfig field that adds a load_map_config() alias
+    must also have a commented example block in generate_default_config() so users
+    can discover the option via `mapify init`.
+    """
+
+    def test_vc9_tdd_enforce_in_default_config(self) -> None:
+        cfg = generate_default_config()
+        assert "tdd.enforce" in cfg, (
+            "tdd.enforce must appear as a commented option in generate_default_config() "
+            "so users can discover it after `mapify init` (#340). "
+            "Add a commented block like '# tdd.enforce: false' to generate_default_config()."
+        )
+
+    def test_vc9_default_config_is_valid_yaml(self) -> None:
+        import yaml
+
+        cfg = generate_default_config()
+        # Strip comment-only lines to get parseable YAML
+        uncommented = "\n".join(
+            line for line in cfg.splitlines() if not line.lstrip().startswith("#")
+        )
+        # Must not raise
+        yaml.safe_load(uncommented)
+
+    def test_vc9_default_config_contains_known_options(self) -> None:
+        cfg = generate_default_config()
+        expected_options = [
+            "execution.max_actors",
+            "tdd.enforce",
+        ]
+        missing = [opt for opt in expected_options if opt not in cfg]
+        assert not missing, (
+            f"generate_default_config() is missing documentation for: {missing}. "
+            "Each MapConfig alias must have a corresponding commented block (#340)."
         )


### PR DESCRIPTION
## Summary

Fixes #340.

The `tdd.enforce` config option was introduced in #285 with:
- A `tdd_enforce: bool = False` field on `MapConfig`
- A `("tdd.enforce", "tdd_enforce")` alias in `load_map_config()`

But the corresponding documentation block was **not added** to `generate_default_config()`, meaning users who run `mapify init` had no way to discover this option in their generated `.map/config.yaml`.

## Changes

- **`src/mapify_cli/config/project_config.py`**: Added a commented example block for `tdd.enforce` in `generate_default_config()`, explaining what it does, when to use it, and that it defaults to off.

- **`tests/test_project_config.py`**: Added `TestVc9DefaultConfigCompleteness` — a regression test class that guards against future config options being silently omitted from `generate_default_config()`. Tests verify:
  - `tdd.enforce` appears in the generated default config
  - The generated config is valid YAML (after stripping comments)
  - All known active options (`execution.max_actors`, `tdd.enforce`) are documented

## Test plan

- [x] `uv run pytest tests/test_project_config.py -v` — 70 passed
- [x] `uv run ruff check src/ tests/test_project_config.py` — no issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEQFrmNrKSrpTMqULhrZGH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default configuration template to include a commented example for the TDD enforcement setting.
  * Improved configuration completeness checks so the generated default config stays valid and includes expected documented options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->