### PR TITLE
feat(#338): add mapify domain-skill init for project-local reference skill bootstrap

### DIFF
--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -159,6 +159,13 @@ code_map_app = typer.Typer(
 
 app.add_typer(code_map_app, name="code-map")
 
+domain_skill_app = typer.Typer(
+    name="domain-skill",
+    help="Bootstrap a project-local domain/reference skill for Claude Code.",
+)
+
+app.add_typer(domain_skill_app, name="domain-skill")
+
 
 def version_callback(value: bool):
     """Callback to show version and exit."""
@@ -2467,3 +2474,70 @@ def code_map_query(
 
     if result.status not in ("ok",):
         raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Domain-skill commands
+# ---------------------------------------------------------------------------
+
+
+@domain_skill_app.command("init")
+def domain_skill_init(
+    project_path: Optional[str] = typer.Argument(
+        None,
+        help="Project directory to bootstrap the domain skill in (default: current directory)",
+    ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        help="Skill name in kebab-case (default: <project-name>-domain)",
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Overwrite an existing domain skill file",
+    ),
+) -> None:
+    """Bootstrap a project-local domain/reference skill.
+
+    Scans README.md, pyproject.toml, package.json, go.mod, and Makefile to
+    extract factual content. Missing facts become explicit placeholders for you
+    to fill. No content is fabricated, and secrets are never read or emitted.
+
+    The generated .claude/skills/<name>/SKILL.md is yours — it is not a
+    MAP-managed shipped template and will not be overwritten by mapify init.
+
+    This differs from /map-learn: this skill provides day-one project context
+    before any workflow runs; /map-learn captures lessons after a run completes.
+
+    Examples:
+
+        mapify domain-skill init
+
+        mapify domain-skill init . --name myproject-domain
+
+        mapify domain-skill init /path/to/project --overwrite
+    """
+    from mapify_cli.delivery.domain_skill import create_domain_skill
+
+    target = Path(project_path) if project_path else Path.cwd()
+    if not target.exists():
+        console.print(f"[red]Error:[/red] Path does not exist: {target}")
+        raise typer.Exit(1)
+
+    skill_file, created = create_domain_skill(target, skill_name=name, overwrite=overwrite)
+
+    rel = skill_file.relative_to(target)
+    if created:
+        console.print(f"[green]Created[/green] {rel}")
+        console.print(
+            "[dim]Edit the file and replace placeholders with real project facts.[/dim]"
+        )
+        console.print(
+            "[dim]Do not commit secrets, tokens, passwords, or API keys into this file.[/dim]"
+        )
+    else:
+        console.print(
+            f"[yellow]Skipped:[/yellow] {rel} already exists"
+            " (use --overwrite to replace)"
+        )

--- a/src/mapify_cli/delivery/__init__.py
+++ b/src/mapify_cli/delivery/__init__.py
@@ -34,6 +34,7 @@ from mapify_cli.delivery.managed_file_copier import (
     extract_metadata,
     compute_hash,
 )
+from mapify_cli.delivery.domain_skill import create_domain_skill
 
 __all__ = [
     "BaseProvider",
@@ -61,4 +62,5 @@ __all__ = [
     "inject_metadata",
     "extract_metadata",
     "compute_hash",
+    "create_domain_skill",
 ]

--- a/src/mapify_cli/delivery/domain_skill.py
+++ b/src/mapify_cli/delivery/domain_skill.py
@@ -1,0 +1,264 @@
+"""Domain skill bootstrap for project-local reference skills.
+
+Generates a minimal, fact-backed .claude/skills/<name>/SKILL.md without
+fabricating content: discovered facts come from local files; missing data
+becomes explicit placeholders for the user to fill.
+
+This is a project-local skill, not a MAP-managed shipped template. It is
+intentionally excluded from skill-rules.json's global catalog so it never
+conflicts with MAP's own shipped skill set.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+
+# File globs that may contain secrets — never read their content.
+_SECRET_FILENAMES = re.compile(
+    r"(\.env|credentials|secrets|\.pem|\.key|id_rsa|\.pfx|\.p12)",
+    re.IGNORECASE,
+)
+
+# Makefile targets that are clearly safe/read-only.
+_SAFE_MAKE_TARGETS = frozenset(
+    ["check", "test", "lint", "build", "run", "dev", "start", "format", "fmt", "help"]
+)
+
+# npm scripts that are clearly safe.
+_SAFE_NPM_SCRIPTS = frozenset(
+    ["test", "lint", "build", "dev", "start", "format", "typecheck", "check"]
+)
+
+# Top-level directory names worth surfacing in the layout section.
+_CANDIDATE_DIRS = (
+    "src", "lib", "pkg", "cmd", "app", "api",
+    "tests", "test", "docs", "scripts", "configs",
+)
+
+
+def _extract_project_name(project_path: Path) -> str:
+    """Extract the project name from common config files or directory name."""
+    pyproject = project_path / "pyproject.toml"
+    if pyproject.exists():
+        text = pyproject.read_text(encoding="utf-8", errors="replace")
+        m = re.search(r'^\s*name\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+        if m:
+            return m.group(1)
+
+    pkg = project_path / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+            if isinstance(data.get("name"), str) and data["name"]:
+                return data["name"]
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    go_mod = project_path / "go.mod"
+    if go_mod.exists():
+        text = go_mod.read_text(encoding="utf-8", errors="replace")
+        m = re.search(r"^module\s+(\S+)", text, re.MULTILINE)
+        if m:
+            return m.group(1).rstrip("/").rsplit("/", 1)[-1]
+
+    return project_path.resolve().name
+
+
+def _extract_readme_summary(project_path: Path) -> Optional[str]:
+    """Return the first meaningful non-heading line from README.md, if any."""
+    for readme_name in ("README.md", "readme.md", "Readme.md"):
+        readme = project_path / readme_name
+        if readme.exists():
+            text = readme.read_text(encoding="utf-8", errors="replace")
+            for line in text.splitlines():
+                stripped = line.strip()
+                if (
+                    stripped
+                    and not stripped.startswith("#")
+                    and not stripped.startswith("!")
+                    and not stripped.startswith("[!")
+                    and not stripped.startswith("[![")
+                ):
+                    return stripped[:200]
+            break
+    return None
+
+
+def _extract_key_dirs(project_path: Path) -> list[str]:
+    """Identify top-level source directories worth surfacing."""
+    found = []
+    for candidate in _CANDIDATE_DIRS:
+        if (project_path / candidate).is_dir():
+            found.append(candidate)
+        if len(found) >= 5:
+            break
+    return found
+
+
+def _extract_safe_commands(project_path: Path) -> list[str]:
+    """Extract read-only / safe commands from Makefile or package.json scripts."""
+    commands: list[str] = []
+
+    makefile = project_path / "Makefile"
+    if makefile.exists():
+        text = makefile.read_text(encoding="utf-8", errors="replace")
+        targets = re.findall(r"^([a-zA-Z][a-zA-Z0-9_-]*)\s*:", text, re.MULTILINE)
+        for t in targets:
+            if t.lower() in _SAFE_MAKE_TARGETS and f"make {t}" not in commands:
+                commands.append(f"make {t}")
+            if len(commands) >= 4:
+                break
+
+    pkg = project_path / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+            scripts = data.get("scripts", {}) if isinstance(data, dict) else {}
+            for name in _SAFE_NPM_SCRIPTS:
+                if name in scripts:
+                    commands.append(f"npm run {name}")
+                if len(commands) >= 6:
+                    break
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    pyproject = project_path / "pyproject.toml"
+    if pyproject.exists() and not any("pytest" in c for c in commands):
+        commands.append("pytest tests/")
+
+    return commands[:6]
+
+
+def _make_skill_name(raw_name: str) -> str:
+    """Normalize a project name to a valid kebab-case skill name."""
+    name = raw_name.lower()
+    name = re.sub(r"[^a-z0-9]+", "-", name)
+    name = name.strip("-")
+    return name or "project-domain"
+
+
+def _resolve_skill_name(user_name: Optional[str], project_path: Path) -> str:
+    """Determine the final skill name from user override or project detection."""
+    if user_name:
+        return _make_skill_name(user_name)
+    project_name = _extract_project_name(project_path)
+    return _make_skill_name(project_name) + "-domain"
+
+
+def _build_skill_md(
+    skill_name: str,
+    project_name: str,
+    summary: Optional[str],
+    key_dirs: list[str],
+    safe_commands: list[str],
+) -> str:
+    """Assemble the SKILL.md content from discovered facts and explicit placeholders."""
+    description = (
+        f"Project-specific domain context for {project_name}. "
+        f"Use when working on {project_name} code, asking about project-specific "
+        f"commands, repo layout, or domain terms. "
+        f"Do NOT use for general MAP workflow commands (use map-efficient, map-plan, etc.) "
+        f"or for cross-project questions."
+    )
+
+    purpose_line = (
+        summary
+        if summary
+        else f"<!-- TODO: one-line description of {project_name} -->"
+    )
+
+    layout_block = ""
+    if key_dirs:
+        layout_block = "## Repo Layout\n\n"
+        for d in key_dirs:
+            layout_block += f"- `{d}/` — <!-- TODO: brief description -->\n"
+        layout_block += "\n"
+
+    commands_block = ""
+    if safe_commands:
+        commands_block = "## Key Commands\n\n"
+        for cmd in safe_commands:
+            commands_block += f"- `{cmd}`\n"
+        commands_block += "\n"
+
+    return (
+        f"---\n"
+        f"name: {skill_name}\n"
+        f"description: >-\n"
+        f"  {description}\n"
+        f"---\n"
+        f"# {skill_name} — Project Domain Reference\n"
+        f"\n"
+        f"> Generated by `mapify domain-skill init`. Edit freely; this file is yours.\n"
+        f"> Replace placeholders with real project facts discovered from local files.\n"
+        f"> **Never commit secrets, tokens, passwords, or API keys into this file.**\n"
+        f"\n"
+        f"## Purpose\n"
+        f"\n"
+        f"{purpose_line}\n"
+        f"\n"
+        f"{layout_block}"
+        f"{commands_block}"
+        f"## Domain Glossary\n"
+        f"\n"
+        f"<!-- TODO: list key domain terms and their definitions -->\n"
+        f"<!-- Example:\n"
+        f"- **WidgetId**: UUID identifying a Widget resource.\n"
+        f"-->\n"
+        f"\n"
+        f"## Safety Boundaries\n"
+        f"\n"
+        f"<!-- TODO: list files or systems this project must never modify -->\n"
+        f"\n"
+        f"## How This Differs From /map-learn\n"
+        f"\n"
+        f"- `/map-learn` captures post-workflow lessons after a run completes.\n"
+        f"- This skill provides day-one project context before any workflow runs.\n"
+        f"- Edit here when you discover stable project-specific knowledge worth persisting.\n"
+    )
+
+
+def create_domain_skill(
+    project_path: Path,
+    *,
+    skill_name: Optional[str] = None,
+    overwrite: bool = False,
+) -> tuple[Path, bool]:
+    """
+    Scaffold a project-local reference skill under .claude/skills/<name>/SKILL.md.
+
+    Scans common project files (README.md, pyproject.toml, package.json, go.mod,
+    Makefile) to extract factual content. Missing facts become explicit placeholders.
+    Secrets are never read or emitted.
+
+    Args:
+        project_path: Root of the target project.
+        skill_name: Optional explicit skill name (kebab-case). Defaults to
+            ``<project-name>-domain`` derived from config files.
+        overwrite: If True, overwrite an existing SKILL.md. Defaults to False.
+
+    Returns:
+        (skill_file, created) where created=False when the file already existed
+        and overwrite=False (no write performed).
+    """
+    resolved_name = _resolve_skill_name(skill_name, project_path)
+    project_name = _extract_project_name(project_path)
+
+    summary = _extract_readme_summary(project_path)
+    key_dirs = _extract_key_dirs(project_path)
+    safe_commands = _extract_safe_commands(project_path)
+
+    skill_dir = project_path / ".claude" / "skills" / resolved_name
+    skill_file = skill_dir / "SKILL.md"
+
+    if skill_file.exists() and not overwrite:
+        return skill_file, False
+
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = _build_skill_md(resolved_name, project_name, summary, key_dirs, safe_commands)
+    skill_file.write_text(content, encoding="utf-8")
+    return skill_file, True

--- a/tests/test_domain_skill.py
+++ b/tests/test_domain_skill.py
@@ -1,0 +1,371 @@
+"""Tests for mapify domain-skill init command and domain skill scaffold generator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mapify_cli import app
+from mapify_cli.delivery.domain_skill import (
+    _extract_key_dirs,
+    _extract_project_name,
+    _extract_readme_summary,
+    _extract_safe_commands,
+    _make_skill_name,
+    _resolve_skill_name,
+    create_domain_skill,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractProjectName:
+    def test_from_pyproject_toml(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-cool-lib"\n')
+        assert _extract_project_name(tmp_path) == "my-cool-lib"
+
+    def test_from_pyproject_toml_with_tool_section(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.poetry]\nname = 'poetry-project'\n"
+        )
+        assert _extract_project_name(tmp_path) == "poetry-project"
+
+    def test_from_package_json(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text('{"name": "my-app", "version": "1.0.0"}')
+        assert _extract_project_name(tmp_path) == "my-app"
+
+    def test_from_go_mod(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text("module github.com/org/my-service\n\ngo 1.21\n")
+        assert _extract_project_name(tmp_path) == "my-service"
+
+    def test_from_go_mod_simple(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text("module my-service\n")
+        assert _extract_project_name(tmp_path) == "my-service"
+
+    def test_fallback_to_dir_name(self, tmp_path: Path) -> None:
+        result = _extract_project_name(tmp_path)
+        assert result == tmp_path.name
+
+    def test_prefers_pyproject_over_package_json(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "pyproject-name"\n')
+        (tmp_path / "package.json").write_text('{"name": "pkg-name"}')
+        assert _extract_project_name(tmp_path) == "pyproject-name"
+
+    def test_invalid_package_json_falls_through(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text("not json {")
+        result = _extract_project_name(tmp_path)
+        assert result == tmp_path.name
+
+
+class TestExtractReadmeSummary:
+    def test_extracts_first_paragraph(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text(
+            "# Title\n\nThis is the summary line.\n\nMore text."
+        )
+        assert _extract_readme_summary(tmp_path) == "This is the summary line."
+
+    def test_no_readme(self, tmp_path: Path) -> None:
+        assert _extract_readme_summary(tmp_path) is None
+
+    def test_skips_headings(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("# Title\n## Sub\nActual summary.\n")
+        assert _extract_readme_summary(tmp_path) == "Actual summary."
+
+    def test_skips_badges(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text(
+            "# Title\n[![badge](url)]\n\nActual summary.\n"
+        )
+        result = _extract_readme_summary(tmp_path)
+        assert result == "Actual summary."
+
+    def test_truncates_long_line(self, tmp_path: Path) -> None:
+        long_line = "A" * 300
+        (tmp_path / "README.md").write_text(f"# T\n{long_line}\n")
+        result = _extract_readme_summary(tmp_path)
+        assert result is not None
+        assert len(result) <= 200
+
+
+class TestExtractKeyDirs:
+    def test_finds_src_and_tests(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        dirs = _extract_key_dirs(tmp_path)
+        assert "src" in dirs
+        assert "tests" in dirs
+
+    def test_empty_project(self, tmp_path: Path) -> None:
+        dirs = _extract_key_dirs(tmp_path)
+        assert dirs == []
+
+    def test_ignores_non_candidate_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / ".git").mkdir()
+        dirs = _extract_key_dirs(tmp_path)
+        assert "node_modules" not in dirs
+        assert ".git" not in dirs
+
+    def test_limits_to_five(self, tmp_path: Path) -> None:
+        for d in ("src", "lib", "pkg", "cmd", "app", "api"):
+            (tmp_path / d).mkdir()
+        dirs = _extract_key_dirs(tmp_path)
+        assert len(dirs) <= 5
+
+
+class TestExtractSafeCommands:
+    def test_from_makefile(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text(
+            "test:\n\tpytest\ncheck:\n\truff check .\nlint:\n\truff .\ndeploy:\n\t./deploy.sh\n"
+        )
+        cmds = _extract_safe_commands(tmp_path)
+        assert "make test" in cmds
+        assert "make check" in cmds
+        assert "make lint" in cmds
+        assert "make deploy" not in cmds
+
+    def test_from_package_json(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"test": "jest", "build": "tsc", "deploy": "aws s3 sync"}})
+        )
+        cmds = _extract_safe_commands(tmp_path)
+        assert "npm run test" in cmds
+        assert "npm run build" in cmds
+        assert "npm run deploy" not in cmds
+
+    def test_adds_pytest_for_python_project(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+        cmds = _extract_safe_commands(tmp_path)
+        assert "pytest tests/" in cmds
+
+    def test_empty_project(self, tmp_path: Path) -> None:
+        cmds = _extract_safe_commands(tmp_path)
+        assert isinstance(cmds, list)
+
+    def test_limits_output(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text(
+            "check:\n\t:\ntest:\n\t:\nlint:\n\t:\nbuild:\n\t:\nrun:\n\t:\nfmt:\n\t:\n"
+        )
+        cmds = _extract_safe_commands(tmp_path)
+        assert len(cmds) <= 6
+
+
+class TestMakeSkillName:
+    def test_kebab_case(self) -> None:
+        assert _make_skill_name("My Project") == "my-project"
+
+    def test_already_valid(self) -> None:
+        assert _make_skill_name("my-skill") == "my-skill"
+
+    def test_special_chars_replaced(self) -> None:
+        assert _make_skill_name("org/my.project_v2") == "org-my-project-v2"
+
+    def test_consecutive_separators_collapsed(self) -> None:
+        result = _make_skill_name("my  project")
+        assert "--" not in result
+
+    def test_empty_input_fallback(self) -> None:
+        assert _make_skill_name("") == "project-domain"
+
+    def test_only_special_chars_fallback(self) -> None:
+        assert _make_skill_name("!!!") == "project-domain"
+
+
+class TestResolveSkillName:
+    def test_user_name_takes_precedence(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "ignored"\n')
+        assert _resolve_skill_name("custom-name", tmp_path) == "custom-name"
+
+    def test_derives_from_project_name(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-lib"\n')
+        result = _resolve_skill_name(None, tmp_path)
+        assert result == "my-lib-domain"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: create_domain_skill
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDomainSkill:
+    def test_creates_skill_file_in_empty_project(self, tmp_path: Path) -> None:
+        skill_file, created = create_domain_skill(tmp_path)
+        assert created is True
+        assert skill_file.exists()
+        assert skill_file.name == "SKILL.md"
+
+    def test_skill_placed_in_claude_skills(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        assert skill_file.parent.parent.name == "skills"
+        assert skill_file.parent.parent.parent.name == ".claude"
+
+    def test_frontmatter_has_name_and_description(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert content.startswith("---")
+        assert "\nname:" in content
+        assert "\ndescription:" in content
+
+    def test_frontmatter_has_do_not_use_trigger(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert "Do NOT" in content
+
+    def test_skips_existing_without_overwrite(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        skill_file.write_text("sentinel content")
+        _, created = create_domain_skill(tmp_path)
+        assert created is False
+        assert skill_file.read_text() == "sentinel content"
+
+    def test_overwrite_replaces_existing(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        skill_file.write_text("old content")
+        skill_file2, created = create_domain_skill(tmp_path, overwrite=True)
+        assert created is True
+        assert skill_file2.read_text() != "old content"
+        assert "\nname:" in skill_file2.read_text()
+
+    def test_includes_readme_summary(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("# P\n\nA great project.\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "p"\n')
+        skill_file, _ = create_domain_skill(tmp_path)
+        assert "A great project." in skill_file.read_text()
+
+    def test_includes_key_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert "src/" in content
+        assert "tests/" in content
+
+    def test_includes_safe_commands(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text("test:\n\tpytest\ncheck:\n\truff .\n")
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert "make test" in content or "make check" in content
+
+    def test_custom_skill_name(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path, skill_name="my-custom-skill")
+        assert skill_file.parent.name == "my-custom-skill"
+        assert "name: my-custom-skill" in skill_file.read_text()
+
+    def test_no_secret_values_emitted(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"\n')
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text().lower()
+        # The warning is present but no real secret values are in the output
+        for token in ("password=", "api_key=", "secret=", "token=abc"):
+            assert token not in content
+
+    def test_placeholder_when_no_readme(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert "TODO" in content
+
+    def test_no_fabricated_dir_entries(self, tmp_path: Path) -> None:
+        # When no candidate dirs exist, no layout block is emitted
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert "## Repo Layout" not in content
+
+    def test_has_map_learn_difference_section(self, tmp_path: Path) -> None:
+        skill_file, _ = create_domain_skill(tmp_path)
+        content = skill_file.read_text()
+        assert "/map-learn" in content
+
+    def test_full_project_docs_present_path(self, tmp_path: Path) -> None:
+        """Full path: pyproject + README + Makefile + src/tests dirs."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "fullproject"\n')
+        (tmp_path / "README.md").write_text("# Full\n\nFull project description.\n")
+        (tmp_path / "Makefile").write_text("test:\n\tpytest\ncheck:\n\truff .\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+
+        skill_file, created = create_domain_skill(tmp_path)
+        assert created is True
+        content = skill_file.read_text()
+        assert "fullproject" in content
+        assert "Full project description." in content
+        assert "src/" in content
+        assert "tests/" in content
+        assert "make test" in content or "make check" in content
+        assert "## Domain Glossary" in content
+        assert "## Safety Boundaries" in content
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDomainSkillCliCommand:
+    def test_init_creates_skill_in_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["domain-skill", "init"])
+        assert result.exit_code == 0, result.output
+        assert "Created" in result.output
+        skills_dir = tmp_path / ".claude" / "skills"
+        assert skills_dir.exists()
+        skill_dirs = list(skills_dir.iterdir())
+        assert len(skill_dirs) == 1
+        assert (skill_dirs[0] / "SKILL.md").exists()
+
+    def test_init_with_explicit_path(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Created" in result.output
+
+    def test_init_with_custom_name(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["domain-skill", "init", str(tmp_path), "--name", "my-domain"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".claude" / "skills" / "my-domain" / "SKILL.md").exists()
+
+    def test_init_skips_existing_by_default(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        result = runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Skipped" in result.output
+
+    def test_init_overwrite_replaces(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        result = runner.invoke(
+            app, ["domain-skill", "init", str(tmp_path), "--overwrite"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Created" in result.output
+
+    def test_init_nonexistent_path_exits_1(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["domain-skill", "init", str(tmp_path / "nonexistent")]
+        )
+        assert result.exit_code == 1
+
+    def test_init_output_mentions_placeholders(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "placeholder" in result.output.lower() or "Edit" in result.output
+
+    def test_init_warns_about_secrets(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "secret" in result.output.lower() or "token" in result.output.lower()
+
+    def test_init_produces_valid_frontmatter(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["domain-skill", "init", str(tmp_path)])
+        skill_files = list((tmp_path / ".claude" / "skills").glob("*/SKILL.md"))
+        assert len(skill_files) == 1
+        content = skill_files[0].read_text()
+        assert content.startswith("---\n")
+        # Must have closing frontmatter delimiter
+        assert "\n---\n" in content


### PR DESCRIPTION
## Summary

Closes #338

- Adds `mapify domain-skill init [PATH] [--name NAME] [--overwrite]` CLI command that scaffolds a project-local `.claude/skills/<name>/SKILL.md`
- Scans `pyproject.toml`, `package.json`, `go.mod`, `README.md`, and `Makefile`/`package.json` scripts to discover real project facts; unknown data becomes explicit `TODO` placeholders
- Secret files (`.env`, credentials, keys, PEM) are never read; generated skill and CLI output both warn against committing secrets/tokens/passwords
- Generated skill is intentionally excluded from `skill-rules.json` so it never conflicts with MAP's shipped global skill catalog
- The skill distinguishes itself from `/map-learn` in a dedicated section

## Changes

**New files:**
- `src/mapify_cli/delivery/domain_skill.py` — core scaffold generator with helpers: `_extract_project_name`, `_extract_readme_summary`, `_extract_key_dirs`, `_extract_safe_commands`, `_make_skill_name`, `_resolve_skill_name`, `_build_skill_md`, `create_domain_skill`
- `tests/test_domain_skill.py` — 54 tests covering all helpers and CLI integration via `typer.testing.CliRunner`

**Modified files:**
- `src/mapify_cli/__init__.py` — registers `domain-skill` Typer subcommand group with `init` command
- `src/mapify_cli/delivery/__init__.py` — exports `create_domain_skill`

## Test plan

- [x] 54 new unit + CLI integration tests — all green
- [x] 3501 total tests: 3501 passed, 4 skipped
- [x] `ruff check src/ tests/` — 0 issues
- [x] `python -m pyright src/` — 0 errors, 0 warnings
- [x] `make check-render` — generated trees match templates_src (no render changes needed; domain skill uses inline generation, not Jinja templates)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FBjHTvYrrSfM5X5xEKXe8u)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `mapify domain-skill` command group.
  * Added `mapify domain-skill init` to generate a project-local Claude Code skill with optional custom name and overwrite support.
  * Skill generation now uses project details to create a structured `SKILL.md` with repository layout, key commands, glossary, and safety guidance.

* **Bug Fixes**
  * Existing skill files are now preserved unless overwrite is explicitly requested.
  * Clear errors are shown when the target project path does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->