### PR TITLE
feat(#287): add --light/--deep modes to map-plan (Codex variant)

### DIFF
--- a/.agents/skills/map-plan/SKILL.md
+++ b/.agents/skills/map-plan/SKILL.md
@@ -22,6 +22,21 @@ description: "ARCHITECT phase - decompose complex tasks into atomic subtasks wit
 
 ---
 
+## Pre-flight: Mode Detection
+
+Read `$ARGUMENTS` for mode flags **before any other action**. Strip detected flags from `$ARGUMENTS` before using the remainder as the task description.
+
+| Flag | Mode | Effect |
+|------|------|--------|
+| `--light` | LIGHT | Spec-only, no research. **Skip** Step 0, Step 0.5 (Already-Implemented Gate), and Step 2b (Devil's Advocate Review). Limit decomposition to 2–5 minimal subtasks. Fastest plan mode — use when scope is small and well-understood. |
+| `--deep` | DEEP | Full research + architecture review. Add extended research sweep **before** Step 0 and an architecture review step **after** Step 3. Use when scope is large or risk is high. |
+| `--force-full` | DEEP alias | Identical to `--deep`. Overrides any scale auto-advisory toward maximum planning depth. |
+| `--force-fast` | FAST exit | Recommend `$map-fast` and STOP. Use when the task is clearly trivial and MAP planning overhead is not warranted. |
+
+If **no flag** is present (standard mode), run all steps as written. The Scale Advisory in the Workflow-Fit Gate may suggest a mode when scope is clear from the task description.
+
+---
+
 ## Pre-flight: Resume Detection
 
 Before any step, detect which artifacts already exist AND whether the request matches the existing plan's goal:
@@ -83,9 +98,34 @@ shell_command:
 - Outcome `map-fast`: recommend `$map-fast` and STOP.
 - Outcome `map-plan`: continue below.
 
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, run:
+
+```
+shell_command:
+  cmd: |
+    python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pathlib import Path
+from mapify_cli.config.project_config import load_map_config
+cfg = load_map_config(Path('.'))
+print('scale_auto:', cfg.scale_auto)
+print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
+print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
+"
+```
+
+If `scale_auto: true`, use your estimate of the task scope to surface an advisory (do not block):
+- Estimated ≤ small thresholds → advise re-invoking as `$map-plan --light`.
+- Estimated > medium thresholds → advise re-invoking as `$map-plan --deep`.
+- Otherwise (medium range) → no advisory; standard mode is appropriate.
+
 ---
 
-## Step 0: Quick Discovery (Optional but Recommended)
+## Step 0: Quick Discovery (Optional but Recommended; SKIP in LIGHT mode)
+
+**LIGHT mode:** Skip this step entirely — proceed directly to Step 1. The spec is written from stated requirements without a prior research phase.
+
+**DEEP mode:** Before this step, run an extended research sweep (full codebase exploration, dependency and hotspot analysis). Dispatch a researcher with a wider scope than the standard Step 0 prompt below; cover recent-change hotspots, dependency graph, existing test coverage gaps, and architectural friction points. Save findings to `.map/$BRANCH/research/plan__deep_discovery.md` in addition to the standard `plan__discovery.md`.
 
 Skip if `.map/<branch>/research/plan__discovery.md` already exists AND contains an `Already Implemented` section (resume rule above), or if the task is greenfield with a fully-provided spec. If the canonical file is absent but legacy `.map/<branch>/findings_<branch>.md` exists, read it as a fallback and migrate it to the canonical research path only if it has the required section. If an existing discovery file predates this format (no `Already Implemented` section), re-run discovery so the Step 0.5 gate has its evidence.
 
@@ -143,7 +183,9 @@ DISCOVERY_EOF
 
 ---
 
-## Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)
+## Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step — no discovery was run, so there is no evidence base for the gate. Surface any overlap during spec writing.
 
 Reconcile the request against the discovery `Already Implemented` section BEFORE interview/spec. Do not plan work the codebase already does. If discovery was skipped (greenfield or fully-provided spec), state the gate was skipped and why. If the findings file lacks an `Already Implemented` section (it predates this format), re-run Step 0 first — do NOT run the gate on incomplete evidence.
 
@@ -312,9 +354,11 @@ Populate from user requirements and discovery findings:
 
 ---
 
-## Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+## Step 2b: Devil's Advocate Review (SPEC_REVIEW; always SKIP in LIGHT mode)
 
-**Skip if ALL true:**
+> **LIGHT mode:** Skip this step unconditionally.
+
+**Skip if ALL true (standard/DEEP mode):**
 - Source spec is under 200 lines
 - Fewer than 5 subtasks expected
 - No cross-cutting concerns (observability, security, concurrency, multi-service)
@@ -386,6 +430,45 @@ Format: `A -[relationship]-> B` (arrow notation). Keep under 200 tokens — only
 
 ---
 
+## Step 3.5: Architecture Review (DEEP mode only)
+
+> **Standard / LIGHT mode:** Skip this step.
+
+Before decomposition, dispatch a monitor agent to review the spec and discovery findings for architecture concerns: component boundary clarity, dependency direction violations, state ownership ambiguity, untestable seams, and conflicts with `docs/ARCHITECTURE.md`.
+
+```
+spawn_agent(
+  agent_type="monitor",
+  message="""You are reviewing a SPECIFICATION for architecture quality (not code). DEEP mode.
+
+Read the spec at: .map/<branch>/spec_<branch>.md
+Read deep discovery at: .map/<branch>/research/plan__deep_discovery.md (if present)
+(Use shell_command to cat both files.)
+
+Check for:
+1. Component boundary clarity — are module/service responsibilities well-defined and non-overlapping?
+2. Dependency direction — does the proposed flow violate layering or create circular dependencies?
+3. State ownership — is shared mutable state owned by exactly one component?
+4. Untestable seams — are there coupling points that make unit testing impractical?
+5. Architecture conflicts — does this design contradict decisions in docs/ARCHITECTURE.md?
+
+Output per finding:
+  SEVERITY: CRITICAL | HIGH | MEDIUM
+  CATEGORY: [boundary|dependency|state|testability|architecture-conflict]
+  DESCRIPTION: [what the issue is, citing the spec section]
+  RECOMMENDATION: [how to resolve]
+
+If no CRITICAL or HIGH findings: output "ARCHITECTURE APPROVED" at the end.
+"""
+)
+```
+
+- `ARCHITECTURE APPROVED` (no CRITICAL/HIGH findings): proceed to Step 4.
+- CRITICAL or HIGH findings: present them and update the spec before decomposition.
+- Add unresolved risks to spec Open Questions.
+
+---
+
 ## Step 4: Call Task Decomposer
 
 ```
@@ -422,6 +505,7 @@ Output requirements per subtask:
 
 Target subtask size: completable within ~4000 tokens (SFT comfort zone).
 Aim for 3-7 subtasks; flag if more than 10 are needed.
+LIGHT mode: target 2-5 minimal bite-sized subtasks; prefer merging related concerns over splitting.
 
 Coverage requirements:
 - Do NOT create subtasks for behavior listed under the spec's "Out of Scope > Already Implemented" subsection — that work already exists. Plan only the remaining gap.
@@ -649,6 +733,7 @@ shell_command:
     echo "[ok] Coverage check passed"
     echo "[ok] Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md"
     echo "[ok] artifact_manifest.json updated"
+    echo "[ok] Mode: [standard | light | deep]"
     echo ""
     echo "Next steps:"
     echo "  1. Review .map/${BRANCH}/task_plan_${BRANCH}.md"

--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -48,6 +48,19 @@ parallel_tool_policy: discovery_only
 
 ## Workflow Steps
 
+### Pre-flight: Mode Detection
+
+Read `$ARGUMENTS` for mode flags **before any other action**. Strip detected flags from `$ARGUMENTS` before using the remainder as the task description.
+
+| Flag | Mode | Effect |
+|------|------|--------|
+| `--light` | LIGHT | Spec-only, no research. **Skip** Step 0, Step 0.5 (Always-Implemented Gate), and Step 2b (Devil's Advocate Review). Limit decomposition to 2–5 minimal subtasks. Fastest plan mode — use when scope is small and well-understood. |
+| `--deep` | DEEP | Full research + architecture review. Add extended research sweep **before** Step 0 and an architecture review step **after** Step 4. Use when scope is large or risk is high. |
+| `--force-full` | DEEP alias | Identical to `--deep`. Overrides any scale auto-advisory toward maximum planning depth. |
+| `--force-fast` | FAST exit | Recommend `/map-fast` and STOP. Use when the task is clearly trivial and MAP planning overhead is not warranted. |
+
+If **no flag** is present (standard mode), run all steps as written. The Scale Advisory in the Workflow-Fit Gate may suggest a mode when scope is clear from the task description.
+
 ### Pre-flight: Resume Detection
 
 ```bash
@@ -107,7 +120,35 @@ Outcomes:
 - `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
-### Step 0: Quick Discovery (Optional but Recommended)
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, query the project's scale-adaptive config:
+
+```bash
+python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pathlib import Path
+from mapify_cli.config.project_config import load_map_config
+cfg = load_map_config(Path('.'))
+print('scale_auto:', cfg.scale_auto)
+print('trivial:', cfg.scale_trivial_max_files, cfg.scale_trivial_max_lines)
+print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
+print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
+"
+```
+
+If `scale_auto: true`, use your estimate of the task's scope to surface an advisory (do not block on this):
+
+- Estimated ≤ trivial thresholds → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
+- Estimated ≤ small thresholds → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
+- Estimated > medium thresholds → advise re-invoking as `/map-plan --deep` for full research + architecture review.
+- Otherwise (medium range) → no advisory; standard mode is appropriate.
+
+The advisory is informational — the user's flags or your judgment prevail. If the user accepts, add the flag and restart; otherwise continue in standard mode.
+
+### Step 0: Quick Discovery (Optional but Recommended; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step entirely — proceed directly to Step 1. The spec is written from the stated requirements without a prior research phase.
+>
+> **DEEP mode:** Before this step, run an extended research sweep (SOFA search if available, full codebase exploration, dependency and hotspot analysis). Dispatch a research-agent with a wider scope than the standard Step 0 prompt below; cover recent-change hotspots, dependency graph, existing test coverage gaps, and architectural friction points. Save findings to `.map/$BRANCH/research/plan__deep_discovery.md` in addition to the standard `plan__discovery.md`. Then continue with Step 0 as written.
 
 Use `.map/<branch>/research/plan__discovery.md` as the canonical plan-scope discovery artifact. If it exists, read it and skip discovery — but ONLY if it contains an `Already Implemented` section (the format this skill now requires). If the canonical file is absent but legacy `.map/<branch>/findings_<branch>.md` exists, read that fallback and migrate it to the canonical path with `save_research "$BRANCH" plan discovery` only if it has the required section. A discovery file written before this format existed lacks that section; in that case re-run discovery with the prompt below so the Step 0.5 gate has the evidence it requires. Otherwise (no discovery file at all) run discovery to find relevant files, existing patterns, risks, and confirmed new files.
 
@@ -138,7 +179,9 @@ if [ ! -f ".map/$BRANCH/research/plan__discovery.md" ]; then
 fi
 ```
 
-### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)
+### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step — no discovery was run, so there is no evidence base for the gate. Rely on the user's statement that the feature is new; if you discover overlap during spec writing, surface it there.
 
 Before interviewing or writing the spec, reconcile the request against the discovery `Already Implemented` section. Do not plan work the codebase already does. This gate runs whenever Step 0 produced findings; if discovery was intentionally skipped (greenfield or fully-provided spec), state that the gate was skipped and why. If the findings file lacks an `Already Implemented` section (it predates this format), do NOT run the gate on incomplete evidence — re-run Step 0 discovery first.
 
@@ -199,7 +242,9 @@ python3 .map/scripts/validate_spec_citations.py --branch "$BRANCH"
 - Exit 1 + `"failures": [...]` with `status` in `{stale-citation, error}` → fix the spec (correct the line number, update the symbol name, or remove the citation) and re-run. Do NOT proceed to decomposition with red failures.
 - Exit 2 → invocation error (missing branch / spec file); fix invocation, do not skip.
 
-### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+### Step 2b: Devil's Advocate Review (SPEC_REVIEW; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step. The spec is written from well-understood requirements; a lightweight self-review of the open-questions list and acceptance criteria suffices before decomposition.
 
 Run Monitor as a spec reviewer before decomposition.
 
@@ -236,6 +281,35 @@ mkdir -p ".map/${BRANCH}"
 
 Add an architecture graph to the spec or plan when the implementation has multiple components, state boundaries, or dependencies. See [plan-reference.md](plan-reference.md#architecture-graph) for examples.
 
+### Step 4.5: Architecture Review (DEEP mode only)
+
+> **DEEP mode:** Before decomposition, dispatch Monitor as an architecture reviewer over the spec + deep discovery findings. Focus on component boundaries, dependency flow, state ownership, testability, and whether the proposed approach is consistent with the existing architecture documented in `docs/ARCHITECTURE.md`.
+
+```text
+Task(
+  subagent_type="monitor",
+  description="Architecture review before decomposition (DEEP mode)",
+  prompt="""
+<documents>
+  <document source="spec"><document_content>{spec_content}</document_content></document>
+  <document source="deep-discovery"><document_content>{deep_discovery_content}</document_content></document>
+</documents>
+<task>
+Review the proposed architecture for: component boundary clarity, dependency direction violations, state ownership ambiguity, untestable seams, and conflicts with the existing system described in docs/ARCHITECTURE.md.
+Evidence first: cite the spec or discovery before each finding.
+CRITICAL findings must identify the exact spec section and the specific risk.
+</task>
+<expected_output>
+Return JSON: {"valid": bool, "findings": [{"severity": "critical|high|medium", "section": "...", "finding": "...", "recommendation": "..."}], "summary": "..."}.
+</expected_output>
+"""
+)
+```
+
+Fix any CRITICAL or HIGH findings before proceeding to Step 5. Add unresolved architecture risks to the spec's Open Questions.
+
+> **Standard / LIGHT mode:** Skip this step.
+
 ### Step 5: Call Task Decomposer
 
 ```text
@@ -258,6 +332,7 @@ Top-level coverage_map must map each acceptance criterion, invariant, and cross-
 Top-level hard_constraints are non-negotiable: every hard_constraints id must appear in coverage_map and bracketed validation_criteria.
 Top-level soft_constraints are negotiable only with coverage or tradeoff_rationale.
 Do NOT create subtasks for behavior listed under the spec's "Out of Scope > Already Implemented" subsection; that work already exists in the codebase. Plan only the remaining gap.
+LIGHT mode: target 2–5 minimal, bite-sized subtasks. Prefer merging related concerns into one subtask rather than splitting them. Do not over-decompose well-understood small tasks.
 </constraints>
 <expected_output>Return only blueprint JSON.</expected_output>
 """
@@ -363,8 +438,11 @@ PLAN COMPLETE
 Spec: .map/<branch>/spec_<branch>.md
 Blueprint: .map/<branch>/blueprint.json
 Task plan: .map/<branch>/task_plan_<branch>.md
+Mode: [standard | light | deep]
 Next: /map-efficient or /map-task for a selected subtask
 ```
+
+Include the active mode (`light` / `deep` / `standard`) so the operator knows which steps ran.
 
 ### Step 8.5: Execution Handoff Note
 
@@ -385,6 +463,9 @@ Detailed rationale moved to [plan-reference.md](plan-reference.md#design-rationa
 - `/map-check`: verify completion.
 - `/map-review`: review the diff.
 - `/map-learn`: preserve reusable learnings.
+- `/map-plan --light`: spec-only mode, no research, 2–5 minimal subtasks (small, well-understood tasks).
+- `/map-plan --deep`: full research + architecture review mode (large or risky tasks). Also `--force-full`.
+- `/map-plan --force-fast`: skip planning; recommend `/map-fast` and stop.
 
 ## State Machine Integration
 
@@ -404,10 +485,13 @@ See [plan-reference.md](plan-reference.md#troubleshooting) for stale artifacts, 
 
 ## Success Criteria
 
+- Mode flags detected and stripped from `$ARGUMENTS` before use.
 - Workflow-fit decision recorded.
-- Already-implemented gate ran (or was explicitly skipped with a reason): whole-feature duplicates off-ramped, partial duplicates moved to spec "Out of Scope > Already Implemented".
+- Already-implemented gate ran (or was explicitly skipped with a reason): whole-feature duplicates off-ramped, partial duplicates moved to spec "Out of Scope > Already Implemented". (LIGHT mode: gate explicitly skipped — noted in checkpoint.)
 - Live/runtime-state gate ran when `depends_on_runtime_state=true`: each runtime assumption was verified read-only, or recorded as an `Unverified Runtime Assumption` (Open Questions / Risks) with the exact check to run and dependent subtasks marked `provisional`.
 - Spec exists or is intentionally reused.
 - Blueprint exists and `validate_blueprint_contract` passed.
 - Human-readable task plan includes scope metadata and coverage.
-- The command stops with a clear execution handoff.
+- DEEP mode: architecture review (Step 4.5) ran and any CRITICAL findings were resolved before decomposition.
+- LIGHT mode: decomposition produced 2–5 minimal subtasks.
+- The command stops with a clear execution handoff that names the active mode.

--- a/src/mapify_cli/templates/codex/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-plan/SKILL.md
@@ -22,6 +22,21 @@ description: "ARCHITECT phase - decompose complex tasks into atomic subtasks wit
 
 ---
 
+## Pre-flight: Mode Detection
+
+Read `$ARGUMENTS` for mode flags **before any other action**. Strip detected flags from `$ARGUMENTS` before using the remainder as the task description.
+
+| Flag | Mode | Effect |
+|------|------|--------|
+| `--light` | LIGHT | Spec-only, no research. **Skip** Step 0, Step 0.5 (Already-Implemented Gate), and Step 2b (Devil's Advocate Review). Limit decomposition to 2–5 minimal subtasks. Fastest plan mode — use when scope is small and well-understood. |
+| `--deep` | DEEP | Full research + architecture review. Add extended research sweep **before** Step 0 and an architecture review step **after** Step 3. Use when scope is large or risk is high. |
+| `--force-full` | DEEP alias | Identical to `--deep`. Overrides any scale auto-advisory toward maximum planning depth. |
+| `--force-fast` | FAST exit | Recommend `$map-fast` and STOP. Use when the task is clearly trivial and MAP planning overhead is not warranted. |
+
+If **no flag** is present (standard mode), run all steps as written. The Scale Advisory in the Workflow-Fit Gate may suggest a mode when scope is clear from the task description.
+
+---
+
 ## Pre-flight: Resume Detection
 
 Before any step, detect which artifacts already exist AND whether the request matches the existing plan's goal:
@@ -83,9 +98,34 @@ shell_command:
 - Outcome `map-fast`: recommend `$map-fast` and STOP.
 - Outcome `map-plan`: continue below.
 
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, run:
+
+```
+shell_command:
+  cmd: |
+    python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pathlib import Path
+from mapify_cli.config.project_config import load_map_config
+cfg = load_map_config(Path('.'))
+print('scale_auto:', cfg.scale_auto)
+print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
+print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
+"
+```
+
+If `scale_auto: true`, use your estimate of the task scope to surface an advisory (do not block):
+- Estimated ≤ small thresholds → advise re-invoking as `$map-plan --light`.
+- Estimated > medium thresholds → advise re-invoking as `$map-plan --deep`.
+- Otherwise (medium range) → no advisory; standard mode is appropriate.
+
 ---
 
-## Step 0: Quick Discovery (Optional but Recommended)
+## Step 0: Quick Discovery (Optional but Recommended; SKIP in LIGHT mode)
+
+**LIGHT mode:** Skip this step entirely — proceed directly to Step 1. The spec is written from stated requirements without a prior research phase.
+
+**DEEP mode:** Before this step, run an extended research sweep (full codebase exploration, dependency and hotspot analysis). Dispatch a researcher with a wider scope than the standard Step 0 prompt below; cover recent-change hotspots, dependency graph, existing test coverage gaps, and architectural friction points. Save findings to `.map/$BRANCH/research/plan__deep_discovery.md` in addition to the standard `plan__discovery.md`.
 
 Skip if `.map/<branch>/research/plan__discovery.md` already exists AND contains an `Already Implemented` section (resume rule above), or if the task is greenfield with a fully-provided spec. If the canonical file is absent but legacy `.map/<branch>/findings_<branch>.md` exists, read it as a fallback and migrate it to the canonical research path only if it has the required section. If an existing discovery file predates this format (no `Already Implemented` section), re-run discovery so the Step 0.5 gate has its evidence.
 
@@ -143,7 +183,9 @@ DISCOVERY_EOF
 
 ---
 
-## Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)
+## Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step — no discovery was run, so there is no evidence base for the gate. Surface any overlap during spec writing.
 
 Reconcile the request against the discovery `Already Implemented` section BEFORE interview/spec. Do not plan work the codebase already does. If discovery was skipped (greenfield or fully-provided spec), state the gate was skipped and why. If the findings file lacks an `Already Implemented` section (it predates this format), re-run Step 0 first — do NOT run the gate on incomplete evidence.
 
@@ -312,9 +354,11 @@ Populate from user requirements and discovery findings:
 
 ---
 
-## Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+## Step 2b: Devil's Advocate Review (SPEC_REVIEW; always SKIP in LIGHT mode)
 
-**Skip if ALL true:**
+> **LIGHT mode:** Skip this step unconditionally.
+
+**Skip if ALL true (standard/DEEP mode):**
 - Source spec is under 200 lines
 - Fewer than 5 subtasks expected
 - No cross-cutting concerns (observability, security, concurrency, multi-service)
@@ -386,6 +430,45 @@ Format: `A -[relationship]-> B` (arrow notation). Keep under 200 tokens — only
 
 ---
 
+## Step 3.5: Architecture Review (DEEP mode only)
+
+> **Standard / LIGHT mode:** Skip this step.
+
+Before decomposition, dispatch a monitor agent to review the spec and discovery findings for architecture concerns: component boundary clarity, dependency direction violations, state ownership ambiguity, untestable seams, and conflicts with `docs/ARCHITECTURE.md`.
+
+```
+spawn_agent(
+  agent_type="monitor",
+  message="""You are reviewing a SPECIFICATION for architecture quality (not code). DEEP mode.
+
+Read the spec at: .map/<branch>/spec_<branch>.md
+Read deep discovery at: .map/<branch>/research/plan__deep_discovery.md (if present)
+(Use shell_command to cat both files.)
+
+Check for:
+1. Component boundary clarity — are module/service responsibilities well-defined and non-overlapping?
+2. Dependency direction — does the proposed flow violate layering or create circular dependencies?
+3. State ownership — is shared mutable state owned by exactly one component?
+4. Untestable seams — are there coupling points that make unit testing impractical?
+5. Architecture conflicts — does this design contradict decisions in docs/ARCHITECTURE.md?
+
+Output per finding:
+  SEVERITY: CRITICAL | HIGH | MEDIUM
+  CATEGORY: [boundary|dependency|state|testability|architecture-conflict]
+  DESCRIPTION: [what the issue is, citing the spec section]
+  RECOMMENDATION: [how to resolve]
+
+If no CRITICAL or HIGH findings: output "ARCHITECTURE APPROVED" at the end.
+"""
+)
+```
+
+- `ARCHITECTURE APPROVED` (no CRITICAL/HIGH findings): proceed to Step 4.
+- CRITICAL or HIGH findings: present them and update the spec before decomposition.
+- Add unresolved risks to spec Open Questions.
+
+---
+
 ## Step 4: Call Task Decomposer
 
 ```
@@ -422,6 +505,7 @@ Output requirements per subtask:
 
 Target subtask size: completable within ~4000 tokens (SFT comfort zone).
 Aim for 3-7 subtasks; flag if more than 10 are needed.
+LIGHT mode: target 2-5 minimal bite-sized subtasks; prefer merging related concerns over splitting.
 
 Coverage requirements:
 - Do NOT create subtasks for behavior listed under the spec's "Out of Scope > Already Implemented" subsection — that work already exists. Plan only the remaining gap.
@@ -649,6 +733,7 @@ shell_command:
     echo "[ok] Coverage check passed"
     echo "[ok] Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md"
     echo "[ok] artifact_manifest.json updated"
+    echo "[ok] Mode: [standard | light | deep]"
     echo ""
     echo "Next steps:"
     echo "  1. Review .map/${BRANCH}/task_plan_${BRANCH}.md"

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -48,6 +48,19 @@ parallel_tool_policy: discovery_only
 
 ## Workflow Steps
 
+### Pre-flight: Mode Detection
+
+Read `$ARGUMENTS` for mode flags **before any other action**. Strip detected flags from `$ARGUMENTS` before using the remainder as the task description.
+
+| Flag | Mode | Effect |
+|------|------|--------|
+| `--light` | LIGHT | Spec-only, no research. **Skip** Step 0, Step 0.5 (Always-Implemented Gate), and Step 2b (Devil's Advocate Review). Limit decomposition to 2–5 minimal subtasks. Fastest plan mode — use when scope is small and well-understood. |
+| `--deep` | DEEP | Full research + architecture review. Add extended research sweep **before** Step 0 and an architecture review step **after** Step 4. Use when scope is large or risk is high. |
+| `--force-full` | DEEP alias | Identical to `--deep`. Overrides any scale auto-advisory toward maximum planning depth. |
+| `--force-fast` | FAST exit | Recommend `/map-fast` and STOP. Use when the task is clearly trivial and MAP planning overhead is not warranted. |
+
+If **no flag** is present (standard mode), run all steps as written. The Scale Advisory in the Workflow-Fit Gate may suggest a mode when scope is clear from the task description.
+
 ### Pre-flight: Resume Detection
 
 ```bash
@@ -107,7 +120,35 @@ Outcomes:
 - `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
-### Step 0: Quick Discovery (Optional but Recommended)
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, query the project's scale-adaptive config:
+
+```bash
+python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pathlib import Path
+from mapify_cli.config.project_config import load_map_config
+cfg = load_map_config(Path('.'))
+print('scale_auto:', cfg.scale_auto)
+print('trivial:', cfg.scale_trivial_max_files, cfg.scale_trivial_max_lines)
+print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
+print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
+"
+```
+
+If `scale_auto: true`, use your estimate of the task's scope to surface an advisory (do not block on this):
+
+- Estimated ≤ trivial thresholds → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
+- Estimated ≤ small thresholds → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
+- Estimated > medium thresholds → advise re-invoking as `/map-plan --deep` for full research + architecture review.
+- Otherwise (medium range) → no advisory; standard mode is appropriate.
+
+The advisory is informational — the user's flags or your judgment prevail. If the user accepts, add the flag and restart; otherwise continue in standard mode.
+
+### Step 0: Quick Discovery (Optional but Recommended; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step entirely — proceed directly to Step 1. The spec is written from the stated requirements without a prior research phase.
+>
+> **DEEP mode:** Before this step, run an extended research sweep (SOFA search if available, full codebase exploration, dependency and hotspot analysis). Dispatch a research-agent with a wider scope than the standard Step 0 prompt below; cover recent-change hotspots, dependency graph, existing test coverage gaps, and architectural friction points. Save findings to `.map/$BRANCH/research/plan__deep_discovery.md` in addition to the standard `plan__discovery.md`. Then continue with Step 0 as written.
 
 Use `.map/<branch>/research/plan__discovery.md` as the canonical plan-scope discovery artifact. If it exists, read it and skip discovery — but ONLY if it contains an `Already Implemented` section (the format this skill now requires). If the canonical file is absent but legacy `.map/<branch>/findings_<branch>.md` exists, read that fallback and migrate it to the canonical path with `save_research "$BRANCH" plan discovery` only if it has the required section. A discovery file written before this format existed lacks that section; in that case re-run discovery with the prompt below so the Step 0.5 gate has the evidence it requires. Otherwise (no discovery file at all) run discovery to find relevant files, existing patterns, risks, and confirmed new files.
 
@@ -138,7 +179,9 @@ if [ ! -f ".map/$BRANCH/research/plan__discovery.md" ]; then
 fi
 ```
 
-### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)
+### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step — no discovery was run, so there is no evidence base for the gate. Rely on the user's statement that the feature is new; if you discover overlap during spec writing, surface it there.
 
 Before interviewing or writing the spec, reconcile the request against the discovery `Already Implemented` section. Do not plan work the codebase already does. This gate runs whenever Step 0 produced findings; if discovery was intentionally skipped (greenfield or fully-provided spec), state that the gate was skipped and why. If the findings file lacks an `Already Implemented` section (it predates this format), do NOT run the gate on incomplete evidence — re-run Step 0 discovery first.
 
@@ -199,7 +242,9 @@ python3 .map/scripts/validate_spec_citations.py --branch "$BRANCH"
 - Exit 1 + `"failures": [...]` with `status` in `{stale-citation, error}` → fix the spec (correct the line number, update the symbol name, or remove the citation) and re-run. Do NOT proceed to decomposition with red failures.
 - Exit 2 → invocation error (missing branch / spec file); fix invocation, do not skip.
 
-### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+### Step 2b: Devil's Advocate Review (SPEC_REVIEW; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step. The spec is written from well-understood requirements; a lightweight self-review of the open-questions list and acceptance criteria suffices before decomposition.
 
 Run Monitor as a spec reviewer before decomposition.
 
@@ -236,6 +281,35 @@ mkdir -p ".map/${BRANCH}"
 
 Add an architecture graph to the spec or plan when the implementation has multiple components, state boundaries, or dependencies. See [plan-reference.md](plan-reference.md#architecture-graph) for examples.
 
+### Step 4.5: Architecture Review (DEEP mode only)
+
+> **DEEP mode:** Before decomposition, dispatch Monitor as an architecture reviewer over the spec + deep discovery findings. Focus on component boundaries, dependency flow, state ownership, testability, and whether the proposed approach is consistent with the existing architecture documented in `docs/ARCHITECTURE.md`.
+
+```text
+Task(
+  subagent_type="monitor",
+  description="Architecture review before decomposition (DEEP mode)",
+  prompt="""
+<documents>
+  <document source="spec"><document_content>{spec_content}</document_content></document>
+  <document source="deep-discovery"><document_content>{deep_discovery_content}</document_content></document>
+</documents>
+<task>
+Review the proposed architecture for: component boundary clarity, dependency direction violations, state ownership ambiguity, untestable seams, and conflicts with the existing system described in docs/ARCHITECTURE.md.
+Evidence first: cite the spec or discovery before each finding.
+CRITICAL findings must identify the exact spec section and the specific risk.
+</task>
+<expected_output>
+Return JSON: {"valid": bool, "findings": [{"severity": "critical|high|medium", "section": "...", "finding": "...", "recommendation": "..."}], "summary": "..."}.
+</expected_output>
+"""
+)
+```
+
+Fix any CRITICAL or HIGH findings before proceeding to Step 5. Add unresolved architecture risks to the spec's Open Questions.
+
+> **Standard / LIGHT mode:** Skip this step.
+
 ### Step 5: Call Task Decomposer
 
 ```text
@@ -258,6 +332,7 @@ Top-level coverage_map must map each acceptance criterion, invariant, and cross-
 Top-level hard_constraints are non-negotiable: every hard_constraints id must appear in coverage_map and bracketed validation_criteria.
 Top-level soft_constraints are negotiable only with coverage or tradeoff_rationale.
 Do NOT create subtasks for behavior listed under the spec's "Out of Scope > Already Implemented" subsection; that work already exists in the codebase. Plan only the remaining gap.
+LIGHT mode: target 2–5 minimal, bite-sized subtasks. Prefer merging related concerns into one subtask rather than splitting them. Do not over-decompose well-understood small tasks.
 </constraints>
 <expected_output>Return only blueprint JSON.</expected_output>
 """
@@ -363,8 +438,11 @@ PLAN COMPLETE
 Spec: .map/<branch>/spec_<branch>.md
 Blueprint: .map/<branch>/blueprint.json
 Task plan: .map/<branch>/task_plan_<branch>.md
+Mode: [standard | light | deep]
 Next: /map-efficient or /map-task for a selected subtask
 ```
+
+Include the active mode (`light` / `deep` / `standard`) so the operator knows which steps ran.
 
 ### Step 8.5: Execution Handoff Note
 
@@ -385,6 +463,9 @@ Detailed rationale moved to [plan-reference.md](plan-reference.md#design-rationa
 - `/map-check`: verify completion.
 - `/map-review`: review the diff.
 - `/map-learn`: preserve reusable learnings.
+- `/map-plan --light`: spec-only mode, no research, 2–5 minimal subtasks (small, well-understood tasks).
+- `/map-plan --deep`: full research + architecture review mode (large or risky tasks). Also `--force-full`.
+- `/map-plan --force-fast`: skip planning; recommend `/map-fast` and stop.
 
 ## State Machine Integration
 
@@ -404,10 +485,13 @@ See [plan-reference.md](plan-reference.md#troubleshooting) for stale artifacts, 
 
 ## Success Criteria
 
+- Mode flags detected and stripped from `$ARGUMENTS` before use.
 - Workflow-fit decision recorded.
-- Already-implemented gate ran (or was explicitly skipped with a reason): whole-feature duplicates off-ramped, partial duplicates moved to spec "Out of Scope > Already Implemented".
+- Already-implemented gate ran (or was explicitly skipped with a reason): whole-feature duplicates off-ramped, partial duplicates moved to spec "Out of Scope > Already Implemented". (LIGHT mode: gate explicitly skipped — noted in checkpoint.)
 - Live/runtime-state gate ran when `depends_on_runtime_state=true`: each runtime assumption was verified read-only, or recorded as an `Unverified Runtime Assumption` (Open Questions / Risks) with the exact check to run and dependent subtasks marked `provisional`.
 - Spec exists or is intentionally reused.
 - Blueprint exists and `validate_blueprint_contract` passed.
 - Human-readable task plan includes scope metadata and coverage.
-- The command stops with a clear execution handoff.
+- DEEP mode: architecture review (Step 4.5) ran and any CRITICAL findings were resolved before decomposition.
+- LIGHT mode: decomposition produced 2–5 minimal subtasks.
+- The command stops with a clear execution handoff that names the active mode.

--- a/src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja
@@ -22,6 +22,21 @@ description: "ARCHITECT phase - decompose complex tasks into atomic subtasks wit
 
 ---
 
+## Pre-flight: Mode Detection
+
+Read `$ARGUMENTS` for mode flags **before any other action**. Strip detected flags from `$ARGUMENTS` before using the remainder as the task description.
+
+| Flag | Mode | Effect |
+|------|------|--------|
+| `--light` | LIGHT | Spec-only, no research. **Skip** Step 0, Step 0.5 (Already-Implemented Gate), and Step 2b (Devil's Advocate Review). Limit decomposition to 2–5 minimal subtasks. Fastest plan mode — use when scope is small and well-understood. |
+| `--deep` | DEEP | Full research + architecture review. Add extended research sweep **before** Step 0 and an architecture review step **after** Step 3. Use when scope is large or risk is high. |
+| `--force-full` | DEEP alias | Identical to `--deep`. Overrides any scale auto-advisory toward maximum planning depth. |
+| `--force-fast` | FAST exit | Recommend `$map-fast` and STOP. Use when the task is clearly trivial and MAP planning overhead is not warranted. |
+
+If **no flag** is present (standard mode), run all steps as written. The Scale Advisory in the Workflow-Fit Gate may suggest a mode when scope is clear from the task description.
+
+---
+
 ## Pre-flight: Resume Detection
 
 Before any step, detect which artifacts already exist AND whether the request matches the existing plan's goal:
@@ -83,9 +98,34 @@ shell_command:
 - Outcome `map-fast`: recommend `$map-fast` and STOP.
 - Outcome `map-plan`: continue below.
 
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, run:
+
+```
+shell_command:
+  cmd: |
+    python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pathlib import Path
+from mapify_cli.config.project_config import load_map_config
+cfg = load_map_config(Path('.'))
+print('scale_auto:', cfg.scale_auto)
+print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
+print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
+"
+```
+
+If `scale_auto: true`, use your estimate of the task scope to surface an advisory (do not block):
+- Estimated ≤ small thresholds → advise re-invoking as `$map-plan --light`.
+- Estimated > medium thresholds → advise re-invoking as `$map-plan --deep`.
+- Otherwise (medium range) → no advisory; standard mode is appropriate.
+
 ---
 
-## Step 0: Quick Discovery (Optional but Recommended)
+## Step 0: Quick Discovery (Optional but Recommended; SKIP in LIGHT mode)
+
+**LIGHT mode:** Skip this step entirely — proceed directly to Step 1. The spec is written from stated requirements without a prior research phase.
+
+**DEEP mode:** Before this step, run an extended research sweep (full codebase exploration, dependency and hotspot analysis). Dispatch a researcher with a wider scope than the standard Step 0 prompt below; cover recent-change hotspots, dependency graph, existing test coverage gaps, and architectural friction points. Save findings to `.map/$BRANCH/research/plan__deep_discovery.md` in addition to the standard `plan__discovery.md`.
 
 Skip if `.map/<branch>/research/plan__discovery.md` already exists AND contains an `Already Implemented` section (resume rule above), or if the task is greenfield with a fully-provided spec. If the canonical file is absent but legacy `.map/<branch>/findings_<branch>.md` exists, read it as a fallback and migrate it to the canonical research path only if it has the required section. If an existing discovery file predates this format (no `Already Implemented` section), re-run discovery so the Step 0.5 gate has its evidence.
 
@@ -143,7 +183,9 @@ DISCOVERY_EOF
 
 ---
 
-## Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)
+## Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step — no discovery was run, so there is no evidence base for the gate. Surface any overlap during spec writing.
 
 Reconcile the request against the discovery `Already Implemented` section BEFORE interview/spec. Do not plan work the codebase already does. If discovery was skipped (greenfield or fully-provided spec), state the gate was skipped and why. If the findings file lacks an `Already Implemented` section (it predates this format), re-run Step 0 first — do NOT run the gate on incomplete evidence.
 
@@ -312,9 +354,11 @@ Populate from user requirements and discovery findings:
 
 ---
 
-## Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+## Step 2b: Devil's Advocate Review (SPEC_REVIEW; always SKIP in LIGHT mode)
 
-**Skip if ALL true:**
+> **LIGHT mode:** Skip this step unconditionally.
+
+**Skip if ALL true (standard/DEEP mode):**
 - Source spec is under 200 lines
 - Fewer than 5 subtasks expected
 - No cross-cutting concerns (observability, security, concurrency, multi-service)
@@ -386,6 +430,45 @@ Format: `A -[relationship]-> B` (arrow notation). Keep under 200 tokens — only
 
 ---
 
+## Step 3.5: Architecture Review (DEEP mode only)
+
+> **Standard / LIGHT mode:** Skip this step.
+
+Before decomposition, dispatch a monitor agent to review the spec and discovery findings for architecture concerns: component boundary clarity, dependency direction violations, state ownership ambiguity, untestable seams, and conflicts with `docs/ARCHITECTURE.md`.
+
+```
+spawn_agent(
+  agent_type="monitor",
+  message="""You are reviewing a SPECIFICATION for architecture quality (not code). DEEP mode.
+
+Read the spec at: .map/<branch>/spec_<branch>.md
+Read deep discovery at: .map/<branch>/research/plan__deep_discovery.md (if present)
+(Use shell_command to cat both files.)
+
+Check for:
+1. Component boundary clarity — are module/service responsibilities well-defined and non-overlapping?
+2. Dependency direction — does the proposed flow violate layering or create circular dependencies?
+3. State ownership — is shared mutable state owned by exactly one component?
+4. Untestable seams — are there coupling points that make unit testing impractical?
+5. Architecture conflicts — does this design contradict decisions in docs/ARCHITECTURE.md?
+
+Output per finding:
+  SEVERITY: CRITICAL | HIGH | MEDIUM
+  CATEGORY: [boundary|dependency|state|testability|architecture-conflict]
+  DESCRIPTION: [what the issue is, citing the spec section]
+  RECOMMENDATION: [how to resolve]
+
+If no CRITICAL or HIGH findings: output "ARCHITECTURE APPROVED" at the end.
+"""
+)
+```
+
+- `ARCHITECTURE APPROVED` (no CRITICAL/HIGH findings): proceed to Step 4.
+- CRITICAL or HIGH findings: present them and update the spec before decomposition.
+- Add unresolved risks to spec Open Questions.
+
+---
+
 ## Step 4: Call Task Decomposer
 
 ```
@@ -422,6 +505,7 @@ Output requirements per subtask:
 
 Target subtask size: completable within ~4000 tokens (SFT comfort zone).
 Aim for 3-7 subtasks; flag if more than 10 are needed.
+LIGHT mode: target 2-5 minimal bite-sized subtasks; prefer merging related concerns over splitting.
 
 Coverage requirements:
 - Do NOT create subtasks for behavior listed under the spec's "Out of Scope > Already Implemented" subsection — that work already exists. Plan only the remaining gap.
@@ -649,6 +733,7 @@ shell_command:
     echo "[ok] Coverage check passed"
     echo "[ok] Plan written to .map/${BRANCH}/task_plan_${BRANCH}.md"
     echo "[ok] artifact_manifest.json updated"
+    echo "[ok] Mode: [standard | light | deep]"
     echo ""
     echo "Next steps:"
     echo "  1. Review .map/${BRANCH}/task_plan_${BRANCH}.md"

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -48,6 +48,19 @@ parallel_tool_policy: discovery_only
 
 ## Workflow Steps
 
+### Pre-flight: Mode Detection
+
+Read `$ARGUMENTS` for mode flags **before any other action**. Strip detected flags from `$ARGUMENTS` before using the remainder as the task description.
+
+| Flag | Mode | Effect |
+|------|------|--------|
+| `--light` | LIGHT | Spec-only, no research. **Skip** Step 0, Step 0.5 (Always-Implemented Gate), and Step 2b (Devil's Advocate Review). Limit decomposition to 2–5 minimal subtasks. Fastest plan mode — use when scope is small and well-understood. |
+| `--deep` | DEEP | Full research + architecture review. Add extended research sweep **before** Step 0 and an architecture review step **after** Step 4. Use when scope is large or risk is high. |
+| `--force-full` | DEEP alias | Identical to `--deep`. Overrides any scale auto-advisory toward maximum planning depth. |
+| `--force-fast` | FAST exit | Recommend `/map-fast` and STOP. Use when the task is clearly trivial and MAP planning overhead is not warranted. |
+
+If **no flag** is present (standard mode), run all steps as written. The Scale Advisory in the Workflow-Fit Gate may suggest a mode when scope is clear from the task description.
+
 ### Pre-flight: Resume Detection
 
 ```bash
@@ -107,7 +120,35 @@ Outcomes:
 - `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
-### Step 0: Quick Discovery (Optional but Recommended)
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, query the project's scale-adaptive config:
+
+```bash
+python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pathlib import Path
+from mapify_cli.config.project_config import load_map_config
+cfg = load_map_config(Path('.'))
+print('scale_auto:', cfg.scale_auto)
+print('trivial:', cfg.scale_trivial_max_files, cfg.scale_trivial_max_lines)
+print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
+print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
+"
+```
+
+If `scale_auto: true`, use your estimate of the task's scope to surface an advisory (do not block on this):
+
+- Estimated ≤ trivial thresholds → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
+- Estimated ≤ small thresholds → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
+- Estimated > medium thresholds → advise re-invoking as `/map-plan --deep` for full research + architecture review.
+- Otherwise (medium range) → no advisory; standard mode is appropriate.
+
+The advisory is informational — the user's flags or your judgment prevail. If the user accepts, add the flag and restart; otherwise continue in standard mode.
+
+### Step 0: Quick Discovery (Optional but Recommended; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step entirely — proceed directly to Step 1. The spec is written from the stated requirements without a prior research phase.
+>
+> **DEEP mode:** Before this step, run an extended research sweep (SOFA search if available, full codebase exploration, dependency and hotspot analysis). Dispatch a research-agent with a wider scope than the standard Step 0 prompt below; cover recent-change hotspots, dependency graph, existing test coverage gaps, and architectural friction points. Save findings to `.map/$BRANCH/research/plan__deep_discovery.md` in addition to the standard `plan__discovery.md`. Then continue with Step 0 as written.
 
 Use `.map/<branch>/research/plan__discovery.md` as the canonical plan-scope discovery artifact. If it exists, read it and skip discovery — but ONLY if it contains an `Already Implemented` section (the format this skill now requires). If the canonical file is absent but legacy `.map/<branch>/findings_<branch>.md` exists, read that fallback and migrate it to the canonical path with `save_research "$BRANCH" plan discovery` only if it has the required section. A discovery file written before this format existed lacks that section; in that case re-run discovery with the prompt below so the Step 0.5 gate has the evidence it requires. Otherwise (no discovery file at all) run discovery to find relevant files, existing patterns, risks, and confirmed new files.
 
@@ -138,7 +179,9 @@ if [ ! -f ".map/$BRANCH/research/plan__discovery.md" ]; then
 fi
 ```
 
-### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran)
+### Step 0.5: Already-Implemented Gate (MANDATORY when discovery ran; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step — no discovery was run, so there is no evidence base for the gate. Rely on the user's statement that the feature is new; if you discover overlap during spec writing, surface it there.
 
 Before interviewing or writing the spec, reconcile the request against the discovery `Already Implemented` section. Do not plan work the codebase already does. This gate runs whenever Step 0 produced findings; if discovery was intentionally skipped (greenfield or fully-provided spec), state that the gate was skipped and why. If the findings file lacks an `Already Implemented` section (it predates this format), do NOT run the gate on incomplete evidence — re-run Step 0 discovery first.
 
@@ -199,7 +242,9 @@ python3 .map/scripts/validate_spec_citations.py --branch "$BRANCH"
 - Exit 1 + `"failures": [...]` with `status` in `{stale-citation, error}` → fix the spec (correct the line number, update the symbol name, or remove the citation) and re-run. Do NOT proceed to decomposition with red failures.
 - Exit 2 → invocation error (missing branch / spec file); fix invocation, do not skip.
 
-### Step 2b: Devil's Advocate Review (SPEC_REVIEW)
+### Step 2b: Devil's Advocate Review (SPEC_REVIEW; SKIP in LIGHT mode)
+
+> **LIGHT mode:** Skip this step. The spec is written from well-understood requirements; a lightweight self-review of the open-questions list and acceptance criteria suffices before decomposition.
 
 Run Monitor as a spec reviewer before decomposition.
 
@@ -236,6 +281,35 @@ mkdir -p ".map/${BRANCH}"
 
 Add an architecture graph to the spec or plan when the implementation has multiple components, state boundaries, or dependencies. See [plan-reference.md](plan-reference.md#architecture-graph) for examples.
 
+### Step 4.5: Architecture Review (DEEP mode only)
+
+> **DEEP mode:** Before decomposition, dispatch Monitor as an architecture reviewer over the spec + deep discovery findings. Focus on component boundaries, dependency flow, state ownership, testability, and whether the proposed approach is consistent with the existing architecture documented in `docs/ARCHITECTURE.md`.
+
+```text
+Task(
+  subagent_type="monitor",
+  description="Architecture review before decomposition (DEEP mode)",
+  prompt="""
+<documents>
+  <document source="spec"><document_content>{spec_content}</document_content></document>
+  <document source="deep-discovery"><document_content>{deep_discovery_content}</document_content></document>
+</documents>
+<task>
+Review the proposed architecture for: component boundary clarity, dependency direction violations, state ownership ambiguity, untestable seams, and conflicts with the existing system described in docs/ARCHITECTURE.md.
+Evidence first: cite the spec or discovery before each finding.
+CRITICAL findings must identify the exact spec section and the specific risk.
+</task>
+<expected_output>
+Return JSON: {"valid": bool, "findings": [{"severity": "critical|high|medium", "section": "...", "finding": "...", "recommendation": "..."}], "summary": "..."}.
+</expected_output>
+"""
+)
+```
+
+Fix any CRITICAL or HIGH findings before proceeding to Step 5. Add unresolved architecture risks to the spec's Open Questions.
+
+> **Standard / LIGHT mode:** Skip this step.
+
 ### Step 5: Call Task Decomposer
 
 ```text
@@ -258,6 +332,7 @@ Top-level coverage_map must map each acceptance criterion, invariant, and cross-
 Top-level hard_constraints are non-negotiable: every hard_constraints id must appear in coverage_map and bracketed validation_criteria.
 Top-level soft_constraints are negotiable only with coverage or tradeoff_rationale.
 Do NOT create subtasks for behavior listed under the spec's "Out of Scope > Already Implemented" subsection; that work already exists in the codebase. Plan only the remaining gap.
+LIGHT mode: target 2–5 minimal, bite-sized subtasks. Prefer merging related concerns into one subtask rather than splitting them. Do not over-decompose well-understood small tasks.
 </constraints>
 <expected_output>Return only blueprint JSON.</expected_output>
 """
@@ -363,8 +438,11 @@ PLAN COMPLETE
 Spec: .map/<branch>/spec_<branch>.md
 Blueprint: .map/<branch>/blueprint.json
 Task plan: .map/<branch>/task_plan_<branch>.md
+Mode: [standard | light | deep]
 Next: /map-efficient or /map-task for a selected subtask
 ```
+
+Include the active mode (`light` / `deep` / `standard`) so the operator knows which steps ran.
 
 ### Step 8.5: Execution Handoff Note
 
@@ -385,6 +463,9 @@ Detailed rationale moved to [plan-reference.md](plan-reference.md#design-rationa
 - `/map-check`: verify completion.
 - `/map-review`: review the diff.
 - `/map-learn`: preserve reusable learnings.
+- `/map-plan --light`: spec-only mode, no research, 2–5 minimal subtasks (small, well-understood tasks).
+- `/map-plan --deep`: full research + architecture review mode (large or risky tasks). Also `--force-full`.
+- `/map-plan --force-fast`: skip planning; recommend `/map-fast` and stop.
 
 ## State Machine Integration
 
@@ -404,10 +485,13 @@ See [plan-reference.md](plan-reference.md#troubleshooting) for stale artifacts, 
 
 ## Success Criteria
 
+- Mode flags detected and stripped from `$ARGUMENTS` before use.
 - Workflow-fit decision recorded.
-- Already-implemented gate ran (or was explicitly skipped with a reason): whole-feature duplicates off-ramped, partial duplicates moved to spec "Out of Scope > Already Implemented".
+- Already-implemented gate ran (or was explicitly skipped with a reason): whole-feature duplicates off-ramped, partial duplicates moved to spec "Out of Scope > Already Implemented". (LIGHT mode: gate explicitly skipped — noted in checkpoint.)
 - Live/runtime-state gate ran when `depends_on_runtime_state=true`: each runtime assumption was verified read-only, or recorded as an `Unverified Runtime Assumption` (Open Questions / Risks) with the exact check to run and dependent subtasks marked `provisional`.
 - Spec exists or is intentionally reused.
 - Blueprint exists and `validate_blueprint_contract` passed.
 - Human-readable task plan includes scope metadata and coverage.
-- The command stops with a clear execution handoff.
+- DEEP mode: architecture review (Step 4.5) ran and any CRITICAL findings were resolved before decomposition.
+- LIGHT mode: decomposition produced 2–5 minimal subtasks.
+- The command stops with a clear execution handoff that names the active mode.


### PR DESCRIPTION
## Summary

Ports the `--light`/`--deep`/`--force-full`/`--force-fast` mode flags from the Claude variant of the `map-plan` skill to the Codex (`spawn_agent`) variant, completing slice 2 of issue #287 (scale-adaptive intelligence).

### Changes

- **`src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja`** — Codex Jinja source: adds Pre-flight Mode Detection section, Scale Advisory block using `shell_command` syntax, LIGHT/DEEP mode annotations in Steps 0/0.5/2b, new Step 3.5 Architecture Review (DEEP mode only) using `spawn_agent(agent_type="monitor")`, LIGHT mode constraint in decomposer call, mode indicator in Step 8 checkpoint
- **`.agents/skills/map-plan/SKILL.md`** — rendered Codex dev tree output
- **`src/mapify_cli/templates/codex/skills/map-plan/SKILL.md`** — rendered template output for Codex provider

The previous commit (`c79170c`) covered the same changes for the Claude variant (`.claude/skills/map-plan/SKILL.md`).

### Verification

- `make check-render` passes (rendered trees match source)
- All 120 tests in `test_scope_classifier.py` and `test_template_render.py` pass
- No Claude-specific API tokens (`subagent_type=`, `Task(`, `AskUserQuestion`) present in Codex output paths

Closes part of #287.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jmbBkJwJByEJGXFAihgh8)_