### PR TITLE
feat(#362): /map-wayfind — decision-frontier wayfinding before planning

### DIFF
--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -71,6 +71,8 @@ Per-artifact resume rules (only when `verdict` is `resume`):
 
 If a `/map-wayfind` map already resolved the key decisions, seed this plan from its handoff instead of re-deciding them.
 
+**Precedence over resume:** a handoff seeds a *fresh* plan, so this step only applies when the Resume Detection verdict is `no_plan` (or `goal_mismatch` after you archive the prior artifacts). On a `resume` verdict the branch already has a `spec`/`task_plan` — that existing artifact wins and the handoff is NOT re-consumed (re-seeding would silently overwrite in-progress work). To plan from a handoff, run `/map-plan --wayfind <slug>` on a branch with no in-progress plan (or archive/rename the existing `.map/<branch>/` artifacts first, with operator confirmation).
+
 - If `$ARGUMENTS` contains `--wayfind <slug>`, read `.map/wayfind/<slug>/handoff.json` (repo-level, not branch-scoped).
 - Otherwise run `python3 .map/scripts/wayfind_runner.py list_handoffs`. If exactly one completed handoff exists, OFFER it to the user ("found a completed wayfinding map `<slug>` — seed the plan from it?") and use it only on an explicit yes. Never match a handoff to the request by guessing; with zero or multiple handoffs and no explicit `--wayfind`, skip this step.
 

--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -67,6 +67,15 @@ Per-artifact resume rules (only when `verdict` is `resume`):
 - Existing `task_plan`: skip decomposition and plan creation.
 - Existing `step_state.json`: plan is complete; print checkpoint and STOP.
 
+### Pre-flight: Wayfinding Handoff (optional)
+
+If a `/map-wayfind` map already resolved the key decisions, seed this plan from its handoff instead of re-deciding them.
+
+- If `$ARGUMENTS` contains `--wayfind <slug>`, read `.map/wayfind/<slug>/handoff.json` (repo-level, not branch-scoped).
+- Otherwise run `python3 .map/scripts/wayfind_runner.py list_handoffs`. If exactly one completed handoff exists, OFFER it to the user ("found a completed wayfinding map `<slug>` — seed the plan from it?") and use it only on an explicit yes. Never match a handoff to the request by guessing; with zero or multiple handoffs and no explicit `--wayfind`, skip this step.
+
+When a handoff is used, pre-seed the spec: `decisions[]` → **Decisions Made** (settled — the interview must NOT re-ask them; carry them as a do-not-re-ask list), `out_of_scope[]` → **Out of Scope**, `remaining_risks[]` → **Open Questions**. Then continue below for anything the handoff did not settle. Do not modify the wayfinding map.
+
 ### Pre-flight: Workflow-Fit Gate
 
 Decide whether MAP planning is warranted before discovery or interview.

--- a/.claude/skills/map-wayfind/SKILL.md
+++ b/.claude/skills/map-wayfind/SKILL.md
@@ -60,7 +60,7 @@ Start a new map. Six steps, mirroring the way a good architect opens a foggy pro
    ```
 
    In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
-5. **Kick off research.** For `research` tickets, you MAY dispatch research-agent subagents in parallel; each writes its findings to `resolutions/<ticket>.md`, then you `resolve_ticket` it. Research resolves are exempt from the one-per-session limit.
+5. **Kick off research.** For each `research` ticket, `claim_ticket` it FIRST — `resolve_ticket` requires the ticket to be claimed by your session, so an unclaimed dispatch-then-resolve returns `not_owner`. Serialize these claim mutations, then you MAY dispatch research-agent subagents in parallel to gather findings; each writes to `resolutions/<ticket>.md`, after which you `resolve_ticket` it (research resolves are exempt from the one-per-session limit).
 6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
 
 ## Mode: work \<slug\> [ticket]

--- a/.claude/skills/map-wayfind/SKILL.md
+++ b/.claude/skills/map-wayfind/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: map-wayfind
+description: |
+  Decision-frontier wayfinding: build and work a durable map of open design decisions BEFORE planning, for large or foggy efforts where /map-plan would force premature decomposition. Use when a task is too big or too vague to decompose — many unknowns, tangled decisions, or "I'm not even sure what to build yet" — and you want to resolve the key decisions one at a time (research, prototype, grilling, task tickets) behind a claim-before-work frontier, with a "fog of war" for questions you cannot yet state sharply. Produces a handoff that /map-plan consumes. Modes are explicit: chart (start a map), work (resolve one ticket), handoff (finish). Do NOT use when scope is already clear enough to specify — go straight to /map-plan; do NOT use to implement code or to decompose an already-specifiable change.
+disable-model-invocation: true
+argument-hint: "[chart \"loose idea\" | work <slug> [ticket] | handoff <slug>]"
+effort: medium
+---
+# /map-wayfind — Decision-Frontier Wayfinding
+
+Purpose: for a large or foggy effort, resolve the key design decisions ONE AT A TIME on a durable map before any planning. If the scope is already clear enough to specify, skip this and run `/map-plan` directly.
+
+Contrast with `/map-plan`: `/map-plan` decomposes an already-understood task into subtasks. `/map-wayfind` comes earlier — it resolves the decisions that make decomposition possible, then hands the settled decisions to `/map-plan`. The map is durable and repo-level (`.map/wayfind/<slug>/`); it outlives branches and can span many sessions.
+
+## Effort and Parallelism Policy
+
+```yaml
+thinking_policy: medium/adaptive
+parallel_tool_policy: research_only
+```
+
+- Use deeper reasoning for the sharpness test (is a question ticketable now?), for wiring dependencies, and for judging whether a decision is truly resolved.
+- Do not over-chart: if a breadth-first interview surfaces no real fog, there is nothing to wayfind — say so and route to `/map-plan`.
+- Parallelize ONLY independent research-agent reads dispatched against research tickets. Keep charting interview, claiming, human grilling, resolving, and handoff strictly sequential.
+
+## Determinism boundary
+
+All state lives in `.map/wayfind/<slug>/state.json` and is mutated ONLY through `python3 .map/scripts/wayfind_runner.py <command>`. You write prose only: resolution files under `resolutions/`, and verbatim human answers under `resolutions/<ticket>.human.md`. Never hand-edit `state.json`, `map.md`, or `tickets/*.md` — the views carry a DO-NOT-EDIT banner and are regenerated on every mutation. Every command prints a JSON result; a non-success `status` means stop and read the message.
+
+See [wayfind-reference.md](wayfind-reference.md) for the full CLI reference, the fog-sharpness rubric, the ticket-type guide, and extended examples/troubleshooting. When a step points to a reference section, read it before executing the step; supporting files are not assumed to be in context automatically.
+
+## Mode selection
+
+Parse `$ARGUMENTS`. The FIRST token is the explicit mode — `chart`, `work`, or `handoff`. There is no auto-detection. If no mode is given, run `python3 .map/scripts/wayfind_runner.py wayfind_status` to show existing maps, then ask the user which mode to run.
+
+Mint ONE session id for this run and reuse it for every claim/record/resolve below:
+
+```bash
+WAYFIND_SESSION="$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+## Mode: chart "\<loose idea\>"
+
+Start a new map. Six steps, mirroring the way a good architect opens a foggy problem.
+
+1. **Name the destination.** Interview the user briefly for where this is headed (1–2 sentences). If it turns out the scope is already crisp, stop and recommend `/map-plan`.
+2. **Breadth-first interview.** Walk the surface of the problem to surface the open decisions. If nothing genuinely uncertain appears, there is no frontier to chart — STOP and route to `/map-plan`.
+3. **Create the map.** Pick a short slug (`[a-z0-9-]`, ≤50 chars). Pass genuinely-unsharp concerns as fog:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py create_wayfind_map \
+     <slug> "<title>" "<destination>" --fog-json '["still-vague concern", "..."]'
+   ```
+
+   Then warn the user: the map is committed by default, so grilling transcripts and prose resolutions are shared with the repo. To keep one map local, add `.map/wayfind/<slug>/.gitignore` with a single `*`.
+4. **Add sharp tickets.** For each decision you can state as ONE sharp question right now, add a ticket. Choose the type deliberately (see the reference): `research` (find out), `prototype` (build a cheap probe — human-in-the-loop), `grilling` (interrogate the human — human-in-the-loop), `task` (a self-contained decision/chore). Keep unsharp concerns as fog via `add_fog`; do not pre-slice fog into fake tickets.
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py add_ticket <slug> "<title>" <type> "<one sharp question>"
+   ```
+
+   In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
+5. **Kick off research.** For `research` tickets, you MAY dispatch research-agent subagents in parallel; each writes its findings to `resolutions/<ticket>.md`, then you `resolve_ticket` it. Research resolves are exempt from the one-per-session limit.
+6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
+
+## Mode: work \<slug\> [ticket]
+
+Resolve exactly ONE non-research decision, then stop. Five steps.
+
+1. **Load low-res.** Read only `.map/wayfind/<slug>/map.md`. Zoom into a specific ticket with `show_ticket <slug> <ticket>` only when needed.
+2. **Claim first.** Pick the named ticket, or the first frontier ticket from `wayfind_frontier <slug>`, and claim it BEFORE any work:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py claim_ticket <slug> <ticket> "$WAYFIND_SESSION"
+   ```
+
+   If the result has `hitl_pending: true`, this is a human-in-the-loop ticket — see step 3b.
+3. **Resolve by type.**
+   - `task`: do the work / make the call, then write the decision prose to `resolutions/<ticket>.md`.
+   - `research`: gather the answer (a subagent may help), write it to `resolutions/<ticket>.md`.
+   - **3b. `prototype` / `grilling` (human-in-the-loop):** ask the human the ticket's question verbatim (AskUserQuestion for grilling; describe the cheap probe for prototype), then STOP and hand control back. Do not answer on the human's behalf. When the human replies, save their words VERBATIM to `resolutions/<ticket>.human.md` and register them:
+
+     ```bash
+     python3 .map/scripts/wayfind_runner.py record_human_input <slug> <ticket> "$WAYFIND_SESSION" resolutions/<ticket>.human.md
+     ```
+
+     `resolve_ticket` refuses a human-in-the-loop ticket until this is recorded.
+4. **Resolve + maintain the map.** Write the one-line gist and the resolution file, then:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py resolve_ticket <slug> <ticket> "$WAYFIND_SESSION" "<one-line gist>" resolutions/<ticket>.md
+   ```
+
+   With what you learned, keep the map honest: `add_ticket` newly-sharp decisions, `graduate_fog` a fog entry that is now sharp, or `rule_out_of_scope` a ticket/fog that is settled as excluded (exclusions never appear under Decisions).
+5. **Stop.** The runner blocks a second non-research resolve in the same session by design. Report the decision and stop; start a fresh session (or `/map-wayfind handoff <slug>`) to continue.
+
+## Mode: handoff \<slug\>
+
+When `wayfind_status <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
+
+```bash
+python3 .map/scripts/wayfind_runner.py emit_wayfind_handoff <slug> --remaining-risks-json '["..."]'
+```
+
+This writes `.map/wayfind/<slug>/handoff.md` (+ `handoff.json`) and registers a `wayfind_handoff` artifact-manifest stage on the current branch. If you must hand off with open items, pass `--early --confirmed-by-user` and confirm with the user first; the open items are folded into remaining risks so nothing is lost. Then, on a feature branch, run `/map-plan --wayfind <slug>` to seed the spec from the settled decisions.
+
+## Guardrails
+
+- Do not pre-slice fog: only create a ticket when you can state its question sharply NOW (rubric in the reference). Otherwise keep it as fog.
+- Resolve at most ONE non-research ticket per session; the runner enforces this.
+- Out-of-scope is an exclusion, not a decision — it never graduates into the plan.
+- No implementation subtasks and no code changes here — that is `/map-plan` + execution.
+- Never write secrets into tickets, resolutions, or the map. Warn about the commit-by-default privacy note in `chart`.
+- Refer to tickets by name in prose, not bare ids, so the map reads for a human.
+- Honesty note: the human-in-the-loop and one-per-session checks add friction and an audit trail; they are not a mechanical guarantee. Ask the human when in doubt.
+
+## Examples
+
+- **Foggy feature:** `/map-wayfind chart "rebuild checkout"` → name destination, interview, create map `checkout` with 2 fog entries + 3 sharp tickets (1 research, 1 grilling, 1 task) → dispatch the research ticket → stop.
+- **Resolve one decision:** `/map-wayfind work checkout` → claim the `grilling` ticket → ask the human verbatim, stop, record their answer, resolve → stop (one non-research decision done).
+- **Finish:** `/map-wayfind handoff checkout` → all tickets resolved/out-of-scope, fog empty → emit handoff → `/map-plan --wayfind checkout`.
+
+More worked examples are in [wayfind-reference.md](wayfind-reference.md).
+
+## Troubleshooting
+
+- `emit_wayfind_handoff` returns `not_terminal`: fog, claimed, or unresolved tickets remain — resolve or rule them out, or hand off `--early --confirmed-by-user`.
+- `resolve_ticket` returns `awaiting_human`: it is a `prototype`/`grilling` ticket — record the human answer with `record_human_input` first.
+- `resolve_ticket` returns `session_limit`: you already resolved a non-research ticket this session — start a new session.
+- `wire_blocking` returns `cycle`: the dependency you added would close a loop — re-check the blocker direction.
+- Full command reference and the fog-sharpness rubric are in [wayfind-reference.md](wayfind-reference.md).

--- a/.claude/skills/map-wayfind/wayfind-reference.md
+++ b/.claude/skills/map-wayfind/wayfind-reference.md
@@ -1,0 +1,132 @@
+# /map-wayfind Supporting Reference
+
+Detail for `/map-wayfind` so the invoked `SKILL.md` stays focused on the active flow. All operations go through `python3 .map/scripts/wayfind_runner.py <command>`; each prints a JSON result with a `status` of `success` or `error`.
+
+## Ticket types
+
+| Type | Meaning | Human-in-the-loop | Counts toward one-per-session |
+|------|---------|-------------------|-------------------------------|
+| `research` | Find out an answer that already exists (read code/docs, run a query). A subagent may do this. | No | No — resolve as many as you learn |
+| `prototype` | Build a cheap, throwaway probe to see how an approach feels, then get the human's read. | Yes | Yes |
+| `grilling` | Interrogate the human: ask the sharp question, capture their verbatim answer. | Yes | Yes |
+| `task` | A self-contained decision or chore you can settle yourself. | No | Yes |
+
+Human-in-the-loop (`prototype`, `grilling`) tickets cannot be resolved until a verbatim human answer is recorded with `record_human_input`.
+
+## Fog-sharpness rubric
+
+Create a ticket only when the concern passes the sharpness test — otherwise keep it as fog and graduate it later.
+
+- **Sharp (make a ticket):** you can state it as ONE question with a bounded answer space, and you know what "resolved" looks like. E.g. "Do we store sessions in Redis or Postgres?"
+- **Foggy (keep as fog):** you can only gesture at an area of unease, the question would be compound, or you cannot yet say what a good answer is. E.g. "auth and the new checkout probably interact somehow."
+- When a session's work makes a foggy area sharp, `graduate_fog` it into a ticket.
+
+## Command reference
+
+Lifecycle / read-only:
+
+```bash
+create_wayfind_map <slug> "<title>" "<destination>" [--notes "..."] [--fog-json '["...", "..."]']
+wayfind_status [--slug <slug>]          # no slug: list all maps; with slug: counts + handoff_eligible
+list_handoffs                           # completed handoffs (used by /map-plan's offer)
+show_ticket <slug> <ticket_id>
+wayfind_frontier <slug>                 # open + unblocked + unclaimed tickets, creation order
+```
+
+Tickets:
+
+```bash
+add_ticket <slug> "<title>" <type> "<sharp question>" [--blocked-by-json '["T-001"]'] [--from-fog F-1]
+wire_blocking <slug> <ticket_id> '["T-001","T-002"]'   # rejects unknown ids, self-block, cycles
+claim_ticket <slug> <ticket_id> <session>              # HITL types return hitl_pending: true
+release_ticket <slug> <ticket_id> <session>            # crash/interrupt recovery; owner only
+record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
+resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
+```
+
+Fog & scope:
+
+```bash
+add_fog <slug> "<still-vague concern>"
+graduate_fog <slug> <fog_id> "<title>" <type> "<sharp question>" [--blocked-by-json '[...]']
+rule_out_of_scope <slug> "<reason>" [--ticket-id T-003] [--fog-id F-2] [--gist "..."]
+```
+
+Handoff:
+
+```bash
+emit_wayfind_handoff <slug> [--remaining-risks-json '["..."]'] [--early --confirmed-by-user] [--branch <branch>]
+```
+
+Every mutating command also accepts `--expected-revision <n>` (optimistic-concurrency guard): it fails with `stale_revision` if the map has advanced past `<n>`, protecting against concurrent sessions clobbering each other. Read `revision` from `wayfind_status` first.
+
+## Files under `.map/wayfind/<slug>/`
+
+- `state.json` — canonical store. Never edit by hand.
+- `map.md` — regenerated low-resolution overview (Destination, Notes, Decisions so far, Frontier, Blocked/claimed, Fog, Out of scope). DO-NOT-EDIT banner.
+- `tickets/T-00N.md` — regenerated per-ticket detail.
+- `resolutions/T-00N.md` — YOUR prose answer for a ticket (you write this before `resolve_ticket`).
+- `resolutions/T-00N.human.md` — the human's VERBATIM answer for a HITL ticket (you save this before `record_human_input`).
+- `handoff.md` / `handoff.json` — the final artifact `/map-plan --wayfind <slug>` consumes.
+
+## Terminal (handoff-eligible) condition
+
+`emit_wayfind_handoff` refuses unless the map is truly exhausted: fog empty AND no active claims AND every ticket in `{resolved, out_of_scope}` AND at least one ticket exists. A map with a claimed or blocked ticket is NOT eligible even if the frontier momentarily looks empty. Use `--early --confirmed-by-user` to override; the open items become explicit remaining risks in the handoff.
+
+## How /map-plan consumes the handoff
+
+`handoff.json` maps 1:1 onto the `/map-plan` spec template:
+
+- `decisions[]` → spec **Decisions Made** (these are settled — the interview must not re-ask them).
+- `out_of_scope[]` → spec **Out of Scope**.
+- `remaining_risks[]` → spec **Open Questions**.
+
+Run `/map-plan --wayfind <slug>` on a feature branch. Without an explicit slug, `/map-plan` runs `list_handoffs`; if exactly one completed handoff exists it OFFERS it, but never consumes silently.
+
+## Examples
+
+**Charting a foggy feature**
+
+```text
+/map-wayfind chart "rebuild checkout"
+→ destination: "a faster, single-page checkout"
+→ interview surfaces real uncertainty → chart it
+create_wayfind_map checkout "Checkout v2" "a faster, single-page checkout" \
+  --fog-json '["how does the new flow interact with legacy auth?"]'
+add_ticket checkout "Session store" task "Redis or Postgres for cart sessions?"
+add_ticket checkout "Payments SDK" research "Which payment SDKs support our regions?"
+add_ticket checkout "One-page vs wizard" grilling "One-page checkout or a 3-step wizard?"
+wire_blocking checkout T-001 '["T-002"]'   # session store waits on the SDK finding
+```
+
+**Working one ticket (human-in-the-loop)**
+
+```text
+/map-wayfind work checkout
+claim_ticket checkout T-003 20260717T101500Z    # grilling → hitl_pending: true
+→ ask the human verbatim: "One-page checkout or a 3-step wizard?"; STOP; hand control back
+→ human answers; save verbatim to resolutions/T-003.human.md
+record_human_input checkout T-003 20260717T101500Z resolutions/T-003.human.md
+→ write resolutions/T-003.md
+resolve_ticket checkout T-003 20260717T101500Z "One-page; wizard tested worse in the poll" resolutions/T-003.md
+→ stop (one non-research decision resolved this session)
+```
+
+**Handing off**
+
+```text
+/map-wayfind handoff checkout
+wayfind_status --slug checkout    # handoff_eligible: true
+emit_wayfind_handoff checkout --remaining-risks-json '["fraud rules not yet scoped"]'
+→ /map-plan --wayfind checkout   (on a feature branch)
+```
+
+## Troubleshooting
+
+- **`not_terminal` on handoff** — an item is still open. Run `wayfind_status --slug <slug>`; the error's `open_items` names each blocker. Resolve or `rule_out_of_scope` them, or hand off `--early --confirmed-by-user`.
+- **`awaiting_human`** — a `prototype`/`grilling` ticket needs a recorded human answer first (`record_human_input`).
+- **`session_limit`** — one non-research resolve per session is the rule; mint a fresh session id and continue.
+- **`already_claimed` / `blocked` / `not_owner`** — the ticket is taken, has unresolved blockers, or is claimed by another session. Check `map.md`'s Blocked/claimed section.
+- **`stale_revision`** — another session advanced the map; re-read it and retry with the current `--expected-revision`.
+- **`cycle`** — a `wire_blocking` call would create a dependency loop; the blocker relationship is likely backwards.
+- **Duplicate slug** — a map with that slug exists; pick another slug or continue the existing one with `work`.

--- a/.claude/skills/skill-rules.json
+++ b/.claude/skills/skill-rules.json
@@ -228,6 +228,28 @@
         ]
       }
     },
+    "map-wayfind": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Decision-frontier wayfinding: resolve open design decisions on a durable map before /map-plan.",
+      "promptTriggers": {
+        "keywords": [
+          "map-wayfind",
+          "wayfind",
+          "decision frontier",
+          "resolve decisions first",
+          "too foggy to plan",
+          "chart the decisions"
+        ],
+        "intentPatterns": [
+          "map-wayfind",
+          "(chart|map|resolve).*(decision|frontier)",
+          "too (foggy|vague|big) to (plan|decompose)"
+        ]
+      }
+    },
     "map-release": {
       "type": "manual",
       "skillClass": "task",

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -250,6 +250,7 @@ ARTIFACT_STAGE_NAMES = (
     "learn_handoff",
     "implementer_readiness",
     "context_usefulness",
+    "wayfind_handoff",
 )
 RUN_HEALTH_TERMINAL_STATUSES = {
     "pending",

--- a/.map/scripts/wayfind_runner.py
+++ b/.map/scripts/wayfind_runner.py
@@ -1,0 +1,1510 @@
+#!/usr/bin/env python3
+"""wayfind_runner.py — deterministic operations for /map-wayfind decision maps.
+
+Self-contained, stdlib-only runner.  Owns EVERY mutation to
+``.map/wayfind/<slug>/state.json`` (the canonical store) and regenerates the
+human-readable views (``map.md``, ``tickets/T-00N.md``) after each mutation.
+
+Design contract (mirrors the wider MAP conventions):
+  * state.json is the single source of truth; map.md / tickets/*.md are derived
+    projections carrying a DO-NOT-EDIT banner and are never parsed back.
+  * The LLM never edits state.json by hand — it calls these operations and
+    writes only prose resolution files under ``resolutions/``.
+  * Every function returns a typed result dict: ``{"status": "success", ...}``
+    or ``{"status": "error", "message": ...}``.  Nothing is raised through the
+    public API; the CLI turns a non-success status into exit code 1.
+  * Invariants (cycle-freedom, one-non-research-resolve-per-session, HITL gate,
+    terminal-handoff condition) live ABOVE persistence so a future non-local
+    backend cannot bypass them.
+
+The only cross-module dependency is a LAZY import of ``map_step_runner`` inside
+:func:`emit_wayfind_handoff`, used solely to register the ``wayfind_handoff``
+artifact-manifest stage on the current branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Vocabulary / constants
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION = "1.0"
+
+WAYFIND_TICKET_TYPES = frozenset({"research", "prototype", "grilling", "task"})
+# Human-in-the-loop ticket types: resolving one requires a recorded verbatim
+# human response (see record_human_input / resolve_ticket).
+HITL_TYPES = frozenset({"prototype", "grilling"})
+# Ticket statuses that count as "closed" for frontier / terminal computations.
+TERMINAL_TICKET_STATUSES = frozenset({"resolved", "out_of_scope"})
+
+_SLUG_RE = re.compile(r"^[a-z0-9-]{1,50}$")
+
+_DO_NOT_EDIT_BANNER = (
+    "<!-- DO NOT EDIT — regenerated from state.json by wayfind_runner.py. "
+    "Manual edits will be overwritten. -->"
+)
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(**fields: Any) -> dict[str, Any]:
+    return {"status": "success", **fields}
+
+
+def _err(message: str, **fields: Any) -> dict[str, Any]:
+    return {"status": "error", "message": message, **fields}
+
+
+def _now() -> str:
+    """Return an RFC3339 UTC timestamp (matches map_step_runner._utc_timestamp)."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _oneline(text: str) -> str:
+    """Collapse whitespace/newlines so untrusted prose stays on one Markdown line."""
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (repo-level, resolved against cwd like .map/<branch>)
+# ---------------------------------------------------------------------------
+
+
+def _wayfind_root() -> Path:
+    return Path(".map/wayfind")
+
+
+def _map_dir(slug: str) -> Path:
+    return _wayfind_root() / slug
+
+
+def _state_path(slug: str) -> Path:
+    return _map_dir(slug) / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# State load / save + derived views
+# ---------------------------------------------------------------------------
+
+
+def _load_state(slug: str) -> Optional[dict[str, Any]]:
+    path = _state_path(slug)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    """Bump revision, atomically persist state.json, and regenerate all views."""
+    slug = state["slug"]
+    state["revision"] = int(state.get("revision", 0)) + 1
+    map_dir = _map_dir(slug)
+    map_dir.mkdir(parents=True, exist_ok=True)
+    path = _state_path(slug)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    tmp.replace(path)
+    _render_views(state)
+
+
+def _revision_guard(
+    state: dict[str, Any], expected_revision: Optional[int]
+) -> Optional[dict[str, Any]]:
+    """Optimistic-concurrency check: reject a mutation against a stale revision."""
+    if expected_revision is None:
+        return None
+    current = int(state.get("revision", 0))
+    if current != int(expected_revision):
+        return _err(
+            f"stale revision: expected {expected_revision}, map is at {current}. "
+            "Re-read the map before mutating.",
+            code="stale_revision",
+            revision=current,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Id minting
+# ---------------------------------------------------------------------------
+
+
+def _next_ticket_id(state: dict[str, Any]) -> str:
+    nums = [
+        int(m.group(1))
+        for tid in state.get("tickets", {})
+        if (m := re.match(r"^T-(\d+)$", tid))
+    ]
+    return f"T-{(max(nums) + 1) if nums else 1:03d}"
+
+
+def _next_fog_id(state: dict[str, Any]) -> str:
+    nums = [
+        int(m.group(1))
+        for f in state.get("fog", [])
+        if (m := re.match(r"^F-(\d+)$", str(f.get("id", ""))))
+    ]
+    return f"F-{(max(nums) + 1) if nums else 1}"
+
+
+# ---------------------------------------------------------------------------
+# Invariant helpers
+# ---------------------------------------------------------------------------
+
+
+def _ticket_blocked(state: dict[str, Any], ticket: dict[str, Any]) -> bool:
+    """True if any blocker is not yet terminal (resolved / out_of_scope)."""
+    tickets = state.get("tickets", {})
+    for bid in ticket.get("blocked_by", []):
+        blocker = tickets.get(bid)
+        if blocker is None or blocker.get("status") not in TERMINAL_TICKET_STATUSES:
+            return True
+    return False
+
+
+def _detect_cycle(graph: dict[str, list[str]]) -> bool:
+    """Return True if the directed graph (node -> blockers) contains a cycle."""
+    white, gray, black = 0, 1, 2
+    color: dict[str, int] = {node: white for node in graph}
+
+    def visit(node: str) -> bool:
+        color[node] = gray
+        for nxt in graph.get(node, []):
+            if nxt not in color:
+                continue
+            if color[nxt] == gray:
+                return True
+            if color[nxt] == white and visit(nxt):
+                return True
+        color[node] = black
+        return False
+
+    return any(color[node] == white and visit(node) for node in list(graph))
+
+
+def _blocking_graph(
+    state: dict[str, Any], override: Optional[tuple[str, list[str]]] = None
+) -> dict[str, list[str]]:
+    """Build a {ticket_id: blocked_by[]} graph, optionally overriding one node."""
+    graph = {
+        tid: list(t.get("blocked_by", [])) for tid, t in state.get("tickets", {}).items()
+    }
+    if override is not None:
+        tid, blockers = override
+        graph[tid] = list(blockers)
+    return graph
+
+
+def _active_claims(state: dict[str, Any]) -> list[str]:
+    """Ticket ids that are claimed and not yet terminal."""
+    return [
+        tid
+        for tid, t in state.get("tickets", {}).items()
+        if t.get("claimed_by") and t.get("status") not in TERMINAL_TICKET_STATUSES
+    ]
+
+
+def _open_fog(state: dict[str, Any]) -> list[dict[str, Any]]:
+    return [f for f in state.get("fog", []) if f.get("status") == "open"]
+
+
+def _is_terminal(state: dict[str, Any]) -> bool:
+    """Terminal (handoff-eligible) condition.
+
+    Fog empty AND no active claims AND at least one ticket AND every ticket in
+    {resolved, out_of_scope}.  A naive ``len(frontier) == 0`` would wrongly fire
+    on a map whose tickets are merely claimed or blocked.
+    """
+    tickets = state.get("tickets", {})
+    if not tickets:
+        return False
+    if any(t.get("status") not in TERMINAL_TICKET_STATUSES for t in tickets.values()):
+        return False
+    if _open_fog(state):
+        return False
+    if _active_claims(state):
+        return False
+    return True
+
+
+def _recompute_status(state: dict[str, Any]) -> None:
+    """Keep status accurate on every mutation (never mutated by a read)."""
+    if state.get("status") == "handed_off":
+        return
+    if _is_terminal(state):
+        state["status"] = "exhausted"
+    elif state.get("status") == "exhausted":
+        # A previously-terminal map became non-terminal again (e.g. new fog).
+        state["status"] = "active"
+
+
+def _ensure_session(state: dict[str, Any], session: str) -> dict[str, Any]:
+    sessions = state.setdefault("sessions", {})
+    if session not in sessions:
+        sessions[session] = {
+            "started_at": _now(),
+            "non_research_resolved": 0,
+            "claimed": [],
+        }
+    return sessions[session]
+
+
+def _frontier_tickets(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Open, unblocked, unclaimed tickets in creation (id) order."""
+    frontier: list[dict[str, Any]] = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") != "open":
+            continue
+        if ticket.get("claimed_by"):
+            continue
+        if _ticket_blocked(state, ticket):
+            continue
+        frontier.append({"ticket_id": tid, **ticket})
+    return frontier
+
+
+def _mint_ticket(
+    state: dict[str, Any],
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by: list[str],
+    from_fog: Optional[str],
+) -> str:
+    ticket_id = _next_ticket_id(state)
+    state.setdefault("tickets", {})[ticket_id] = {
+        "title": _oneline(title),
+        "type": ticket_type,
+        "question": _oneline(question),
+        "status": "open",
+        "blocked_by": list(blocked_by),
+        "claimed_by": None,
+        "claimed_at": None,
+        "created_at": _now(),
+        "resolved_at": None,
+        "human_input_path": None,
+        "resolution": None,
+        "from_fog": from_fog or None,
+    }
+    return ticket_id
+
+
+# ---------------------------------------------------------------------------
+# View rendering
+# ---------------------------------------------------------------------------
+
+
+def _ticket_badge(state: dict[str, Any], ticket: dict[str, Any]) -> str:
+    if (
+        ticket.get("status") == "open"
+        and ticket.get("claimed_by")
+        and ticket.get("type") in HITL_TYPES
+        and not ticket.get("human_input_path")
+    ):
+        return " — 🔴 AWAITING HUMAN"
+    return ""
+
+
+def _render_map_md(state: dict[str, Any]) -> str:
+    tickets = state.get("tickets", {})
+    lines: list[str] = [
+        _DO_NOT_EDIT_BANNER,
+        f"# Wayfinding Map: {_oneline(state.get('title', state['slug']))}",
+        "",
+        f"- **Slug:** `{state['slug']}`",
+        f"- **Status:** {state.get('status', 'active')}",
+        f"- **Map ID:** `{state.get('map_id', '')}`",
+        f"- **Revision:** {state.get('revision', 0)}",
+        "",
+        "## Destination",
+        "",
+        _oneline(state.get("destination", "")) or "_Not stated._",
+        "",
+        "## Notes",
+        "",
+        _oneline(state.get("notes", "")) or "_None._",
+        "",
+        "## Decisions so far",
+        "",
+    ]
+
+    resolved = [
+        (tid, tickets[tid])
+        for tid in sorted(tickets)
+        if tickets[tid].get("status") == "resolved"
+    ]
+    if resolved:
+        for tid, ticket in resolved:
+            resolution = ticket.get("resolution") or {}
+            gist = _oneline(resolution.get("gist", ""))
+            path = resolution.get("path", "")
+            link = f"  ([resolution]({path}))" if path else ""
+            lines.append(f"- **{tid}** {_oneline(ticket.get('title', ''))} — {gist}{link}")
+    else:
+        lines.append("_None yet._")
+
+    lines += ["", "## Frontier (resolve next, one non-research at a time)", ""]
+    frontier = _frontier_tickets(state)
+    if frontier:
+        for ticket in frontier:
+            lines.append(
+                f"- **{ticket['ticket_id']}** [{ticket['type']}] "
+                f"{_oneline(ticket.get('title', ''))} — {_oneline(ticket.get('question', ''))}"
+            )
+    else:
+        lines.append("_Empty._")
+
+    lines += ["", "## Blocked / claimed", ""]
+    pending: list[str] = []
+    for tid in sorted(tickets):
+        ticket = tickets[tid]
+        if ticket.get("status") != "open":
+            continue
+        blocked = _ticket_blocked(state, ticket)
+        claimed = bool(ticket.get("claimed_by"))
+        if not blocked and not claimed:
+            continue
+        detail_parts: list[str] = []
+        if blocked:
+            detail_parts.append(
+                "blocked by " + ", ".join(ticket.get("blocked_by", []))
+            )
+        if claimed:
+            detail_parts.append(f"claimed by `{ticket['claimed_by']}`")
+        detail = "; ".join(detail_parts)
+        badge = _ticket_badge(state, ticket)
+        pending.append(
+            f"- **{tid}** [{ticket['type']}] {_oneline(ticket.get('title', ''))}"
+            f" — {detail}{badge}"
+        )
+    lines += pending if pending else ["_None._"]
+
+    lines += ["", "## Fog of war (too vague to ticket yet)", ""]
+    open_fog = _open_fog(state)
+    if open_fog:
+        for fog in open_fog:
+            lines.append(f"- **{fog.get('id')}** {_oneline(fog.get('text', ''))}")
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Out of scope", ""]
+    out_of_scope = state.get("out_of_scope", [])
+    if out_of_scope:
+        for entry in out_of_scope:
+            ref = entry.get("ticket_id") or entry.get("fog_id") or ""
+            ref_text = f" (from {ref})" if ref else ""
+            lines.append(
+                f"- {_oneline(entry.get('gist', ''))} — "
+                f"{_oneline(entry.get('reason', ''))}{ref_text}"
+            )
+    else:
+        lines.append("_None._")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_ticket_md(state: dict[str, Any], ticket_id: str) -> str:
+    ticket = state["tickets"][ticket_id]
+    resolution = ticket.get("resolution") or {}
+    lines = [
+        _DO_NOT_EDIT_BANNER,
+        f"# {ticket_id}: {_oneline(ticket.get('title', ''))}",
+        "",
+        f"- **Type:** {ticket.get('type')}",
+        f"- **Status:** {ticket.get('status')}",
+        f"- **Blocked by:** {', '.join(ticket.get('blocked_by', [])) or '—'}",
+        f"- **Claimed by:** {ticket.get('claimed_by') or '—'}",
+        f"- **From fog:** {ticket.get('from_fog') or '—'}",
+        f"- **Created:** {ticket.get('created_at')}",
+        f"- **Resolved:** {ticket.get('resolved_at') or '—'}",
+        "",
+        "## Question",
+        "",
+        _oneline(ticket.get("question", "")),
+        "",
+    ]
+    if resolution:
+        lines += [
+            "## Resolution",
+            "",
+            _oneline(resolution.get("gist", "")),
+            "",
+            f"See `{resolution.get('path', '')}`.",
+            "",
+        ]
+    if ticket.get("human_input_path"):
+        lines += [f"Human input recorded at `{ticket['human_input_path']}`.", ""]
+    return "\n".join(lines)
+
+
+def _render_views(state: dict[str, Any]) -> None:
+    map_dir = _map_dir(state["slug"])
+    map_dir.mkdir(parents=True, exist_ok=True)
+    (map_dir / "map.md").write_text(_render_map_md(state), encoding="utf-8")
+    tickets_dir = map_dir / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    for ticket_id in state.get("tickets", {}):
+        (tickets_dir / f"{ticket_id}.md").write_text(
+            _render_ticket_md(state, ticket_id), encoding="utf-8"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operations — map lifecycle
+# ---------------------------------------------------------------------------
+
+
+def create_wayfind_map(
+    slug: str,
+    title: str,
+    destination: str,
+    notes: str = "",
+    fog_json: str = "[]",
+) -> dict[str, Any]:
+    """Create a new decision map at .map/wayfind/<slug>/."""
+    if not _SLUG_RE.match(slug or ""):
+        return _err(
+            f"invalid slug {slug!r}: must match [a-z0-9-] and be 1-50 chars."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(destination):
+        return _err("destination must be a non-empty string (name where you are headed).")
+    if _state_path(slug).exists():
+        return _err(f"a map with slug {slug!r} already exists.", code="duplicate")
+
+    try:
+        parsed_fog = json.loads(fog_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _err(f"invalid fog JSON: {exc}")
+    if not isinstance(parsed_fog, list):
+        return _err("fog must be a JSON array of strings.")
+
+    fog: list[dict[str, Any]] = []
+    for i, text in enumerate(parsed_fog, 1):
+        if not isinstance(text, str) or not text.strip():
+            return _err(f"fog[{i - 1}] must be a non-empty string.")
+        fog.append({"id": f"F-{i}", "text": _oneline(text), "status": "open"})
+
+    state: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "backend": "local",
+        "revision": 0,
+        "map_id": uuid.uuid4().hex,
+        "slug": slug,
+        "title": _oneline(title),
+        "status": "charting",
+        "destination": _oneline(destination),
+        "notes": _oneline(notes),
+        "fog": fog,
+        "out_of_scope": [],
+        "tickets": {},
+        "sessions": {},
+    }
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        map_id=state["map_id"],
+        state_path=str(_state_path(slug)),
+        map_path=str(_map_dir(slug) / "map.md"),
+        fog_count=len(fog),
+    )
+
+
+def wayfind_status(slug: Optional[str] = None) -> dict[str, Any]:
+    """Without slug: list all maps. With slug: counts + handoff eligibility."""
+    if slug is None:
+        root = _wayfind_root()
+        maps: list[dict[str, Any]] = []
+        if root.exists():
+            for child in sorted(root.iterdir()):
+                if not child.is_dir():
+                    continue
+                state = _load_state(child.name)
+                if state is None:
+                    continue
+                maps.append(_status_summary(state))
+        return _ok(maps=maps, count=len(maps))
+
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    return _ok(**_status_summary(state))
+
+
+def _status_summary(state: dict[str, Any]) -> dict[str, Any]:
+    tickets = state.get("tickets", {})
+    open_ids = [tid for tid, t in tickets.items() if t.get("status") == "open"]
+    blocked = [tid for tid in open_ids if _ticket_blocked(state, tickets[tid])]
+    claimed = _active_claims(state)
+    resolved = [tid for tid, t in tickets.items() if t.get("status") == "resolved"]
+    out_of_scope = [
+        tid for tid, t in tickets.items() if t.get("status") == "out_of_scope"
+    ]
+    return {
+        "slug": state["slug"],
+        "title": state.get("title", ""),
+        "map_status": state.get("status", "active"),
+        "revision": state.get("revision", 0),
+        "counts": {
+            "open": len(open_ids),
+            "blocked": len(blocked),
+            "claimed": len(claimed),
+            "resolved": len(resolved),
+            "out_of_scope": len(out_of_scope),
+            "open_fog": len(_open_fog(state)),
+            "frontier": len(_frontier_tickets(state)),
+        },
+        "handoff_eligible": _is_terminal(state),
+    }
+
+
+def list_handoffs() -> dict[str, Any]:
+    """Return completed handoffs — the read-only source for /map-plan's offer."""
+    root = _wayfind_root()
+    handoffs: list[dict[str, Any]] = []
+    if root.exists():
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            handoff_path = child / "handoff.json"
+            state = _load_state(child.name)
+            if state is None or not handoff_path.exists():
+                continue
+            try:
+                payload = json.loads(handoff_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            handoffs.append(
+                {
+                    "slug": state["slug"],
+                    "title": state.get("title", ""),
+                    "handoff_path": str(child / "handoff.md"),
+                    "decisions_count": len(payload.get("decisions", [])),
+                    "generated_at": payload.get("generated_at", ""),
+                }
+            )
+    return _ok(handoffs=handoffs, count=len(handoffs))
+
+
+def show_ticket(slug: str, ticket_id: str) -> dict[str, Any]:
+    """Read-only zoom into a single ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    return _ok(ticket_id=ticket_id, ticket=ticket)
+
+
+# ---------------------------------------------------------------------------
+# Operations — tickets
+# ---------------------------------------------------------------------------
+
+
+def _parse_blocked_by(
+    state: dict[str, Any], blocked_by_json: str
+) -> tuple[Optional[list[str]], Optional[dict[str, Any]]]:
+    """Parse + validate a blocked_by list. Returns (list, None) or (None, error)."""
+    try:
+        parsed = json.loads(blocked_by_json or "[]")
+    except json.JSONDecodeError as exc:
+        return None, _err(f"invalid blocked_by JSON: {exc}")
+    if not isinstance(parsed, list):
+        return None, _err("blocked_by must be a JSON array of ticket ids.")
+    tickets = state.get("tickets", {})
+    seen: list[str] = []
+    for bid in parsed:
+        if not isinstance(bid, str) or bid not in tickets:
+            return None, _err(f"unknown blocker ticket id: {bid!r}.")
+        if bid not in seen:
+            seen.append(bid)
+    return seen, None
+
+
+def add_ticket(
+    slug: str,
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by_json: str = "[]",
+    from_fog: str = "",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Add a decision ticket with a single sharp question."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if ticket_type not in WAYFIND_TICKET_TYPES:
+        return _err(
+            f"invalid ticket type {ticket_type!r}. "
+            f"Must be one of: {sorted(WAYFIND_TICKET_TYPES)}."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(question):
+        return _err(
+            "question must be a single, sharply-stated question. "
+            "If you cannot state it sharply now, keep it as fog (add_fog) instead."
+        )
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+    if from_fog:
+        if not any(f.get("id") == from_fog for f in state.get("fog", [])):
+            return _err(f"unknown fog id: {from_fog!r}.")
+
+    ticket_id = _mint_ticket(state, title, ticket_type, question, blocked_by, from_fog)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, revision=state["revision"])
+
+
+def wire_blocking(
+    slug: str,
+    ticket_id: str,
+    blocked_by_json: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Replace a ticket's blocked_by set; rejects unknown ids and cycles."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if ticket_id not in state.get("tickets", {}):
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+    if ticket_id in blocked_by:
+        return _err("a ticket cannot block itself.")
+
+    graph = _blocking_graph(state, override=(ticket_id, blocked_by))
+    if _detect_cycle(graph):
+        return _err(
+            f"wiring {ticket_id!r} to block on {blocked_by} would create a cycle.",
+            code="cycle",
+        )
+
+    state["tickets"][ticket_id]["blocked_by"] = blocked_by
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, blocked_by=blocked_by, revision=state["revision"])
+
+
+def claim_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Claim a frontier ticket before working it (claim-before-work invariant)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not session:
+        return _err("session id is required to claim a ticket.")
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("status") != "open":
+        return _err(
+            f"ticket {ticket_id!r} is {ticket.get('status')!r}; only open tickets "
+            "can be claimed.",
+            code="not_open",
+        )
+    if ticket.get("claimed_by"):
+        return _err(
+            f"ticket {ticket_id!r} is already claimed by {ticket['claimed_by']!r}.",
+            code="already_claimed",
+        )
+    if _ticket_blocked(state, ticket):
+        return _err(
+            f"ticket {ticket_id!r} is blocked by unresolved tickets "
+            f"{ticket.get('blocked_by', [])}.",
+            code="blocked",
+        )
+
+    ticket["claimed_by"] = session
+    ticket["claimed_at"] = _now()
+    ledger = _ensure_session(state, session)
+    if ticket_id not in ledger["claimed"]:
+        ledger["claimed"].append(ticket_id)
+    if state.get("status") == "charting":
+        state["status"] = "active"
+    _recompute_status(state)
+    _save_state(state)
+
+    hitl_pending = ticket.get("type") in HITL_TYPES
+    result = _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        session=session,
+        hitl_pending=hitl_pending,
+        revision=state["revision"],
+    )
+    if hitl_pending:
+        result["message"] = (
+            f"{ticket['type']} ticket claimed. Ask the human the question verbatim, "
+            "STOP generating, and hand control back. When the human answers, save "
+            "their verbatim words to a file and call record_human_input before "
+            "resolve_ticket."
+        )
+    return result
+
+
+def release_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Release a ticket claimed by this session (crash / interruption recovery)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} is not claimed by session {session!r} "
+            f"(claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    ticket["claimed_by"] = None
+    ticket["claimed_at"] = None
+    ledger = state.get("sessions", {}).get(session)
+    if ledger and ticket_id in ledger.get("claimed", []):
+        ledger["claimed"].remove(ticket_id)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, revision=state["revision"])
+
+
+def record_human_input(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    path: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Register a verbatim human response file — required before a HITL resolve."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} must be claimed by session {session!r} to record "
+            f"human input (claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    # Paths are relative to the map dir (.map/wayfind/<slug>/) so the value stored
+    # in state.json doubles as a correct link target from the co-located views.
+    input_path = _map_dir(slug) / path
+    if not input_path.exists() or not input_path.read_text(
+        encoding="utf-8", errors="replace"
+    ).strip():
+        return _err(
+            f"human input file {path!r} (under the map dir) does not exist or is empty. "
+            "Save the human's verbatim answer there first.",
+            code="missing_input",
+        )
+    ticket["human_input_path"] = path
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, human_input_path=path, revision=state["revision"])
+
+
+def resolve_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    gist: str,
+    resolution_path: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Close a claimed ticket with a one-line gist + a prose resolution file."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} must be claimed by session {session!r} to resolve "
+            f"(claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    if ticket.get("status") != "open":
+        return _err(
+            f"ticket {ticket_id!r} is already {ticket.get('status')!r}.",
+            code="not_open",
+        )
+    if not _oneline(gist):
+        return _err("gist must be a non-empty one-line summary of the decision.")
+    # resolution_path is relative to the map dir (.map/wayfind/<slug>/) so the stored
+    # value is a correct link target from the co-located map.md / handoff.md views.
+    resolution_file = _map_dir(slug) / resolution_path
+    if not resolution_file.exists() or not resolution_file.read_text(
+        encoding="utf-8", errors="replace"
+    ).strip():
+        return _err(
+            f"resolution file {resolution_path!r} (under the map dir) does not exist or "
+            "is empty. Write the prose resolution first.",
+            code="missing_resolution",
+        )
+
+    is_hitl = ticket.get("type") in HITL_TYPES
+    if is_hitl and not ticket.get("human_input_path"):
+        return _err(
+            f"ticket {ticket_id!r} is a {ticket.get('type')} (human-in-the-loop) "
+            "ticket awaiting a human response. Call record_human_input first.",
+            code="awaiting_human",
+        )
+
+    is_non_research = ticket.get("type") != "research"
+    ledger = _ensure_session(state, session)
+    if is_non_research and int(ledger.get("non_research_resolved", 0)) >= 1:
+        return _err(
+            "this session has already resolved a non-research ticket. Resolve at most "
+            "ONE non-research ticket per session; start a new session to continue.",
+            code="session_limit",
+        )
+
+    ticket["status"] = "resolved"
+    ticket["resolved_at"] = _now()
+    ticket["resolution"] = {"gist": _oneline(gist), "path": resolution_path}
+    if ticket_id in ledger.get("claimed", []):
+        ledger["claimed"].remove(ticket_id)
+    if is_non_research:
+        ledger["non_research_resolved"] = int(ledger.get("non_research_resolved", 0)) + 1
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        ticket_status="resolved",
+        handoff_eligible=_is_terminal(state),
+        revision=state["revision"],
+    )
+
+
+def wayfind_frontier(slug: str) -> dict[str, Any]:
+    """Return open + unblocked + unclaimed tickets (creation order)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    frontier = [
+        {
+            "ticket_id": t["ticket_id"],
+            "title": t.get("title", ""),
+            "type": t.get("type"),
+            "question": t.get("question", ""),
+        }
+        for t in _frontier_tickets(state)
+    ]
+    return _ok(slug=slug, frontier=frontier, count=len(frontier))
+
+
+# ---------------------------------------------------------------------------
+# Operations — fog & out-of-scope
+# ---------------------------------------------------------------------------
+
+
+def add_fog(
+    slug: str, text: str, expected_revision: Optional[int] = None
+) -> dict[str, Any]:
+    """Record a still-too-vague concern that cannot yet be a sharp ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not _oneline(text):
+        return _err("fog text must be a non-empty string.")
+    fog_id = _next_fog_id(state)
+    state.setdefault("fog", []).append(
+        {"id": fog_id, "text": _oneline(text), "status": "open"}
+    )
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, fog_id=fog_id, revision=state["revision"])
+
+
+def graduate_fog(
+    slug: str,
+    fog_id: str,
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by_json: str = "[]",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Atomically graduate a fog entry into a sharp ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    fog_entry = next((f for f in state.get("fog", []) if f.get("id") == fog_id), None)
+    if fog_entry is None:
+        return _err(f"no fog entry {fog_id!r} in map {slug!r}.", code="not_found")
+    if fog_entry.get("status") != "open":
+        return _err(
+            f"fog {fog_id!r} is already {fog_entry.get('status')!r}; cannot graduate "
+            "it again.",
+            code="already_graduated",
+        )
+    if ticket_type not in WAYFIND_TICKET_TYPES:
+        return _err(
+            f"invalid ticket type {ticket_type!r}. "
+            f"Must be one of: {sorted(WAYFIND_TICKET_TYPES)}."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(question):
+        return _err("question must be a single, sharply-stated question.")
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+
+    ticket_id = _mint_ticket(state, title, ticket_type, question, blocked_by, fog_id)
+    fog_entry["status"] = "graduated"
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, fog_id=fog_id, revision=state["revision"])
+
+
+def rule_out_of_scope(
+    slug: str,
+    reason: str,
+    ticket_id: str = "",
+    fog_id: str = "",
+    gist: str = "",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Permanently rule a ticket (or fog entry) out of scope.
+
+    Out-of-scope items are recorded separately and never appear in Decisions so
+    far — an exclusion is not a decision that graduates into the plan.
+    """
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not _oneline(reason):
+        return _err("reason must be a non-empty string.")
+    if bool(ticket_id) == bool(fog_id):
+        return _err("provide exactly one of ticket_id or fog_id.")
+
+    entry: dict[str, Any] = {"reason": _oneline(reason), "ruled_at": _now()}
+    if ticket_id:
+        ticket = state.get("tickets", {}).get(ticket_id)
+        if ticket is None:
+            return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+        if ticket.get("status") in TERMINAL_TICKET_STATUSES:
+            return _err(
+                f"ticket {ticket_id!r} is already {ticket.get('status')!r}.",
+                code="not_open",
+            )
+        ticket["status"] = "out_of_scope"
+        session = ticket.get("claimed_by")
+        ticket["claimed_by"] = None
+        ticket["claimed_at"] = None
+        ledger = state.get("sessions", {}).get(session) if session else None
+        if ledger and ticket_id in ledger.get("claimed", []):
+            ledger["claimed"].remove(ticket_id)
+        entry["ticket_id"] = ticket_id
+        entry["gist"] = _oneline(gist) or _oneline(ticket.get("title", ""))
+    else:
+        fog_entry = next(
+            (f for f in state.get("fog", []) if f.get("id") == fog_id), None
+        )
+        if fog_entry is None:
+            return _err(f"no fog entry {fog_id!r} in map {slug!r}.", code="not_found")
+        if fog_entry.get("status") != "open":
+            return _err(
+                f"fog {fog_id!r} is already {fog_entry.get('status')!r}.",
+                code="not_open",
+            )
+        fog_entry["status"] = "retired"
+        entry["fog_id"] = fog_id
+        entry["gist"] = _oneline(gist) or _oneline(fog_entry.get("text", ""))
+
+    state.setdefault("out_of_scope", []).append(entry)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ruled=ticket_id or fog_id, revision=state["revision"])
+
+
+# ---------------------------------------------------------------------------
+# Operations — handoff
+# ---------------------------------------------------------------------------
+
+
+def _open_item_labels(state: dict[str, Any]) -> list[str]:
+    """Human-readable list of items blocking a clean (non-early) handoff."""
+    labels: list[str] = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") in TERMINAL_TICKET_STATUSES:
+            continue
+        state_word = "claimed" if ticket.get("claimed_by") else "open"
+        labels.append(f"{tid} ({ticket.get('type')}, {state_word}): {ticket.get('title', '')}")
+    for fog in _open_fog(state):
+        labels.append(f"{fog.get('id')} (fog): {fog.get('text', '')}")
+    return labels
+
+
+def emit_wayfind_handoff(
+    slug: str,
+    remaining_risks_json: str = "[]",
+    early: bool = False,
+    confirmed_by_user: bool = False,
+    branch: Optional[str] = None,
+) -> dict[str, Any]:
+    """Write the handoff artifact consumed by /map-plan and mark the map handed off."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+
+    try:
+        remaining_risks = json.loads(remaining_risks_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _err(f"invalid remaining_risks JSON: {exc}")
+    if not isinstance(remaining_risks, list) or not all(
+        isinstance(r, str) for r in remaining_risks
+    ):
+        return _err("remaining_risks must be a JSON array of strings.")
+    remaining_risks = [_oneline(r) for r in remaining_risks]
+
+    open_items = _open_item_labels(state)
+    if not _is_terminal(state):
+        if not (early and confirmed_by_user):
+            return _err(
+                "map is not exhausted: fog, claimed, or unresolved tickets remain. "
+                "Resolve or rule out every item, or pass --early with "
+                "--confirmed-by-user to hand off with open items as remaining risks.",
+                code="not_terminal",
+                open_items=open_items,
+            )
+        # Early handoff: fold open items into remaining risks so nothing is lost.
+        remaining_risks = remaining_risks + [f"UNRESOLVED: {label}" for label in open_items]
+
+    decisions = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") != "resolved":
+            continue
+        resolution = ticket.get("resolution") or {}
+        decisions.append(
+            {
+                "ticket_id": tid,
+                "title": ticket.get("title", ""),
+                "type": ticket.get("type"),
+                "question": ticket.get("question", ""),
+                "gist": resolution.get("gist", ""),
+                "resolution_path": resolution.get("path", ""),
+            }
+        )
+
+    out_of_scope = [
+        {
+            "gist": entry.get("gist", ""),
+            "reason": entry.get("reason", ""),
+            "ref": entry.get("ticket_id") or entry.get("fog_id") or "",
+        }
+        for entry in state.get("out_of_scope", [])
+    ]
+
+    generated_at = _now()
+    map_dir = _map_dir(slug)
+    handoff_payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "slug": slug,
+        "map_id": state.get("map_id", ""),
+        "title": state.get("title", ""),
+        "destination": state.get("destination", ""),
+        "generated_at": generated_at,
+        "early": bool(early and not _is_terminal(state)),
+        "decisions": decisions,
+        "out_of_scope": out_of_scope,
+        "remaining_risks": remaining_risks,
+    }
+    json_path = map_dir / "handoff.json"
+    md_path = map_dir / "handoff.md"
+    tmp_json = json_path.with_name(json_path.name + ".tmp")
+    tmp_json.write_text(
+        json.dumps(handoff_payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp_json.replace(json_path)
+    md_path.write_text(_render_handoff_md(handoff_payload), encoding="utf-8")
+
+    state["status"] = "handed_off"
+    _save_state(state)
+
+    manifest_info = _register_handoff_manifest(slug, json_path, md_path, decisions, branch)
+
+    return _ok(
+        slug=slug,
+        handoff_path=str(md_path),
+        handoff_json=str(json_path),
+        decisions_count=len(decisions),
+        remaining_risks_count=len(remaining_risks),
+        manifest=manifest_info,
+        revision=state["revision"],
+    )
+
+
+def _render_handoff_md(payload: dict[str, Any]) -> str:
+    lines = [
+        f"# Wayfinding Handoff: {_oneline(payload.get('title', ''))}",
+        "",
+        f"- **Slug:** `{payload.get('slug', '')}`",
+        f"- **Generated:** {payload.get('generated_at', '')}",
+        f"- **Early handoff:** {'yes' if payload.get('early') else 'no'}",
+        "",
+        "## Destination",
+        "",
+        _oneline(payload.get("destination", "")) or "_Not stated._",
+        "",
+        "## Decisions Made",
+        "",
+        "| # | Question | Decision | Resolution |",
+        "|---|----------|----------|------------|",
+    ]
+    if payload.get("decisions"):
+        for i, decision in enumerate(payload["decisions"], 1):
+            path = decision.get("resolution_path", "")
+            link = f"[{decision.get('ticket_id', '')}]({path})" if path else decision.get("ticket_id", "")
+            lines.append(
+                f"| {i} | {_oneline(decision.get('question', ''))} | "
+                f"{_oneline(decision.get('gist', ''))} | {link} |"
+            )
+    else:
+        lines.append("| — | _No decisions resolved._ | | |")
+
+    lines += ["", "## Out of Scope", ""]
+    if payload.get("out_of_scope"):
+        for entry in payload["out_of_scope"]:
+            ref = entry.get("ref", "")
+            ref_text = f" (from {ref})" if ref else ""
+            lines.append(
+                f"- {_oneline(entry.get('gist', ''))} — "
+                f"{_oneline(entry.get('reason', ''))}{ref_text}"
+            )
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Open Questions / Remaining Risks", ""]
+    if payload.get("remaining_risks"):
+        for risk in payload["remaining_risks"]:
+            lines.append(f"- {_oneline(risk)}")
+    else:
+        lines.append("_None._")
+
+    lines += [
+        "",
+        "---",
+        "",
+        "Feed this into planning with "
+        "`/map-plan --wayfind " + str(payload.get("slug", "")) + "` on a feature branch.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _register_handoff_manifest(
+    slug: str,
+    json_path: Path,
+    md_path: Path,
+    decisions: list[dict[str, Any]],
+    branch: Optional[str],
+) -> dict[str, Any]:
+    """Register the wayfind_handoff manifest stage on the current branch.
+
+    LAZY import of map_step_runner — the ONLY cross-module coupling. A manifest
+    failure is reported but never loses the already-written handoff artifact.
+    """
+    try:
+        import map_step_runner  # noqa: PLC0415 — lazy sibling in .map/scripts/  # pyright: ignore[reportMissingImports]
+
+        manifest = map_step_runner.load_artifact_manifest(branch)
+        map_step_runner._set_manifest_stage(
+            manifest,
+            "wayfind_handoff",
+            "ready",
+            artifacts=[
+                map_step_runner._artifact_ref(md_path, "wayfind-handoff"),
+                map_step_runner._artifact_ref(json_path, "wayfind-handoff-json"),
+            ],
+            metadata={"slug": slug, "decisions_count": len(decisions)},
+        )
+        result = map_step_runner.save_artifact_manifest(manifest, branch)
+        return {"status": "success", "path": result.get("path")}
+    except Exception as exc:  # noqa: BLE001 — manifest is best-effort, never fatal
+        return {"status": "skipped", "reason": f"manifest registration failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print(result: dict[str, Any]) -> int:
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    return 0 if result.get("status") == "success" else 1
+
+
+def _add_revision_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--expected-revision",
+        type=int,
+        default=None,
+        help="optimistic-concurrency guard: fail if the map is not at this revision",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wayfind_runner.py",
+        description="Deterministic operations for /map-wayfind decision maps.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    types = sorted(WAYFIND_TICKET_TYPES)
+
+    p = sub.add_parser("create_wayfind_map", help="create a new decision map")
+    p.add_argument("slug")
+    p.add_argument("title")
+    p.add_argument("destination")
+    p.add_argument("--notes", default="")
+    p.add_argument("--fog-json", default="[]")
+
+    p = sub.add_parser("wayfind_status", help="list maps or show one map's status")
+    p.add_argument("--slug", default=None)
+
+    sub.add_parser("list_handoffs", help="list completed handoffs")
+
+    p = sub.add_parser("show_ticket", help="show one ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+
+    p = sub.add_parser("add_ticket", help="add a decision ticket")
+    p.add_argument("slug")
+    p.add_argument("title")
+    p.add_argument("ticket_type", choices=types)
+    p.add_argument("question")
+    p.add_argument("--blocked-by-json", default="[]")
+    p.add_argument("--from-fog", default="")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("wire_blocking", help="set a ticket's blocked_by set")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("blocked_by_json")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("claim_ticket", help="claim a frontier ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("release_ticket", help="release a claimed ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("record_human_input", help="register a verbatim human response")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    p.add_argument("path")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("resolve_ticket", help="resolve a claimed ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    p.add_argument("gist")
+    p.add_argument("resolution_path")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
+    p.add_argument("slug")
+
+    p = sub.add_parser("add_fog", help="record a still-vague concern")
+    p.add_argument("slug")
+    p.add_argument("text")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("graduate_fog", help="turn a fog entry into a ticket")
+    p.add_argument("slug")
+    p.add_argument("fog_id")
+    p.add_argument("title")
+    p.add_argument("ticket_type", choices=types)
+    p.add_argument("question")
+    p.add_argument("--blocked-by-json", default="[]")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("rule_out_of_scope", help="rule a ticket or fog out of scope")
+    p.add_argument("slug")
+    p.add_argument("reason")
+    p.add_argument("--ticket-id", default="")
+    p.add_argument("--fog-id", default="")
+    p.add_argument("--gist", default="")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("emit_wayfind_handoff", help="write the handoff artifact")
+    p.add_argument("slug")
+    p.add_argument("--remaining-risks-json", default="[]")
+    p.add_argument("--early", action="store_true")
+    p.add_argument("--confirmed-by-user", action="store_true")
+    p.add_argument("--branch", default=None)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
+    command = args.command
+    if command == "create_wayfind_map":
+        return create_wayfind_map(
+            args.slug, args.title, args.destination, args.notes, args.fog_json
+        )
+    if command == "wayfind_status":
+        return wayfind_status(args.slug)
+    if command == "list_handoffs":
+        return list_handoffs()
+    if command == "show_ticket":
+        return show_ticket(args.slug, args.ticket_id)
+    if command == "add_ticket":
+        return add_ticket(
+            args.slug,
+            args.title,
+            args.ticket_type,
+            args.question,
+            args.blocked_by_json,
+            args.from_fog,
+            args.expected_revision,
+        )
+    if command == "wire_blocking":
+        return wire_blocking(
+            args.slug, args.ticket_id, args.blocked_by_json, args.expected_revision
+        )
+    if command == "claim_ticket":
+        return claim_ticket(
+            args.slug, args.ticket_id, args.session, args.expected_revision
+        )
+    if command == "release_ticket":
+        return release_ticket(
+            args.slug, args.ticket_id, args.session, args.expected_revision
+        )
+    if command == "record_human_input":
+        return record_human_input(
+            args.slug, args.ticket_id, args.session, args.path, args.expected_revision
+        )
+    if command == "resolve_ticket":
+        return resolve_ticket(
+            args.slug,
+            args.ticket_id,
+            args.session,
+            args.gist,
+            args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "wayfind_frontier":
+        return wayfind_frontier(args.slug)
+    if command == "add_fog":
+        return add_fog(args.slug, args.text, args.expected_revision)
+    if command == "graduate_fog":
+        return graduate_fog(
+            args.slug,
+            args.fog_id,
+            args.title,
+            args.ticket_type,
+            args.question,
+            args.blocked_by_json,
+            args.expected_revision,
+        )
+    if command == "rule_out_of_scope":
+        return rule_out_of_scope(
+            args.slug,
+            args.reason,
+            args.ticket_id,
+            args.fog_id,
+            args.gist,
+            args.expected_revision,
+        )
+    if command == "emit_wayfind_handoff":
+        return emit_wayfind_handoff(
+            args.slug,
+            args.remaining_risks_json,
+            args.early,
+            args.confirmed_by_user,
+            args.branch,
+        )
+    return _err(f"unknown command: {command!r}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return _print(_dispatch(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.map/scripts/wayfind_runner.py
+++ b/.map/scripts/wayfind_runner.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import uuid
@@ -94,6 +95,25 @@ def _state_path(slug: str) -> Path:
     return _map_dir(slug) / "state.json"
 
 
+def _resolve_evidence_path(slug: str, rel: str) -> Optional[Path]:
+    """Resolve an evidence file (resolution / human-input) path under the map dir.
+
+    Returns the resolved Path only when *rel* names a regular file contained in
+    the map directory. Absolute paths, ``..`` escapes, directories, and missing
+    files all return None — so a caller cannot use the provenance gate to read
+    (or claim provenance over) a file outside its own map.
+    """
+    if not rel:
+        return None
+    base = _map_dir(slug).resolve()
+    candidate = (base / rel).resolve()
+    if candidate != base and base not in candidate.parents:
+        return None  # absolute path or ../ escape left the map dir
+    if not candidate.is_file():
+        return None  # missing, or a directory
+    return candidate
+
+
 # ---------------------------------------------------------------------------
 # State load / save + derived views
 # ---------------------------------------------------------------------------
@@ -117,7 +137,10 @@ def _save_state(state: dict[str, Any]) -> None:
     map_dir = _map_dir(slug)
     map_dir.mkdir(parents=True, exist_ok=True)
     path = _state_path(slug)
-    tmp = path.with_name(path.name + ".tmp")
+    # Per-process-unique temp name so two writers never share (and corrupt) one
+    # scratch file. NB: this makes the write atomic, not the read-modify-write —
+    # see _revision_guard for the (best-effort, single-operator) staleness check.
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp.write_text(
         json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
     )
@@ -128,7 +151,15 @@ def _save_state(state: dict[str, Any]) -> None:
 def _revision_guard(
     state: dict[str, Any], expected_revision: Optional[int]
 ) -> Optional[dict[str, Any]]:
-    """Optimistic-concurrency check: reject a mutation against a stale revision."""
+    """Best-effort stale-write detection: reject a mutation whose caller read an
+    older revision than the map now holds.
+
+    This is a friction/audit aid for a single-operator, sequential tool — NOT a
+    true compare-and-swap. It closes the common "I read, then something else
+    advanced the map, then I wrote" window, but does not lock: two processes that
+    both read the same revision before either writes can still lose an update.
+    Concurrent multi-process writers to one map are out of scope by design (a map
+    is charted and worked by one operator at a time)."""
     if expected_revision is None:
         return None
     current = int(state.get("revision", 0))
@@ -140,6 +171,25 @@ def _revision_guard(
             revision=current,
         )
     return None
+
+
+def _mutation_guard(
+    state: dict[str, Any], expected_revision: Optional[int]
+) -> Optional[dict[str, Any]]:
+    """Pre-mutation gate for ticket/fog operations.
+
+    Rejects any mutation once the map is handed off (its handoff artifact is
+    frozen, so a further edit would leave a discoverable handoff that omits the
+    new state), then applies the optimistic staleness check. Not used by
+    emit_wayfind_handoff, which may idempotently re-emit a handed-off map."""
+    if state.get("status") == "handed_off":
+        return _err(
+            f"map {state.get('slug')!r} is already handed off; its handoff artifact "
+            "is frozen. Start a follow-up map (or a new session) rather than mutating "
+            "a handed-off map.",
+            code="handed_off",
+        )
+    return _revision_guard(state, expected_revision)
 
 
 # ---------------------------------------------------------------------------
@@ -658,7 +708,7 @@ def add_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if ticket_type not in WAYFIND_TICKET_TYPES:
@@ -697,7 +747,7 @@ def wire_blocking(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if ticket_id not in state.get("tickets", {}):
@@ -732,7 +782,7 @@ def claim_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not session:
@@ -796,7 +846,7 @@ def release_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -829,7 +879,7 @@ def record_human_input(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -842,14 +892,15 @@ def record_human_input(
             code="not_owner",
         )
     # Paths are relative to the map dir (.map/wayfind/<slug>/) so the value stored
-    # in state.json doubles as a correct link target from the co-located views.
-    input_path = _map_dir(slug) / path
-    if not input_path.exists() or not input_path.read_text(
+    # in state.json doubles as a correct link target from the co-located views;
+    # containment is enforced so absolute/../ paths cannot claim provenance.
+    input_path = _resolve_evidence_path(slug, path)
+    if input_path is None or not input_path.read_text(
         encoding="utf-8", errors="replace"
     ).strip():
         return _err(
-            f"human input file {path!r} (under the map dir) does not exist or is empty. "
-            "Save the human's verbatim answer there first.",
+            f"human input file {path!r} must be a non-empty regular file INSIDE the map "
+            "dir (.map/wayfind/<slug>/). Save the human's verbatim answer there first.",
             code="missing_input",
         )
     ticket["human_input_path"] = path
@@ -869,7 +920,7 @@ def resolve_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -889,14 +940,15 @@ def resolve_ticket(
     if not _oneline(gist):
         return _err("gist must be a non-empty one-line summary of the decision.")
     # resolution_path is relative to the map dir (.map/wayfind/<slug>/) so the stored
-    # value is a correct link target from the co-located map.md / handoff.md views.
-    resolution_file = _map_dir(slug) / resolution_path
-    if not resolution_file.exists() or not resolution_file.read_text(
+    # value is a correct link target from the co-located map.md / handoff.md views;
+    # containment is enforced so absolute/../ paths cannot stand in as a resolution.
+    resolution_file = _resolve_evidence_path(slug, resolution_path)
+    if resolution_file is None or not resolution_file.read_text(
         encoding="utf-8", errors="replace"
     ).strip():
         return _err(
-            f"resolution file {resolution_path!r} (under the map dir) does not exist or "
-            "is empty. Write the prose resolution first.",
+            f"resolution file {resolution_path!r} must be a non-empty regular file INSIDE "
+            "the map dir (.map/wayfind/<slug>/). Write the prose resolution first.",
             code="missing_resolution",
         )
 
@@ -920,6 +972,10 @@ def resolve_ticket(
     ticket["status"] = "resolved"
     ticket["resolved_at"] = _now()
     ticket["resolution"] = {"gist": _oneline(gist), "path": resolution_path}
+    # Clear the active claim on close (consistent with rule_out_of_scope); the
+    # resolver of record is captured in the resolution/git history, not claimed_by.
+    ticket["claimed_by"] = None
+    ticket["claimed_at"] = None
     if ticket_id in ledger.get("claimed", []):
         ledger["claimed"].remove(ticket_id)
     if is_non_research:
@@ -965,7 +1021,7 @@ def add_fog(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not _oneline(text):
@@ -992,7 +1048,7 @@ def graduate_fog(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     fog_entry = next((f for f in state.get("fog", []) if f.get("id") == fog_id), None)
@@ -1041,7 +1097,7 @@ def rule_out_of_scope(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not _oneline(reason):
@@ -1114,11 +1170,17 @@ def emit_wayfind_handoff(
     early: bool = False,
     confirmed_by_user: bool = False,
     branch: Optional[str] = None,
+    expected_revision: Optional[int] = None,
 ) -> dict[str, Any]:
     """Write the handoff artifact consumed by /map-plan and mark the map handed off."""
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
+    # Pure staleness check (not _mutation_guard): a handed-off map may be
+    # idempotently re-emitted, so we do not reject on status == "handed_off".
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
 
     try:
         remaining_risks = json.loads(remaining_risks_json or "[]")
@@ -1185,7 +1247,7 @@ def emit_wayfind_handoff(
     }
     json_path = map_dir / "handoff.json"
     md_path = map_dir / "handoff.md"
-    tmp_json = json_path.with_name(json_path.name + ".tmp")
+    tmp_json = json_path.with_name(f".{json_path.name}.{os.getpid()}.tmp")
     tmp_json.write_text(
         json.dumps(handoff_payload, indent=2, ensure_ascii=True) + "\n",
         encoding="utf-8",
@@ -1415,6 +1477,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--early", action="store_true")
     p.add_argument("--confirmed-by-user", action="store_true")
     p.add_argument("--branch", default=None)
+    _add_revision_arg(p)
 
     return parser
 
@@ -1496,6 +1559,7 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.early,
             args.confirmed_by_user,
             args.branch,
+            args.expected_revision,
         )
     return _err(f"unknown command: {command!r}")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/map-wayfind` — decision-frontier wayfinding before planning (closes #362).** A new opt-in skill for large or foggy efforts where `/map-plan` would force premature decomposition. It builds a durable, repo-level decision map under `.map/wayfind/<slug>/` and resolves open decisions one at a time behind a claim-before-work frontier, with a "fog of war" for questions that cannot yet be stated sharply. Three explicit modes: `chart` (start a map), `work` (resolve one ticket), `handoff` (finish). Tickets are typed `research | prototype | grilling | task`; `prototype`/`grilling` are human-in-the-loop and cannot be resolved until a verbatim human answer is recorded via `record_human_input`. All state mutations go through the new stdlib-only `wayfind_runner.py` (canonical `state.json` + regenerated `map.md`/`tickets/*.md` views); invariants — DFS cycle-freedom, one-non-research-resolve-per-session, the human-in-the-loop gate, and the terminal handoff condition (fog empty AND no active claims AND every ticket resolved/out-of-scope) — are enforced in the runner. `emit_wayfind_handoff` writes a `handoff.md`/`handoff.json` pair and registers a new `wayfind_handoff` artifact-manifest stage; `/map-plan --wayfind <slug>` (or a single-candidate offer via `list_handoffs`) pre-seeds the spec's Decisions Made / Out of Scope / Open Questions. Maps are committed by default so decisions are durable; `chart` warns about the commit-by-default privacy note and the per-slug opt-out. (Also syncs the artifact-manifest JSON schema to the stage-name authority, adding the previously-missing `approval_hold`/`worktree`/`context_usefulness` stages.)
+
 ## [3.22.0] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You drive the whole loop with two core commands plus three gates:
 - **Start with `/map-plan`** for anything non-trivial — it clarifies behavior and splits the work into contract-sized subtasks.
 - **Already scoped?** Go straight to `/map-efficient`.
 - **Tiny edit?** `/map-plan` off-ramps you to a direct edit or `/map-fast` instead of forcing full planning.
+- **Too foggy to plan?** `/map-wayfind` resolves the open design decisions one at a time on a durable map, then hands the settled decisions to `/map-plan`.
 
 > Codex CLI users invoke the same skills with `$`: `$map-plan`, `$map-efficient`, `$map-check`. See the [Usage Guide](docs/USAGE.md#codex-cli-provider).
 
@@ -133,6 +134,7 @@ The DevOpsConf 2026 case study applies this process to a production Kubernetes P
 | Command | Use For |
 |---------|---------|
 | `/map-plan` | **Start here** for non-trivial work; clarify behavior and decompose tasks |
+| `/map-wayfind` | Too foggy to plan? Resolve open design decisions on a durable map *before* `/map-plan` |
 | `/map-efficient` | **Implement** an approved plan or already-scoped task |
 | `/map-fast` | Small, low-risk changes where full planning would be overhead |
 | `/map-check` | Quality gates, verification, and artifact checks |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,7 @@ The remainder of this file contains the deeper implementation dive (workflow-spe
 - `.map/eval-runs/<skill>/`: durable skill-evaluation run logs and optimization JSON/HTML reports
 - `.map/mapify.lock.json`: Install manifest/lock — aggregate audit of all MAP-managed files, written by `mapify init` and read by `mapify check-installed`
 - `.map/<branch>/approval_holds.json` and `.map/<branch>/approval_hold_<id>.md`: Durable human-gate artifacts for pending/decided approval holds
+- `.map/wayfind/<slug>/`: **Repo-level** (not branch-scoped) decision maps for `/map-wayfind`. Holds the canonical `state.json`, regenerated `map.md` and `tickets/*.md` views (DO-NOT-EDIT banner), author-written `resolutions/*.md` (+ `*.human.md` verbatim human answers), and the final `handoff.md`/`handoff.json`. Maps outlive branches and are committed by default.
 
 Claude skill metadata includes `skillClass` in `.claude/skills/skill-rules.json` so the runtime contract is explicit: `task` skills behave like manual slash workflows or opt-in interactive task surfaces, `reference` skills provide inline guidance, and `hybrid` skills combine reference material with declared runtime effects. Today the MAP slash surfaces are `task` skills, including `/map-understand`, whose checklist is transient in the conversation and has no runtime effects; `map-state` is `hybrid` because it documents planning state and ships hooks/scripts that interact with `.map/<branch>/` artifacts, and `map-so-search` is `hybrid` because it ships a script with declared network/credential runtime effects (the opt-in SOFA search; see [Stack Overflow for Agents (SOFA) Integration](#stack-overflow-for-agents-sofa-integration)).
 
@@ -324,6 +325,43 @@ Actor/research phase or pauses for input. The entire SOFA test suite is mocked
 
 (Out of scope for this integration: writing/contributing to SOFA, a SOFA MCP
 surface, and rate-limit handling.)
+
+## Decision-Frontier Wayfinding (`/map-wayfind`)
+
+A manually-invoked, Claude-only skill for large or foggy efforts where `/map-plan`
+would force premature decomposition. It resolves the open design decisions on a
+durable, repo-level map **before** planning; if scope is already crisp it off-ramps
+straight to `/map-plan`.
+
+- **`wayfind_runner.py`** (`.map/scripts/`): a self-contained, **stdlib-only** runner
+  (sibling of `map_step_runner.py`, mirroring the `sofa_client.py` pattern) that owns
+  EVERY mutation to `.map/wayfind/<slug>/state.json` and regenerates the `map.md` /
+  `tickets/*.md` views after each write. The LLM writes only prose (resolutions,
+  verbatim human answers); it never hand-edits the JSON or the views. Each subcommand
+  prints a typed JSON result; the CLI exits non-zero on an error status.
+- **Determinism boundary**: every invariant lives above persistence in the runner —
+  DFS cycle-freedom for `blocked_by` wiring, claim-before-work, one-non-research-resolve
+  per session (a session ledger in `state.json`), the human-in-the-loop gate (a
+  `prototype`/`grilling` ticket cannot resolve until `record_human_input` registers a
+  non-empty verbatim answer file), and the terminal handoff condition (fog empty AND no
+  active claims AND every ticket in `{resolved, out_of_scope}`). A naive
+  `len(frontier)==0` would wrongly fire on a map with claimed or blocked tickets.
+- **Fog of war**: concerns that cannot yet be stated as one sharp question are held as
+  fog rather than pre-sliced into fake tickets, and `graduate_fog` promotes one atomically
+  when it sharpens. Out-of-scope rulings are recorded separately and never graduate into
+  the plan.
+- **Handoff → `/map-plan`**: `emit_wayfind_handoff` writes `handoff.md`/`handoff.json`
+  and registers a `wayfind_handoff` artifact-manifest stage on the current branch (its
+  only cross-module coupling — a lazy import of `map_step_runner` for the manifest
+  helpers, best-effort so a manifest failure never loses the handoff). `/map-plan
+  --wayfind <slug>` (or a single-candidate `list_handoffs` offer, never a silent match)
+  pre-seeds the spec's Decisions Made / Out of Scope / Open Questions. The map is
+  repo-level because it outlives the feature branch that later consumes it.
+
+The runner is optimistic-concurrency aware (`--expected-revision` guards against
+concurrent sessions clobbering the map). Honesty note: the human-in-the-loop and
+session-limit checks add friction and an audit trail, not a mechanical guarantee that an
+LLM cannot fabricate input — the same layered-defense posture MAP uses elsewhere.
 
 ## Cross-cutting Concepts
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -14,6 +14,33 @@ After discovery, `/map-plan` also runs an already-implemented gate: discovery re
 
 When a MAP run enters a merge/rebase conflict, the PreToolUse workflow-context hook adds a conflict-resolution discipline block to `additionalContext`. It fires before `git merge` / `git rebase` and whenever git reports unmerged paths via `git diff --name-only --diff-filter=U`. The protocol is deliberately manual and intent-preserving: list conflicted files, resolve one file or small batch at a time, preserve both sides' intended behavior, check for conflict markers, run the project's test gate after each batch, stage only resolved files, and continue the merge/rebase only after no unmerged files remain. Final verification is: branch current with `origin/main`, no conflict markers, and tests green. The hook never mutates the worktree and never auto-runs tests.
 
+## Decision-frontier wayfinding (`/map-wayfind`)
+
+For a large or foggy effort where `/map-plan` would force premature decomposition, `/map-wayfind` resolves the open design decisions **before** planning. It is a Claude-only, manually-invoked skill; if the scope is already clear enough to specify, skip it and run `/map-plan` directly.
+
+The unit of work is a **decision ticket** on a durable, repo-level map at `.map/wayfind/<slug>/` (the map outlives branches and can span sessions). Tickets are typed:
+
+- `research` — find out an answer that already exists (a subagent may help). Exempt from the one-per-session limit.
+- `prototype` — build a cheap throwaway probe, then get the human's read. Human-in-the-loop.
+- `grilling` — interrogate the human: ask the sharp question, capture their verbatim answer. Human-in-the-loop.
+- `task` — a self-contained decision or chore you settle yourself.
+
+Rules that shape the flow: a ticket exists only when you can state its question sharply **now** — vaguer concerns stay in a **"fog of war"** and graduate later; you **claim before work**; you resolve at most **one non-research ticket per session**; and human-in-the-loop tickets cannot be resolved until a verbatim human answer is recorded. Exclusions are ruled **out of scope** and never graduate into the plan.
+
+Three explicit modes (no auto-detection):
+
+```text
+/map-wayfind chart "rebuild checkout"   # start a map: name the destination, interview, add tickets + fog
+/map-wayfind work checkout              # claim one frontier ticket, resolve it, maintain the map, stop
+/map-wayfind handoff checkout           # when exhausted, emit the handoff for /map-plan
+```
+
+All state lives in `.map/wayfind/<slug>/state.json` and is mutated only through `python3 .map/scripts/wayfind_runner.py <command>`; you write prose only (resolutions, verbatim human answers). The `map.md` and `tickets/*.md` views are regenerated on every mutation and carry a DO-NOT-EDIT banner. Every command prints a JSON result; a non-success `status` means stop and read the message.
+
+`/map-wayfind handoff <slug>` requires the map to be **exhausted** — fog empty, no active claims, and every ticket resolved or out-of-scope (`--early --confirmed-by-user` overrides, folding open items into remaining risks). It writes `handoff.md`/`handoff.json` and registers a `wayfind_handoff` artifact-manifest stage. Feed it into planning with `/map-plan --wayfind <slug>` on a feature branch: the handoff's decisions seed the spec's **Decisions Made** (settled — the interview does not re-ask them), out-of-scope items seed **Out of Scope**, and remaining risks seed **Open Questions**. Without an explicit `--wayfind`, `/map-plan` runs `list_handoffs` and offers a single completed handoff but never consumes one silently.
+
+**Sharing / privacy.** Maps are committed by default (decisions are durable, reviewable history). `grilling` transcripts and prose resolutions may contain sensitive content — `chart` warns about this. To keep one map local, add `.map/wayfind/<slug>/.gitignore` with a single `*`.
+
 ## Canonical Flows
 
 ### Standard flow

--- a/src/mapify_cli/schemas.py
+++ b/src/mapify_cli/schemas.py
@@ -822,6 +822,13 @@ ARTIFACT_MANIFEST_SCHEMA = {
                 "run_health": ARTIFACT_STAGE_SCHEMA,
                 "learn_handoff": ARTIFACT_STAGE_SCHEMA,
                 "implementer_readiness": ARTIFACT_STAGE_SCHEMA,
+                # Stages previously missing from this schema though present in
+                # ARTIFACT_STAGE_NAMES (documentary only — the manifest schema has
+                # no runtime validator; kept in sync to match the stage authority).
+                "approval_hold": ARTIFACT_STAGE_SCHEMA,
+                "worktree": ARTIFACT_STAGE_SCHEMA,
+                "context_usefulness": ARTIFACT_STAGE_SCHEMA,
+                "wayfind_handoff": ARTIFACT_STAGE_SCHEMA,
             },
             "required": [
                 "workflow_fit",

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -250,6 +250,7 @@ ARTIFACT_STAGE_NAMES = (
     "learn_handoff",
     "implementer_readiness",
     "context_usefulness",
+    "wayfind_handoff",
 )
 RUN_HEALTH_TERMINAL_STATUSES = {
     "pending",

--- a/src/mapify_cli/templates/map/scripts/wayfind_runner.py
+++ b/src/mapify_cli/templates/map/scripts/wayfind_runner.py
@@ -1,0 +1,1510 @@
+#!/usr/bin/env python3
+"""wayfind_runner.py — deterministic operations for /map-wayfind decision maps.
+
+Self-contained, stdlib-only runner.  Owns EVERY mutation to
+``.map/wayfind/<slug>/state.json`` (the canonical store) and regenerates the
+human-readable views (``map.md``, ``tickets/T-00N.md``) after each mutation.
+
+Design contract (mirrors the wider MAP conventions):
+  * state.json is the single source of truth; map.md / tickets/*.md are derived
+    projections carrying a DO-NOT-EDIT banner and are never parsed back.
+  * The LLM never edits state.json by hand — it calls these operations and
+    writes only prose resolution files under ``resolutions/``.
+  * Every function returns a typed result dict: ``{"status": "success", ...}``
+    or ``{"status": "error", "message": ...}``.  Nothing is raised through the
+    public API; the CLI turns a non-success status into exit code 1.
+  * Invariants (cycle-freedom, one-non-research-resolve-per-session, HITL gate,
+    terminal-handoff condition) live ABOVE persistence so a future non-local
+    backend cannot bypass them.
+
+The only cross-module dependency is a LAZY import of ``map_step_runner`` inside
+:func:`emit_wayfind_handoff`, used solely to register the ``wayfind_handoff``
+artifact-manifest stage on the current branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Vocabulary / constants
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION = "1.0"
+
+WAYFIND_TICKET_TYPES = frozenset({"research", "prototype", "grilling", "task"})
+# Human-in-the-loop ticket types: resolving one requires a recorded verbatim
+# human response (see record_human_input / resolve_ticket).
+HITL_TYPES = frozenset({"prototype", "grilling"})
+# Ticket statuses that count as "closed" for frontier / terminal computations.
+TERMINAL_TICKET_STATUSES = frozenset({"resolved", "out_of_scope"})
+
+_SLUG_RE = re.compile(r"^[a-z0-9-]{1,50}$")
+
+_DO_NOT_EDIT_BANNER = (
+    "<!-- DO NOT EDIT — regenerated from state.json by wayfind_runner.py. "
+    "Manual edits will be overwritten. -->"
+)
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(**fields: Any) -> dict[str, Any]:
+    return {"status": "success", **fields}
+
+
+def _err(message: str, **fields: Any) -> dict[str, Any]:
+    return {"status": "error", "message": message, **fields}
+
+
+def _now() -> str:
+    """Return an RFC3339 UTC timestamp (matches map_step_runner._utc_timestamp)."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _oneline(text: str) -> str:
+    """Collapse whitespace/newlines so untrusted prose stays on one Markdown line."""
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (repo-level, resolved against cwd like .map/<branch>)
+# ---------------------------------------------------------------------------
+
+
+def _wayfind_root() -> Path:
+    return Path(".map/wayfind")
+
+
+def _map_dir(slug: str) -> Path:
+    return _wayfind_root() / slug
+
+
+def _state_path(slug: str) -> Path:
+    return _map_dir(slug) / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# State load / save + derived views
+# ---------------------------------------------------------------------------
+
+
+def _load_state(slug: str) -> Optional[dict[str, Any]]:
+    path = _state_path(slug)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    """Bump revision, atomically persist state.json, and regenerate all views."""
+    slug = state["slug"]
+    state["revision"] = int(state.get("revision", 0)) + 1
+    map_dir = _map_dir(slug)
+    map_dir.mkdir(parents=True, exist_ok=True)
+    path = _state_path(slug)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    tmp.replace(path)
+    _render_views(state)
+
+
+def _revision_guard(
+    state: dict[str, Any], expected_revision: Optional[int]
+) -> Optional[dict[str, Any]]:
+    """Optimistic-concurrency check: reject a mutation against a stale revision."""
+    if expected_revision is None:
+        return None
+    current = int(state.get("revision", 0))
+    if current != int(expected_revision):
+        return _err(
+            f"stale revision: expected {expected_revision}, map is at {current}. "
+            "Re-read the map before mutating.",
+            code="stale_revision",
+            revision=current,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Id minting
+# ---------------------------------------------------------------------------
+
+
+def _next_ticket_id(state: dict[str, Any]) -> str:
+    nums = [
+        int(m.group(1))
+        for tid in state.get("tickets", {})
+        if (m := re.match(r"^T-(\d+)$", tid))
+    ]
+    return f"T-{(max(nums) + 1) if nums else 1:03d}"
+
+
+def _next_fog_id(state: dict[str, Any]) -> str:
+    nums = [
+        int(m.group(1))
+        for f in state.get("fog", [])
+        if (m := re.match(r"^F-(\d+)$", str(f.get("id", ""))))
+    ]
+    return f"F-{(max(nums) + 1) if nums else 1}"
+
+
+# ---------------------------------------------------------------------------
+# Invariant helpers
+# ---------------------------------------------------------------------------
+
+
+def _ticket_blocked(state: dict[str, Any], ticket: dict[str, Any]) -> bool:
+    """True if any blocker is not yet terminal (resolved / out_of_scope)."""
+    tickets = state.get("tickets", {})
+    for bid in ticket.get("blocked_by", []):
+        blocker = tickets.get(bid)
+        if blocker is None or blocker.get("status") not in TERMINAL_TICKET_STATUSES:
+            return True
+    return False
+
+
+def _detect_cycle(graph: dict[str, list[str]]) -> bool:
+    """Return True if the directed graph (node -> blockers) contains a cycle."""
+    white, gray, black = 0, 1, 2
+    color: dict[str, int] = {node: white for node in graph}
+
+    def visit(node: str) -> bool:
+        color[node] = gray
+        for nxt in graph.get(node, []):
+            if nxt not in color:
+                continue
+            if color[nxt] == gray:
+                return True
+            if color[nxt] == white and visit(nxt):
+                return True
+        color[node] = black
+        return False
+
+    return any(color[node] == white and visit(node) for node in list(graph))
+
+
+def _blocking_graph(
+    state: dict[str, Any], override: Optional[tuple[str, list[str]]] = None
+) -> dict[str, list[str]]:
+    """Build a {ticket_id: blocked_by[]} graph, optionally overriding one node."""
+    graph = {
+        tid: list(t.get("blocked_by", [])) for tid, t in state.get("tickets", {}).items()
+    }
+    if override is not None:
+        tid, blockers = override
+        graph[tid] = list(blockers)
+    return graph
+
+
+def _active_claims(state: dict[str, Any]) -> list[str]:
+    """Ticket ids that are claimed and not yet terminal."""
+    return [
+        tid
+        for tid, t in state.get("tickets", {}).items()
+        if t.get("claimed_by") and t.get("status") not in TERMINAL_TICKET_STATUSES
+    ]
+
+
+def _open_fog(state: dict[str, Any]) -> list[dict[str, Any]]:
+    return [f for f in state.get("fog", []) if f.get("status") == "open"]
+
+
+def _is_terminal(state: dict[str, Any]) -> bool:
+    """Terminal (handoff-eligible) condition.
+
+    Fog empty AND no active claims AND at least one ticket AND every ticket in
+    {resolved, out_of_scope}.  A naive ``len(frontier) == 0`` would wrongly fire
+    on a map whose tickets are merely claimed or blocked.
+    """
+    tickets = state.get("tickets", {})
+    if not tickets:
+        return False
+    if any(t.get("status") not in TERMINAL_TICKET_STATUSES for t in tickets.values()):
+        return False
+    if _open_fog(state):
+        return False
+    if _active_claims(state):
+        return False
+    return True
+
+
+def _recompute_status(state: dict[str, Any]) -> None:
+    """Keep status accurate on every mutation (never mutated by a read)."""
+    if state.get("status") == "handed_off":
+        return
+    if _is_terminal(state):
+        state["status"] = "exhausted"
+    elif state.get("status") == "exhausted":
+        # A previously-terminal map became non-terminal again (e.g. new fog).
+        state["status"] = "active"
+
+
+def _ensure_session(state: dict[str, Any], session: str) -> dict[str, Any]:
+    sessions = state.setdefault("sessions", {})
+    if session not in sessions:
+        sessions[session] = {
+            "started_at": _now(),
+            "non_research_resolved": 0,
+            "claimed": [],
+        }
+    return sessions[session]
+
+
+def _frontier_tickets(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Open, unblocked, unclaimed tickets in creation (id) order."""
+    frontier: list[dict[str, Any]] = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") != "open":
+            continue
+        if ticket.get("claimed_by"):
+            continue
+        if _ticket_blocked(state, ticket):
+            continue
+        frontier.append({"ticket_id": tid, **ticket})
+    return frontier
+
+
+def _mint_ticket(
+    state: dict[str, Any],
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by: list[str],
+    from_fog: Optional[str],
+) -> str:
+    ticket_id = _next_ticket_id(state)
+    state.setdefault("tickets", {})[ticket_id] = {
+        "title": _oneline(title),
+        "type": ticket_type,
+        "question": _oneline(question),
+        "status": "open",
+        "blocked_by": list(blocked_by),
+        "claimed_by": None,
+        "claimed_at": None,
+        "created_at": _now(),
+        "resolved_at": None,
+        "human_input_path": None,
+        "resolution": None,
+        "from_fog": from_fog or None,
+    }
+    return ticket_id
+
+
+# ---------------------------------------------------------------------------
+# View rendering
+# ---------------------------------------------------------------------------
+
+
+def _ticket_badge(state: dict[str, Any], ticket: dict[str, Any]) -> str:
+    if (
+        ticket.get("status") == "open"
+        and ticket.get("claimed_by")
+        and ticket.get("type") in HITL_TYPES
+        and not ticket.get("human_input_path")
+    ):
+        return " — 🔴 AWAITING HUMAN"
+    return ""
+
+
+def _render_map_md(state: dict[str, Any]) -> str:
+    tickets = state.get("tickets", {})
+    lines: list[str] = [
+        _DO_NOT_EDIT_BANNER,
+        f"# Wayfinding Map: {_oneline(state.get('title', state['slug']))}",
+        "",
+        f"- **Slug:** `{state['slug']}`",
+        f"- **Status:** {state.get('status', 'active')}",
+        f"- **Map ID:** `{state.get('map_id', '')}`",
+        f"- **Revision:** {state.get('revision', 0)}",
+        "",
+        "## Destination",
+        "",
+        _oneline(state.get("destination", "")) or "_Not stated._",
+        "",
+        "## Notes",
+        "",
+        _oneline(state.get("notes", "")) or "_None._",
+        "",
+        "## Decisions so far",
+        "",
+    ]
+
+    resolved = [
+        (tid, tickets[tid])
+        for tid in sorted(tickets)
+        if tickets[tid].get("status") == "resolved"
+    ]
+    if resolved:
+        for tid, ticket in resolved:
+            resolution = ticket.get("resolution") or {}
+            gist = _oneline(resolution.get("gist", ""))
+            path = resolution.get("path", "")
+            link = f"  ([resolution]({path}))" if path else ""
+            lines.append(f"- **{tid}** {_oneline(ticket.get('title', ''))} — {gist}{link}")
+    else:
+        lines.append("_None yet._")
+
+    lines += ["", "## Frontier (resolve next, one non-research at a time)", ""]
+    frontier = _frontier_tickets(state)
+    if frontier:
+        for ticket in frontier:
+            lines.append(
+                f"- **{ticket['ticket_id']}** [{ticket['type']}] "
+                f"{_oneline(ticket.get('title', ''))} — {_oneline(ticket.get('question', ''))}"
+            )
+    else:
+        lines.append("_Empty._")
+
+    lines += ["", "## Blocked / claimed", ""]
+    pending: list[str] = []
+    for tid in sorted(tickets):
+        ticket = tickets[tid]
+        if ticket.get("status") != "open":
+            continue
+        blocked = _ticket_blocked(state, ticket)
+        claimed = bool(ticket.get("claimed_by"))
+        if not blocked and not claimed:
+            continue
+        detail_parts: list[str] = []
+        if blocked:
+            detail_parts.append(
+                "blocked by " + ", ".join(ticket.get("blocked_by", []))
+            )
+        if claimed:
+            detail_parts.append(f"claimed by `{ticket['claimed_by']}`")
+        detail = "; ".join(detail_parts)
+        badge = _ticket_badge(state, ticket)
+        pending.append(
+            f"- **{tid}** [{ticket['type']}] {_oneline(ticket.get('title', ''))}"
+            f" — {detail}{badge}"
+        )
+    lines += pending if pending else ["_None._"]
+
+    lines += ["", "## Fog of war (too vague to ticket yet)", ""]
+    open_fog = _open_fog(state)
+    if open_fog:
+        for fog in open_fog:
+            lines.append(f"- **{fog.get('id')}** {_oneline(fog.get('text', ''))}")
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Out of scope", ""]
+    out_of_scope = state.get("out_of_scope", [])
+    if out_of_scope:
+        for entry in out_of_scope:
+            ref = entry.get("ticket_id") or entry.get("fog_id") or ""
+            ref_text = f" (from {ref})" if ref else ""
+            lines.append(
+                f"- {_oneline(entry.get('gist', ''))} — "
+                f"{_oneline(entry.get('reason', ''))}{ref_text}"
+            )
+    else:
+        lines.append("_None._")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_ticket_md(state: dict[str, Any], ticket_id: str) -> str:
+    ticket = state["tickets"][ticket_id]
+    resolution = ticket.get("resolution") or {}
+    lines = [
+        _DO_NOT_EDIT_BANNER,
+        f"# {ticket_id}: {_oneline(ticket.get('title', ''))}",
+        "",
+        f"- **Type:** {ticket.get('type')}",
+        f"- **Status:** {ticket.get('status')}",
+        f"- **Blocked by:** {', '.join(ticket.get('blocked_by', [])) or '—'}",
+        f"- **Claimed by:** {ticket.get('claimed_by') or '—'}",
+        f"- **From fog:** {ticket.get('from_fog') or '—'}",
+        f"- **Created:** {ticket.get('created_at')}",
+        f"- **Resolved:** {ticket.get('resolved_at') or '—'}",
+        "",
+        "## Question",
+        "",
+        _oneline(ticket.get("question", "")),
+        "",
+    ]
+    if resolution:
+        lines += [
+            "## Resolution",
+            "",
+            _oneline(resolution.get("gist", "")),
+            "",
+            f"See `{resolution.get('path', '')}`.",
+            "",
+        ]
+    if ticket.get("human_input_path"):
+        lines += [f"Human input recorded at `{ticket['human_input_path']}`.", ""]
+    return "\n".join(lines)
+
+
+def _render_views(state: dict[str, Any]) -> None:
+    map_dir = _map_dir(state["slug"])
+    map_dir.mkdir(parents=True, exist_ok=True)
+    (map_dir / "map.md").write_text(_render_map_md(state), encoding="utf-8")
+    tickets_dir = map_dir / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    for ticket_id in state.get("tickets", {}):
+        (tickets_dir / f"{ticket_id}.md").write_text(
+            _render_ticket_md(state, ticket_id), encoding="utf-8"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operations — map lifecycle
+# ---------------------------------------------------------------------------
+
+
+def create_wayfind_map(
+    slug: str,
+    title: str,
+    destination: str,
+    notes: str = "",
+    fog_json: str = "[]",
+) -> dict[str, Any]:
+    """Create a new decision map at .map/wayfind/<slug>/."""
+    if not _SLUG_RE.match(slug or ""):
+        return _err(
+            f"invalid slug {slug!r}: must match [a-z0-9-] and be 1-50 chars."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(destination):
+        return _err("destination must be a non-empty string (name where you are headed).")
+    if _state_path(slug).exists():
+        return _err(f"a map with slug {slug!r} already exists.", code="duplicate")
+
+    try:
+        parsed_fog = json.loads(fog_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _err(f"invalid fog JSON: {exc}")
+    if not isinstance(parsed_fog, list):
+        return _err("fog must be a JSON array of strings.")
+
+    fog: list[dict[str, Any]] = []
+    for i, text in enumerate(parsed_fog, 1):
+        if not isinstance(text, str) or not text.strip():
+            return _err(f"fog[{i - 1}] must be a non-empty string.")
+        fog.append({"id": f"F-{i}", "text": _oneline(text), "status": "open"})
+
+    state: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "backend": "local",
+        "revision": 0,
+        "map_id": uuid.uuid4().hex,
+        "slug": slug,
+        "title": _oneline(title),
+        "status": "charting",
+        "destination": _oneline(destination),
+        "notes": _oneline(notes),
+        "fog": fog,
+        "out_of_scope": [],
+        "tickets": {},
+        "sessions": {},
+    }
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        map_id=state["map_id"],
+        state_path=str(_state_path(slug)),
+        map_path=str(_map_dir(slug) / "map.md"),
+        fog_count=len(fog),
+    )
+
+
+def wayfind_status(slug: Optional[str] = None) -> dict[str, Any]:
+    """Without slug: list all maps. With slug: counts + handoff eligibility."""
+    if slug is None:
+        root = _wayfind_root()
+        maps: list[dict[str, Any]] = []
+        if root.exists():
+            for child in sorted(root.iterdir()):
+                if not child.is_dir():
+                    continue
+                state = _load_state(child.name)
+                if state is None:
+                    continue
+                maps.append(_status_summary(state))
+        return _ok(maps=maps, count=len(maps))
+
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    return _ok(**_status_summary(state))
+
+
+def _status_summary(state: dict[str, Any]) -> dict[str, Any]:
+    tickets = state.get("tickets", {})
+    open_ids = [tid for tid, t in tickets.items() if t.get("status") == "open"]
+    blocked = [tid for tid in open_ids if _ticket_blocked(state, tickets[tid])]
+    claimed = _active_claims(state)
+    resolved = [tid for tid, t in tickets.items() if t.get("status") == "resolved"]
+    out_of_scope = [
+        tid for tid, t in tickets.items() if t.get("status") == "out_of_scope"
+    ]
+    return {
+        "slug": state["slug"],
+        "title": state.get("title", ""),
+        "map_status": state.get("status", "active"),
+        "revision": state.get("revision", 0),
+        "counts": {
+            "open": len(open_ids),
+            "blocked": len(blocked),
+            "claimed": len(claimed),
+            "resolved": len(resolved),
+            "out_of_scope": len(out_of_scope),
+            "open_fog": len(_open_fog(state)),
+            "frontier": len(_frontier_tickets(state)),
+        },
+        "handoff_eligible": _is_terminal(state),
+    }
+
+
+def list_handoffs() -> dict[str, Any]:
+    """Return completed handoffs — the read-only source for /map-plan's offer."""
+    root = _wayfind_root()
+    handoffs: list[dict[str, Any]] = []
+    if root.exists():
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            handoff_path = child / "handoff.json"
+            state = _load_state(child.name)
+            if state is None or not handoff_path.exists():
+                continue
+            try:
+                payload = json.loads(handoff_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            handoffs.append(
+                {
+                    "slug": state["slug"],
+                    "title": state.get("title", ""),
+                    "handoff_path": str(child / "handoff.md"),
+                    "decisions_count": len(payload.get("decisions", [])),
+                    "generated_at": payload.get("generated_at", ""),
+                }
+            )
+    return _ok(handoffs=handoffs, count=len(handoffs))
+
+
+def show_ticket(slug: str, ticket_id: str) -> dict[str, Any]:
+    """Read-only zoom into a single ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    return _ok(ticket_id=ticket_id, ticket=ticket)
+
+
+# ---------------------------------------------------------------------------
+# Operations — tickets
+# ---------------------------------------------------------------------------
+
+
+def _parse_blocked_by(
+    state: dict[str, Any], blocked_by_json: str
+) -> tuple[Optional[list[str]], Optional[dict[str, Any]]]:
+    """Parse + validate a blocked_by list. Returns (list, None) or (None, error)."""
+    try:
+        parsed = json.loads(blocked_by_json or "[]")
+    except json.JSONDecodeError as exc:
+        return None, _err(f"invalid blocked_by JSON: {exc}")
+    if not isinstance(parsed, list):
+        return None, _err("blocked_by must be a JSON array of ticket ids.")
+    tickets = state.get("tickets", {})
+    seen: list[str] = []
+    for bid in parsed:
+        if not isinstance(bid, str) or bid not in tickets:
+            return None, _err(f"unknown blocker ticket id: {bid!r}.")
+        if bid not in seen:
+            seen.append(bid)
+    return seen, None
+
+
+def add_ticket(
+    slug: str,
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by_json: str = "[]",
+    from_fog: str = "",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Add a decision ticket with a single sharp question."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if ticket_type not in WAYFIND_TICKET_TYPES:
+        return _err(
+            f"invalid ticket type {ticket_type!r}. "
+            f"Must be one of: {sorted(WAYFIND_TICKET_TYPES)}."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(question):
+        return _err(
+            "question must be a single, sharply-stated question. "
+            "If you cannot state it sharply now, keep it as fog (add_fog) instead."
+        )
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+    if from_fog:
+        if not any(f.get("id") == from_fog for f in state.get("fog", [])):
+            return _err(f"unknown fog id: {from_fog!r}.")
+
+    ticket_id = _mint_ticket(state, title, ticket_type, question, blocked_by, from_fog)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, revision=state["revision"])
+
+
+def wire_blocking(
+    slug: str,
+    ticket_id: str,
+    blocked_by_json: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Replace a ticket's blocked_by set; rejects unknown ids and cycles."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if ticket_id not in state.get("tickets", {}):
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+    if ticket_id in blocked_by:
+        return _err("a ticket cannot block itself.")
+
+    graph = _blocking_graph(state, override=(ticket_id, blocked_by))
+    if _detect_cycle(graph):
+        return _err(
+            f"wiring {ticket_id!r} to block on {blocked_by} would create a cycle.",
+            code="cycle",
+        )
+
+    state["tickets"][ticket_id]["blocked_by"] = blocked_by
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, blocked_by=blocked_by, revision=state["revision"])
+
+
+def claim_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Claim a frontier ticket before working it (claim-before-work invariant)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not session:
+        return _err("session id is required to claim a ticket.")
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("status") != "open":
+        return _err(
+            f"ticket {ticket_id!r} is {ticket.get('status')!r}; only open tickets "
+            "can be claimed.",
+            code="not_open",
+        )
+    if ticket.get("claimed_by"):
+        return _err(
+            f"ticket {ticket_id!r} is already claimed by {ticket['claimed_by']!r}.",
+            code="already_claimed",
+        )
+    if _ticket_blocked(state, ticket):
+        return _err(
+            f"ticket {ticket_id!r} is blocked by unresolved tickets "
+            f"{ticket.get('blocked_by', [])}.",
+            code="blocked",
+        )
+
+    ticket["claimed_by"] = session
+    ticket["claimed_at"] = _now()
+    ledger = _ensure_session(state, session)
+    if ticket_id not in ledger["claimed"]:
+        ledger["claimed"].append(ticket_id)
+    if state.get("status") == "charting":
+        state["status"] = "active"
+    _recompute_status(state)
+    _save_state(state)
+
+    hitl_pending = ticket.get("type") in HITL_TYPES
+    result = _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        session=session,
+        hitl_pending=hitl_pending,
+        revision=state["revision"],
+    )
+    if hitl_pending:
+        result["message"] = (
+            f"{ticket['type']} ticket claimed. Ask the human the question verbatim, "
+            "STOP generating, and hand control back. When the human answers, save "
+            "their verbatim words to a file and call record_human_input before "
+            "resolve_ticket."
+        )
+    return result
+
+
+def release_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Release a ticket claimed by this session (crash / interruption recovery)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} is not claimed by session {session!r} "
+            f"(claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    ticket["claimed_by"] = None
+    ticket["claimed_at"] = None
+    ledger = state.get("sessions", {}).get(session)
+    if ledger and ticket_id in ledger.get("claimed", []):
+        ledger["claimed"].remove(ticket_id)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, revision=state["revision"])
+
+
+def record_human_input(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    path: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Register a verbatim human response file — required before a HITL resolve."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} must be claimed by session {session!r} to record "
+            f"human input (claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    # Paths are relative to the map dir (.map/wayfind/<slug>/) so the value stored
+    # in state.json doubles as a correct link target from the co-located views.
+    input_path = _map_dir(slug) / path
+    if not input_path.exists() or not input_path.read_text(
+        encoding="utf-8", errors="replace"
+    ).strip():
+        return _err(
+            f"human input file {path!r} (under the map dir) does not exist or is empty. "
+            "Save the human's verbatim answer there first.",
+            code="missing_input",
+        )
+    ticket["human_input_path"] = path
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, human_input_path=path, revision=state["revision"])
+
+
+def resolve_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    gist: str,
+    resolution_path: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Close a claimed ticket with a one-line gist + a prose resolution file."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} must be claimed by session {session!r} to resolve "
+            f"(claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    if ticket.get("status") != "open":
+        return _err(
+            f"ticket {ticket_id!r} is already {ticket.get('status')!r}.",
+            code="not_open",
+        )
+    if not _oneline(gist):
+        return _err("gist must be a non-empty one-line summary of the decision.")
+    # resolution_path is relative to the map dir (.map/wayfind/<slug>/) so the stored
+    # value is a correct link target from the co-located map.md / handoff.md views.
+    resolution_file = _map_dir(slug) / resolution_path
+    if not resolution_file.exists() or not resolution_file.read_text(
+        encoding="utf-8", errors="replace"
+    ).strip():
+        return _err(
+            f"resolution file {resolution_path!r} (under the map dir) does not exist or "
+            "is empty. Write the prose resolution first.",
+            code="missing_resolution",
+        )
+
+    is_hitl = ticket.get("type") in HITL_TYPES
+    if is_hitl and not ticket.get("human_input_path"):
+        return _err(
+            f"ticket {ticket_id!r} is a {ticket.get('type')} (human-in-the-loop) "
+            "ticket awaiting a human response. Call record_human_input first.",
+            code="awaiting_human",
+        )
+
+    is_non_research = ticket.get("type") != "research"
+    ledger = _ensure_session(state, session)
+    if is_non_research and int(ledger.get("non_research_resolved", 0)) >= 1:
+        return _err(
+            "this session has already resolved a non-research ticket. Resolve at most "
+            "ONE non-research ticket per session; start a new session to continue.",
+            code="session_limit",
+        )
+
+    ticket["status"] = "resolved"
+    ticket["resolved_at"] = _now()
+    ticket["resolution"] = {"gist": _oneline(gist), "path": resolution_path}
+    if ticket_id in ledger.get("claimed", []):
+        ledger["claimed"].remove(ticket_id)
+    if is_non_research:
+        ledger["non_research_resolved"] = int(ledger.get("non_research_resolved", 0)) + 1
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        ticket_status="resolved",
+        handoff_eligible=_is_terminal(state),
+        revision=state["revision"],
+    )
+
+
+def wayfind_frontier(slug: str) -> dict[str, Any]:
+    """Return open + unblocked + unclaimed tickets (creation order)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    frontier = [
+        {
+            "ticket_id": t["ticket_id"],
+            "title": t.get("title", ""),
+            "type": t.get("type"),
+            "question": t.get("question", ""),
+        }
+        for t in _frontier_tickets(state)
+    ]
+    return _ok(slug=slug, frontier=frontier, count=len(frontier))
+
+
+# ---------------------------------------------------------------------------
+# Operations — fog & out-of-scope
+# ---------------------------------------------------------------------------
+
+
+def add_fog(
+    slug: str, text: str, expected_revision: Optional[int] = None
+) -> dict[str, Any]:
+    """Record a still-too-vague concern that cannot yet be a sharp ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not _oneline(text):
+        return _err("fog text must be a non-empty string.")
+    fog_id = _next_fog_id(state)
+    state.setdefault("fog", []).append(
+        {"id": fog_id, "text": _oneline(text), "status": "open"}
+    )
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, fog_id=fog_id, revision=state["revision"])
+
+
+def graduate_fog(
+    slug: str,
+    fog_id: str,
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by_json: str = "[]",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Atomically graduate a fog entry into a sharp ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    fog_entry = next((f for f in state.get("fog", []) if f.get("id") == fog_id), None)
+    if fog_entry is None:
+        return _err(f"no fog entry {fog_id!r} in map {slug!r}.", code="not_found")
+    if fog_entry.get("status") != "open":
+        return _err(
+            f"fog {fog_id!r} is already {fog_entry.get('status')!r}; cannot graduate "
+            "it again.",
+            code="already_graduated",
+        )
+    if ticket_type not in WAYFIND_TICKET_TYPES:
+        return _err(
+            f"invalid ticket type {ticket_type!r}. "
+            f"Must be one of: {sorted(WAYFIND_TICKET_TYPES)}."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(question):
+        return _err("question must be a single, sharply-stated question.")
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+
+    ticket_id = _mint_ticket(state, title, ticket_type, question, blocked_by, fog_id)
+    fog_entry["status"] = "graduated"
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, fog_id=fog_id, revision=state["revision"])
+
+
+def rule_out_of_scope(
+    slug: str,
+    reason: str,
+    ticket_id: str = "",
+    fog_id: str = "",
+    gist: str = "",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Permanently rule a ticket (or fog entry) out of scope.
+
+    Out-of-scope items are recorded separately and never appear in Decisions so
+    far — an exclusion is not a decision that graduates into the plan.
+    """
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not _oneline(reason):
+        return _err("reason must be a non-empty string.")
+    if bool(ticket_id) == bool(fog_id):
+        return _err("provide exactly one of ticket_id or fog_id.")
+
+    entry: dict[str, Any] = {"reason": _oneline(reason), "ruled_at": _now()}
+    if ticket_id:
+        ticket = state.get("tickets", {}).get(ticket_id)
+        if ticket is None:
+            return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+        if ticket.get("status") in TERMINAL_TICKET_STATUSES:
+            return _err(
+                f"ticket {ticket_id!r} is already {ticket.get('status')!r}.",
+                code="not_open",
+            )
+        ticket["status"] = "out_of_scope"
+        session = ticket.get("claimed_by")
+        ticket["claimed_by"] = None
+        ticket["claimed_at"] = None
+        ledger = state.get("sessions", {}).get(session) if session else None
+        if ledger and ticket_id in ledger.get("claimed", []):
+            ledger["claimed"].remove(ticket_id)
+        entry["ticket_id"] = ticket_id
+        entry["gist"] = _oneline(gist) or _oneline(ticket.get("title", ""))
+    else:
+        fog_entry = next(
+            (f for f in state.get("fog", []) if f.get("id") == fog_id), None
+        )
+        if fog_entry is None:
+            return _err(f"no fog entry {fog_id!r} in map {slug!r}.", code="not_found")
+        if fog_entry.get("status") != "open":
+            return _err(
+                f"fog {fog_id!r} is already {fog_entry.get('status')!r}.",
+                code="not_open",
+            )
+        fog_entry["status"] = "retired"
+        entry["fog_id"] = fog_id
+        entry["gist"] = _oneline(gist) or _oneline(fog_entry.get("text", ""))
+
+    state.setdefault("out_of_scope", []).append(entry)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ruled=ticket_id or fog_id, revision=state["revision"])
+
+
+# ---------------------------------------------------------------------------
+# Operations — handoff
+# ---------------------------------------------------------------------------
+
+
+def _open_item_labels(state: dict[str, Any]) -> list[str]:
+    """Human-readable list of items blocking a clean (non-early) handoff."""
+    labels: list[str] = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") in TERMINAL_TICKET_STATUSES:
+            continue
+        state_word = "claimed" if ticket.get("claimed_by") else "open"
+        labels.append(f"{tid} ({ticket.get('type')}, {state_word}): {ticket.get('title', '')}")
+    for fog in _open_fog(state):
+        labels.append(f"{fog.get('id')} (fog): {fog.get('text', '')}")
+    return labels
+
+
+def emit_wayfind_handoff(
+    slug: str,
+    remaining_risks_json: str = "[]",
+    early: bool = False,
+    confirmed_by_user: bool = False,
+    branch: Optional[str] = None,
+) -> dict[str, Any]:
+    """Write the handoff artifact consumed by /map-plan and mark the map handed off."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+
+    try:
+        remaining_risks = json.loads(remaining_risks_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _err(f"invalid remaining_risks JSON: {exc}")
+    if not isinstance(remaining_risks, list) or not all(
+        isinstance(r, str) for r in remaining_risks
+    ):
+        return _err("remaining_risks must be a JSON array of strings.")
+    remaining_risks = [_oneline(r) for r in remaining_risks]
+
+    open_items = _open_item_labels(state)
+    if not _is_terminal(state):
+        if not (early and confirmed_by_user):
+            return _err(
+                "map is not exhausted: fog, claimed, or unresolved tickets remain. "
+                "Resolve or rule out every item, or pass --early with "
+                "--confirmed-by-user to hand off with open items as remaining risks.",
+                code="not_terminal",
+                open_items=open_items,
+            )
+        # Early handoff: fold open items into remaining risks so nothing is lost.
+        remaining_risks = remaining_risks + [f"UNRESOLVED: {label}" for label in open_items]
+
+    decisions = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") != "resolved":
+            continue
+        resolution = ticket.get("resolution") or {}
+        decisions.append(
+            {
+                "ticket_id": tid,
+                "title": ticket.get("title", ""),
+                "type": ticket.get("type"),
+                "question": ticket.get("question", ""),
+                "gist": resolution.get("gist", ""),
+                "resolution_path": resolution.get("path", ""),
+            }
+        )
+
+    out_of_scope = [
+        {
+            "gist": entry.get("gist", ""),
+            "reason": entry.get("reason", ""),
+            "ref": entry.get("ticket_id") or entry.get("fog_id") or "",
+        }
+        for entry in state.get("out_of_scope", [])
+    ]
+
+    generated_at = _now()
+    map_dir = _map_dir(slug)
+    handoff_payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "slug": slug,
+        "map_id": state.get("map_id", ""),
+        "title": state.get("title", ""),
+        "destination": state.get("destination", ""),
+        "generated_at": generated_at,
+        "early": bool(early and not _is_terminal(state)),
+        "decisions": decisions,
+        "out_of_scope": out_of_scope,
+        "remaining_risks": remaining_risks,
+    }
+    json_path = map_dir / "handoff.json"
+    md_path = map_dir / "handoff.md"
+    tmp_json = json_path.with_name(json_path.name + ".tmp")
+    tmp_json.write_text(
+        json.dumps(handoff_payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp_json.replace(json_path)
+    md_path.write_text(_render_handoff_md(handoff_payload), encoding="utf-8")
+
+    state["status"] = "handed_off"
+    _save_state(state)
+
+    manifest_info = _register_handoff_manifest(slug, json_path, md_path, decisions, branch)
+
+    return _ok(
+        slug=slug,
+        handoff_path=str(md_path),
+        handoff_json=str(json_path),
+        decisions_count=len(decisions),
+        remaining_risks_count=len(remaining_risks),
+        manifest=manifest_info,
+        revision=state["revision"],
+    )
+
+
+def _render_handoff_md(payload: dict[str, Any]) -> str:
+    lines = [
+        f"# Wayfinding Handoff: {_oneline(payload.get('title', ''))}",
+        "",
+        f"- **Slug:** `{payload.get('slug', '')}`",
+        f"- **Generated:** {payload.get('generated_at', '')}",
+        f"- **Early handoff:** {'yes' if payload.get('early') else 'no'}",
+        "",
+        "## Destination",
+        "",
+        _oneline(payload.get("destination", "")) or "_Not stated._",
+        "",
+        "## Decisions Made",
+        "",
+        "| # | Question | Decision | Resolution |",
+        "|---|----------|----------|------------|",
+    ]
+    if payload.get("decisions"):
+        for i, decision in enumerate(payload["decisions"], 1):
+            path = decision.get("resolution_path", "")
+            link = f"[{decision.get('ticket_id', '')}]({path})" if path else decision.get("ticket_id", "")
+            lines.append(
+                f"| {i} | {_oneline(decision.get('question', ''))} | "
+                f"{_oneline(decision.get('gist', ''))} | {link} |"
+            )
+    else:
+        lines.append("| — | _No decisions resolved._ | | |")
+
+    lines += ["", "## Out of Scope", ""]
+    if payload.get("out_of_scope"):
+        for entry in payload["out_of_scope"]:
+            ref = entry.get("ref", "")
+            ref_text = f" (from {ref})" if ref else ""
+            lines.append(
+                f"- {_oneline(entry.get('gist', ''))} — "
+                f"{_oneline(entry.get('reason', ''))}{ref_text}"
+            )
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Open Questions / Remaining Risks", ""]
+    if payload.get("remaining_risks"):
+        for risk in payload["remaining_risks"]:
+            lines.append(f"- {_oneline(risk)}")
+    else:
+        lines.append("_None._")
+
+    lines += [
+        "",
+        "---",
+        "",
+        "Feed this into planning with "
+        "`/map-plan --wayfind " + str(payload.get("slug", "")) + "` on a feature branch.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _register_handoff_manifest(
+    slug: str,
+    json_path: Path,
+    md_path: Path,
+    decisions: list[dict[str, Any]],
+    branch: Optional[str],
+) -> dict[str, Any]:
+    """Register the wayfind_handoff manifest stage on the current branch.
+
+    LAZY import of map_step_runner — the ONLY cross-module coupling. A manifest
+    failure is reported but never loses the already-written handoff artifact.
+    """
+    try:
+        import map_step_runner  # noqa: PLC0415 — lazy sibling in .map/scripts/  # pyright: ignore[reportMissingImports]
+
+        manifest = map_step_runner.load_artifact_manifest(branch)
+        map_step_runner._set_manifest_stage(
+            manifest,
+            "wayfind_handoff",
+            "ready",
+            artifacts=[
+                map_step_runner._artifact_ref(md_path, "wayfind-handoff"),
+                map_step_runner._artifact_ref(json_path, "wayfind-handoff-json"),
+            ],
+            metadata={"slug": slug, "decisions_count": len(decisions)},
+        )
+        result = map_step_runner.save_artifact_manifest(manifest, branch)
+        return {"status": "success", "path": result.get("path")}
+    except Exception as exc:  # noqa: BLE001 — manifest is best-effort, never fatal
+        return {"status": "skipped", "reason": f"manifest registration failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print(result: dict[str, Any]) -> int:
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    return 0 if result.get("status") == "success" else 1
+
+
+def _add_revision_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--expected-revision",
+        type=int,
+        default=None,
+        help="optimistic-concurrency guard: fail if the map is not at this revision",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wayfind_runner.py",
+        description="Deterministic operations for /map-wayfind decision maps.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    types = sorted(WAYFIND_TICKET_TYPES)
+
+    p = sub.add_parser("create_wayfind_map", help="create a new decision map")
+    p.add_argument("slug")
+    p.add_argument("title")
+    p.add_argument("destination")
+    p.add_argument("--notes", default="")
+    p.add_argument("--fog-json", default="[]")
+
+    p = sub.add_parser("wayfind_status", help="list maps or show one map's status")
+    p.add_argument("--slug", default=None)
+
+    sub.add_parser("list_handoffs", help="list completed handoffs")
+
+    p = sub.add_parser("show_ticket", help="show one ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+
+    p = sub.add_parser("add_ticket", help="add a decision ticket")
+    p.add_argument("slug")
+    p.add_argument("title")
+    p.add_argument("ticket_type", choices=types)
+    p.add_argument("question")
+    p.add_argument("--blocked-by-json", default="[]")
+    p.add_argument("--from-fog", default="")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("wire_blocking", help="set a ticket's blocked_by set")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("blocked_by_json")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("claim_ticket", help="claim a frontier ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("release_ticket", help="release a claimed ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("record_human_input", help="register a verbatim human response")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    p.add_argument("path")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("resolve_ticket", help="resolve a claimed ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    p.add_argument("gist")
+    p.add_argument("resolution_path")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
+    p.add_argument("slug")
+
+    p = sub.add_parser("add_fog", help="record a still-vague concern")
+    p.add_argument("slug")
+    p.add_argument("text")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("graduate_fog", help="turn a fog entry into a ticket")
+    p.add_argument("slug")
+    p.add_argument("fog_id")
+    p.add_argument("title")
+    p.add_argument("ticket_type", choices=types)
+    p.add_argument("question")
+    p.add_argument("--blocked-by-json", default="[]")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("rule_out_of_scope", help="rule a ticket or fog out of scope")
+    p.add_argument("slug")
+    p.add_argument("reason")
+    p.add_argument("--ticket-id", default="")
+    p.add_argument("--fog-id", default="")
+    p.add_argument("--gist", default="")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("emit_wayfind_handoff", help="write the handoff artifact")
+    p.add_argument("slug")
+    p.add_argument("--remaining-risks-json", default="[]")
+    p.add_argument("--early", action="store_true")
+    p.add_argument("--confirmed-by-user", action="store_true")
+    p.add_argument("--branch", default=None)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
+    command = args.command
+    if command == "create_wayfind_map":
+        return create_wayfind_map(
+            args.slug, args.title, args.destination, args.notes, args.fog_json
+        )
+    if command == "wayfind_status":
+        return wayfind_status(args.slug)
+    if command == "list_handoffs":
+        return list_handoffs()
+    if command == "show_ticket":
+        return show_ticket(args.slug, args.ticket_id)
+    if command == "add_ticket":
+        return add_ticket(
+            args.slug,
+            args.title,
+            args.ticket_type,
+            args.question,
+            args.blocked_by_json,
+            args.from_fog,
+            args.expected_revision,
+        )
+    if command == "wire_blocking":
+        return wire_blocking(
+            args.slug, args.ticket_id, args.blocked_by_json, args.expected_revision
+        )
+    if command == "claim_ticket":
+        return claim_ticket(
+            args.slug, args.ticket_id, args.session, args.expected_revision
+        )
+    if command == "release_ticket":
+        return release_ticket(
+            args.slug, args.ticket_id, args.session, args.expected_revision
+        )
+    if command == "record_human_input":
+        return record_human_input(
+            args.slug, args.ticket_id, args.session, args.path, args.expected_revision
+        )
+    if command == "resolve_ticket":
+        return resolve_ticket(
+            args.slug,
+            args.ticket_id,
+            args.session,
+            args.gist,
+            args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "wayfind_frontier":
+        return wayfind_frontier(args.slug)
+    if command == "add_fog":
+        return add_fog(args.slug, args.text, args.expected_revision)
+    if command == "graduate_fog":
+        return graduate_fog(
+            args.slug,
+            args.fog_id,
+            args.title,
+            args.ticket_type,
+            args.question,
+            args.blocked_by_json,
+            args.expected_revision,
+        )
+    if command == "rule_out_of_scope":
+        return rule_out_of_scope(
+            args.slug,
+            args.reason,
+            args.ticket_id,
+            args.fog_id,
+            args.gist,
+            args.expected_revision,
+        )
+    if command == "emit_wayfind_handoff":
+        return emit_wayfind_handoff(
+            args.slug,
+            args.remaining_risks_json,
+            args.early,
+            args.confirmed_by_user,
+            args.branch,
+        )
+    return _err(f"unknown command: {command!r}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return _print(_dispatch(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mapify_cli/templates/map/scripts/wayfind_runner.py
+++ b/src/mapify_cli/templates/map/scripts/wayfind_runner.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import uuid
@@ -94,6 +95,25 @@ def _state_path(slug: str) -> Path:
     return _map_dir(slug) / "state.json"
 
 
+def _resolve_evidence_path(slug: str, rel: str) -> Optional[Path]:
+    """Resolve an evidence file (resolution / human-input) path under the map dir.
+
+    Returns the resolved Path only when *rel* names a regular file contained in
+    the map directory. Absolute paths, ``..`` escapes, directories, and missing
+    files all return None — so a caller cannot use the provenance gate to read
+    (or claim provenance over) a file outside its own map.
+    """
+    if not rel:
+        return None
+    base = _map_dir(slug).resolve()
+    candidate = (base / rel).resolve()
+    if candidate != base and base not in candidate.parents:
+        return None  # absolute path or ../ escape left the map dir
+    if not candidate.is_file():
+        return None  # missing, or a directory
+    return candidate
+
+
 # ---------------------------------------------------------------------------
 # State load / save + derived views
 # ---------------------------------------------------------------------------
@@ -117,7 +137,10 @@ def _save_state(state: dict[str, Any]) -> None:
     map_dir = _map_dir(slug)
     map_dir.mkdir(parents=True, exist_ok=True)
     path = _state_path(slug)
-    tmp = path.with_name(path.name + ".tmp")
+    # Per-process-unique temp name so two writers never share (and corrupt) one
+    # scratch file. NB: this makes the write atomic, not the read-modify-write —
+    # see _revision_guard for the (best-effort, single-operator) staleness check.
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp.write_text(
         json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
     )
@@ -128,7 +151,15 @@ def _save_state(state: dict[str, Any]) -> None:
 def _revision_guard(
     state: dict[str, Any], expected_revision: Optional[int]
 ) -> Optional[dict[str, Any]]:
-    """Optimistic-concurrency check: reject a mutation against a stale revision."""
+    """Best-effort stale-write detection: reject a mutation whose caller read an
+    older revision than the map now holds.
+
+    This is a friction/audit aid for a single-operator, sequential tool — NOT a
+    true compare-and-swap. It closes the common "I read, then something else
+    advanced the map, then I wrote" window, but does not lock: two processes that
+    both read the same revision before either writes can still lose an update.
+    Concurrent multi-process writers to one map are out of scope by design (a map
+    is charted and worked by one operator at a time)."""
     if expected_revision is None:
         return None
     current = int(state.get("revision", 0))
@@ -140,6 +171,25 @@ def _revision_guard(
             revision=current,
         )
     return None
+
+
+def _mutation_guard(
+    state: dict[str, Any], expected_revision: Optional[int]
+) -> Optional[dict[str, Any]]:
+    """Pre-mutation gate for ticket/fog operations.
+
+    Rejects any mutation once the map is handed off (its handoff artifact is
+    frozen, so a further edit would leave a discoverable handoff that omits the
+    new state), then applies the optimistic staleness check. Not used by
+    emit_wayfind_handoff, which may idempotently re-emit a handed-off map."""
+    if state.get("status") == "handed_off":
+        return _err(
+            f"map {state.get('slug')!r} is already handed off; its handoff artifact "
+            "is frozen. Start a follow-up map (or a new session) rather than mutating "
+            "a handed-off map.",
+            code="handed_off",
+        )
+    return _revision_guard(state, expected_revision)
 
 
 # ---------------------------------------------------------------------------
@@ -658,7 +708,7 @@ def add_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if ticket_type not in WAYFIND_TICKET_TYPES:
@@ -697,7 +747,7 @@ def wire_blocking(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if ticket_id not in state.get("tickets", {}):
@@ -732,7 +782,7 @@ def claim_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not session:
@@ -796,7 +846,7 @@ def release_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -829,7 +879,7 @@ def record_human_input(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -842,14 +892,15 @@ def record_human_input(
             code="not_owner",
         )
     # Paths are relative to the map dir (.map/wayfind/<slug>/) so the value stored
-    # in state.json doubles as a correct link target from the co-located views.
-    input_path = _map_dir(slug) / path
-    if not input_path.exists() or not input_path.read_text(
+    # in state.json doubles as a correct link target from the co-located views;
+    # containment is enforced so absolute/../ paths cannot claim provenance.
+    input_path = _resolve_evidence_path(slug, path)
+    if input_path is None or not input_path.read_text(
         encoding="utf-8", errors="replace"
     ).strip():
         return _err(
-            f"human input file {path!r} (under the map dir) does not exist or is empty. "
-            "Save the human's verbatim answer there first.",
+            f"human input file {path!r} must be a non-empty regular file INSIDE the map "
+            "dir (.map/wayfind/<slug>/). Save the human's verbatim answer there first.",
             code="missing_input",
         )
     ticket["human_input_path"] = path
@@ -869,7 +920,7 @@ def resolve_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -889,14 +940,15 @@ def resolve_ticket(
     if not _oneline(gist):
         return _err("gist must be a non-empty one-line summary of the decision.")
     # resolution_path is relative to the map dir (.map/wayfind/<slug>/) so the stored
-    # value is a correct link target from the co-located map.md / handoff.md views.
-    resolution_file = _map_dir(slug) / resolution_path
-    if not resolution_file.exists() or not resolution_file.read_text(
+    # value is a correct link target from the co-located map.md / handoff.md views;
+    # containment is enforced so absolute/../ paths cannot stand in as a resolution.
+    resolution_file = _resolve_evidence_path(slug, resolution_path)
+    if resolution_file is None or not resolution_file.read_text(
         encoding="utf-8", errors="replace"
     ).strip():
         return _err(
-            f"resolution file {resolution_path!r} (under the map dir) does not exist or "
-            "is empty. Write the prose resolution first.",
+            f"resolution file {resolution_path!r} must be a non-empty regular file INSIDE "
+            "the map dir (.map/wayfind/<slug>/). Write the prose resolution first.",
             code="missing_resolution",
         )
 
@@ -920,6 +972,10 @@ def resolve_ticket(
     ticket["status"] = "resolved"
     ticket["resolved_at"] = _now()
     ticket["resolution"] = {"gist": _oneline(gist), "path": resolution_path}
+    # Clear the active claim on close (consistent with rule_out_of_scope); the
+    # resolver of record is captured in the resolution/git history, not claimed_by.
+    ticket["claimed_by"] = None
+    ticket["claimed_at"] = None
     if ticket_id in ledger.get("claimed", []):
         ledger["claimed"].remove(ticket_id)
     if is_non_research:
@@ -965,7 +1021,7 @@ def add_fog(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not _oneline(text):
@@ -992,7 +1048,7 @@ def graduate_fog(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     fog_entry = next((f for f in state.get("fog", []) if f.get("id") == fog_id), None)
@@ -1041,7 +1097,7 @@ def rule_out_of_scope(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not _oneline(reason):
@@ -1114,11 +1170,17 @@ def emit_wayfind_handoff(
     early: bool = False,
     confirmed_by_user: bool = False,
     branch: Optional[str] = None,
+    expected_revision: Optional[int] = None,
 ) -> dict[str, Any]:
     """Write the handoff artifact consumed by /map-plan and mark the map handed off."""
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
+    # Pure staleness check (not _mutation_guard): a handed-off map may be
+    # idempotently re-emitted, so we do not reject on status == "handed_off".
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
 
     try:
         remaining_risks = json.loads(remaining_risks_json or "[]")
@@ -1185,7 +1247,7 @@ def emit_wayfind_handoff(
     }
     json_path = map_dir / "handoff.json"
     md_path = map_dir / "handoff.md"
-    tmp_json = json_path.with_name(json_path.name + ".tmp")
+    tmp_json = json_path.with_name(f".{json_path.name}.{os.getpid()}.tmp")
     tmp_json.write_text(
         json.dumps(handoff_payload, indent=2, ensure_ascii=True) + "\n",
         encoding="utf-8",
@@ -1415,6 +1477,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--early", action="store_true")
     p.add_argument("--confirmed-by-user", action="store_true")
     p.add_argument("--branch", default=None)
+    _add_revision_arg(p)
 
     return parser
 
@@ -1496,6 +1559,7 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.early,
             args.confirmed_by_user,
             args.branch,
+            args.expected_revision,
         )
     return _err(f"unknown command: {command!r}")
 

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -71,6 +71,8 @@ Per-artifact resume rules (only when `verdict` is `resume`):
 
 If a `/map-wayfind` map already resolved the key decisions, seed this plan from its handoff instead of re-deciding them.
 
+**Precedence over resume:** a handoff seeds a *fresh* plan, so this step only applies when the Resume Detection verdict is `no_plan` (or `goal_mismatch` after you archive the prior artifacts). On a `resume` verdict the branch already has a `spec`/`task_plan` — that existing artifact wins and the handoff is NOT re-consumed (re-seeding would silently overwrite in-progress work). To plan from a handoff, run `/map-plan --wayfind <slug>` on a branch with no in-progress plan (or archive/rename the existing `.map/<branch>/` artifacts first, with operator confirmation).
+
 - If `$ARGUMENTS` contains `--wayfind <slug>`, read `.map/wayfind/<slug>/handoff.json` (repo-level, not branch-scoped).
 - Otherwise run `python3 .map/scripts/wayfind_runner.py list_handoffs`. If exactly one completed handoff exists, OFFER it to the user ("found a completed wayfinding map `<slug>` — seed the plan from it?") and use it only on an explicit yes. Never match a handoff to the request by guessing; with zero or multiple handoffs and no explicit `--wayfind`, skip this step.
 

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -67,6 +67,15 @@ Per-artifact resume rules (only when `verdict` is `resume`):
 - Existing `task_plan`: skip decomposition and plan creation.
 - Existing `step_state.json`: plan is complete; print checkpoint and STOP.
 
+### Pre-flight: Wayfinding Handoff (optional)
+
+If a `/map-wayfind` map already resolved the key decisions, seed this plan from its handoff instead of re-deciding them.
+
+- If `$ARGUMENTS` contains `--wayfind <slug>`, read `.map/wayfind/<slug>/handoff.json` (repo-level, not branch-scoped).
+- Otherwise run `python3 .map/scripts/wayfind_runner.py list_handoffs`. If exactly one completed handoff exists, OFFER it to the user ("found a completed wayfinding map `<slug>` — seed the plan from it?") and use it only on an explicit yes. Never match a handoff to the request by guessing; with zero or multiple handoffs and no explicit `--wayfind`, skip this step.
+
+When a handoff is used, pre-seed the spec: `decisions[]` → **Decisions Made** (settled — the interview must NOT re-ask them; carry them as a do-not-re-ask list), `out_of_scope[]` → **Out of Scope**, `remaining_risks[]` → **Open Questions**. Then continue below for anything the handoff did not settle. Do not modify the wayfinding map.
+
 ### Pre-flight: Workflow-Fit Gate
 
 Decide whether MAP planning is warranted before discovery or interview.

--- a/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
@@ -60,7 +60,7 @@ Start a new map. Six steps, mirroring the way a good architect opens a foggy pro
    ```
 
    In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
-5. **Kick off research.** For `research` tickets, you MAY dispatch research-agent subagents in parallel; each writes its findings to `resolutions/<ticket>.md`, then you `resolve_ticket` it. Research resolves are exempt from the one-per-session limit.
+5. **Kick off research.** For each `research` ticket, `claim_ticket` it FIRST — `resolve_ticket` requires the ticket to be claimed by your session, so an unclaimed dispatch-then-resolve returns `not_owner`. Serialize these claim mutations, then you MAY dispatch research-agent subagents in parallel to gather findings; each writes to `resolutions/<ticket>.md`, after which you `resolve_ticket` it (research resolves are exempt from the one-per-session limit).
 6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
 
 ## Mode: work \<slug\> [ticket]

--- a/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: map-wayfind
+description: |
+  Decision-frontier wayfinding: build and work a durable map of open design decisions BEFORE planning, for large or foggy efforts where /map-plan would force premature decomposition. Use when a task is too big or too vague to decompose — many unknowns, tangled decisions, or "I'm not even sure what to build yet" — and you want to resolve the key decisions one at a time (research, prototype, grilling, task tickets) behind a claim-before-work frontier, with a "fog of war" for questions you cannot yet state sharply. Produces a handoff that /map-plan consumes. Modes are explicit: chart (start a map), work (resolve one ticket), handoff (finish). Do NOT use when scope is already clear enough to specify — go straight to /map-plan; do NOT use to implement code or to decompose an already-specifiable change.
+disable-model-invocation: true
+argument-hint: "[chart \"loose idea\" | work <slug> [ticket] | handoff <slug>]"
+effort: medium
+---
+# /map-wayfind — Decision-Frontier Wayfinding
+
+Purpose: for a large or foggy effort, resolve the key design decisions ONE AT A TIME on a durable map before any planning. If the scope is already clear enough to specify, skip this and run `/map-plan` directly.
+
+Contrast with `/map-plan`: `/map-plan` decomposes an already-understood task into subtasks. `/map-wayfind` comes earlier — it resolves the decisions that make decomposition possible, then hands the settled decisions to `/map-plan`. The map is durable and repo-level (`.map/wayfind/<slug>/`); it outlives branches and can span many sessions.
+
+## Effort and Parallelism Policy
+
+```yaml
+thinking_policy: medium/adaptive
+parallel_tool_policy: research_only
+```
+
+- Use deeper reasoning for the sharpness test (is a question ticketable now?), for wiring dependencies, and for judging whether a decision is truly resolved.
+- Do not over-chart: if a breadth-first interview surfaces no real fog, there is nothing to wayfind — say so and route to `/map-plan`.
+- Parallelize ONLY independent research-agent reads dispatched against research tickets. Keep charting interview, claiming, human grilling, resolving, and handoff strictly sequential.
+
+## Determinism boundary
+
+All state lives in `.map/wayfind/<slug>/state.json` and is mutated ONLY through `python3 .map/scripts/wayfind_runner.py <command>`. You write prose only: resolution files under `resolutions/`, and verbatim human answers under `resolutions/<ticket>.human.md`. Never hand-edit `state.json`, `map.md`, or `tickets/*.md` — the views carry a DO-NOT-EDIT banner and are regenerated on every mutation. Every command prints a JSON result; a non-success `status` means stop and read the message.
+
+See [wayfind-reference.md](wayfind-reference.md) for the full CLI reference, the fog-sharpness rubric, the ticket-type guide, and extended examples/troubleshooting. When a step points to a reference section, read it before executing the step; supporting files are not assumed to be in context automatically.
+
+## Mode selection
+
+Parse `$ARGUMENTS`. The FIRST token is the explicit mode — `chart`, `work`, or `handoff`. There is no auto-detection. If no mode is given, run `python3 .map/scripts/wayfind_runner.py wayfind_status` to show existing maps, then ask the user which mode to run.
+
+Mint ONE session id for this run and reuse it for every claim/record/resolve below:
+
+```bash
+WAYFIND_SESSION="$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+## Mode: chart "\<loose idea\>"
+
+Start a new map. Six steps, mirroring the way a good architect opens a foggy problem.
+
+1. **Name the destination.** Interview the user briefly for where this is headed (1–2 sentences). If it turns out the scope is already crisp, stop and recommend `/map-plan`.
+2. **Breadth-first interview.** Walk the surface of the problem to surface the open decisions. If nothing genuinely uncertain appears, there is no frontier to chart — STOP and route to `/map-plan`.
+3. **Create the map.** Pick a short slug (`[a-z0-9-]`, ≤50 chars). Pass genuinely-unsharp concerns as fog:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py create_wayfind_map \
+     <slug> "<title>" "<destination>" --fog-json '["still-vague concern", "..."]'
+   ```
+
+   Then warn the user: the map is committed by default, so grilling transcripts and prose resolutions are shared with the repo. To keep one map local, add `.map/wayfind/<slug>/.gitignore` with a single `*`.
+4. **Add sharp tickets.** For each decision you can state as ONE sharp question right now, add a ticket. Choose the type deliberately (see the reference): `research` (find out), `prototype` (build a cheap probe — human-in-the-loop), `grilling` (interrogate the human — human-in-the-loop), `task` (a self-contained decision/chore). Keep unsharp concerns as fog via `add_fog`; do not pre-slice fog into fake tickets.
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py add_ticket <slug> "<title>" <type> "<one sharp question>"
+   ```
+
+   In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
+5. **Kick off research.** For `research` tickets, you MAY dispatch research-agent subagents in parallel; each writes its findings to `resolutions/<ticket>.md`, then you `resolve_ticket` it. Research resolves are exempt from the one-per-session limit.
+6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
+
+## Mode: work \<slug\> [ticket]
+
+Resolve exactly ONE non-research decision, then stop. Five steps.
+
+1. **Load low-res.** Read only `.map/wayfind/<slug>/map.md`. Zoom into a specific ticket with `show_ticket <slug> <ticket>` only when needed.
+2. **Claim first.** Pick the named ticket, or the first frontier ticket from `wayfind_frontier <slug>`, and claim it BEFORE any work:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py claim_ticket <slug> <ticket> "$WAYFIND_SESSION"
+   ```
+
+   If the result has `hitl_pending: true`, this is a human-in-the-loop ticket — see step 3b.
+3. **Resolve by type.**
+   - `task`: do the work / make the call, then write the decision prose to `resolutions/<ticket>.md`.
+   - `research`: gather the answer (a subagent may help), write it to `resolutions/<ticket>.md`.
+   - **3b. `prototype` / `grilling` (human-in-the-loop):** ask the human the ticket's question verbatim (AskUserQuestion for grilling; describe the cheap probe for prototype), then STOP and hand control back. Do not answer on the human's behalf. When the human replies, save their words VERBATIM to `resolutions/<ticket>.human.md` and register them:
+
+     ```bash
+     python3 .map/scripts/wayfind_runner.py record_human_input <slug> <ticket> "$WAYFIND_SESSION" resolutions/<ticket>.human.md
+     ```
+
+     `resolve_ticket` refuses a human-in-the-loop ticket until this is recorded.
+4. **Resolve + maintain the map.** Write the one-line gist and the resolution file, then:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py resolve_ticket <slug> <ticket> "$WAYFIND_SESSION" "<one-line gist>" resolutions/<ticket>.md
+   ```
+
+   With what you learned, keep the map honest: `add_ticket` newly-sharp decisions, `graduate_fog` a fog entry that is now sharp, or `rule_out_of_scope` a ticket/fog that is settled as excluded (exclusions never appear under Decisions).
+5. **Stop.** The runner blocks a second non-research resolve in the same session by design. Report the decision and stop; start a fresh session (or `/map-wayfind handoff <slug>`) to continue.
+
+## Mode: handoff \<slug\>
+
+When `wayfind_status <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
+
+```bash
+python3 .map/scripts/wayfind_runner.py emit_wayfind_handoff <slug> --remaining-risks-json '["..."]'
+```
+
+This writes `.map/wayfind/<slug>/handoff.md` (+ `handoff.json`) and registers a `wayfind_handoff` artifact-manifest stage on the current branch. If you must hand off with open items, pass `--early --confirmed-by-user` and confirm with the user first; the open items are folded into remaining risks so nothing is lost. Then, on a feature branch, run `/map-plan --wayfind <slug>` to seed the spec from the settled decisions.
+
+## Guardrails
+
+- Do not pre-slice fog: only create a ticket when you can state its question sharply NOW (rubric in the reference). Otherwise keep it as fog.
+- Resolve at most ONE non-research ticket per session; the runner enforces this.
+- Out-of-scope is an exclusion, not a decision — it never graduates into the plan.
+- No implementation subtasks and no code changes here — that is `/map-plan` + execution.
+- Never write secrets into tickets, resolutions, or the map. Warn about the commit-by-default privacy note in `chart`.
+- Refer to tickets by name in prose, not bare ids, so the map reads for a human.
+- Honesty note: the human-in-the-loop and one-per-session checks add friction and an audit trail; they are not a mechanical guarantee. Ask the human when in doubt.
+
+## Examples
+
+- **Foggy feature:** `/map-wayfind chart "rebuild checkout"` → name destination, interview, create map `checkout` with 2 fog entries + 3 sharp tickets (1 research, 1 grilling, 1 task) → dispatch the research ticket → stop.
+- **Resolve one decision:** `/map-wayfind work checkout` → claim the `grilling` ticket → ask the human verbatim, stop, record their answer, resolve → stop (one non-research decision done).
+- **Finish:** `/map-wayfind handoff checkout` → all tickets resolved/out-of-scope, fog empty → emit handoff → `/map-plan --wayfind checkout`.
+
+More worked examples are in [wayfind-reference.md](wayfind-reference.md).
+
+## Troubleshooting
+
+- `emit_wayfind_handoff` returns `not_terminal`: fog, claimed, or unresolved tickets remain — resolve or rule them out, or hand off `--early --confirmed-by-user`.
+- `resolve_ticket` returns `awaiting_human`: it is a `prototype`/`grilling` ticket — record the human answer with `record_human_input` first.
+- `resolve_ticket` returns `session_limit`: you already resolved a non-research ticket this session — start a new session.
+- `wire_blocking` returns `cycle`: the dependency you added would close a loop — re-check the blocker direction.
+- Full command reference and the fog-sharpness rubric are in [wayfind-reference.md](wayfind-reference.md).

--- a/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
@@ -1,0 +1,132 @@
+# /map-wayfind Supporting Reference
+
+Detail for `/map-wayfind` so the invoked `SKILL.md` stays focused on the active flow. All operations go through `python3 .map/scripts/wayfind_runner.py <command>`; each prints a JSON result with a `status` of `success` or `error`.
+
+## Ticket types
+
+| Type | Meaning | Human-in-the-loop | Counts toward one-per-session |
+|------|---------|-------------------|-------------------------------|
+| `research` | Find out an answer that already exists (read code/docs, run a query). A subagent may do this. | No | No — resolve as many as you learn |
+| `prototype` | Build a cheap, throwaway probe to see how an approach feels, then get the human's read. | Yes | Yes |
+| `grilling` | Interrogate the human: ask the sharp question, capture their verbatim answer. | Yes | Yes |
+| `task` | A self-contained decision or chore you can settle yourself. | No | Yes |
+
+Human-in-the-loop (`prototype`, `grilling`) tickets cannot be resolved until a verbatim human answer is recorded with `record_human_input`.
+
+## Fog-sharpness rubric
+
+Create a ticket only when the concern passes the sharpness test — otherwise keep it as fog and graduate it later.
+
+- **Sharp (make a ticket):** you can state it as ONE question with a bounded answer space, and you know what "resolved" looks like. E.g. "Do we store sessions in Redis or Postgres?"
+- **Foggy (keep as fog):** you can only gesture at an area of unease, the question would be compound, or you cannot yet say what a good answer is. E.g. "auth and the new checkout probably interact somehow."
+- When a session's work makes a foggy area sharp, `graduate_fog` it into a ticket.
+
+## Command reference
+
+Lifecycle / read-only:
+
+```bash
+create_wayfind_map <slug> "<title>" "<destination>" [--notes "..."] [--fog-json '["...", "..."]']
+wayfind_status [--slug <slug>]          # no slug: list all maps; with slug: counts + handoff_eligible
+list_handoffs                           # completed handoffs (used by /map-plan's offer)
+show_ticket <slug> <ticket_id>
+wayfind_frontier <slug>                 # open + unblocked + unclaimed tickets, creation order
+```
+
+Tickets:
+
+```bash
+add_ticket <slug> "<title>" <type> "<sharp question>" [--blocked-by-json '["T-001"]'] [--from-fog F-1]
+wire_blocking <slug> <ticket_id> '["T-001","T-002"]'   # rejects unknown ids, self-block, cycles
+claim_ticket <slug> <ticket_id> <session>              # HITL types return hitl_pending: true
+release_ticket <slug> <ticket_id> <session>            # crash/interrupt recovery; owner only
+record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
+resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
+```
+
+Fog & scope:
+
+```bash
+add_fog <slug> "<still-vague concern>"
+graduate_fog <slug> <fog_id> "<title>" <type> "<sharp question>" [--blocked-by-json '[...]']
+rule_out_of_scope <slug> "<reason>" [--ticket-id T-003] [--fog-id F-2] [--gist "..."]
+```
+
+Handoff:
+
+```bash
+emit_wayfind_handoff <slug> [--remaining-risks-json '["..."]'] [--early --confirmed-by-user] [--branch <branch>]
+```
+
+Every mutating command also accepts `--expected-revision <n>` (optimistic-concurrency guard): it fails with `stale_revision` if the map has advanced past `<n>`, protecting against concurrent sessions clobbering each other. Read `revision` from `wayfind_status` first.
+
+## Files under `.map/wayfind/<slug>/`
+
+- `state.json` — canonical store. Never edit by hand.
+- `map.md` — regenerated low-resolution overview (Destination, Notes, Decisions so far, Frontier, Blocked/claimed, Fog, Out of scope). DO-NOT-EDIT banner.
+- `tickets/T-00N.md` — regenerated per-ticket detail.
+- `resolutions/T-00N.md` — YOUR prose answer for a ticket (you write this before `resolve_ticket`).
+- `resolutions/T-00N.human.md` — the human's VERBATIM answer for a HITL ticket (you save this before `record_human_input`).
+- `handoff.md` / `handoff.json` — the final artifact `/map-plan --wayfind <slug>` consumes.
+
+## Terminal (handoff-eligible) condition
+
+`emit_wayfind_handoff` refuses unless the map is truly exhausted: fog empty AND no active claims AND every ticket in `{resolved, out_of_scope}` AND at least one ticket exists. A map with a claimed or blocked ticket is NOT eligible even if the frontier momentarily looks empty. Use `--early --confirmed-by-user` to override; the open items become explicit remaining risks in the handoff.
+
+## How /map-plan consumes the handoff
+
+`handoff.json` maps 1:1 onto the `/map-plan` spec template:
+
+- `decisions[]` → spec **Decisions Made** (these are settled — the interview must not re-ask them).
+- `out_of_scope[]` → spec **Out of Scope**.
+- `remaining_risks[]` → spec **Open Questions**.
+
+Run `/map-plan --wayfind <slug>` on a feature branch. Without an explicit slug, `/map-plan` runs `list_handoffs`; if exactly one completed handoff exists it OFFERS it, but never consumes silently.
+
+## Examples
+
+**Charting a foggy feature**
+
+```text
+/map-wayfind chart "rebuild checkout"
+→ destination: "a faster, single-page checkout"
+→ interview surfaces real uncertainty → chart it
+create_wayfind_map checkout "Checkout v2" "a faster, single-page checkout" \
+  --fog-json '["how does the new flow interact with legacy auth?"]'
+add_ticket checkout "Session store" task "Redis or Postgres for cart sessions?"
+add_ticket checkout "Payments SDK" research "Which payment SDKs support our regions?"
+add_ticket checkout "One-page vs wizard" grilling "One-page checkout or a 3-step wizard?"
+wire_blocking checkout T-001 '["T-002"]'   # session store waits on the SDK finding
+```
+
+**Working one ticket (human-in-the-loop)**
+
+```text
+/map-wayfind work checkout
+claim_ticket checkout T-003 20260717T101500Z    # grilling → hitl_pending: true
+→ ask the human verbatim: "One-page checkout or a 3-step wizard?"; STOP; hand control back
+→ human answers; save verbatim to resolutions/T-003.human.md
+record_human_input checkout T-003 20260717T101500Z resolutions/T-003.human.md
+→ write resolutions/T-003.md
+resolve_ticket checkout T-003 20260717T101500Z "One-page; wizard tested worse in the poll" resolutions/T-003.md
+→ stop (one non-research decision resolved this session)
+```
+
+**Handing off**
+
+```text
+/map-wayfind handoff checkout
+wayfind_status --slug checkout    # handoff_eligible: true
+emit_wayfind_handoff checkout --remaining-risks-json '["fraud rules not yet scoped"]'
+→ /map-plan --wayfind checkout   (on a feature branch)
+```
+
+## Troubleshooting
+
+- **`not_terminal` on handoff** — an item is still open. Run `wayfind_status --slug <slug>`; the error's `open_items` names each blocker. Resolve or `rule_out_of_scope` them, or hand off `--early --confirmed-by-user`.
+- **`awaiting_human`** — a `prototype`/`grilling` ticket needs a recorded human answer first (`record_human_input`).
+- **`session_limit`** — one non-research resolve per session is the rule; mint a fresh session id and continue.
+- **`already_claimed` / `blocked` / `not_owner`** — the ticket is taken, has unresolved blockers, or is claimed by another session. Check `map.md`'s Blocked/claimed section.
+- **`stale_revision`** — another session advanced the map; re-read it and retry with the current `--expected-revision`.
+- **`cycle`** — a `wire_blocking` call would create a dependency loop; the blocker relationship is likely backwards.
+- **Duplicate slug** — a map with that slug exists; pick another slug or continue the existing one with `work`.

--- a/src/mapify_cli/templates/skills/skill-rules.json
+++ b/src/mapify_cli/templates/skills/skill-rules.json
@@ -228,6 +228,28 @@
         ]
       }
     },
+    "map-wayfind": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Decision-frontier wayfinding: resolve open design decisions on a durable map before /map-plan.",
+      "promptTriggers": {
+        "keywords": [
+          "map-wayfind",
+          "wayfind",
+          "decision frontier",
+          "resolve decisions first",
+          "too foggy to plan",
+          "chart the decisions"
+        ],
+        "intentPatterns": [
+          "map-wayfind",
+          "(chart|map|resolve).*(decision|frontier)",
+          "too (foggy|vague|big) to (plan|decompose)"
+        ]
+      }
+    },
     "map-release": {
       "type": "manual",
       "skillClass": "task",

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -250,6 +250,7 @@ ARTIFACT_STAGE_NAMES = (
     "learn_handoff",
     "implementer_readiness",
     "context_usefulness",
+    "wayfind_handoff",
 )
 RUN_HEALTH_TERMINAL_STATUSES = {
     "pending",

--- a/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
@@ -1,0 +1,1510 @@
+#!/usr/bin/env python3
+"""wayfind_runner.py — deterministic operations for /map-wayfind decision maps.
+
+Self-contained, stdlib-only runner.  Owns EVERY mutation to
+``.map/wayfind/<slug>/state.json`` (the canonical store) and regenerates the
+human-readable views (``map.md``, ``tickets/T-00N.md``) after each mutation.
+
+Design contract (mirrors the wider MAP conventions):
+  * state.json is the single source of truth; map.md / tickets/*.md are derived
+    projections carrying a DO-NOT-EDIT banner and are never parsed back.
+  * The LLM never edits state.json by hand — it calls these operations and
+    writes only prose resolution files under ``resolutions/``.
+  * Every function returns a typed result dict: ``{"status": "success", ...}``
+    or ``{"status": "error", "message": ...}``.  Nothing is raised through the
+    public API; the CLI turns a non-success status into exit code 1.
+  * Invariants (cycle-freedom, one-non-research-resolve-per-session, HITL gate,
+    terminal-handoff condition) live ABOVE persistence so a future non-local
+    backend cannot bypass them.
+
+The only cross-module dependency is a LAZY import of ``map_step_runner`` inside
+:func:`emit_wayfind_handoff`, used solely to register the ``wayfind_handoff``
+artifact-manifest stage on the current branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Vocabulary / constants
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION = "1.0"
+
+WAYFIND_TICKET_TYPES = frozenset({"research", "prototype", "grilling", "task"})
+# Human-in-the-loop ticket types: resolving one requires a recorded verbatim
+# human response (see record_human_input / resolve_ticket).
+HITL_TYPES = frozenset({"prototype", "grilling"})
+# Ticket statuses that count as "closed" for frontier / terminal computations.
+TERMINAL_TICKET_STATUSES = frozenset({"resolved", "out_of_scope"})
+
+_SLUG_RE = re.compile(r"^[a-z0-9-]{1,50}$")
+
+_DO_NOT_EDIT_BANNER = (
+    "<!-- DO NOT EDIT — regenerated from state.json by wayfind_runner.py. "
+    "Manual edits will be overwritten. -->"
+)
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(**fields: Any) -> dict[str, Any]:
+    return {"status": "success", **fields}
+
+
+def _err(message: str, **fields: Any) -> dict[str, Any]:
+    return {"status": "error", "message": message, **fields}
+
+
+def _now() -> str:
+    """Return an RFC3339 UTC timestamp (matches map_step_runner._utc_timestamp)."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _oneline(text: str) -> str:
+    """Collapse whitespace/newlines so untrusted prose stays on one Markdown line."""
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (repo-level, resolved against cwd like .map/<branch>)
+# ---------------------------------------------------------------------------
+
+
+def _wayfind_root() -> Path:
+    return Path(".map/wayfind")
+
+
+def _map_dir(slug: str) -> Path:
+    return _wayfind_root() / slug
+
+
+def _state_path(slug: str) -> Path:
+    return _map_dir(slug) / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# State load / save + derived views
+# ---------------------------------------------------------------------------
+
+
+def _load_state(slug: str) -> Optional[dict[str, Any]]:
+    path = _state_path(slug)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    """Bump revision, atomically persist state.json, and regenerate all views."""
+    slug = state["slug"]
+    state["revision"] = int(state.get("revision", 0)) + 1
+    map_dir = _map_dir(slug)
+    map_dir.mkdir(parents=True, exist_ok=True)
+    path = _state_path(slug)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    )
+    tmp.replace(path)
+    _render_views(state)
+
+
+def _revision_guard(
+    state: dict[str, Any], expected_revision: Optional[int]
+) -> Optional[dict[str, Any]]:
+    """Optimistic-concurrency check: reject a mutation against a stale revision."""
+    if expected_revision is None:
+        return None
+    current = int(state.get("revision", 0))
+    if current != int(expected_revision):
+        return _err(
+            f"stale revision: expected {expected_revision}, map is at {current}. "
+            "Re-read the map before mutating.",
+            code="stale_revision",
+            revision=current,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Id minting
+# ---------------------------------------------------------------------------
+
+
+def _next_ticket_id(state: dict[str, Any]) -> str:
+    nums = [
+        int(m.group(1))
+        for tid in state.get("tickets", {})
+        if (m := re.match(r"^T-(\d+)$", tid))
+    ]
+    return f"T-{(max(nums) + 1) if nums else 1:03d}"
+
+
+def _next_fog_id(state: dict[str, Any]) -> str:
+    nums = [
+        int(m.group(1))
+        for f in state.get("fog", [])
+        if (m := re.match(r"^F-(\d+)$", str(f.get("id", ""))))
+    ]
+    return f"F-{(max(nums) + 1) if nums else 1}"
+
+
+# ---------------------------------------------------------------------------
+# Invariant helpers
+# ---------------------------------------------------------------------------
+
+
+def _ticket_blocked(state: dict[str, Any], ticket: dict[str, Any]) -> bool:
+    """True if any blocker is not yet terminal (resolved / out_of_scope)."""
+    tickets = state.get("tickets", {})
+    for bid in ticket.get("blocked_by", []):
+        blocker = tickets.get(bid)
+        if blocker is None or blocker.get("status") not in TERMINAL_TICKET_STATUSES:
+            return True
+    return False
+
+
+def _detect_cycle(graph: dict[str, list[str]]) -> bool:
+    """Return True if the directed graph (node -> blockers) contains a cycle."""
+    white, gray, black = 0, 1, 2
+    color: dict[str, int] = {node: white for node in graph}
+
+    def visit(node: str) -> bool:
+        color[node] = gray
+        for nxt in graph.get(node, []):
+            if nxt not in color:
+                continue
+            if color[nxt] == gray:
+                return True
+            if color[nxt] == white and visit(nxt):
+                return True
+        color[node] = black
+        return False
+
+    return any(color[node] == white and visit(node) for node in list(graph))
+
+
+def _blocking_graph(
+    state: dict[str, Any], override: Optional[tuple[str, list[str]]] = None
+) -> dict[str, list[str]]:
+    """Build a {ticket_id: blocked_by[]} graph, optionally overriding one node."""
+    graph = {
+        tid: list(t.get("blocked_by", [])) for tid, t in state.get("tickets", {}).items()
+    }
+    if override is not None:
+        tid, blockers = override
+        graph[tid] = list(blockers)
+    return graph
+
+
+def _active_claims(state: dict[str, Any]) -> list[str]:
+    """Ticket ids that are claimed and not yet terminal."""
+    return [
+        tid
+        for tid, t in state.get("tickets", {}).items()
+        if t.get("claimed_by") and t.get("status") not in TERMINAL_TICKET_STATUSES
+    ]
+
+
+def _open_fog(state: dict[str, Any]) -> list[dict[str, Any]]:
+    return [f for f in state.get("fog", []) if f.get("status") == "open"]
+
+
+def _is_terminal(state: dict[str, Any]) -> bool:
+    """Terminal (handoff-eligible) condition.
+
+    Fog empty AND no active claims AND at least one ticket AND every ticket in
+    {resolved, out_of_scope}.  A naive ``len(frontier) == 0`` would wrongly fire
+    on a map whose tickets are merely claimed or blocked.
+    """
+    tickets = state.get("tickets", {})
+    if not tickets:
+        return False
+    if any(t.get("status") not in TERMINAL_TICKET_STATUSES for t in tickets.values()):
+        return False
+    if _open_fog(state):
+        return False
+    if _active_claims(state):
+        return False
+    return True
+
+
+def _recompute_status(state: dict[str, Any]) -> None:
+    """Keep status accurate on every mutation (never mutated by a read)."""
+    if state.get("status") == "handed_off":
+        return
+    if _is_terminal(state):
+        state["status"] = "exhausted"
+    elif state.get("status") == "exhausted":
+        # A previously-terminal map became non-terminal again (e.g. new fog).
+        state["status"] = "active"
+
+
+def _ensure_session(state: dict[str, Any], session: str) -> dict[str, Any]:
+    sessions = state.setdefault("sessions", {})
+    if session not in sessions:
+        sessions[session] = {
+            "started_at": _now(),
+            "non_research_resolved": 0,
+            "claimed": [],
+        }
+    return sessions[session]
+
+
+def _frontier_tickets(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Open, unblocked, unclaimed tickets in creation (id) order."""
+    frontier: list[dict[str, Any]] = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") != "open":
+            continue
+        if ticket.get("claimed_by"):
+            continue
+        if _ticket_blocked(state, ticket):
+            continue
+        frontier.append({"ticket_id": tid, **ticket})
+    return frontier
+
+
+def _mint_ticket(
+    state: dict[str, Any],
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by: list[str],
+    from_fog: Optional[str],
+) -> str:
+    ticket_id = _next_ticket_id(state)
+    state.setdefault("tickets", {})[ticket_id] = {
+        "title": _oneline(title),
+        "type": ticket_type,
+        "question": _oneline(question),
+        "status": "open",
+        "blocked_by": list(blocked_by),
+        "claimed_by": None,
+        "claimed_at": None,
+        "created_at": _now(),
+        "resolved_at": None,
+        "human_input_path": None,
+        "resolution": None,
+        "from_fog": from_fog or None,
+    }
+    return ticket_id
+
+
+# ---------------------------------------------------------------------------
+# View rendering
+# ---------------------------------------------------------------------------
+
+
+def _ticket_badge(state: dict[str, Any], ticket: dict[str, Any]) -> str:
+    if (
+        ticket.get("status") == "open"
+        and ticket.get("claimed_by")
+        and ticket.get("type") in HITL_TYPES
+        and not ticket.get("human_input_path")
+    ):
+        return " — 🔴 AWAITING HUMAN"
+    return ""
+
+
+def _render_map_md(state: dict[str, Any]) -> str:
+    tickets = state.get("tickets", {})
+    lines: list[str] = [
+        _DO_NOT_EDIT_BANNER,
+        f"# Wayfinding Map: {_oneline(state.get('title', state['slug']))}",
+        "",
+        f"- **Slug:** `{state['slug']}`",
+        f"- **Status:** {state.get('status', 'active')}",
+        f"- **Map ID:** `{state.get('map_id', '')}`",
+        f"- **Revision:** {state.get('revision', 0)}",
+        "",
+        "## Destination",
+        "",
+        _oneline(state.get("destination", "")) or "_Not stated._",
+        "",
+        "## Notes",
+        "",
+        _oneline(state.get("notes", "")) or "_None._",
+        "",
+        "## Decisions so far",
+        "",
+    ]
+
+    resolved = [
+        (tid, tickets[tid])
+        for tid in sorted(tickets)
+        if tickets[tid].get("status") == "resolved"
+    ]
+    if resolved:
+        for tid, ticket in resolved:
+            resolution = ticket.get("resolution") or {}
+            gist = _oneline(resolution.get("gist", ""))
+            path = resolution.get("path", "")
+            link = f"  ([resolution]({path}))" if path else ""
+            lines.append(f"- **{tid}** {_oneline(ticket.get('title', ''))} — {gist}{link}")
+    else:
+        lines.append("_None yet._")
+
+    lines += ["", "## Frontier (resolve next, one non-research at a time)", ""]
+    frontier = _frontier_tickets(state)
+    if frontier:
+        for ticket in frontier:
+            lines.append(
+                f"- **{ticket['ticket_id']}** [{ticket['type']}] "
+                f"{_oneline(ticket.get('title', ''))} — {_oneline(ticket.get('question', ''))}"
+            )
+    else:
+        lines.append("_Empty._")
+
+    lines += ["", "## Blocked / claimed", ""]
+    pending: list[str] = []
+    for tid in sorted(tickets):
+        ticket = tickets[tid]
+        if ticket.get("status") != "open":
+            continue
+        blocked = _ticket_blocked(state, ticket)
+        claimed = bool(ticket.get("claimed_by"))
+        if not blocked and not claimed:
+            continue
+        detail_parts: list[str] = []
+        if blocked:
+            detail_parts.append(
+                "blocked by " + ", ".join(ticket.get("blocked_by", []))
+            )
+        if claimed:
+            detail_parts.append(f"claimed by `{ticket['claimed_by']}`")
+        detail = "; ".join(detail_parts)
+        badge = _ticket_badge(state, ticket)
+        pending.append(
+            f"- **{tid}** [{ticket['type']}] {_oneline(ticket.get('title', ''))}"
+            f" — {detail}{badge}"
+        )
+    lines += pending if pending else ["_None._"]
+
+    lines += ["", "## Fog of war (too vague to ticket yet)", ""]
+    open_fog = _open_fog(state)
+    if open_fog:
+        for fog in open_fog:
+            lines.append(f"- **{fog.get('id')}** {_oneline(fog.get('text', ''))}")
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Out of scope", ""]
+    out_of_scope = state.get("out_of_scope", [])
+    if out_of_scope:
+        for entry in out_of_scope:
+            ref = entry.get("ticket_id") or entry.get("fog_id") or ""
+            ref_text = f" (from {ref})" if ref else ""
+            lines.append(
+                f"- {_oneline(entry.get('gist', ''))} — "
+                f"{_oneline(entry.get('reason', ''))}{ref_text}"
+            )
+    else:
+        lines.append("_None._")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_ticket_md(state: dict[str, Any], ticket_id: str) -> str:
+    ticket = state["tickets"][ticket_id]
+    resolution = ticket.get("resolution") or {}
+    lines = [
+        _DO_NOT_EDIT_BANNER,
+        f"# {ticket_id}: {_oneline(ticket.get('title', ''))}",
+        "",
+        f"- **Type:** {ticket.get('type')}",
+        f"- **Status:** {ticket.get('status')}",
+        f"- **Blocked by:** {', '.join(ticket.get('blocked_by', [])) or '—'}",
+        f"- **Claimed by:** {ticket.get('claimed_by') or '—'}",
+        f"- **From fog:** {ticket.get('from_fog') or '—'}",
+        f"- **Created:** {ticket.get('created_at')}",
+        f"- **Resolved:** {ticket.get('resolved_at') or '—'}",
+        "",
+        "## Question",
+        "",
+        _oneline(ticket.get("question", "")),
+        "",
+    ]
+    if resolution:
+        lines += [
+            "## Resolution",
+            "",
+            _oneline(resolution.get("gist", "")),
+            "",
+            f"See `{resolution.get('path', '')}`.",
+            "",
+        ]
+    if ticket.get("human_input_path"):
+        lines += [f"Human input recorded at `{ticket['human_input_path']}`.", ""]
+    return "\n".join(lines)
+
+
+def _render_views(state: dict[str, Any]) -> None:
+    map_dir = _map_dir(state["slug"])
+    map_dir.mkdir(parents=True, exist_ok=True)
+    (map_dir / "map.md").write_text(_render_map_md(state), encoding="utf-8")
+    tickets_dir = map_dir / "tickets"
+    tickets_dir.mkdir(parents=True, exist_ok=True)
+    for ticket_id in state.get("tickets", {}):
+        (tickets_dir / f"{ticket_id}.md").write_text(
+            _render_ticket_md(state, ticket_id), encoding="utf-8"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operations — map lifecycle
+# ---------------------------------------------------------------------------
+
+
+def create_wayfind_map(
+    slug: str,
+    title: str,
+    destination: str,
+    notes: str = "",
+    fog_json: str = "[]",
+) -> dict[str, Any]:
+    """Create a new decision map at .map/wayfind/<slug>/."""
+    if not _SLUG_RE.match(slug or ""):
+        return _err(
+            f"invalid slug {slug!r}: must match [a-z0-9-] and be 1-50 chars."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(destination):
+        return _err("destination must be a non-empty string (name where you are headed).")
+    if _state_path(slug).exists():
+        return _err(f"a map with slug {slug!r} already exists.", code="duplicate")
+
+    try:
+        parsed_fog = json.loads(fog_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _err(f"invalid fog JSON: {exc}")
+    if not isinstance(parsed_fog, list):
+        return _err("fog must be a JSON array of strings.")
+
+    fog: list[dict[str, Any]] = []
+    for i, text in enumerate(parsed_fog, 1):
+        if not isinstance(text, str) or not text.strip():
+            return _err(f"fog[{i - 1}] must be a non-empty string.")
+        fog.append({"id": f"F-{i}", "text": _oneline(text), "status": "open"})
+
+    state: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "backend": "local",
+        "revision": 0,
+        "map_id": uuid.uuid4().hex,
+        "slug": slug,
+        "title": _oneline(title),
+        "status": "charting",
+        "destination": _oneline(destination),
+        "notes": _oneline(notes),
+        "fog": fog,
+        "out_of_scope": [],
+        "tickets": {},
+        "sessions": {},
+    }
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        map_id=state["map_id"],
+        state_path=str(_state_path(slug)),
+        map_path=str(_map_dir(slug) / "map.md"),
+        fog_count=len(fog),
+    )
+
+
+def wayfind_status(slug: Optional[str] = None) -> dict[str, Any]:
+    """Without slug: list all maps. With slug: counts + handoff eligibility."""
+    if slug is None:
+        root = _wayfind_root()
+        maps: list[dict[str, Any]] = []
+        if root.exists():
+            for child in sorted(root.iterdir()):
+                if not child.is_dir():
+                    continue
+                state = _load_state(child.name)
+                if state is None:
+                    continue
+                maps.append(_status_summary(state))
+        return _ok(maps=maps, count=len(maps))
+
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    return _ok(**_status_summary(state))
+
+
+def _status_summary(state: dict[str, Any]) -> dict[str, Any]:
+    tickets = state.get("tickets", {})
+    open_ids = [tid for tid, t in tickets.items() if t.get("status") == "open"]
+    blocked = [tid for tid in open_ids if _ticket_blocked(state, tickets[tid])]
+    claimed = _active_claims(state)
+    resolved = [tid for tid, t in tickets.items() if t.get("status") == "resolved"]
+    out_of_scope = [
+        tid for tid, t in tickets.items() if t.get("status") == "out_of_scope"
+    ]
+    return {
+        "slug": state["slug"],
+        "title": state.get("title", ""),
+        "map_status": state.get("status", "active"),
+        "revision": state.get("revision", 0),
+        "counts": {
+            "open": len(open_ids),
+            "blocked": len(blocked),
+            "claimed": len(claimed),
+            "resolved": len(resolved),
+            "out_of_scope": len(out_of_scope),
+            "open_fog": len(_open_fog(state)),
+            "frontier": len(_frontier_tickets(state)),
+        },
+        "handoff_eligible": _is_terminal(state),
+    }
+
+
+def list_handoffs() -> dict[str, Any]:
+    """Return completed handoffs — the read-only source for /map-plan's offer."""
+    root = _wayfind_root()
+    handoffs: list[dict[str, Any]] = []
+    if root.exists():
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            handoff_path = child / "handoff.json"
+            state = _load_state(child.name)
+            if state is None or not handoff_path.exists():
+                continue
+            try:
+                payload = json.loads(handoff_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            handoffs.append(
+                {
+                    "slug": state["slug"],
+                    "title": state.get("title", ""),
+                    "handoff_path": str(child / "handoff.md"),
+                    "decisions_count": len(payload.get("decisions", [])),
+                    "generated_at": payload.get("generated_at", ""),
+                }
+            )
+    return _ok(handoffs=handoffs, count=len(handoffs))
+
+
+def show_ticket(slug: str, ticket_id: str) -> dict[str, Any]:
+    """Read-only zoom into a single ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    return _ok(ticket_id=ticket_id, ticket=ticket)
+
+
+# ---------------------------------------------------------------------------
+# Operations — tickets
+# ---------------------------------------------------------------------------
+
+
+def _parse_blocked_by(
+    state: dict[str, Any], blocked_by_json: str
+) -> tuple[Optional[list[str]], Optional[dict[str, Any]]]:
+    """Parse + validate a blocked_by list. Returns (list, None) or (None, error)."""
+    try:
+        parsed = json.loads(blocked_by_json or "[]")
+    except json.JSONDecodeError as exc:
+        return None, _err(f"invalid blocked_by JSON: {exc}")
+    if not isinstance(parsed, list):
+        return None, _err("blocked_by must be a JSON array of ticket ids.")
+    tickets = state.get("tickets", {})
+    seen: list[str] = []
+    for bid in parsed:
+        if not isinstance(bid, str) or bid not in tickets:
+            return None, _err(f"unknown blocker ticket id: {bid!r}.")
+        if bid not in seen:
+            seen.append(bid)
+    return seen, None
+
+
+def add_ticket(
+    slug: str,
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by_json: str = "[]",
+    from_fog: str = "",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Add a decision ticket with a single sharp question."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if ticket_type not in WAYFIND_TICKET_TYPES:
+        return _err(
+            f"invalid ticket type {ticket_type!r}. "
+            f"Must be one of: {sorted(WAYFIND_TICKET_TYPES)}."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(question):
+        return _err(
+            "question must be a single, sharply-stated question. "
+            "If you cannot state it sharply now, keep it as fog (add_fog) instead."
+        )
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+    if from_fog:
+        if not any(f.get("id") == from_fog for f in state.get("fog", [])):
+            return _err(f"unknown fog id: {from_fog!r}.")
+
+    ticket_id = _mint_ticket(state, title, ticket_type, question, blocked_by, from_fog)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, revision=state["revision"])
+
+
+def wire_blocking(
+    slug: str,
+    ticket_id: str,
+    blocked_by_json: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Replace a ticket's blocked_by set; rejects unknown ids and cycles."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if ticket_id not in state.get("tickets", {}):
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+    if ticket_id in blocked_by:
+        return _err("a ticket cannot block itself.")
+
+    graph = _blocking_graph(state, override=(ticket_id, blocked_by))
+    if _detect_cycle(graph):
+        return _err(
+            f"wiring {ticket_id!r} to block on {blocked_by} would create a cycle.",
+            code="cycle",
+        )
+
+    state["tickets"][ticket_id]["blocked_by"] = blocked_by
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, blocked_by=blocked_by, revision=state["revision"])
+
+
+def claim_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Claim a frontier ticket before working it (claim-before-work invariant)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not session:
+        return _err("session id is required to claim a ticket.")
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("status") != "open":
+        return _err(
+            f"ticket {ticket_id!r} is {ticket.get('status')!r}; only open tickets "
+            "can be claimed.",
+            code="not_open",
+        )
+    if ticket.get("claimed_by"):
+        return _err(
+            f"ticket {ticket_id!r} is already claimed by {ticket['claimed_by']!r}.",
+            code="already_claimed",
+        )
+    if _ticket_blocked(state, ticket):
+        return _err(
+            f"ticket {ticket_id!r} is blocked by unresolved tickets "
+            f"{ticket.get('blocked_by', [])}.",
+            code="blocked",
+        )
+
+    ticket["claimed_by"] = session
+    ticket["claimed_at"] = _now()
+    ledger = _ensure_session(state, session)
+    if ticket_id not in ledger["claimed"]:
+        ledger["claimed"].append(ticket_id)
+    if state.get("status") == "charting":
+        state["status"] = "active"
+    _recompute_status(state)
+    _save_state(state)
+
+    hitl_pending = ticket.get("type") in HITL_TYPES
+    result = _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        session=session,
+        hitl_pending=hitl_pending,
+        revision=state["revision"],
+    )
+    if hitl_pending:
+        result["message"] = (
+            f"{ticket['type']} ticket claimed. Ask the human the question verbatim, "
+            "STOP generating, and hand control back. When the human answers, save "
+            "their verbatim words to a file and call record_human_input before "
+            "resolve_ticket."
+        )
+    return result
+
+
+def release_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Release a ticket claimed by this session (crash / interruption recovery)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} is not claimed by session {session!r} "
+            f"(claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    ticket["claimed_by"] = None
+    ticket["claimed_at"] = None
+    ledger = state.get("sessions", {}).get(session)
+    if ledger and ticket_id in ledger.get("claimed", []):
+        ledger["claimed"].remove(ticket_id)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, revision=state["revision"])
+
+
+def record_human_input(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    path: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Register a verbatim human response file — required before a HITL resolve."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} must be claimed by session {session!r} to record "
+            f"human input (claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    # Paths are relative to the map dir (.map/wayfind/<slug>/) so the value stored
+    # in state.json doubles as a correct link target from the co-located views.
+    input_path = _map_dir(slug) / path
+    if not input_path.exists() or not input_path.read_text(
+        encoding="utf-8", errors="replace"
+    ).strip():
+        return _err(
+            f"human input file {path!r} (under the map dir) does not exist or is empty. "
+            "Save the human's verbatim answer there first.",
+            code="missing_input",
+        )
+    ticket["human_input_path"] = path
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, human_input_path=path, revision=state["revision"])
+
+
+def resolve_ticket(
+    slug: str,
+    ticket_id: str,
+    session: str,
+    gist: str,
+    resolution_path: str,
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Close a claimed ticket with a one-line gist + a prose resolution file."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("claimed_by") != session:
+        return _err(
+            f"ticket {ticket_id!r} must be claimed by session {session!r} to resolve "
+            f"(claimed by {ticket.get('claimed_by')!r}).",
+            code="not_owner",
+        )
+    if ticket.get("status") != "open":
+        return _err(
+            f"ticket {ticket_id!r} is already {ticket.get('status')!r}.",
+            code="not_open",
+        )
+    if not _oneline(gist):
+        return _err("gist must be a non-empty one-line summary of the decision.")
+    # resolution_path is relative to the map dir (.map/wayfind/<slug>/) so the stored
+    # value is a correct link target from the co-located map.md / handoff.md views.
+    resolution_file = _map_dir(slug) / resolution_path
+    if not resolution_file.exists() or not resolution_file.read_text(
+        encoding="utf-8", errors="replace"
+    ).strip():
+        return _err(
+            f"resolution file {resolution_path!r} (under the map dir) does not exist or "
+            "is empty. Write the prose resolution first.",
+            code="missing_resolution",
+        )
+
+    is_hitl = ticket.get("type") in HITL_TYPES
+    if is_hitl and not ticket.get("human_input_path"):
+        return _err(
+            f"ticket {ticket_id!r} is a {ticket.get('type')} (human-in-the-loop) "
+            "ticket awaiting a human response. Call record_human_input first.",
+            code="awaiting_human",
+        )
+
+    is_non_research = ticket.get("type") != "research"
+    ledger = _ensure_session(state, session)
+    if is_non_research and int(ledger.get("non_research_resolved", 0)) >= 1:
+        return _err(
+            "this session has already resolved a non-research ticket. Resolve at most "
+            "ONE non-research ticket per session; start a new session to continue.",
+            code="session_limit",
+        )
+
+    ticket["status"] = "resolved"
+    ticket["resolved_at"] = _now()
+    ticket["resolution"] = {"gist": _oneline(gist), "path": resolution_path}
+    if ticket_id in ledger.get("claimed", []):
+        ledger["claimed"].remove(ticket_id)
+    if is_non_research:
+        ledger["non_research_resolved"] = int(ledger.get("non_research_resolved", 0)) + 1
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        ticket_status="resolved",
+        handoff_eligible=_is_terminal(state),
+        revision=state["revision"],
+    )
+
+
+def wayfind_frontier(slug: str) -> dict[str, Any]:
+    """Return open + unblocked + unclaimed tickets (creation order)."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    frontier = [
+        {
+            "ticket_id": t["ticket_id"],
+            "title": t.get("title", ""),
+            "type": t.get("type"),
+            "question": t.get("question", ""),
+        }
+        for t in _frontier_tickets(state)
+    ]
+    return _ok(slug=slug, frontier=frontier, count=len(frontier))
+
+
+# ---------------------------------------------------------------------------
+# Operations — fog & out-of-scope
+# ---------------------------------------------------------------------------
+
+
+def add_fog(
+    slug: str, text: str, expected_revision: Optional[int] = None
+) -> dict[str, Any]:
+    """Record a still-too-vague concern that cannot yet be a sharp ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not _oneline(text):
+        return _err("fog text must be a non-empty string.")
+    fog_id = _next_fog_id(state)
+    state.setdefault("fog", []).append(
+        {"id": fog_id, "text": _oneline(text), "status": "open"}
+    )
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, fog_id=fog_id, revision=state["revision"])
+
+
+def graduate_fog(
+    slug: str,
+    fog_id: str,
+    title: str,
+    ticket_type: str,
+    question: str,
+    blocked_by_json: str = "[]",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Atomically graduate a fog entry into a sharp ticket."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    fog_entry = next((f for f in state.get("fog", []) if f.get("id") == fog_id), None)
+    if fog_entry is None:
+        return _err(f"no fog entry {fog_id!r} in map {slug!r}.", code="not_found")
+    if fog_entry.get("status") != "open":
+        return _err(
+            f"fog {fog_id!r} is already {fog_entry.get('status')!r}; cannot graduate "
+            "it again.",
+            code="already_graduated",
+        )
+    if ticket_type not in WAYFIND_TICKET_TYPES:
+        return _err(
+            f"invalid ticket type {ticket_type!r}. "
+            f"Must be one of: {sorted(WAYFIND_TICKET_TYPES)}."
+        )
+    if not _oneline(title):
+        return _err("title must be a non-empty string.")
+    if not _oneline(question):
+        return _err("question must be a single, sharply-stated question.")
+    blocked_by, error = _parse_blocked_by(state, blocked_by_json)
+    if error is not None:
+        return error
+    assert blocked_by is not None
+
+    ticket_id = _mint_ticket(state, title, ticket_type, question, blocked_by, fog_id)
+    fog_entry["status"] = "graduated"
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ticket_id=ticket_id, fog_id=fog_id, revision=state["revision"])
+
+
+def rule_out_of_scope(
+    slug: str,
+    reason: str,
+    ticket_id: str = "",
+    fog_id: str = "",
+    gist: str = "",
+    expected_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Permanently rule a ticket (or fog entry) out of scope.
+
+    Out-of-scope items are recorded separately and never appear in Decisions so
+    far — an exclusion is not a decision that graduates into the plan.
+    """
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if not _oneline(reason):
+        return _err("reason must be a non-empty string.")
+    if bool(ticket_id) == bool(fog_id):
+        return _err("provide exactly one of ticket_id or fog_id.")
+
+    entry: dict[str, Any] = {"reason": _oneline(reason), "ruled_at": _now()}
+    if ticket_id:
+        ticket = state.get("tickets", {}).get(ticket_id)
+        if ticket is None:
+            return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+        if ticket.get("status") in TERMINAL_TICKET_STATUSES:
+            return _err(
+                f"ticket {ticket_id!r} is already {ticket.get('status')!r}.",
+                code="not_open",
+            )
+        ticket["status"] = "out_of_scope"
+        session = ticket.get("claimed_by")
+        ticket["claimed_by"] = None
+        ticket["claimed_at"] = None
+        ledger = state.get("sessions", {}).get(session) if session else None
+        if ledger and ticket_id in ledger.get("claimed", []):
+            ledger["claimed"].remove(ticket_id)
+        entry["ticket_id"] = ticket_id
+        entry["gist"] = _oneline(gist) or _oneline(ticket.get("title", ""))
+    else:
+        fog_entry = next(
+            (f for f in state.get("fog", []) if f.get("id") == fog_id), None
+        )
+        if fog_entry is None:
+            return _err(f"no fog entry {fog_id!r} in map {slug!r}.", code="not_found")
+        if fog_entry.get("status") != "open":
+            return _err(
+                f"fog {fog_id!r} is already {fog_entry.get('status')!r}.",
+                code="not_open",
+            )
+        fog_entry["status"] = "retired"
+        entry["fog_id"] = fog_id
+        entry["gist"] = _oneline(gist) or _oneline(fog_entry.get("text", ""))
+
+    state.setdefault("out_of_scope", []).append(entry)
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(slug=slug, ruled=ticket_id or fog_id, revision=state["revision"])
+
+
+# ---------------------------------------------------------------------------
+# Operations — handoff
+# ---------------------------------------------------------------------------
+
+
+def _open_item_labels(state: dict[str, Any]) -> list[str]:
+    """Human-readable list of items blocking a clean (non-early) handoff."""
+    labels: list[str] = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") in TERMINAL_TICKET_STATUSES:
+            continue
+        state_word = "claimed" if ticket.get("claimed_by") else "open"
+        labels.append(f"{tid} ({ticket.get('type')}, {state_word}): {ticket.get('title', '')}")
+    for fog in _open_fog(state):
+        labels.append(f"{fog.get('id')} (fog): {fog.get('text', '')}")
+    return labels
+
+
+def emit_wayfind_handoff(
+    slug: str,
+    remaining_risks_json: str = "[]",
+    early: bool = False,
+    confirmed_by_user: bool = False,
+    branch: Optional[str] = None,
+) -> dict[str, Any]:
+    """Write the handoff artifact consumed by /map-plan and mark the map handed off."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+
+    try:
+        remaining_risks = json.loads(remaining_risks_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _err(f"invalid remaining_risks JSON: {exc}")
+    if not isinstance(remaining_risks, list) or not all(
+        isinstance(r, str) for r in remaining_risks
+    ):
+        return _err("remaining_risks must be a JSON array of strings.")
+    remaining_risks = [_oneline(r) for r in remaining_risks]
+
+    open_items = _open_item_labels(state)
+    if not _is_terminal(state):
+        if not (early and confirmed_by_user):
+            return _err(
+                "map is not exhausted: fog, claimed, or unresolved tickets remain. "
+                "Resolve or rule out every item, or pass --early with "
+                "--confirmed-by-user to hand off with open items as remaining risks.",
+                code="not_terminal",
+                open_items=open_items,
+            )
+        # Early handoff: fold open items into remaining risks so nothing is lost.
+        remaining_risks = remaining_risks + [f"UNRESOLVED: {label}" for label in open_items]
+
+    decisions = []
+    for tid in sorted(state.get("tickets", {})):
+        ticket = state["tickets"][tid]
+        if ticket.get("status") != "resolved":
+            continue
+        resolution = ticket.get("resolution") or {}
+        decisions.append(
+            {
+                "ticket_id": tid,
+                "title": ticket.get("title", ""),
+                "type": ticket.get("type"),
+                "question": ticket.get("question", ""),
+                "gist": resolution.get("gist", ""),
+                "resolution_path": resolution.get("path", ""),
+            }
+        )
+
+    out_of_scope = [
+        {
+            "gist": entry.get("gist", ""),
+            "reason": entry.get("reason", ""),
+            "ref": entry.get("ticket_id") or entry.get("fog_id") or "",
+        }
+        for entry in state.get("out_of_scope", [])
+    ]
+
+    generated_at = _now()
+    map_dir = _map_dir(slug)
+    handoff_payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "slug": slug,
+        "map_id": state.get("map_id", ""),
+        "title": state.get("title", ""),
+        "destination": state.get("destination", ""),
+        "generated_at": generated_at,
+        "early": bool(early and not _is_terminal(state)),
+        "decisions": decisions,
+        "out_of_scope": out_of_scope,
+        "remaining_risks": remaining_risks,
+    }
+    json_path = map_dir / "handoff.json"
+    md_path = map_dir / "handoff.md"
+    tmp_json = json_path.with_name(json_path.name + ".tmp")
+    tmp_json.write_text(
+        json.dumps(handoff_payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp_json.replace(json_path)
+    md_path.write_text(_render_handoff_md(handoff_payload), encoding="utf-8")
+
+    state["status"] = "handed_off"
+    _save_state(state)
+
+    manifest_info = _register_handoff_manifest(slug, json_path, md_path, decisions, branch)
+
+    return _ok(
+        slug=slug,
+        handoff_path=str(md_path),
+        handoff_json=str(json_path),
+        decisions_count=len(decisions),
+        remaining_risks_count=len(remaining_risks),
+        manifest=manifest_info,
+        revision=state["revision"],
+    )
+
+
+def _render_handoff_md(payload: dict[str, Any]) -> str:
+    lines = [
+        f"# Wayfinding Handoff: {_oneline(payload.get('title', ''))}",
+        "",
+        f"- **Slug:** `{payload.get('slug', '')}`",
+        f"- **Generated:** {payload.get('generated_at', '')}",
+        f"- **Early handoff:** {'yes' if payload.get('early') else 'no'}",
+        "",
+        "## Destination",
+        "",
+        _oneline(payload.get("destination", "")) or "_Not stated._",
+        "",
+        "## Decisions Made",
+        "",
+        "| # | Question | Decision | Resolution |",
+        "|---|----------|----------|------------|",
+    ]
+    if payload.get("decisions"):
+        for i, decision in enumerate(payload["decisions"], 1):
+            path = decision.get("resolution_path", "")
+            link = f"[{decision.get('ticket_id', '')}]({path})" if path else decision.get("ticket_id", "")
+            lines.append(
+                f"| {i} | {_oneline(decision.get('question', ''))} | "
+                f"{_oneline(decision.get('gist', ''))} | {link} |"
+            )
+    else:
+        lines.append("| — | _No decisions resolved._ | | |")
+
+    lines += ["", "## Out of Scope", ""]
+    if payload.get("out_of_scope"):
+        for entry in payload["out_of_scope"]:
+            ref = entry.get("ref", "")
+            ref_text = f" (from {ref})" if ref else ""
+            lines.append(
+                f"- {_oneline(entry.get('gist', ''))} — "
+                f"{_oneline(entry.get('reason', ''))}{ref_text}"
+            )
+    else:
+        lines.append("_None._")
+
+    lines += ["", "## Open Questions / Remaining Risks", ""]
+    if payload.get("remaining_risks"):
+        for risk in payload["remaining_risks"]:
+            lines.append(f"- {_oneline(risk)}")
+    else:
+        lines.append("_None._")
+
+    lines += [
+        "",
+        "---",
+        "",
+        "Feed this into planning with "
+        "`/map-plan --wayfind " + str(payload.get("slug", "")) + "` on a feature branch.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _register_handoff_manifest(
+    slug: str,
+    json_path: Path,
+    md_path: Path,
+    decisions: list[dict[str, Any]],
+    branch: Optional[str],
+) -> dict[str, Any]:
+    """Register the wayfind_handoff manifest stage on the current branch.
+
+    LAZY import of map_step_runner — the ONLY cross-module coupling. A manifest
+    failure is reported but never loses the already-written handoff artifact.
+    """
+    try:
+        import map_step_runner  # noqa: PLC0415 — lazy sibling in .map/scripts/  # pyright: ignore[reportMissingImports]
+
+        manifest = map_step_runner.load_artifact_manifest(branch)
+        map_step_runner._set_manifest_stage(
+            manifest,
+            "wayfind_handoff",
+            "ready",
+            artifacts=[
+                map_step_runner._artifact_ref(md_path, "wayfind-handoff"),
+                map_step_runner._artifact_ref(json_path, "wayfind-handoff-json"),
+            ],
+            metadata={"slug": slug, "decisions_count": len(decisions)},
+        )
+        result = map_step_runner.save_artifact_manifest(manifest, branch)
+        return {"status": "success", "path": result.get("path")}
+    except Exception as exc:  # noqa: BLE001 — manifest is best-effort, never fatal
+        return {"status": "skipped", "reason": f"manifest registration failed: {exc}"}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print(result: dict[str, Any]) -> int:
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    return 0 if result.get("status") == "success" else 1
+
+
+def _add_revision_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--expected-revision",
+        type=int,
+        default=None,
+        help="optimistic-concurrency guard: fail if the map is not at this revision",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wayfind_runner.py",
+        description="Deterministic operations for /map-wayfind decision maps.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    types = sorted(WAYFIND_TICKET_TYPES)
+
+    p = sub.add_parser("create_wayfind_map", help="create a new decision map")
+    p.add_argument("slug")
+    p.add_argument("title")
+    p.add_argument("destination")
+    p.add_argument("--notes", default="")
+    p.add_argument("--fog-json", default="[]")
+
+    p = sub.add_parser("wayfind_status", help="list maps or show one map's status")
+    p.add_argument("--slug", default=None)
+
+    sub.add_parser("list_handoffs", help="list completed handoffs")
+
+    p = sub.add_parser("show_ticket", help="show one ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+
+    p = sub.add_parser("add_ticket", help="add a decision ticket")
+    p.add_argument("slug")
+    p.add_argument("title")
+    p.add_argument("ticket_type", choices=types)
+    p.add_argument("question")
+    p.add_argument("--blocked-by-json", default="[]")
+    p.add_argument("--from-fog", default="")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("wire_blocking", help="set a ticket's blocked_by set")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("blocked_by_json")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("claim_ticket", help="claim a frontier ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("release_ticket", help="release a claimed ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("record_human_input", help="register a verbatim human response")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    p.add_argument("path")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("resolve_ticket", help="resolve a claimed ticket")
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("session")
+    p.add_argument("gist")
+    p.add_argument("resolution_path")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
+    p.add_argument("slug")
+
+    p = sub.add_parser("add_fog", help="record a still-vague concern")
+    p.add_argument("slug")
+    p.add_argument("text")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("graduate_fog", help="turn a fog entry into a ticket")
+    p.add_argument("slug")
+    p.add_argument("fog_id")
+    p.add_argument("title")
+    p.add_argument("ticket_type", choices=types)
+    p.add_argument("question")
+    p.add_argument("--blocked-by-json", default="[]")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("rule_out_of_scope", help="rule a ticket or fog out of scope")
+    p.add_argument("slug")
+    p.add_argument("reason")
+    p.add_argument("--ticket-id", default="")
+    p.add_argument("--fog-id", default="")
+    p.add_argument("--gist", default="")
+    _add_revision_arg(p)
+
+    p = sub.add_parser("emit_wayfind_handoff", help="write the handoff artifact")
+    p.add_argument("slug")
+    p.add_argument("--remaining-risks-json", default="[]")
+    p.add_argument("--early", action="store_true")
+    p.add_argument("--confirmed-by-user", action="store_true")
+    p.add_argument("--branch", default=None)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
+    command = args.command
+    if command == "create_wayfind_map":
+        return create_wayfind_map(
+            args.slug, args.title, args.destination, args.notes, args.fog_json
+        )
+    if command == "wayfind_status":
+        return wayfind_status(args.slug)
+    if command == "list_handoffs":
+        return list_handoffs()
+    if command == "show_ticket":
+        return show_ticket(args.slug, args.ticket_id)
+    if command == "add_ticket":
+        return add_ticket(
+            args.slug,
+            args.title,
+            args.ticket_type,
+            args.question,
+            args.blocked_by_json,
+            args.from_fog,
+            args.expected_revision,
+        )
+    if command == "wire_blocking":
+        return wire_blocking(
+            args.slug, args.ticket_id, args.blocked_by_json, args.expected_revision
+        )
+    if command == "claim_ticket":
+        return claim_ticket(
+            args.slug, args.ticket_id, args.session, args.expected_revision
+        )
+    if command == "release_ticket":
+        return release_ticket(
+            args.slug, args.ticket_id, args.session, args.expected_revision
+        )
+    if command == "record_human_input":
+        return record_human_input(
+            args.slug, args.ticket_id, args.session, args.path, args.expected_revision
+        )
+    if command == "resolve_ticket":
+        return resolve_ticket(
+            args.slug,
+            args.ticket_id,
+            args.session,
+            args.gist,
+            args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "wayfind_frontier":
+        return wayfind_frontier(args.slug)
+    if command == "add_fog":
+        return add_fog(args.slug, args.text, args.expected_revision)
+    if command == "graduate_fog":
+        return graduate_fog(
+            args.slug,
+            args.fog_id,
+            args.title,
+            args.ticket_type,
+            args.question,
+            args.blocked_by_json,
+            args.expected_revision,
+        )
+    if command == "rule_out_of_scope":
+        return rule_out_of_scope(
+            args.slug,
+            args.reason,
+            args.ticket_id,
+            args.fog_id,
+            args.gist,
+            args.expected_revision,
+        )
+    if command == "emit_wayfind_handoff":
+        return emit_wayfind_handoff(
+            args.slug,
+            args.remaining_risks_json,
+            args.early,
+            args.confirmed_by_user,
+            args.branch,
+        )
+    return _err(f"unknown command: {command!r}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return _print(_dispatch(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import uuid
@@ -94,6 +95,25 @@ def _state_path(slug: str) -> Path:
     return _map_dir(slug) / "state.json"
 
 
+def _resolve_evidence_path(slug: str, rel: str) -> Optional[Path]:
+    """Resolve an evidence file (resolution / human-input) path under the map dir.
+
+    Returns the resolved Path only when *rel* names a regular file contained in
+    the map directory. Absolute paths, ``..`` escapes, directories, and missing
+    files all return None — so a caller cannot use the provenance gate to read
+    (or claim provenance over) a file outside its own map.
+    """
+    if not rel:
+        return None
+    base = _map_dir(slug).resolve()
+    candidate = (base / rel).resolve()
+    if candidate != base and base not in candidate.parents:
+        return None  # absolute path or ../ escape left the map dir
+    if not candidate.is_file():
+        return None  # missing, or a directory
+    return candidate
+
+
 # ---------------------------------------------------------------------------
 # State load / save + derived views
 # ---------------------------------------------------------------------------
@@ -117,7 +137,10 @@ def _save_state(state: dict[str, Any]) -> None:
     map_dir = _map_dir(slug)
     map_dir.mkdir(parents=True, exist_ok=True)
     path = _state_path(slug)
-    tmp = path.with_name(path.name + ".tmp")
+    # Per-process-unique temp name so two writers never share (and corrupt) one
+    # scratch file. NB: this makes the write atomic, not the read-modify-write —
+    # see _revision_guard for the (best-effort, single-operator) staleness check.
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp.write_text(
         json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
     )
@@ -128,7 +151,15 @@ def _save_state(state: dict[str, Any]) -> None:
 def _revision_guard(
     state: dict[str, Any], expected_revision: Optional[int]
 ) -> Optional[dict[str, Any]]:
-    """Optimistic-concurrency check: reject a mutation against a stale revision."""
+    """Best-effort stale-write detection: reject a mutation whose caller read an
+    older revision than the map now holds.
+
+    This is a friction/audit aid for a single-operator, sequential tool — NOT a
+    true compare-and-swap. It closes the common "I read, then something else
+    advanced the map, then I wrote" window, but does not lock: two processes that
+    both read the same revision before either writes can still lose an update.
+    Concurrent multi-process writers to one map are out of scope by design (a map
+    is charted and worked by one operator at a time)."""
     if expected_revision is None:
         return None
     current = int(state.get("revision", 0))
@@ -140,6 +171,25 @@ def _revision_guard(
             revision=current,
         )
     return None
+
+
+def _mutation_guard(
+    state: dict[str, Any], expected_revision: Optional[int]
+) -> Optional[dict[str, Any]]:
+    """Pre-mutation gate for ticket/fog operations.
+
+    Rejects any mutation once the map is handed off (its handoff artifact is
+    frozen, so a further edit would leave a discoverable handoff that omits the
+    new state), then applies the optimistic staleness check. Not used by
+    emit_wayfind_handoff, which may idempotently re-emit a handed-off map."""
+    if state.get("status") == "handed_off":
+        return _err(
+            f"map {state.get('slug')!r} is already handed off; its handoff artifact "
+            "is frozen. Start a follow-up map (or a new session) rather than mutating "
+            "a handed-off map.",
+            code="handed_off",
+        )
+    return _revision_guard(state, expected_revision)
 
 
 # ---------------------------------------------------------------------------
@@ -658,7 +708,7 @@ def add_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if ticket_type not in WAYFIND_TICKET_TYPES:
@@ -697,7 +747,7 @@ def wire_blocking(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if ticket_id not in state.get("tickets", {}):
@@ -732,7 +782,7 @@ def claim_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not session:
@@ -796,7 +846,7 @@ def release_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -829,7 +879,7 @@ def record_human_input(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -842,14 +892,15 @@ def record_human_input(
             code="not_owner",
         )
     # Paths are relative to the map dir (.map/wayfind/<slug>/) so the value stored
-    # in state.json doubles as a correct link target from the co-located views.
-    input_path = _map_dir(slug) / path
-    if not input_path.exists() or not input_path.read_text(
+    # in state.json doubles as a correct link target from the co-located views;
+    # containment is enforced so absolute/../ paths cannot claim provenance.
+    input_path = _resolve_evidence_path(slug, path)
+    if input_path is None or not input_path.read_text(
         encoding="utf-8", errors="replace"
     ).strip():
         return _err(
-            f"human input file {path!r} (under the map dir) does not exist or is empty. "
-            "Save the human's verbatim answer there first.",
+            f"human input file {path!r} must be a non-empty regular file INSIDE the map "
+            "dir (.map/wayfind/<slug>/). Save the human's verbatim answer there first.",
             code="missing_input",
         )
     ticket["human_input_path"] = path
@@ -869,7 +920,7 @@ def resolve_ticket(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     ticket = state.get("tickets", {}).get(ticket_id)
@@ -889,14 +940,15 @@ def resolve_ticket(
     if not _oneline(gist):
         return _err("gist must be a non-empty one-line summary of the decision.")
     # resolution_path is relative to the map dir (.map/wayfind/<slug>/) so the stored
-    # value is a correct link target from the co-located map.md / handoff.md views.
-    resolution_file = _map_dir(slug) / resolution_path
-    if not resolution_file.exists() or not resolution_file.read_text(
+    # value is a correct link target from the co-located map.md / handoff.md views;
+    # containment is enforced so absolute/../ paths cannot stand in as a resolution.
+    resolution_file = _resolve_evidence_path(slug, resolution_path)
+    if resolution_file is None or not resolution_file.read_text(
         encoding="utf-8", errors="replace"
     ).strip():
         return _err(
-            f"resolution file {resolution_path!r} (under the map dir) does not exist or "
-            "is empty. Write the prose resolution first.",
+            f"resolution file {resolution_path!r} must be a non-empty regular file INSIDE "
+            "the map dir (.map/wayfind/<slug>/). Write the prose resolution first.",
             code="missing_resolution",
         )
 
@@ -920,6 +972,10 @@ def resolve_ticket(
     ticket["status"] = "resolved"
     ticket["resolved_at"] = _now()
     ticket["resolution"] = {"gist": _oneline(gist), "path": resolution_path}
+    # Clear the active claim on close (consistent with rule_out_of_scope); the
+    # resolver of record is captured in the resolution/git history, not claimed_by.
+    ticket["claimed_by"] = None
+    ticket["claimed_at"] = None
     if ticket_id in ledger.get("claimed", []):
         ledger["claimed"].remove(ticket_id)
     if is_non_research:
@@ -965,7 +1021,7 @@ def add_fog(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not _oneline(text):
@@ -992,7 +1048,7 @@ def graduate_fog(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     fog_entry = next((f for f in state.get("fog", []) if f.get("id") == fog_id), None)
@@ -1041,7 +1097,7 @@ def rule_out_of_scope(
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
-    guard = _revision_guard(state, expected_revision)
+    guard = _mutation_guard(state, expected_revision)
     if guard is not None:
         return guard
     if not _oneline(reason):
@@ -1114,11 +1170,17 @@ def emit_wayfind_handoff(
     early: bool = False,
     confirmed_by_user: bool = False,
     branch: Optional[str] = None,
+    expected_revision: Optional[int] = None,
 ) -> dict[str, Any]:
     """Write the handoff artifact consumed by /map-plan and mark the map handed off."""
     state = _load_state(slug)
     if state is None:
         return _err(f"no map with slug {slug!r}.", code="not_found")
+    # Pure staleness check (not _mutation_guard): a handed-off map may be
+    # idempotently re-emitted, so we do not reject on status == "handed_off".
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
 
     try:
         remaining_risks = json.loads(remaining_risks_json or "[]")
@@ -1185,7 +1247,7 @@ def emit_wayfind_handoff(
     }
     json_path = map_dir / "handoff.json"
     md_path = map_dir / "handoff.md"
-    tmp_json = json_path.with_name(json_path.name + ".tmp")
+    tmp_json = json_path.with_name(f".{json_path.name}.{os.getpid()}.tmp")
     tmp_json.write_text(
         json.dumps(handoff_payload, indent=2, ensure_ascii=True) + "\n",
         encoding="utf-8",
@@ -1415,6 +1477,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--early", action="store_true")
     p.add_argument("--confirmed-by-user", action="store_true")
     p.add_argument("--branch", default=None)
+    _add_revision_arg(p)
 
     return parser
 
@@ -1496,6 +1559,7 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.early,
             args.confirmed_by_user,
             args.branch,
+            args.expected_revision,
         )
     return _err(f"unknown command: {command!r}")
 

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -71,6 +71,8 @@ Per-artifact resume rules (only when `verdict` is `resume`):
 
 If a `/map-wayfind` map already resolved the key decisions, seed this plan from its handoff instead of re-deciding them.
 
+**Precedence over resume:** a handoff seeds a *fresh* plan, so this step only applies when the Resume Detection verdict is `no_plan` (or `goal_mismatch` after you archive the prior artifacts). On a `resume` verdict the branch already has a `spec`/`task_plan` — that existing artifact wins and the handoff is NOT re-consumed (re-seeding would silently overwrite in-progress work). To plan from a handoff, run `/map-plan --wayfind <slug>` on a branch with no in-progress plan (or archive/rename the existing `.map/<branch>/` artifacts first, with operator confirmation).
+
 - If `$ARGUMENTS` contains `--wayfind <slug>`, read `.map/wayfind/<slug>/handoff.json` (repo-level, not branch-scoped).
 - Otherwise run `python3 .map/scripts/wayfind_runner.py list_handoffs`. If exactly one completed handoff exists, OFFER it to the user ("found a completed wayfinding map `<slug>` — seed the plan from it?") and use it only on an explicit yes. Never match a handoff to the request by guessing; with zero or multiple handoffs and no explicit `--wayfind`, skip this step.
 

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -67,6 +67,15 @@ Per-artifact resume rules (only when `verdict` is `resume`):
 - Existing `task_plan`: skip decomposition and plan creation.
 - Existing `step_state.json`: plan is complete; print checkpoint and STOP.
 
+### Pre-flight: Wayfinding Handoff (optional)
+
+If a `/map-wayfind` map already resolved the key decisions, seed this plan from its handoff instead of re-deciding them.
+
+- If `$ARGUMENTS` contains `--wayfind <slug>`, read `.map/wayfind/<slug>/handoff.json` (repo-level, not branch-scoped).
+- Otherwise run `python3 .map/scripts/wayfind_runner.py list_handoffs`. If exactly one completed handoff exists, OFFER it to the user ("found a completed wayfinding map `<slug>` — seed the plan from it?") and use it only on an explicit yes. Never match a handoff to the request by guessing; with zero or multiple handoffs and no explicit `--wayfind`, skip this step.
+
+When a handoff is used, pre-seed the spec: `decisions[]` → **Decisions Made** (settled — the interview must NOT re-ask them; carry them as a do-not-re-ask list), `out_of_scope[]` → **Out of Scope**, `remaining_risks[]` → **Open Questions**. Then continue below for anything the handoff did not settle. Do not modify the wayfinding map.
+
 ### Pre-flight: Workflow-Fit Gate
 
 Decide whether MAP planning is warranted before discovery or interview.

--- a/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
@@ -60,7 +60,7 @@ Start a new map. Six steps, mirroring the way a good architect opens a foggy pro
    ```
 
    In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
-5. **Kick off research.** For `research` tickets, you MAY dispatch research-agent subagents in parallel; each writes its findings to `resolutions/<ticket>.md`, then you `resolve_ticket` it. Research resolves are exempt from the one-per-session limit.
+5. **Kick off research.** For each `research` ticket, `claim_ticket` it FIRST — `resolve_ticket` requires the ticket to be claimed by your session, so an unclaimed dispatch-then-resolve returns `not_owner`. Serialize these claim mutations, then you MAY dispatch research-agent subagents in parallel to gather findings; each writes to `resolutions/<ticket>.md`, after which you `resolve_ticket` it (research resolves are exempt from the one-per-session limit).
 6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
 
 ## Mode: work \<slug\> [ticket]

--- a/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
@@ -1,0 +1,131 @@
+---
+name: map-wayfind
+description: |
+  Decision-frontier wayfinding: build and work a durable map of open design decisions BEFORE planning, for large or foggy efforts where /map-plan would force premature decomposition. Use when a task is too big or too vague to decompose — many unknowns, tangled decisions, or "I'm not even sure what to build yet" — and you want to resolve the key decisions one at a time (research, prototype, grilling, task tickets) behind a claim-before-work frontier, with a "fog of war" for questions you cannot yet state sharply. Produces a handoff that /map-plan consumes. Modes are explicit: chart (start a map), work (resolve one ticket), handoff (finish). Do NOT use when scope is already clear enough to specify — go straight to /map-plan; do NOT use to implement code or to decompose an already-specifiable change.
+disable-model-invocation: true
+argument-hint: "[chart \"loose idea\" | work <slug> [ticket] | handoff <slug>]"
+effort: medium
+---
+# /map-wayfind — Decision-Frontier Wayfinding
+
+Purpose: for a large or foggy effort, resolve the key design decisions ONE AT A TIME on a durable map before any planning. If the scope is already clear enough to specify, skip this and run `/map-plan` directly.
+
+Contrast with `/map-plan`: `/map-plan` decomposes an already-understood task into subtasks. `/map-wayfind` comes earlier — it resolves the decisions that make decomposition possible, then hands the settled decisions to `/map-plan`. The map is durable and repo-level (`.map/wayfind/<slug>/`); it outlives branches and can span many sessions.
+
+## Effort and Parallelism Policy
+
+```yaml
+thinking_policy: medium/adaptive
+parallel_tool_policy: research_only
+```
+
+- Use deeper reasoning for the sharpness test (is a question ticketable now?), for wiring dependencies, and for judging whether a decision is truly resolved.
+- Do not over-chart: if a breadth-first interview surfaces no real fog, there is nothing to wayfind — say so and route to `/map-plan`.
+- Parallelize ONLY independent research-agent reads dispatched against research tickets. Keep charting interview, claiming, human grilling, resolving, and handoff strictly sequential.
+
+## Determinism boundary
+
+All state lives in `.map/wayfind/<slug>/state.json` and is mutated ONLY through `python3 .map/scripts/wayfind_runner.py <command>`. You write prose only: resolution files under `resolutions/`, and verbatim human answers under `resolutions/<ticket>.human.md`. Never hand-edit `state.json`, `map.md`, or `tickets/*.md` — the views carry a DO-NOT-EDIT banner and are regenerated on every mutation. Every command prints a JSON result; a non-success `status` means stop and read the message.
+
+See [wayfind-reference.md](wayfind-reference.md) for the full CLI reference, the fog-sharpness rubric, the ticket-type guide, and extended examples/troubleshooting. When a step points to a reference section, read it before executing the step; supporting files are not assumed to be in context automatically.
+
+## Mode selection
+
+Parse `$ARGUMENTS`. The FIRST token is the explicit mode — `chart`, `work`, or `handoff`. There is no auto-detection. If no mode is given, run `python3 .map/scripts/wayfind_runner.py wayfind_status` to show existing maps, then ask the user which mode to run.
+
+Mint ONE session id for this run and reuse it for every claim/record/resolve below:
+
+```bash
+WAYFIND_SESSION="$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+## Mode: chart "\<loose idea\>"
+
+Start a new map. Six steps, mirroring the way a good architect opens a foggy problem.
+
+1. **Name the destination.** Interview the user briefly for where this is headed (1–2 sentences). If it turns out the scope is already crisp, stop and recommend `/map-plan`.
+2. **Breadth-first interview.** Walk the surface of the problem to surface the open decisions. If nothing genuinely uncertain appears, there is no frontier to chart — STOP and route to `/map-plan`.
+3. **Create the map.** Pick a short slug (`[a-z0-9-]`, ≤50 chars). Pass genuinely-unsharp concerns as fog:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py create_wayfind_map \
+     <slug> "<title>" "<destination>" --fog-json '["still-vague concern", "..."]'
+   ```
+
+   Then warn the user: the map is committed by default, so grilling transcripts and prose resolutions are shared with the repo. To keep one map local, add `.map/wayfind/<slug>/.gitignore` with a single `*`.
+4. **Add sharp tickets.** For each decision you can state as ONE sharp question right now, add a ticket. Choose the type deliberately (see the reference): `research` (find out), `prototype` (build a cheap probe — human-in-the-loop), `grilling` (interrogate the human — human-in-the-loop), `task` (a self-contained decision/chore). Keep unsharp concerns as fog via `add_fog`; do not pre-slice fog into fake tickets.
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py add_ticket <slug> "<title>" <type> "<one sharp question>"
+   ```
+
+   In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
+5. **Kick off research.** For `research` tickets, you MAY dispatch research-agent subagents in parallel; each writes its findings to `resolutions/<ticket>.md`, then you `resolve_ticket` it. Research resolves are exempt from the one-per-session limit.
+6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
+
+## Mode: work \<slug\> [ticket]
+
+Resolve exactly ONE non-research decision, then stop. Five steps.
+
+1. **Load low-res.** Read only `.map/wayfind/<slug>/map.md`. Zoom into a specific ticket with `show_ticket <slug> <ticket>` only when needed.
+2. **Claim first.** Pick the named ticket, or the first frontier ticket from `wayfind_frontier <slug>`, and claim it BEFORE any work:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py claim_ticket <slug> <ticket> "$WAYFIND_SESSION"
+   ```
+
+   If the result has `hitl_pending: true`, this is a human-in-the-loop ticket — see step 3b.
+3. **Resolve by type.**
+   - `task`: do the work / make the call, then write the decision prose to `resolutions/<ticket>.md`.
+   - `research`: gather the answer (a subagent may help), write it to `resolutions/<ticket>.md`.
+   - **3b. `prototype` / `grilling` (human-in-the-loop):** ask the human the ticket's question verbatim (AskUserQuestion for grilling; describe the cheap probe for prototype), then STOP and hand control back. Do not answer on the human's behalf. When the human replies, save their words VERBATIM to `resolutions/<ticket>.human.md` and register them:
+
+     ```bash
+     python3 .map/scripts/wayfind_runner.py record_human_input <slug> <ticket> "$WAYFIND_SESSION" resolutions/<ticket>.human.md
+     ```
+
+     `resolve_ticket` refuses a human-in-the-loop ticket until this is recorded.
+4. **Resolve + maintain the map.** Write the one-line gist and the resolution file, then:
+
+   ```bash
+   python3 .map/scripts/wayfind_runner.py resolve_ticket <slug> <ticket> "$WAYFIND_SESSION" "<one-line gist>" resolutions/<ticket>.md
+   ```
+
+   With what you learned, keep the map honest: `add_ticket` newly-sharp decisions, `graduate_fog` a fog entry that is now sharp, or `rule_out_of_scope` a ticket/fog that is settled as excluded (exclusions never appear under Decisions).
+5. **Stop.** The runner blocks a second non-research resolve in the same session by design. Report the decision and stop; start a fresh session (or `/map-wayfind handoff <slug>`) to continue.
+
+## Mode: handoff \<slug\>
+
+When `wayfind_status <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
+
+```bash
+python3 .map/scripts/wayfind_runner.py emit_wayfind_handoff <slug> --remaining-risks-json '["..."]'
+```
+
+This writes `.map/wayfind/<slug>/handoff.md` (+ `handoff.json`) and registers a `wayfind_handoff` artifact-manifest stage on the current branch. If you must hand off with open items, pass `--early --confirmed-by-user` and confirm with the user first; the open items are folded into remaining risks so nothing is lost. Then, on a feature branch, run `/map-plan --wayfind <slug>` to seed the spec from the settled decisions.
+
+## Guardrails
+
+- Do not pre-slice fog: only create a ticket when you can state its question sharply NOW (rubric in the reference). Otherwise keep it as fog.
+- Resolve at most ONE non-research ticket per session; the runner enforces this.
+- Out-of-scope is an exclusion, not a decision — it never graduates into the plan.
+- No implementation subtasks and no code changes here — that is `/map-plan` + execution.
+- Never write secrets into tickets, resolutions, or the map. Warn about the commit-by-default privacy note in `chart`.
+- Refer to tickets by name in prose, not bare ids, so the map reads for a human.
+- Honesty note: the human-in-the-loop and one-per-session checks add friction and an audit trail; they are not a mechanical guarantee. Ask the human when in doubt.
+
+## Examples
+
+- **Foggy feature:** `/map-wayfind chart "rebuild checkout"` → name destination, interview, create map `checkout` with 2 fog entries + 3 sharp tickets (1 research, 1 grilling, 1 task) → dispatch the research ticket → stop.
+- **Resolve one decision:** `/map-wayfind work checkout` → claim the `grilling` ticket → ask the human verbatim, stop, record their answer, resolve → stop (one non-research decision done).
+- **Finish:** `/map-wayfind handoff checkout` → all tickets resolved/out-of-scope, fog empty → emit handoff → `/map-plan --wayfind checkout`.
+
+More worked examples are in [wayfind-reference.md](wayfind-reference.md).
+
+## Troubleshooting
+
+- `emit_wayfind_handoff` returns `not_terminal`: fog, claimed, or unresolved tickets remain — resolve or rule them out, or hand off `--early --confirmed-by-user`.
+- `resolve_ticket` returns `awaiting_human`: it is a `prototype`/`grilling` ticket — record the human answer with `record_human_input` first.
+- `resolve_ticket` returns `session_limit`: you already resolved a non-research ticket this session — start a new session.
+- `wire_blocking` returns `cycle`: the dependency you added would close a loop — re-check the blocker direction.
+- Full command reference and the fog-sharpness rubric are in [wayfind-reference.md](wayfind-reference.md).

--- a/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
@@ -1,0 +1,132 @@
+# /map-wayfind Supporting Reference
+
+Detail for `/map-wayfind` so the invoked `SKILL.md` stays focused on the active flow. All operations go through `python3 .map/scripts/wayfind_runner.py <command>`; each prints a JSON result with a `status` of `success` or `error`.
+
+## Ticket types
+
+| Type | Meaning | Human-in-the-loop | Counts toward one-per-session |
+|------|---------|-------------------|-------------------------------|
+| `research` | Find out an answer that already exists (read code/docs, run a query). A subagent may do this. | No | No — resolve as many as you learn |
+| `prototype` | Build a cheap, throwaway probe to see how an approach feels, then get the human's read. | Yes | Yes |
+| `grilling` | Interrogate the human: ask the sharp question, capture their verbatim answer. | Yes | Yes |
+| `task` | A self-contained decision or chore you can settle yourself. | No | Yes |
+
+Human-in-the-loop (`prototype`, `grilling`) tickets cannot be resolved until a verbatim human answer is recorded with `record_human_input`.
+
+## Fog-sharpness rubric
+
+Create a ticket only when the concern passes the sharpness test — otherwise keep it as fog and graduate it later.
+
+- **Sharp (make a ticket):** you can state it as ONE question with a bounded answer space, and you know what "resolved" looks like. E.g. "Do we store sessions in Redis or Postgres?"
+- **Foggy (keep as fog):** you can only gesture at an area of unease, the question would be compound, or you cannot yet say what a good answer is. E.g. "auth and the new checkout probably interact somehow."
+- When a session's work makes a foggy area sharp, `graduate_fog` it into a ticket.
+
+## Command reference
+
+Lifecycle / read-only:
+
+```bash
+create_wayfind_map <slug> "<title>" "<destination>" [--notes "..."] [--fog-json '["...", "..."]']
+wayfind_status [--slug <slug>]          # no slug: list all maps; with slug: counts + handoff_eligible
+list_handoffs                           # completed handoffs (used by /map-plan's offer)
+show_ticket <slug> <ticket_id>
+wayfind_frontier <slug>                 # open + unblocked + unclaimed tickets, creation order
+```
+
+Tickets:
+
+```bash
+add_ticket <slug> "<title>" <type> "<sharp question>" [--blocked-by-json '["T-001"]'] [--from-fog F-1]
+wire_blocking <slug> <ticket_id> '["T-001","T-002"]'   # rejects unknown ids, self-block, cycles
+claim_ticket <slug> <ticket_id> <session>              # HITL types return hitl_pending: true
+release_ticket <slug> <ticket_id> <session>            # crash/interrupt recovery; owner only
+record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
+resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
+```
+
+Fog & scope:
+
+```bash
+add_fog <slug> "<still-vague concern>"
+graduate_fog <slug> <fog_id> "<title>" <type> "<sharp question>" [--blocked-by-json '[...]']
+rule_out_of_scope <slug> "<reason>" [--ticket-id T-003] [--fog-id F-2] [--gist "..."]
+```
+
+Handoff:
+
+```bash
+emit_wayfind_handoff <slug> [--remaining-risks-json '["..."]'] [--early --confirmed-by-user] [--branch <branch>]
+```
+
+Every mutating command also accepts `--expected-revision <n>` (optimistic-concurrency guard): it fails with `stale_revision` if the map has advanced past `<n>`, protecting against concurrent sessions clobbering each other. Read `revision` from `wayfind_status` first.
+
+## Files under `.map/wayfind/<slug>/`
+
+- `state.json` — canonical store. Never edit by hand.
+- `map.md` — regenerated low-resolution overview (Destination, Notes, Decisions so far, Frontier, Blocked/claimed, Fog, Out of scope). DO-NOT-EDIT banner.
+- `tickets/T-00N.md` — regenerated per-ticket detail.
+- `resolutions/T-00N.md` — YOUR prose answer for a ticket (you write this before `resolve_ticket`).
+- `resolutions/T-00N.human.md` — the human's VERBATIM answer for a HITL ticket (you save this before `record_human_input`).
+- `handoff.md` / `handoff.json` — the final artifact `/map-plan --wayfind <slug>` consumes.
+
+## Terminal (handoff-eligible) condition
+
+`emit_wayfind_handoff` refuses unless the map is truly exhausted: fog empty AND no active claims AND every ticket in `{resolved, out_of_scope}` AND at least one ticket exists. A map with a claimed or blocked ticket is NOT eligible even if the frontier momentarily looks empty. Use `--early --confirmed-by-user` to override; the open items become explicit remaining risks in the handoff.
+
+## How /map-plan consumes the handoff
+
+`handoff.json` maps 1:1 onto the `/map-plan` spec template:
+
+- `decisions[]` → spec **Decisions Made** (these are settled — the interview must not re-ask them).
+- `out_of_scope[]` → spec **Out of Scope**.
+- `remaining_risks[]` → spec **Open Questions**.
+
+Run `/map-plan --wayfind <slug>` on a feature branch. Without an explicit slug, `/map-plan` runs `list_handoffs`; if exactly one completed handoff exists it OFFERS it, but never consumes silently.
+
+## Examples
+
+**Charting a foggy feature**
+
+```text
+/map-wayfind chart "rebuild checkout"
+→ destination: "a faster, single-page checkout"
+→ interview surfaces real uncertainty → chart it
+create_wayfind_map checkout "Checkout v2" "a faster, single-page checkout" \
+  --fog-json '["how does the new flow interact with legacy auth?"]'
+add_ticket checkout "Session store" task "Redis or Postgres for cart sessions?"
+add_ticket checkout "Payments SDK" research "Which payment SDKs support our regions?"
+add_ticket checkout "One-page vs wizard" grilling "One-page checkout or a 3-step wizard?"
+wire_blocking checkout T-001 '["T-002"]'   # session store waits on the SDK finding
+```
+
+**Working one ticket (human-in-the-loop)**
+
+```text
+/map-wayfind work checkout
+claim_ticket checkout T-003 20260717T101500Z    # grilling → hitl_pending: true
+→ ask the human verbatim: "One-page checkout or a 3-step wizard?"; STOP; hand control back
+→ human answers; save verbatim to resolutions/T-003.human.md
+record_human_input checkout T-003 20260717T101500Z resolutions/T-003.human.md
+→ write resolutions/T-003.md
+resolve_ticket checkout T-003 20260717T101500Z "One-page; wizard tested worse in the poll" resolutions/T-003.md
+→ stop (one non-research decision resolved this session)
+```
+
+**Handing off**
+
+```text
+/map-wayfind handoff checkout
+wayfind_status --slug checkout    # handoff_eligible: true
+emit_wayfind_handoff checkout --remaining-risks-json '["fraud rules not yet scoped"]'
+→ /map-plan --wayfind checkout   (on a feature branch)
+```
+
+## Troubleshooting
+
+- **`not_terminal` on handoff** — an item is still open. Run `wayfind_status --slug <slug>`; the error's `open_items` names each blocker. Resolve or `rule_out_of_scope` them, or hand off `--early --confirmed-by-user`.
+- **`awaiting_human`** — a `prototype`/`grilling` ticket needs a recorded human answer first (`record_human_input`).
+- **`session_limit`** — one non-research resolve per session is the rule; mint a fresh session id and continue.
+- **`already_claimed` / `blocked` / `not_owner`** — the ticket is taken, has unresolved blockers, or is claimed by another session. Check `map.md`'s Blocked/claimed section.
+- **`stale_revision`** — another session advanced the map; re-read it and retry with the current `--expected-revision`.
+- **`cycle`** — a `wire_blocking` call would create a dependency loop; the blocker relationship is likely backwards.
+- **Duplicate slug** — a map with that slug exists; pick another slug or continue the existing one with `work`.

--- a/src/mapify_cli/templates_src/skills/skill-rules.json.jinja
+++ b/src/mapify_cli/templates_src/skills/skill-rules.json.jinja
@@ -228,6 +228,28 @@
         ]
       }
     },
+    "map-wayfind": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "medium",
+      "description": "Decision-frontier wayfinding: resolve open design decisions on a durable map before /map-plan.",
+      "promptTriggers": {
+        "keywords": [
+          "map-wayfind",
+          "wayfind",
+          "decision frontier",
+          "resolve decisions first",
+          "too foggy to plan",
+          "chart the decisions"
+        ],
+        "intentPatterns": [
+          "map-wayfind",
+          "(chart|map|resolve).*(decision|frontier)",
+          "too (foggy|vague|big) to (plan|decompose)"
+        ]
+      }
+    },
     "map-release": {
       "type": "manual",
       "skillClass": "task",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -66,6 +66,7 @@ WORKFLOW_EFFORT_PROFILES = {
     "map-learn": "medium/adaptive",
     "map-explain": "medium/adaptive",
     "map-understand": "medium/adaptive",
+    "map-wayfind": "medium/adaptive",
     "map-plan": "high/adaptive",
     "map-review": "high/adaptive",
     "map-release": "high/adaptive",

--- a/tests/test_skills_consistency.py
+++ b/tests/test_skills_consistency.py
@@ -477,12 +477,12 @@ def detect_skill_deps(skill_dir: Path) -> dict[str, set[str]]:
 
 
 def test_skill_discovery_non_empty(skill_names: list[str]) -> None:
-    """Guard: skill-rules.json must list exactly 18 skills (prevents vacuous pass).
+    """Guard: skill-rules.json must list exactly 19 skills (prevents vacuous pass).
 
-    18 = the 16 core MAP skills + map-so-search + map-understand.
+    19 = the 16 core MAP skills + map-so-search + map-understand + map-wayfind.
     """
-    assert len(skill_names) == 18, (
-        f"Expected 18 skills in skill-rules.json, found {len(skill_names)}: "
+    assert len(skill_names) == 19, (
+        f"Expected 19 skills in skill-rules.json, found {len(skill_names)}: "
         f"{sorted(skill_names)}"
     )
 

--- a/tests/test_wayfind_runner.py
+++ b/tests/test_wayfind_runner.py
@@ -1,0 +1,488 @@
+"""Tests for wayfind_runner — /map-wayfind decision-frontier map operations."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPTS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "mapify_cli"
+    / "templates"
+    / "map"
+    / "scripts"
+)
+
+sys.path.insert(0, str(SCRIPTS_PATH))
+
+import wayfind_runner as wr  # noqa: E402  # type: ignore[import-not-found]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _chdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scope every test's .map/wayfind/ to an isolated tmp cwd."""
+    monkeypatch.chdir(tmp_path)
+
+
+# Pytest finds fixtures via module-namespace lookup, which Pylance/Pyright
+# can't see — without this sentinel the IDE flags `_chdir` as "not accessed".
+# The reference is a no-op at runtime (mirrors tests/conftest.py).
+_ = _chdir
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """The tmp cwd, for tests that assert on written files."""
+    return tmp_path
+
+
+def _write_resolution(slug: str, ticket_id: str, text: str = "The decision prose.") -> str:
+    """Write a prose resolution and return its MAP-DIR-relative path (runner contract)."""
+    rel = f"resolutions/{ticket_id}.md"
+    path = Path(".map/wayfind") / slug / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return rel
+
+
+def _write_human_input(slug: str, ticket_id: str, text: str = "Human says: option B.") -> str:
+    rel = f"resolutions/{ticket_id}.human.md"
+    path = Path(".map/wayfind") / slug / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return rel
+
+
+def _create(slug: str = "checkout", **kw: Any) -> dict[str, Any]:
+    return wr.create_wayfind_map(
+        slug,
+        kw.get("title", "Checkout v2"),
+        kw.get("destination", "Ship a redesigned checkout flow."),
+        kw.get("notes", ""),
+        kw.get("fog_json", "[]"),
+    )
+
+
+def _resolve(slug: str, ticket_id: str, session: str, gist: str = "decided") -> dict[str, Any]:
+    """Claim + resolve a non-HITL ticket (task/research) in one shot."""
+    wr.claim_ticket(slug, ticket_id, session)
+    path = _write_resolution(slug, ticket_id)
+    return wr.resolve_ticket(slug, ticket_id, session, gist, path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Map creation
+# ---------------------------------------------------------------------------
+
+
+class TestMapCreation:
+    def test_creates_state_and_views(self, repo: Path) -> None:
+        result = _create(fog_json='["how does auth interact?"]')
+        assert result["status"] == "success"
+        state_file = repo / ".map" / "wayfind" / "checkout" / "state.json"
+        map_file = repo / ".map" / "wayfind" / "checkout" / "map.md"
+        assert state_file.exists()
+        assert map_file.exists()
+        state = json.loads(state_file.read_text())
+        assert state["slug"] == "checkout"
+        assert state["backend"] == "local"
+        assert state["map_id"]
+        assert state["revision"] == 1
+        assert state["status"] == "charting"
+        assert len(state["fog"]) == 1
+        assert state["fog"][0]["id"] == "F-1"
+
+    def test_map_md_has_all_sections_and_banner(self, repo: Path) -> None:
+        _create()
+        content = (repo / ".map" / "wayfind" / "checkout" / "map.md").read_text()
+        assert "DO NOT EDIT" in content
+        for heading in (
+            "## Destination",
+            "## Notes",
+            "## Decisions so far",
+            "## Frontier",
+            "## Fog of war",
+            "## Out of scope",
+        ):
+            assert heading in content, f"missing section {heading!r}"
+
+    @pytest.mark.parametrize("bad", ["", "Has Space", "UPPER", "a" * 51, "bad/slug"])
+    def test_rejects_invalid_slug(self, bad: str) -> None:
+        assert _create(slug=bad)["status"] == "error"
+
+    def test_duplicate_slug_rejected(self) -> None:
+        assert _create()["status"] == "success"
+        dup = _create()
+        assert dup["status"] == "error"
+        assert dup["code"] == "duplicate"
+
+    def test_empty_destination_rejected(self) -> None:
+        assert _create(destination="")["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# 2. Claiming
+# ---------------------------------------------------------------------------
+
+
+class TestClaiming:
+    def test_claim_sets_fields(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Pick a store", "task", "Which store?")["ticket_id"]
+        result = wr.claim_ticket("checkout", tid, "sess-1")
+        assert result["status"] == "success"
+        assert result["hitl_pending"] is False
+        state = wr._load_state("checkout")
+        assert state["tickets"][tid]["claimed_by"] == "sess-1"
+        assert state["tickets"][tid]["claimed_at"]
+        assert state["status"] == "active"
+
+    def test_double_claim_rejected(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "T", "task", "Q?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        again = wr.claim_ticket("checkout", tid, "sess-2")
+        assert again["status"] == "error"
+        assert again["code"] == "already_claimed"
+
+    def test_claim_blocked_ticket_rejected(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?", blocked_by_json=json.dumps([a]))["ticket_id"]
+        result = wr.claim_ticket("checkout", b, "sess-1")
+        assert result["status"] == "error"
+        assert result["code"] == "blocked"
+
+    def test_resolve_without_claim_rejected(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "T", "task", "Q?")["ticket_id"]
+        path = _write_resolution("checkout", tid)
+        result = wr.resolve_ticket("checkout", tid, "sess-1", "g", path)
+        assert result["status"] == "error"
+        assert result["code"] == "not_owner"
+
+    def test_release_restores_claimability(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "T", "task", "Q?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        assert wr.release_ticket("checkout", tid, "sess-2")["status"] == "error"  # not owner
+        assert wr.release_ticket("checkout", tid, "sess-1")["status"] == "success"
+        assert wr.claim_ticket("checkout", tid, "sess-2")["status"] == "success"
+
+    def test_claim_hitl_returns_pending(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Grill me", "grilling", "What exactly?")["ticket_id"]
+        result = wr.claim_ticket("checkout", tid, "sess-1")
+        assert result["status"] == "success"
+        assert result["hitl_pending"] is True
+        assert "human" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Frontier
+# ---------------------------------------------------------------------------
+
+
+class TestFrontier:
+    def test_blocked_excluded_until_blocker_resolved(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "research", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?", blocked_by_json=json.dumps([a]))["ticket_id"]
+        frontier = [t["ticket_id"] for t in wr.wayfind_frontier("checkout")["frontier"]]
+        assert frontier == [a]
+        _resolve("checkout", a, "sess-1")
+        frontier = [t["ticket_id"] for t in wr.wayfind_frontier("checkout")["frontier"]]
+        assert b in frontier
+
+    def test_cycle_rejected(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?", blocked_by_json=json.dumps([a]))["ticket_id"]
+        result = wr.wire_blocking("checkout", a, json.dumps([b]))
+        assert result["status"] == "error"
+        assert result["code"] == "cycle"
+
+    def test_unknown_blocker_rejected(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        assert wr.wire_blocking("checkout", a, json.dumps(["T-999"]))["status"] == "error"
+        assert wr.add_ticket(
+            "checkout", "B", "task", "Qb?", blocked_by_json=json.dumps(["T-999"])
+        )["status"] == "error"
+
+    def test_claimed_excluded_from_frontier(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        wr.claim_ticket("checkout", a, "sess-1")
+        frontier = [t["ticket_id"] for t in wr.wayfind_frontier("checkout")["frontier"]]
+        assert a not in frontier
+
+    def test_self_block_rejected(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        assert wr.wire_blocking("checkout", a, json.dumps([a]))["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# 4. Fog graduation
+# ---------------------------------------------------------------------------
+
+
+class TestFogGraduation:
+    def test_graduate_creates_ticket_and_marks_fog(self, repo: Path) -> None:
+        _create(fog_json='["auth interplay unclear"]')
+        result = wr.graduate_fog("checkout", "F-1", "Resolve auth", "grilling", "How does auth interact?")
+        assert result["status"] == "success"
+        tid = result["ticket_id"]
+        state = wr._load_state("checkout")
+        assert state["tickets"][tid]["from_fog"] == "F-1"
+        assert state["fog"][0]["status"] == "graduated"
+        content = (repo / ".map" / "wayfind" / "checkout" / "map.md").read_text()
+        fog_section = content.split("## Fog of war")[1].split("## Out of scope")[0]
+        assert "auth interplay unclear" not in fog_section
+
+    def test_double_graduation_rejected(self) -> None:
+        _create(fog_json='["x"]')
+        wr.graduate_fog("checkout", "F-1", "T", "task", "Q?")
+        again = wr.graduate_fog("checkout", "F-1", "T2", "task", "Q2?")
+        assert again["status"] == "error"
+        assert again["code"] == "already_graduated"
+
+    def test_add_fog_mints_incrementing_ids(self) -> None:
+        _create()
+        assert wr.add_fog("checkout", "first")["fog_id"] == "F-1"
+        assert wr.add_fog("checkout", "second")["fog_id"] == "F-2"
+
+
+# ---------------------------------------------------------------------------
+# 5. Out of scope
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfScope:
+    def test_ticket_ruled_out_leaves_frontier_and_records_reason(self, repo: Path) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Maybe later", "task", "Support legacy?")["ticket_id"]
+        result = wr.rule_out_of_scope("checkout", "Legacy is EOL", ticket_id=tid)
+        assert result["status"] == "success"
+        frontier = [t["ticket_id"] for t in wr.wayfind_frontier("checkout")["frontier"]]
+        assert tid not in frontier
+        content = (repo / ".map" / "wayfind" / "checkout" / "map.md").read_text()
+        oos_section = content.split("## Out of scope")[1]
+        assert "Legacy is EOL" in oos_section
+        decisions_section = content.split("## Decisions so far")[1].split("## Frontier")[0]
+        assert tid not in decisions_section
+
+    def test_retire_fog(self) -> None:
+        _create(fog_json='["speculative idea"]')
+        result = wr.rule_out_of_scope("checkout", "Not this quarter", fog_id="F-1")
+        assert result["status"] == "success"
+        state = wr._load_state("checkout")
+        assert state["fog"][0]["status"] == "retired"
+
+    def test_requires_exactly_one_target(self) -> None:
+        _create()
+        assert wr.rule_out_of_scope("checkout", "r")["status"] == "error"
+        assert wr.rule_out_of_scope("checkout", "r", ticket_id="T-1", fog_id="F-1")["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# 6. Handoff
+# ---------------------------------------------------------------------------
+
+
+class TestHandoff:
+    def test_open_items_block_handoff(self) -> None:
+        _create()
+        wr.add_ticket("checkout", "Open", "task", "Q?")
+        result = wr.emit_wayfind_handoff("checkout", branch="test-branch")
+        assert result["status"] == "error"
+        assert result["code"] == "not_terminal"
+        assert result["open_items"]
+
+    def test_clean_emit_writes_artifacts_and_manifest(self, repo: Path) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Pick DB", "research", "Which DB?")["ticket_id"]
+        _resolve("checkout", tid, "sess-1", gist="Use Postgres")
+        result = wr.emit_wayfind_handoff("checkout", branch="test-branch")
+        assert result["status"] == "success", result
+        assert (repo / ".map" / "wayfind" / "checkout" / "handoff.md").exists()
+        handoff = json.loads((repo / ".map" / "wayfind" / "checkout" / "handoff.json").read_text())
+        assert handoff["decisions"][0]["gist"] == "Use Postgres"
+        assert wr._load_state("checkout")["status"] == "handed_off"
+        assert result["manifest"]["status"] == "success"
+        manifest = json.loads((repo / ".map" / "test-branch" / "artifact_manifest.json").read_text())
+        assert manifest["stages"]["wayfind_handoff"]["status"] == "ready"
+
+    def test_early_requires_confirmation_and_folds_open_items(self, repo: Path) -> None:
+        _create()
+        wr.add_ticket("checkout", "Still open", "task", "Q?")
+        assert wr.emit_wayfind_handoff("checkout", early=True, branch="test-branch")["status"] == "error"
+        result = wr.emit_wayfind_handoff(
+            "checkout", early=True, confirmed_by_user=True, branch="test-branch"
+        )
+        assert result["status"] == "success"
+        handoff = json.loads((repo / ".map" / "wayfind" / "checkout" / "handoff.json").read_text())
+        assert any("UNRESOLVED" in r for r in handoff["remaining_risks"])
+
+    def test_list_handoffs_finds_completed(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Pick DB", "research", "Which DB?")["ticket_id"]
+        _resolve("checkout", tid, "sess-1")
+        wr.emit_wayfind_handoff("checkout", branch="test-branch")
+        result = wr.list_handoffs()
+        assert result["count"] == 1
+        assert result["handoffs"][0]["slug"] == "checkout"
+
+
+# ---------------------------------------------------------------------------
+# 7. Session guardrail + HITL gate
+# ---------------------------------------------------------------------------
+
+
+class TestSessionGuardrail:
+    def test_second_non_research_resolve_blocked(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?")["ticket_id"]
+        assert _resolve("checkout", a, "sess-1")["status"] == "success"
+        second = _resolve("checkout", b, "sess-1")
+        assert second["status"] == "error"
+        assert second["code"] == "session_limit"
+
+    def test_two_research_resolves_allowed(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "research", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "research", "Qb?")["ticket_id"]
+        assert _resolve("checkout", a, "sess-1")["status"] == "success"
+        assert _resolve("checkout", b, "sess-1")["status"] == "success"
+
+    def test_new_session_can_resolve_again(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?")["ticket_id"]
+        assert _resolve("checkout", a, "sess-1")["status"] == "success"
+        assert _resolve("checkout", b, "sess-2")["status"] == "success"
+
+    def test_hitl_resolve_without_human_input_blocked(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Grill", "grilling", "What exactly?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        path = _write_resolution("checkout", tid)
+        blocked = wr.resolve_ticket("checkout", tid, "sess-1", "g", path)
+        assert blocked["status"] == "error"
+        assert blocked["code"] == "awaiting_human"
+        human = _write_human_input("checkout", tid)
+        assert wr.record_human_input("checkout", tid, "sess-1", human)["status"] == "success"
+        assert wr.resolve_ticket("checkout", tid, "sess-1", "g", path)["status"] == "success"
+
+    def test_record_human_input_requires_nonempty_file(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Grill", "grilling", "What?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        empty_rel = f"resolutions/{tid}.human.md"
+        empty = Path(".map/wayfind/checkout") / empty_rel
+        empty.parent.mkdir(parents=True, exist_ok=True)
+        empty.write_text("   \n", encoding="utf-8")
+        result = wr.record_human_input("checkout", tid, "sess-1", empty_rel)
+        assert result["status"] == "error"
+        assert result["code"] == "missing_input"
+
+
+# ---------------------------------------------------------------------------
+# 8. Views / files
+# ---------------------------------------------------------------------------
+
+
+class TestViews:
+    def test_empty_resolution_file_blocks_resolve(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "T", "task", "Q?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        empty_rel = f"resolutions/{tid}.md"
+        empty = Path(".map/wayfind/checkout") / empty_rel
+        empty.parent.mkdir(parents=True, exist_ok=True)
+        empty.write_text("", encoding="utf-8")
+        result = wr.resolve_ticket("checkout", tid, "sess-1", "g", empty_rel)
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
+    def test_one_decision_line_per_resolved_ticket(self, repo: Path) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "Alpha", "research", "Qa?")["ticket_id"]
+        _resolve("checkout", a, "sess-1", gist="Chose alpha")
+        content = (repo / ".map" / "wayfind" / "checkout" / "map.md").read_text()
+        decisions_section = content.split("## Decisions so far")[1].split("## Frontier")[0]
+        assert decisions_section.count(f"**{a}**") == 1
+        assert "Chose alpha" in decisions_section
+
+    def test_ticket_view_written(self, repo: Path) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Alpha", "task", "Qa?")["ticket_id"]
+        assert (repo / ".map" / "wayfind" / "checkout" / "tickets" / f"{tid}.md").exists()
+
+    def test_awaiting_human_badge_in_map(self, repo: Path) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Grill", "grilling", "What?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        content = (repo / ".map" / "wayfind" / "checkout" / "map.md").read_text()
+        assert "AWAITING HUMAN" in content
+
+
+# ---------------------------------------------------------------------------
+# 9. Revision guard
+# ---------------------------------------------------------------------------
+
+
+class TestRevisionGuard:
+    def test_stale_expected_revision_rejected(self) -> None:
+        _create()
+        current = wr._load_state("checkout")["revision"]
+        good = wr.add_ticket("checkout", "T", "task", "Q?", expected_revision=current)
+        assert good["status"] == "success"
+        stale = wr.add_ticket("checkout", "T2", "task", "Q2?", expected_revision=current)
+        assert stale["status"] == "error"
+        assert stale["code"] == "stale_revision"
+
+
+# ---------------------------------------------------------------------------
+# 10. CLI smoke
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def _run(self, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS_PATH / "wayfind_runner.py"), *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+        )
+
+    def test_create_and_status_via_cli(self, repo: Path) -> None:
+        created = self._run(repo, "create_wayfind_map", "cli-map", "T", "Dest")
+        assert created.returncode == 0, created.stderr
+        assert json.loads(created.stdout)["status"] == "success"
+        status = self._run(repo, "wayfind_status", "--slug", "cli-map")
+        assert status.returncode == 0, status.stdout
+        payload = json.loads(status.stdout)
+        assert payload["status"] == "success"
+        assert payload["slug"] == "cli-map"
+
+    def test_error_status_exits_nonzero(self, repo: Path) -> None:
+        result = self._run(repo, "wayfind_status", "--slug", "nope")
+        assert result.returncode == 1
+        assert json.loads(result.stdout)["status"] == "error"
+
+    def test_unknown_subcommand_exits_nonzero(self, repo: Path) -> None:
+        result = self._run(repo, "bogus_command")
+        assert result.returncode != 0

--- a/tests/test_wayfind_runner.py
+++ b/tests/test_wayfind_runner.py
@@ -186,6 +186,14 @@ class TestClaiming:
         assert result["hitl_pending"] is True
         assert "human" in result["message"].lower()
 
+    def test_resolve_clears_claim(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "T", "research", "Q?")["ticket_id"]
+        _resolve("checkout", tid, "sess-1")
+        ticket = wr._load_state("checkout")["tickets"][tid]
+        assert ticket["claimed_by"] is None
+        assert ticket["claimed_at"] is None
+
 
 # ---------------------------------------------------------------------------
 # 3. Frontier
@@ -342,6 +350,72 @@ class TestHandoff:
         result = wr.list_handoffs()
         assert result["count"] == 1
         assert result["handoffs"][0]["slug"] == "checkout"
+
+    def test_mutation_after_handoff_rejected(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Pick DB", "research", "Which DB?")["ticket_id"]
+        _resolve("checkout", tid, "sess-1")
+        assert wr.emit_wayfind_handoff("checkout", branch="test-branch")["status"] == "success"
+        # any ticket/fog mutation after handoff must be rejected (frozen handoff)
+        blocked = wr.add_ticket("checkout", "Late idea", "task", "too late?")
+        assert blocked["status"] == "error"
+        assert blocked["code"] == "handed_off"
+        assert wr.add_fog("checkout", "late fog")["code"] == "handed_off"
+
+    def test_emit_stale_revision_rejected(self) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "Pick DB", "research", "Which DB?")["ticket_id"]
+        _resolve("checkout", tid, "sess-1")
+        stale = wr.emit_wayfind_handoff("checkout", branch="test-branch", expected_revision=0)
+        assert stale["status"] == "error"
+        assert stale["code"] == "stale_revision"
+
+
+# ---------------------------------------------------------------------------
+# 6b. Evidence-path containment
+# ---------------------------------------------------------------------------
+
+
+class TestEvidencePathContainment:
+    def _claimed_ticket(self) -> str:
+        _create()
+        tid = wr.add_ticket("checkout", "T", "task", "Q?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        return tid
+
+    def test_absolute_resolution_path_rejected(self, repo: Path) -> None:
+        tid = self._claimed_ticket()
+        outside = repo / "outside.md"
+        outside.write_text("secret", encoding="utf-8")
+        result = wr.resolve_ticket("checkout", tid, "sess-1", "g", str(outside))
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
+    def test_parent_escape_resolution_rejected(self) -> None:
+        tid = self._claimed_ticket()
+        escape = Path(".map/wayfind") / "escape.md"
+        escape.write_text("x", encoding="utf-8")  # real file OUTSIDE the map dir
+        result = wr.resolve_ticket("checkout", tid, "sess-1", "g", "../escape.md")
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
+    def test_directory_resolution_rejected(self) -> None:
+        tid = self._claimed_ticket()
+        adir = Path(".map/wayfind/checkout/resolutions/adir")
+        adir.mkdir(parents=True, exist_ok=True)
+        result = wr.resolve_ticket("checkout", tid, "sess-1", "g", "resolutions/adir")
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
+    def test_absolute_human_input_path_rejected(self, repo: Path) -> None:
+        _create()
+        tid = wr.add_ticket("checkout", "G", "grilling", "Q?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        outside = repo / "human.md"
+        outside.write_text("hi", encoding="utf-8")
+        result = wr.record_human_input("checkout", tid, "sess-1", str(outside))
+        assert result["status"] == "error"
+        assert result["code"] == "missing_input"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds **`/map-wayfind`** — an opt-in, Claude-only skill for large or foggy efforts where `/map-plan` would force premature decomposition. It resolves the open design decisions one at a time on a durable, repo-level decision map under `.map/wayfind/<slug>/` **before** planning, then hands the settled decisions to `/map-plan`. Design was validated with llm-council (conv `3caf21ee`); implementation follows the plan on this branch.

Closes #362.

## What's in it

**Runtime — `wayfind_runner.py`** (new, stdlib-only, sibling of `map_step_runner.py`)
- Owns *every* mutation to the canonical `state.json` and regenerates the `map.md` / `tickets/*.md` views (DO-NOT-EDIT banner); the LLM writes only prose (resolutions + verbatim human answers).
- Invariants enforced **above persistence** so a future non-local backend can't bypass them: DFS cycle-freedom on `blocked_by` wiring, claim-before-work, **one-non-research-resolve-per-session**, the **human-in-the-loop gate** (`record_human_input` required before resolving a `prototype`/`grilling` ticket), and the **terminal handoff condition** (fog empty AND no active claims AND every ticket resolved/out-of-scope — a naive `len(frontier)==0` would misfire on a claimed/blocked map). Optimistic concurrency via `--expected-revision`.

**Skill — `map-wayfind`** (SKILL.md + wayfind-reference.md)
- Three **explicit** modes `chart | work | handoff` (no auto-detection); `effort: medium`.
- Ticket types `research | prototype | grilling | task`; fog-of-war for questions not yet stateable sharply; out-of-scope rulings never graduate into the plan.

**Handoff → `/map-plan`**
- New `wayfind_handoff` artifact-manifest stage; `emit_wayfind_handoff` writes `handoff.md`/`handoff.json`.
- `/map-plan --wayfind <slug>` (or a single-candidate `list_handoffs` offer — never a silent match) pre-seeds the spec's **Decisions Made / Out of Scope / Open Questions**.

**Housekeeping**
- Syncs the artifact-manifest JSON schema to the `ARTIFACT_STAGE_NAMES` authority, adding the previously-missing `approval_hold` / `worktree` / `context_usefulness` stages.
- Docs: README, `docs/USAGE.md`, `docs/ARCHITECTURE.md`, CHANGELOG.

## Deviations from the plan (evidence-based)
1. **No gitignore change.** The plan assumed a wholesale `.map/*` ignore needing `!.map/wayfind/`; the actual `.gitignore.jinja` only ignores `.map/*/sessions/scratch/` and `.map/*/compacted/`, so maps already commit by default (as council wanted). Privacy is handled by a commit-by-default warning in `chart` + a per-slug `.gitignore` opt-out.
2. Two real bugs caught during dev: a payload key `status` collided with the result-envelope `status` (renamed to `ticket_status` / `map_status`); resolution/human-input paths are resolved relative to the map dir so `map.md`/`handoff.md` links are correct.

## Testing
- `make check` → **green**: ruff, mypy, pyright (0/0/0), **3788 passed / 3 skipped**, `check-render` byte-identical.
- `tests/test_wayfind_runner.py` → **43 passed** (creation, claiming, frontier + cycles, fog graduation, out-of-scope, handoff + manifest, session guardrail + HITL gate, views, revision guard, CLI smoke).
- **Live e2e** via `mapify init … --no-git`: full cycle create → tickets → research/task/HITL → session-limit → fog retire → `handoff_eligible` → handoff (3 decisions, `wayfind_handoff` stage `ready`) with correct rendered Decisions Made table and resolution links.

## Single-source render note
All shipped trees are rendered from `templates_src/**/*.jinja` via `make render-templates`; generated trees in this PR are the byte-identical output (`check-render` enforced).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/map-wayfind` workflow for resolving uncertain design decisions through guided decision maps, tickets, fog tracking, and human-in-the-loop steps.
  * Added handoff artifacts that summarize decisions, out-of-scope items, and remaining risks.
  * Added optional `/map-plan --wayfind <slug>` integration to seed planning from a completed handoff.

* **Documentation**
  * Added usage guidance, command references, troubleshooting information, and architecture documentation for wayfinding.

* **Tests**
  * Added comprehensive coverage for wayfinding workflows, validation, handoffs, concurrency, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->