### PR TITLE
feat: /map-plan → /map-wayfind off-ramp (too-foggy Workflow-Fit route)

### DIFF
--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -93,7 +93,7 @@ Signals:
 Persist the decision (use the keyword form so the new signal is unambiguous):
 
 ```bash
-python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fast|map-plan>" \
+python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fast|map-wayfind|map-plan>" \
   --diff-size "<tiny|small|medium|large>" \
   --has-new-invariants <0|1> --needs-independent-review <0|1> \
   --has-clear-acceptance-criteria <0|1> --test-first-required <0|1> \
@@ -104,6 +104,7 @@ python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fa
 Outcomes:
 - `direct-edit`: explain MAP is not needed and STOP.
 - `map-fast`: recommend `/map-fast` and STOP.
+- `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
 ### Step 0: Quick Discovery (Optional but Recommended)

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -302,6 +302,9 @@ WORKFLOW_FIT_ROUTES = {
     "map-efficient",
     "map-tdd",
     "map-plan",
+    # Too foggy to specify: core decisions are still unresolved, so /map-plan
+    # off-ramps to decision-frontier wayfinding before any decomposition.
+    "map-wayfind",
 }
 DIFF_SIZE_LEVELS = {"tiny", "small", "medium", "large"}
 SUBTASK_CONCERN_TYPES = {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,6 +18,8 @@ When a MAP run enters a merge/rebase conflict, the PreToolUse workflow-context h
 
 For a large or foggy effort where `/map-plan` would force premature decomposition, `/map-wayfind` resolves the open design decisions **before** planning. It is a Claude-only, manually-invoked skill; if the scope is already clear enough to specify, skip it and run `/map-plan` directly.
 
+You reach it two ways: invoke it yourself, or let `/map-plan` send you. `/map-plan`'s Workflow-Fit Gate now has a `map-wayfind` outcome — when it finds the task too foggy to specify (several core decisions unresolved and entangled, not just "needs a little research"), it recommends `/map-wayfind chart "…"` and stops instead of writing a spec dominated by Open Questions. That closes the loop: `/map-plan` → (too foggy) → `/map-wayfind` → handoff → `/map-plan --wayfind <slug>`.
+
 The unit of work is a **decision ticket** on a durable, repo-level map at `.map/wayfind/<slug>/` (the map outlives branches and can span sessions). Tickets are typed:
 
 - `research` — find out an answer that already exists (a subagent may help). Exempt from the one-per-session limit.

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -302,6 +302,9 @@ WORKFLOW_FIT_ROUTES = {
     "map-efficient",
     "map-tdd",
     "map-plan",
+    # Too foggy to specify: core decisions are still unresolved, so /map-plan
+    # off-ramps to decision-frontier wayfinding before any decomposition.
+    "map-wayfind",
 }
 DIFF_SIZE_LEVELS = {"tiny", "small", "medium", "large"}
 SUBTASK_CONCERN_TYPES = {

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -93,7 +93,7 @@ Signals:
 Persist the decision (use the keyword form so the new signal is unambiguous):
 
 ```bash
-python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fast|map-plan>" \
+python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fast|map-wayfind|map-plan>" \
   --diff-size "<tiny|small|medium|large>" \
   --has-new-invariants <0|1> --needs-independent-review <0|1> \
   --has-clear-acceptance-criteria <0|1> --test-first-required <0|1> \
@@ -104,6 +104,7 @@ python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fa
 Outcomes:
 - `direct-edit`: explain MAP is not needed and STOP.
 - `map-fast`: recommend `/map-fast` and STOP.
+- `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
 ### Step 0: Quick Discovery (Optional but Recommended)

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -302,6 +302,9 @@ WORKFLOW_FIT_ROUTES = {
     "map-efficient",
     "map-tdd",
     "map-plan",
+    # Too foggy to specify: core decisions are still unresolved, so /map-plan
+    # off-ramps to decision-frontier wayfinding before any decomposition.
+    "map-wayfind",
 }
 DIFF_SIZE_LEVELS = {"tiny", "small", "medium", "large"}
 SUBTASK_CONCERN_TYPES = {

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -93,7 +93,7 @@ Signals:
 Persist the decision (use the keyword form so the new signal is unambiguous):
 
 ```bash
-python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fast|map-plan>" \
+python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fast|map-wayfind|map-plan>" \
   --diff-size "<tiny|small|medium|large>" \
   --has-new-invariants <0|1> --needs-independent-review <0|1> \
   --has-clear-acceptance-criteria <0|1> --test-first-required <0|1> \
@@ -104,6 +104,7 @@ python3 .map/scripts/map_step_runner.py record_workflow_fit "<direct-edit|map-fa
 Outcomes:
 - `direct-edit`: explain MAP is not needed and STOP.
 - `map-fast`: recommend `/map-fast` and STOP.
+- `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
 ### Step 0: Quick Discovery (Optional but Recommended)

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -1300,6 +1300,25 @@ def test_record_workflow_fit_direct_edit_marks_needs_map_false(branch_workspace)
     assert stage["metadata"]["needs_map"] is False
 
 
+def test_record_workflow_fit_accepts_map_wayfind_route(branch_workspace):
+    """/map-plan can off-ramp a too-foggy task to decision-frontier wayfinding."""
+    result = map_step_runner.record_workflow_fit(
+        "map-wayfind",
+        "large",
+        "true",
+        "true",
+        "false",
+        "false",
+        "Core decisions unresolved and entangled; resolve the frontier first",
+    )
+
+    assert result["status"] == "success"
+    decision = json.loads((branch_workspace / "workflow-fit.json").read_text())
+    assert decision["recommended_workflow"] == "map-wayfind"
+    # map-wayfind is not direct-edit, so the branch still tracks the decision.
+    assert decision["needs_map"] is True
+
+
 def test_record_workflow_fit_persists_depends_on_runtime_state_signal(
     branch_workspace,
 ):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2125,6 +2125,24 @@ class TestPlanDiscoveryResearchNamespace:
         content = path.read_text(encoding="utf-8")
         assert "cat > .map/${BRANCH}/findings_${BRANCH}.md" not in content
 
+    def test_claude_map_plan_documents_wayfind_offramp(self) -> None:
+        """Claude /map-plan must expose the map-wayfind Workflow-Fit off-ramp (#362).
+
+        map-wayfind is Claude-only, so the Codex surface intentionally omits it.
+        """
+        root = Path(__file__).parent.parent
+        for rel in (
+            ".claude/skills/map-plan/SKILL.md",
+            "src/mapify_cli/templates/skills/map-plan/SKILL.md",
+        ):
+            content = (root / rel).read_text(encoding="utf-8")
+            assert "map-wayfind" in content, f"{rel} must document the map-wayfind route"
+            assert "record_workflow_fit" in content
+            # the too-foggy off-ramp must recommend charting a map, not just mention it
+            assert "/map-wayfind chart" in content, (
+                f"{rel} must recommend `/map-wayfind chart` when too foggy to specify"
+            )
+
     @pytest.fixture(
         params=[
             Path(".claude/agents/actor.md"),


### PR DESCRIPTION
## Summary

Closes the **reverse direction** of decision-frontier wayfinding. #362 shipped `/map-wayfind` and the forward hook (`/map-plan --wayfind <slug>` consumes a finished handoff). This adds the missing entry off-ramp: `/map-plan` can now route a **too-foggy** task *into* `/map-wayfind` instead of producing a spec dominated by Open Questions.

The Workflow-Fit Gate was already a readiness router with off-ramps *down* (too small → `direct-edit` / `map-fast`); it lacked the *sideways* one (too foggy → `map-wayfind`). Now:

- too small → `direct-edit` / `map-fast`
- **too foggy, decisions unresolved → `map-wayfind`** ← this PR
- right size, resolvable → `map-plan`

## Changes

- **`WORKFLOW_FIT_ROUTES`**: add `"map-wayfind"` as a first-class route so `record_workflow_fit` accepts and persists it (auditable in `workflow-fit.json` + the `workflow_fit` manifest stage), symmetric with the existing outcomes.
- **`map-plan` SKILL** (Claude): new Workflow-Fit Gate outcome — when acceptance criteria can't be made sharp because several core decisions are unresolved and entangled (**not** merely "needs a little research"), recommend `/map-wayfind chart "…"` and STOP, then return with `/map-plan --wayfind <slug>`. Explicitly framed as the inverse of the Wayfinding Handoff pre-flight (which consumes a finished map).
- **Codex `map-plan`** intentionally omits the outcome — `map-wayfind` is Claude-only.
- Docs (`docs/USAGE.md`) note the two entry paths and the closed loop.

## Tests
- `test_record_workflow_fit_accepts_map_wayfind_route` — the runner accepts the new route and records it (`needs_map=True`).
- `test_claude_map_plan_documents_wayfind_offramp` — both Claude `map-plan` surfaces document the off-ramp and recommend `/map-wayfind chart`; the Codex surface stays free of it.
- `make check` green: ruff, mypy, pyright (0/0/0), **3797 passed / 3 skipped**, `check-render` byte-identical.

## Single-source render
All shipped trees are rendered from `templates_src/**/*.jinja` via `make render-templates`; generated trees here are the byte-identical output (`check-render` enforced).

Follow-up to #362.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a decision-frontier wayfinding route to `/map-plan`.
  - When a request is too ambiguous to plan effectively, the workflow now recommends creating a wayfinding map before continuing with detailed planning.
  - Added `map-wayfind` support to generated planning workflows and step selection.

- **Documentation**
  - Updated usage guidance and workflow instructions to explain the new wayfinding handoff and when planning stops for clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->