### PR TITLE
feat(#342): add mapify governance report for MAP behavior-shaping asset inventory

### DIFF
--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -166,6 +166,13 @@ domain_skill_app = typer.Typer(
 
 app.add_typer(domain_skill_app, name="domain-skill")
 
+governance_app = typer.Typer(
+    name="governance",
+    help="Inventory and audit MAP behavior-shaping assets installed in a project.",
+)
+
+app.add_typer(governance_app, name="governance")
+
 
 def version_callback(value: bool):
     """Callback to show version and exit."""
@@ -2541,3 +2548,73 @@ def domain_skill_init(
             f"[yellow]Skipped:[/yellow] {rel} already exists"
             " (use --overwrite to replace)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Governance commands
+# ---------------------------------------------------------------------------
+
+
+@governance_app.command("report")
+def governance_report(
+    project_path: Optional[str] = typer.Argument(
+        None,
+        help="Project directory to audit (default: current directory)",
+    ),
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Output the report as JSON instead of Markdown",
+    ),
+    out: Optional[str] = typer.Option(
+        None,
+        "--out",
+        help="Write the report to a file instead of stdout",
+    ),
+) -> None:
+    """Generate a governance report for MAP behavior-shaping assets.
+
+    Inventories installed skills, hooks, references, and learned rules in the
+    .claude/ directory and classifies each asset under six governance categories:
+    Charter, Policy, Context, Harness, Oversight, Learning.
+
+    Distinguishes enforced controls (runtime hooks) from prompt-only guidance
+    (skills, references, learned rules) and lists governance gaps where
+    policy claims rely solely on prompt text without a backing harness control.
+
+    Examples:
+
+        mapify governance report
+
+        mapify governance report /path/to/project
+
+        mapify governance report --json --out .map/governance.json
+    """
+    from mapify_cli.delivery.governance_report import build_governance_report
+
+    target = Path(project_path) if project_path else Path.cwd()
+    if not target.exists():
+        console.print(f"[red]Error:[/red] Path does not exist: {target}")
+        raise typer.Exit(1)
+
+    report = build_governance_report(target)
+
+    if not report.assets:
+        console.print(
+            f"[yellow]No MAP assets found[/yellow] in {target} — "
+            "run 'mapify init' first to install the MAP framework."
+        )
+        raise typer.Exit(1)
+
+    content = report.as_json() if output_json else report.as_markdown()
+
+    if out is not None:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(content, encoding="utf-8")
+        console.print(f"[green]Written[/green] {out_path}")
+    elif output_json:
+        # Bypass Rich to avoid ANSI escape codes in JSON output
+        typer.echo(content)
+    else:
+        console.print(content)

--- a/src/mapify_cli/delivery/__init__.py
+++ b/src/mapify_cli/delivery/__init__.py
@@ -35,6 +35,11 @@ from mapify_cli.delivery.managed_file_copier import (
     compute_hash,
 )
 from mapify_cli.delivery.domain_skill import create_domain_skill
+from mapify_cli.delivery.governance_report import (
+    GovernanceAsset,
+    GovernanceReport,
+    build_governance_report,
+)
 
 __all__ = [
     "BaseProvider",
@@ -63,4 +68,7 @@ __all__ = [
     "extract_metadata",
     "compute_hash",
     "create_domain_skill",
+    "GovernanceAsset",
+    "GovernanceReport",
+    "build_governance_report",
 ]

--- a/src/mapify_cli/delivery/governance_report.py
+++ b/src/mapify_cli/delivery/governance_report.py
@@ -1,0 +1,612 @@
+"""Governance report for MAP behavior-shaping assets.
+
+Inventories installed skills, hooks, references, and learned rules in a
+.claude/ directory and classifies each asset under six governance categories:
+Charter, Policy, Context, Harness, Oversight, Learning.
+
+Distinguishes enforced controls (hooks that run at the harness layer) from
+prompt-only guidance (skills, references, learned rules).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Governance categories
+# ---------------------------------------------------------------------------
+
+CATEGORIES: list[str] = [
+    "charter",
+    "policy",
+    "context",
+    "harness",
+    "oversight",
+    "learning",
+]
+
+CATEGORY_DESCRIPTIONS: dict[str, str] = {
+    "charter": "Defines why workflows exist, where they apply, and where they must not be used",
+    "policy": "Non-negotiable constraints enforced at the harness or credential level",
+    "context": "Controls what the agent can see and what it is optimizing for",
+    "harness": "Permissions, checks, proof requirements, and recovery paths",
+    "oversight": "Accountability, escalation thresholds, pause/stop authority, and risk ownership",
+    "learning": "Mechanisms that turn repeated failures into rules, skills, controls, or evals",
+}
+
+# ---------------------------------------------------------------------------
+# Static classification tables
+# ---------------------------------------------------------------------------
+
+#: Default descriptions for known hooks (enforcement = "enforced")
+_HOOK_META: dict[str, tuple[str, str]] = {
+    # name -> (category, description)
+    "safety-guardrails.py": (
+        "policy",
+        "Denies dangerous commands and sensitive-file access at the shell level",
+    ),
+    "workflow-gate.py": (
+        "harness",
+        "Returns permissionDecision=deny for out-of-phase or out-of-scope edits",
+    ),
+    "context-meter.py": (
+        "context",
+        "Measures context window utilization and emits a usage signal",
+    ),
+    "workflow-context-injector.py": (
+        "context",
+        "Injects branch-scoped workflow artifacts into the agent context",
+    ),
+    "map-memory-capture.py": (
+        "learning",
+        "Captures per-turn scratch memory for end-of-session finalization",
+    ),
+    "map-memory-recall.py": (
+        "context",
+        "Injects recalled session memory and learned rules into context at session start",
+    ),
+    "map-memory-finalize.py": (
+        "learning",
+        "Finalizes and persists session memory digests to .map/<branch>/",
+    ),
+    "map-memory-endmark.py": (
+        "learning",
+        "Emits end-of-session marker for memory boundary detection",
+    ),
+    "end-of-turn.sh": (
+        "oversight",
+        "Runs end-of-turn housekeeping and token accounting summary",
+    ),
+    "map-statusline.py": (
+        "oversight",
+        "Renders the MAP workflow status line in the terminal",
+    ),
+    "map-token-meter.py": (
+        "oversight",
+        "Records per-turn token usage for cost accounting and budget enforcement",
+    ),
+    "post-compact-context.py": (
+        "context",
+        "Restores essential MAP context after a conversation compaction event",
+    ),
+    "pre-compact-save-transcript.py": (
+        "learning",
+        "Saves the pre-compaction transcript for future session recall",
+    ),
+    "ralph-context-pruner.py": (
+        "context",
+        "Prunes low-value context entries to preserve budget for high-value signals",
+    ),
+    "ralph-iteration-logger.py": (
+        "oversight",
+        "Logs each RALPH iteration attempt for escalation and recovery audit",
+    ),
+    "detect-clarification-triggers.py": (
+        "harness",
+        "Detects prompts that should trigger clarification instead of silent assumption",
+    ),
+    "scrub-internal-ids.py": (
+        "policy",
+        "Strips internal IDs and private platform details from emitted content",
+    ),
+}
+
+#: Default categories for known skills (enforcement = "prompt-only")
+_SKILL_META: dict[str, tuple[str, str]] = {
+    # name -> (category, description from skill-rules.json or best-known)
+    "map-state": (
+        "charter",
+        "File-based planning with branch-scoped task tracking",
+    ),
+    "map-plan": (
+        "charter",
+        "ARCHITECT phase: decompose a complex task into atomic subtasks",
+    ),
+    "map-efficient": (
+        "harness",
+        "Token-efficient MAP workflow with state-machine orchestration",
+    ),
+    "map-fast": (
+        "harness",
+        "Minimal MAP workflow for small low-risk changes (no Predictor/Reflector)",
+    ),
+    "map-tdd": (
+        "harness",
+        "TDD MAP workflow: spec-driven tests written before implementation",
+    ),
+    "map-check": (
+        "harness",
+        "Run quality gates (lint, types, tests) and verify MAP workflow completion",
+    ),
+    "map-debug": (
+        "harness",
+        "Structured MAP debugging via task-decomposer, actor, monitor agents",
+    ),
+    "map-task": (
+        "harness",
+        "Execute a single subtask from an existing MAP plan",
+    ),
+    "map-review": (
+        "harness",
+        "Interactive code review using Monitor, Predictor, Evaluator agents",
+    ),
+    "map-learn": (
+        "learning",
+        "Extract and persist workflow lessons to .claude/rules/learned/",
+    ),
+    "map-memory-now": (
+        "learning",
+        "On-demand finalize of session memory (current scratch + --finalize-all sweep)",
+    ),
+    "map-skill-eval": (
+        "learning",
+        "Evaluate a skill's trigger accuracy and cost, or optimize its description",
+    ),
+    "map-tokenreport": (
+        "oversight",
+        "Render per-subtask/agent token accounting for the current branch",
+    ),
+    "map-resume": (
+        "oversight",
+        "Resume an interrupted MAP workflow from step_state.json checkpoint",
+    ),
+    "map-release": (
+        "oversight",
+        "Execute mapify-cli package release workflow with validation gates",
+    ),
+    "map-explain": (
+        "context",
+        "Deep code/PR explanation that builds a complete mental model",
+    ),
+    "map-understand": (
+        "context",
+        "Interactive deep-understanding and quiz mode for incremental teaching",
+    ),
+    "map-so-search": (
+        "context",
+        "Opt-in read-only prior-art search against Stack Overflow for Agents (SOFA)",
+    ),
+}
+
+#: Default categories for known references (enforcement = "prompt-only")
+_REFERENCE_META: dict[str, tuple[str, str]] = {
+    "bash-guidelines.md": ("policy", "Safe bash command patterns for MAP workflow scripts"),
+    "decomposition-examples.md": ("context", "Reference examples for task decomposition"),
+    "escalation-matrix.md": ("oversight", "Escalation paths and thresholds for MAP workflows"),
+    "hook-patterns.md": ("harness", "Canonical patterns for MAP hook authoring"),
+    "host-paths.md": ("harness", "Authoritative host paths for MAP-managed directories"),
+    "map-json-output-contracts.md": (
+        "harness",
+        "JSON schema contracts for agent output validation",
+    ),
+    "map-output-examples.md": ("context", "Canonical output examples for MAP agents"),
+    "map-xml-prompt-envelopes.md": ("harness", "XML prompt envelope schemas and usage"),
+    "mcp-usage-examples.md": ("context", "MCP server usage examples for MAP workflows"),
+    "step-state-schema.md": ("harness", "Schema for step_state.json workflow state file"),
+    "workflow-state-schema.md": ("harness", "Schema for MAP workflow state artifacts"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GovernanceAsset:
+    """A single behavior-shaping asset with its governance metadata."""
+
+    name: str
+    kind: str  # "hook" | "skill" | "reference" | "learned-rule" | "config"
+    category: str
+    enforcement: str  # "enforced" | "prompt-only"
+    description: str
+    path: str  # relative to project root
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "category": self.category,
+            "enforcement": self.enforcement,
+            "description": self.description,
+            "path": self.path,
+        }
+
+
+@dataclass
+class GovernanceReport:
+    """Compiled governance inventory for a MAP installation."""
+
+    project_path: Path
+    assets: list[GovernanceAsset] = field(default_factory=list)
+    gaps: list[str] = field(default_factory=list)
+    skill_rules_version: Optional[str] = None
+
+    # ------------------------------------------------------------------ #
+    # Derived views                                                        #
+    # ------------------------------------------------------------------ #
+
+    def by_category(self) -> dict[str, list[GovernanceAsset]]:
+        result: dict[str, list[GovernanceAsset]] = {c: [] for c in CATEGORIES}
+        for asset in self.assets:
+            result.setdefault(asset.category, []).append(asset)
+        return result
+
+    def enforced_count(self) -> int:
+        return sum(1 for a in self.assets if a.enforcement == "enforced")
+
+    def prompt_only_count(self) -> int:
+        return sum(1 for a in self.assets if a.enforcement == "prompt-only")
+
+    # ------------------------------------------------------------------ #
+    # JSON export                                                          #
+    # ------------------------------------------------------------------ #
+
+    def as_json(self) -> str:
+        by_cat = {cat: len(assets) for cat, assets in self.by_category().items()}
+        return json.dumps(
+            {
+                "version": "1.0",
+                "project": str(self.project_path),
+                "skill_rules_version": self.skill_rules_version,
+                "summary": {
+                    "total": len(self.assets),
+                    "by_category": by_cat,
+                    "enforced": self.enforced_count(),
+                    "prompt_only": self.prompt_only_count(),
+                    "gap_count": len(self.gaps),
+                },
+                "assets": [a.as_dict() for a in self.assets],
+                "gaps": self.gaps,
+            },
+            indent=2,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Markdown export                                                      #
+    # ------------------------------------------------------------------ #
+
+    def as_markdown(self) -> str:
+        lines: list[str] = []
+        lines.append("# MAP Governance Report\n")
+        lines.append(f"**Project:** `{self.project_path}`  ")
+        if self.skill_rules_version:
+            lines.append(f"**skill-rules version:** {self.skill_rules_version}  ")
+        lines.append(
+            f"**Assets:** {len(self.assets)} total "
+            f"({self.enforced_count()} enforced, "
+            f"{self.prompt_only_count()} prompt-only)  "
+        )
+        lines.append("")
+
+        lines.append("## Summary\n")
+        lines.append(
+            f"{len(self.assets)} behavior-shaping assets found across "
+            f"{len(CATEGORIES)} governance categories."
+        )
+        lines.append(
+            f"- **{self.enforced_count()} enforced** controls (runtime hooks that "
+            f"block or modify behavior deterministically)"
+        )
+        lines.append(
+            f"- **{self.prompt_only_count()} prompt-only** assets (skills, references, "
+            f"and learned rules that shape behavior through context injection)"
+        )
+        lines.append("")
+
+        by_cat = self.by_category()
+        for category in CATEGORIES:
+            assets = by_cat.get(category, [])
+            title = category.capitalize()
+            lines.append(f"## {title}\n")
+            lines.append(f"*{CATEGORY_DESCRIPTIONS[category]}*\n")
+            if not assets:
+                lines.append("*(no assets in this category)*\n")
+            else:
+                for a in assets:
+                    badge = "**enforced**" if a.enforcement == "enforced" else "prompt-only"
+                    lines.append(f"- `[{a.kind}]` **{a.name}** — {badge}")
+                    lines.append(f"  {a.description}  ")
+                    lines.append(f"  `{a.path}`")
+                lines.append("")
+
+        if self.gaps:
+            lines.append("## Gaps\n")
+            lines.append(
+                "The following prompt-only controls lack a backing enforced hook or permission "
+                "gate. Consider adding a harness-level check or documenting the accepted risk.\n"
+            )
+            for gap in self.gaps:
+                lines.append(f"- {gap}")
+            lines.append("")
+
+        lines.append("## Evidence Artifacts\n")
+        lines.append(
+            "The following MAP artifacts are available for audit in the installed `.claude/` "
+            "directory:\n"
+        )
+        lines.append("| Artifact | Purpose |")
+        lines.append("|---|---|")
+        lines.append(
+            "| `.claude/skills/skill-rules.json` | Complete skill catalog with trigger "
+            "patterns, enforcement levels, and runtime effects |"
+        )
+        lines.append(
+            "| `.claude/hooks/` | All installed hook scripts (runtime enforced controls) |"
+        )
+        lines.append(
+            "| `.claude/references/` | Reference documentation injected into agent context |"
+        )
+        lines.append(
+            "| `.claude/rules/learned/` | Accumulated project-specific lessons from MAP "
+            "workflows |"
+        )
+        lines.append("")
+        lines.append(
+            "> **Note:** This report inventories prompt-only guidance and enforced hooks "
+            "separately. Prompt-only controls are advice; they do not block execution without "
+            "a backing hook or credential boundary. Review the Gap section to identify "
+            "policy claims that rely solely on text instructions."
+        )
+
+        return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+
+def _read_skill_rules(claude_dir: Path) -> tuple[Optional[str], dict[str, dict[str, object]]]:
+    """Read skill-rules.json and return (version, skills_dict)."""
+    rules_path = claude_dir / "skills" / "skill-rules.json"
+    if not rules_path.exists():
+        return None, {}
+    try:
+        data = json.loads(rules_path.read_text(encoding="utf-8"))
+        version = str(data.get("version", "unknown")) if isinstance(data, dict) else None
+        skills = data.get("skills", {}) if isinstance(data, dict) else {}
+        return version, skills if isinstance(skills, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return None, {}
+
+
+def _scan_hooks(claude_dir: Path) -> list[GovernanceAsset]:
+    hooks_dir = claude_dir / "hooks"
+    if not hooks_dir.is_dir():
+        return []
+    assets: list[GovernanceAsset] = []
+    for hook_path in sorted(hooks_dir.iterdir()):
+        if hook_path.name == "README.md":
+            continue
+        if hook_path.suffix not in (".py", ".sh"):
+            continue
+        meta = _HOOK_META.get(hook_path.name)
+        if meta:
+            category, description = meta
+        else:
+            category = "harness"
+            description = "Hook script (category not classified in governance table)"
+        assets.append(
+            GovernanceAsset(
+                name=hook_path.name,
+                kind="hook",
+                category=category,
+                enforcement="enforced",
+                description=description,
+                path=str(hook_path.relative_to(claude_dir.parent)),
+            )
+        )
+    return assets
+
+
+def _scan_skills(
+    claude_dir: Path,
+    skills_dict: dict[str, dict[str, object]],
+) -> list[GovernanceAsset]:
+    skills_dir = claude_dir / "skills"
+    if not skills_dir.is_dir():
+        return []
+    assets: list[GovernanceAsset] = []
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_name = skill_dir.name
+        skill_file = skill_dir / "SKILL.md"
+
+        # Description: prefer skill-rules.json, fall back to static table, then generic
+        rules_entry = skills_dict.get(skill_name)
+        if isinstance(rules_entry, dict) and rules_entry.get("description"):
+            description = str(rules_entry["description"])
+        else:
+            description = _SKILL_META.get(skill_name, ("", ""))[1] or (
+                "Skill (description not found in skill-rules.json)"
+            )
+
+        # Category: prefer static table, fall back to skill-rules type
+        static = _SKILL_META.get(skill_name)
+        if static:
+            category = static[0]
+        elif isinstance(rules_entry, dict):
+            skill_type = str(rules_entry.get("type", ""))
+            category = "context" if skill_type == "domain" else "harness"
+        else:
+            category = "harness"
+
+        assets.append(
+            GovernanceAsset(
+                name=skill_name,
+                kind="skill",
+                category=category,
+                enforcement="prompt-only",
+                description=description,
+                path=str(skill_file.relative_to(claude_dir.parent))
+                if skill_file.exists()
+                else str(skill_dir.relative_to(claude_dir.parent)),
+            )
+        )
+    return assets
+
+
+def _scan_references(claude_dir: Path) -> list[GovernanceAsset]:
+    refs_dir = claude_dir / "references"
+    if not refs_dir.is_dir():
+        return []
+    assets: list[GovernanceAsset] = []
+    for ref_path in sorted(refs_dir.iterdir()):
+        if ref_path.suffix != ".md":
+            continue
+        meta = _REFERENCE_META.get(ref_path.name)
+        if meta:
+            category, description = meta
+        else:
+            category = "context"
+            description = "Reference document (category not classified in governance table)"
+        assets.append(
+            GovernanceAsset(
+                name=ref_path.name,
+                kind="reference",
+                category=category,
+                enforcement="prompt-only",
+                description=description,
+                path=str(ref_path.relative_to(claude_dir.parent)),
+            )
+        )
+    return assets
+
+
+def _scan_learned_rules(claude_dir: Path) -> list[GovernanceAsset]:
+    learned_dir = claude_dir / "rules" / "learned"
+    if not learned_dir.is_dir():
+        return []
+    assets: list[GovernanceAsset] = []
+    for rule_path in sorted(learned_dir.iterdir()):
+        if rule_path.suffix != ".md":
+            continue
+        # Extract first heading as description
+        description = _first_heading(rule_path) or "Accumulated project-specific lessons"
+        assets.append(
+            GovernanceAsset(
+                name=rule_path.name,
+                kind="learned-rule",
+                category="learning",
+                enforcement="prompt-only",
+                description=description,
+                path=str(rule_path.relative_to(claude_dir.parent)),
+            )
+        )
+    return assets
+
+
+def _first_heading(path: Path) -> Optional[str]:
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            m = re.match(r"^#+\s+(.+)", line.strip())
+            if m:
+                return m.group(1).strip()
+    except OSError:
+        pass
+    return None
+
+
+def _derive_gaps(assets: list[GovernanceAsset]) -> list[str]:
+    """Identify prompt-only policy/harness controls lacking a backing enforced hook."""
+    enforced_names = {a.name for a in assets if a.enforcement == "enforced"}
+    gaps: list[str] = []
+
+    # Policy skills with no parallel enforced hook covering the same concern
+    _POLICY_SKILLS_WITHOUT_HOOKS = {
+        # map-plan has no gate enforcing plan quality — it's all prompt guidance
+        "map-plan": (
+            "map-plan: decomposition quality is prompt guidance; "
+            "no harness gate enforces subtask structure or completeness"
+        ),
+        # map-check invokes quality gates but cannot block LLM from skipping the invocation
+        "map-check": (
+            "map-check: quality gates are prompt-driven invocation; "
+            "no hook enforces map-check is called before a commit"
+        ),
+    }
+    for skill_name, gap_msg in _POLICY_SKILLS_WITHOUT_HOOKS.items():
+        if any(a.name == skill_name for a in assets) and skill_name not in enforced_names:
+            gaps.append(gap_msg)
+
+    # If no workflow-gate hook is present, flag it
+    if "workflow-gate.py" not in enforced_names and any(
+        a.kind == "skill" for a in assets
+    ):
+        gaps.append(
+            "workflow-gate.py not found: no harness-level hook is enforcing "
+            "phase-scoped edit permissions"
+        )
+
+    # If no safety-guardrails hook is present, flag it
+    if "safety-guardrails.py" not in enforced_names and any(
+        a.kind == "skill" for a in assets
+    ):
+        gaps.append(
+            "safety-guardrails.py not found: no harness-level hook is blocking "
+            "dangerous shell commands"
+        )
+
+    return gaps
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_governance_report(project_path: Path) -> GovernanceReport:
+    """Scan an installed MAP project and return a GovernanceReport.
+
+    Looks for a `.claude/` directory inside *project_path*. If none exists,
+    returns an empty report (no assets found).
+
+    Args:
+        project_path: Root of the target project (must exist).
+
+    Returns:
+        GovernanceReport with all discovered assets classified.
+    """
+    claude_dir = project_path / ".claude"
+    report = GovernanceReport(project_path=project_path.resolve())
+
+    if not claude_dir.is_dir():
+        return report
+
+    version, skills_dict = _read_skill_rules(claude_dir)
+    report.skill_rules_version = version
+
+    report.assets.extend(_scan_hooks(claude_dir))
+    report.assets.extend(_scan_skills(claude_dir, skills_dict))
+    report.assets.extend(_scan_references(claude_dir))
+    report.assets.extend(_scan_learned_rules(claude_dir))
+
+    report.gaps = _derive_gaps(report.assets)
+    return report

--- a/tests/test_governance_report.py
+++ b/tests/test_governance_report.py
@@ -1,0 +1,487 @@
+"""Tests for mapify governance report command and build_governance_report function."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mapify_cli import app
+from mapify_cli.delivery.governance_report import (
+    CATEGORIES,
+    GovernanceAsset,
+    GovernanceReport,
+    build_governance_report,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_skill_rules(skills_dir: Path, skills: dict | None = None) -> None:
+    """Write a minimal skill-rules.json to skills_dir."""
+    if skills is None:
+        skills = {
+            "map-plan": {
+                "type": "manual",
+                "skillClass": "task",
+                "enforcement": "manual",
+                "priority": "high",
+                "description": "ARCHITECT phase: decompose a complex task",
+                "promptTriggers": {"keywords": ["map-plan"], "intentPatterns": []},
+            },
+            "map-check": {
+                "type": "manual",
+                "skillClass": "task",
+                "enforcement": "manual",
+                "priority": "high",
+                "description": "Run quality gates",
+                "promptTriggers": {"keywords": ["map-check"], "intentPatterns": []},
+            },
+        }
+    (skills_dir / "skill-rules.json").write_text(
+        json.dumps({"version": "1.0", "description": "test", "skills": skills}),
+        encoding="utf-8",
+    )
+
+
+def _make_skill_dir(skills_dir: Path, name: str) -> None:
+    (skills_dir / name).mkdir(parents=True, exist_ok=True)
+    (skills_dir / name / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+
+def _make_hook(hooks_dir: Path, name: str) -> None:
+    (hooks_dir / name).write_text(f"# {name}\n", encoding="utf-8")
+
+
+def _make_reference(refs_dir: Path, name: str) -> None:
+    (refs_dir / name).write_text(f"# {name} reference\n", encoding="utf-8")
+
+
+def _make_learned_rule(learned_dir: Path, name: str, heading: str = "Title") -> None:
+    (learned_dir / name).write_text(f"# {heading}\n\nContent.\n", encoding="utf-8")
+
+
+@pytest.fixture()
+def map_project(tmp_path: Path) -> Path:
+    """Build a minimal but complete MAP project layout."""
+    claude = tmp_path / ".claude"
+    hooks = claude / "hooks"
+    skills = claude / "skills"
+    refs = claude / "references"
+    learned = claude / "rules" / "learned"
+
+    for d in (hooks, skills, refs, learned):
+        d.mkdir(parents=True)
+
+    _make_hook(hooks, "safety-guardrails.py")
+    _make_hook(hooks, "workflow-gate.py")
+    _make_hook(hooks, "map-memory-capture.py")
+
+    _make_skill_rules(skills)
+    _make_skill_dir(skills, "map-plan")
+    _make_skill_dir(skills, "map-check")
+
+    _make_reference(refs, "escalation-matrix.md")
+    _make_reference(refs, "step-state-schema.md")
+
+    _make_learned_rule(learned, "error-patterns.md", "Error Patterns (Learned)")
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: build_governance_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGovernanceReport:
+    def test_returns_empty_report_when_no_claude_dir(self, tmp_path: Path) -> None:
+        report = build_governance_report(tmp_path)
+        assert report.assets == []
+        assert report.gaps == []
+
+    def test_scans_hooks(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        hook_names = {a.name for a in report.assets if a.kind == "hook"}
+        assert "safety-guardrails.py" in hook_names
+        assert "workflow-gate.py" in hook_names
+
+    def test_hooks_are_enforced(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        for asset in report.assets:
+            if asset.kind == "hook":
+                assert asset.enforcement == "enforced"
+
+    def test_scans_skills(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        skill_names = {a.name for a in report.assets if a.kind == "skill"}
+        assert "map-plan" in skill_names
+        assert "map-check" in skill_names
+
+    def test_skills_are_prompt_only(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        for asset in report.assets:
+            if asset.kind == "skill":
+                assert asset.enforcement == "prompt-only"
+
+    def test_scans_references(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        ref_names = {a.name for a in report.assets if a.kind == "reference"}
+        assert "escalation-matrix.md" in ref_names
+        assert "step-state-schema.md" in ref_names
+
+    def test_references_are_prompt_only(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        for asset in report.assets:
+            if asset.kind == "reference":
+                assert asset.enforcement == "prompt-only"
+
+    def test_scans_learned_rules(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        learned_names = {a.name for a in report.assets if a.kind == "learned-rule"}
+        assert "error-patterns.md" in learned_names
+
+    def test_learned_rules_are_learning_category(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        for asset in report.assets:
+            if asset.kind == "learned-rule":
+                assert asset.category == "learning"
+
+    def test_reads_skill_rules_version(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        assert report.skill_rules_version == "1.0"
+
+    def test_safety_guardrails_classified_as_policy(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        sg = next(a for a in report.assets if a.name == "safety-guardrails.py")
+        assert sg.category == "policy"
+
+    def test_workflow_gate_classified_as_harness(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        wg = next(a for a in report.assets if a.name == "workflow-gate.py")
+        assert wg.category == "harness"
+
+    def test_escalation_matrix_classified_as_oversight(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        em = next(a for a in report.assets if a.name == "escalation-matrix.md")
+        assert em.category == "oversight"
+
+    def test_map_memory_capture_classified_as_learning(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        mmc = next(a for a in report.assets if a.name == "map-memory-capture.py")
+        assert mmc.category == "learning"
+
+    def test_map_plan_classified_as_charter(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        mp = next(a for a in report.assets if a.name == "map-plan")
+        assert mp.category == "charter"
+
+    def test_asset_paths_are_relative_to_project(self, map_project: Path) -> None:
+        report = build_governance_report(map_project)
+        for asset in report.assets:
+            assert not Path(asset.path).is_absolute()
+            assert asset.path.startswith(".claude/")
+
+    def test_generates_gap_when_both_key_hooks_present(
+        self, map_project: Path
+    ) -> None:
+        report = build_governance_report(map_project)
+        # With workflow-gate + safety-guardrails present, the hook-missing gaps should be absent
+        hook_gaps = [g for g in report.gaps if "not found" in g]
+        assert not hook_gaps
+
+    def test_generates_gap_when_workflow_gate_missing(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        hooks = claude / "hooks"
+        skills = claude / "skills"
+        hooks.mkdir(parents=True)
+        skills.mkdir(parents=True)
+        _make_hook(hooks, "safety-guardrails.py")
+        _make_skill_rules(skills)
+        _make_skill_dir(skills, "map-plan")
+        report = build_governance_report(tmp_path)
+        assert any("workflow-gate.py not found" in g for g in report.gaps)
+
+    def test_generates_gap_when_safety_guardrails_missing(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        hooks = claude / "hooks"
+        skills = claude / "skills"
+        hooks.mkdir(parents=True)
+        skills.mkdir(parents=True)
+        _make_hook(hooks, "workflow-gate.py")
+        _make_skill_rules(skills)
+        _make_skill_dir(skills, "map-plan")
+        report = build_governance_report(tmp_path)
+        assert any("safety-guardrails.py not found" in g for g in report.gaps)
+
+    def test_unknown_hook_classified_as_harness(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        hooks = claude / "hooks"
+        hooks.mkdir(parents=True)
+        _make_hook(hooks, "custom-hook.py")
+        report = build_governance_report(tmp_path)
+        custom = next((a for a in report.assets if a.name == "custom-hook.py"), None)
+        assert custom is not None
+        assert custom.category == "harness"
+
+    def test_readme_in_hooks_is_skipped(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        hooks = claude / "hooks"
+        hooks.mkdir(parents=True)
+        _make_hook(hooks, "README.md")
+        report = build_governance_report(tmp_path)
+        assert not any(a.name == "README.md" for a in report.assets)
+
+    def test_description_from_skill_rules_json(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        skills = claude / "skills"
+        skills.mkdir(parents=True)
+        _make_skill_rules(
+            skills,
+            {"my-skill": {"description": "Custom description from rules", "type": "manual"}},
+        )
+        _make_skill_dir(skills, "my-skill")
+        report = build_governance_report(tmp_path)
+        asset = next(a for a in report.assets if a.name == "my-skill")
+        assert asset.description == "Custom description from rules"
+
+    def test_learned_rule_extracts_heading(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        learned = claude / "rules" / "learned"
+        learned.mkdir(parents=True)
+        _make_learned_rule(learned, "my-rules.md", "My Custom Rules")
+        report = build_governance_report(tmp_path)
+        rule = next(a for a in report.assets if a.name == "my-rules.md")
+        assert rule.description == "My Custom Rules"
+
+    def test_invalid_skill_rules_json_falls_through(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        skills = claude / "skills"
+        skills.mkdir(parents=True)
+        (skills / "skill-rules.json").write_text("not json {", encoding="utf-8")
+        _make_skill_dir(skills, "map-plan")
+        report = build_governance_report(tmp_path)
+        assert report.skill_rules_version is None
+        assert any(a.name == "map-plan" for a in report.assets)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: GovernanceReport methods
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceReport:
+    def _make_report(self) -> GovernanceReport:
+        return GovernanceReport(
+            project_path=Path("/fake/project"),
+            assets=[
+                GovernanceAsset(
+                    "safety-guardrails.py",
+                    "hook",
+                    "policy",
+                    "enforced",
+                    "Denies dangerous commands",
+                    ".claude/hooks/safety-guardrails.py",
+                ),
+                GovernanceAsset(
+                    "workflow-gate.py",
+                    "hook",
+                    "harness",
+                    "enforced",
+                    "Phase gate",
+                    ".claude/hooks/workflow-gate.py",
+                ),
+                GovernanceAsset(
+                    "map-learn",
+                    "skill",
+                    "learning",
+                    "prompt-only",
+                    "Extract lessons",
+                    ".claude/skills/map-learn/SKILL.md",
+                ),
+                GovernanceAsset(
+                    "escalation-matrix.md",
+                    "reference",
+                    "oversight",
+                    "prompt-only",
+                    "Escalation paths",
+                    ".claude/references/escalation-matrix.md",
+                ),
+            ],
+            gaps=["map-plan: no harness gate"],
+        )
+
+    def test_by_category_covers_all_categories(self) -> None:
+        report = self._make_report()
+        by_cat = report.by_category()
+        assert set(by_cat.keys()) == set(CATEGORIES)
+
+    def test_by_category_groups_correctly(self) -> None:
+        report = self._make_report()
+        by_cat = report.by_category()
+        assert len(by_cat["policy"]) == 1
+        assert len(by_cat["harness"]) == 1
+        assert len(by_cat["learning"]) == 1
+        assert len(by_cat["oversight"]) == 1
+
+    def test_enforced_count(self) -> None:
+        report = self._make_report()
+        assert report.enforced_count() == 2
+
+    def test_prompt_only_count(self) -> None:
+        report = self._make_report()
+        assert report.prompt_only_count() == 2
+
+    def test_as_json_valid(self) -> None:
+        report = self._make_report()
+        data = json.loads(report.as_json())
+        assert data["version"] == "1.0"
+        assert data["summary"]["total"] == 4
+        assert data["summary"]["enforced"] == 2
+        assert data["summary"]["prompt_only"] == 2
+        assert len(data["assets"]) == 4
+        assert data["gaps"] == ["map-plan: no harness gate"]
+
+    def test_as_json_by_category_sums_correctly(self) -> None:
+        report = self._make_report()
+        data = json.loads(report.as_json())
+        total = sum(data["summary"]["by_category"].values())
+        assert total == 4
+
+    def test_as_markdown_starts_with_heading(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        assert md.startswith("# MAP Governance Report")
+
+    def test_as_markdown_has_all_category_sections(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        for cat in CATEGORIES:
+            assert f"## {cat.capitalize()}" in md
+
+    def test_as_markdown_has_summary_section(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        assert "## Summary" in md
+
+    def test_as_markdown_has_gaps_section(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        assert "## Gaps" in md
+        assert "map-plan: no harness gate" in md
+
+    def test_as_markdown_has_evidence_section(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        assert "## Evidence Artifacts" in md
+
+    def test_as_markdown_labels_enforced(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        assert "**enforced**" in md
+
+    def test_as_markdown_labels_prompt_only(self) -> None:
+        report = self._make_report()
+        md = report.as_markdown()
+        assert "prompt-only" in md
+
+    def test_as_json_asset_has_required_fields(self) -> None:
+        report = self._make_report()
+        data = json.loads(report.as_json())
+        for asset in data["assets"]:
+            for field in ("name", "kind", "category", "enforcement", "description", "path"):
+                assert field in asset
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceReportCli:
+    def test_report_on_empty_dir_exits_1(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["governance", "report", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "No MAP assets found" in result.output
+
+    def test_report_nonexistent_path_exits_1(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["governance", "report", str(tmp_path / "nope")])
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+
+    def test_report_on_map_project_exits_0(self, map_project: Path) -> None:
+        result = runner.invoke(app, ["governance", "report", str(map_project)])
+        assert result.exit_code == 0, result.output
+
+    def test_report_outputs_markdown_by_default(self, map_project: Path) -> None:
+        result = runner.invoke(app, ["governance", "report", str(map_project)])
+        assert "# MAP Governance Report" in result.output
+
+    def test_report_json_flag_outputs_valid_json(self, map_project: Path) -> None:
+        result = runner.invoke(app, ["governance", "report", str(map_project), "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "assets" in data
+        assert "summary" in data
+
+    def test_report_writes_to_out_file(self, map_project: Path, tmp_path: Path) -> None:
+        out_file = tmp_path / "report.md"
+        result = runner.invoke(
+            app, ["governance", "report", str(map_project), "--out", str(out_file)]
+        )
+        assert result.exit_code == 0, result.output
+        assert out_file.exists()
+        content = out_file.read_text()
+        assert "# MAP Governance Report" in content
+
+    def test_report_json_out_file(self, map_project: Path, tmp_path: Path) -> None:
+        out_file = tmp_path / "report.json"
+        result = runner.invoke(
+            app,
+            ["governance", "report", str(map_project), "--json", "--out", str(out_file)],
+        )
+        assert result.exit_code == 0, result.output
+        assert out_file.exists()
+        data = json.loads(out_file.read_text())
+        assert data["version"] == "1.0"
+
+    def test_report_uses_cwd_by_default(
+        self, map_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(map_project)
+        result = runner.invoke(app, ["governance", "report"])
+        assert result.exit_code == 0, result.output
+        assert "# MAP Governance Report" in result.output
+
+    def test_report_contains_asset_counts(self, map_project: Path) -> None:
+        result = runner.invoke(app, ["governance", "report", str(map_project)])
+        assert result.exit_code == 0, result.output
+        # Summary section contains count info
+        assert "Assets:" in result.output
+
+    def test_report_on_real_framework_repo(self) -> None:
+        """Smoke test: run against this actual framework repo's .claude/ directory."""
+        repo_root = Path(__file__).parent.parent
+        result = runner.invoke(app, ["governance", "report", str(repo_root)])
+        assert result.exit_code == 0, result.output
+        assert "# MAP Governance Report" in result.output
+        # Real repo should have enforced and prompt-only assets
+        assert "**enforced**" in result.output
+        assert "prompt-only" in result.output
+
+    def test_report_json_on_real_framework_repo(self) -> None:
+        """Smoke test: JSON output against the real framework repo."""
+        repo_root = Path(__file__).parent.parent
+        result = runner.invoke(app, ["governance", "report", str(repo_root), "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["summary"]["total"] > 0
+        assert data["summary"]["enforced"] > 0
+        assert data["summary"]["prompt_only"] > 0


### PR DESCRIPTION
## Summary

Closes #342

- Adds `mapify governance report [PATH] [--json] [--out FILE]` command that inventories behavior-shaping assets in a MAP installation and classifies them under six governance categories: **Charter, Policy, Context, Harness, Oversight, Learning**
- Distinguishes **enforced** controls (runtime hooks that block/modify behavior deterministically) from **prompt-only** guidance (skills, references, learned rules injected as context)
- Surfaces a **Gaps** section identifying prompt-only policy claims that lack a backing harness control, and flags missing critical hooks (`workflow-gate.py`, `safety-guardrails.py`)
- Supports both Markdown (default) and JSON (`--json`) output; `--out FILE` writes to a file
- JSON output bypasses Rich console to produce clean, parseable output

## Changes

**New files:**
- `src/mapify_cli/delivery/governance_report.py` — core scanner and report builder: static classification tables for hooks/skills/references, `GovernanceAsset` dataclass, `GovernanceReport` with `as_markdown()`/`as_json()`/`by_category()`, `build_governance_report(path)` public API
- `tests/test_governance_report.py` — 49 tests covering scanner, data model, and CLI integration (including smoke tests against the real framework repo's `.claude/` directory)

**Modified files:**
- `src/mapify_cli/__init__.py` — registers `governance` Typer subcommand group with `report` subcommand
- `src/mapify_cli/delivery/__init__.py` — exports `GovernanceAsset`, `GovernanceReport`, `build_governance_report`

## Test plan

- [x] 49 new tests — all green
- [x] 3550 total tests: 3550 passed, 4 skipped
- [x] `ruff check src/ tests/` — 0 issues
- [x] `python -m pyright src/` — 0 errors, 0 warnings
- [x] `make check-render` — generated trees unchanged (no template changes)
- [x] Smoke tests run against the real framework `.claude/` directory and verify enforced + prompt-only assets are found


---
_Generated by [Claude Code](https://claude.ai/code/session_01FBjHTvYrrSfM5X5xEKXe8u)_