### PR TITLE
feat(#287): classify_scope.py entry-point script and Scale Advisory fix

### DIFF
--- a/.agents/skills/map-plan/SKILL.md
+++ b/.agents/skills/map-plan/SKILL.md
@@ -98,26 +98,18 @@ shell_command:
 - Outcome `map-fast`: recommend `$map-fast` and STOP.
 - Outcome `map-plan`: continue below.
 
-**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, run:
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, estimate the task scope and run:
 
 ```
 shell_command:
-  cmd: |
-    python3 -c "
-import sys; sys.path.insert(0, 'src')
-from pathlib import Path
-from mapify_cli.config.project_config import load_map_config
-cfg = load_map_config(Path('.'))
-print('scale_auto:', cfg.scale_auto)
-print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
-print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
-"
+  cmd: python3 .map/scripts/classify_scope.py --files ESTIMATED_FILES --lines ESTIMATED_LINES
 ```
 
-If `scale_auto: true`, use your estimate of the task scope to surface an advisory (do not block):
-- Estimated ≤ small thresholds → advise re-invoking as `$map-plan --light`.
-- Estimated > medium thresholds → advise re-invoking as `$map-plan --deep`.
-- Otherwise (medium range) → no advisory; standard mode is appropriate.
+If `auto_enabled: true` in the JSON result, surface an advisory based on `bracket` (do not block):
+- `small` → advise re-invoking as `$map-plan --light`.
+- `large` → advise re-invoking as `$map-plan --deep`.
+- `trivial` → advise `$map-fast` instead.
+- `medium` → no advisory; standard mode is appropriate.
 
 ---
 

--- a/.claude/skills/map-plan/SKILL.md
+++ b/.claude/skills/map-plan/SKILL.md
@@ -120,27 +120,18 @@ Outcomes:
 - `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
-**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, query the project's scale-adaptive config:
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, estimate the task's scope (files to change, lines to add/modify) and run:
 
 ```bash
-python3 -c "
-import sys; sys.path.insert(0, 'src')
-from pathlib import Path
-from mapify_cli.config.project_config import load_map_config
-cfg = load_map_config(Path('.'))
-print('scale_auto:', cfg.scale_auto)
-print('trivial:', cfg.scale_trivial_max_files, cfg.scale_trivial_max_lines)
-print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
-print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
-"
+python3 .map/scripts/classify_scope.py --files ESTIMATED_FILES --lines ESTIMATED_LINES
 ```
 
-If `scale_auto: true`, use your estimate of the task's scope to surface an advisory (do not block on this):
+If `auto_enabled: true` in the JSON result, surface an advisory based on `bracket` (do not block):
 
-- Estimated ≤ trivial thresholds → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
-- Estimated ≤ small thresholds → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
-- Estimated > medium thresholds → advise re-invoking as `/map-plan --deep` for full research + architecture review.
-- Otherwise (medium range) → no advisory; standard mode is appropriate.
+- `trivial` → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
+- `small` → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
+- `large` → advise re-invoking as `/map-plan --deep` for full research + architecture review.
+- `medium` → no advisory; standard mode is appropriate.
 
 The advisory is informational — the user's flags or your judgment prevail. If the user accepts, add the flag and restart; otherwise continue in standard mode.
 

--- a/.map/scripts/classify_scope.py
+++ b/.map/scripts/classify_scope.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""classify_scope.py — Scale-adaptive scope classifier for MAP workflows (#287).
+
+Reads scale thresholds from .map/config.yaml (dotted-key notation) and
+classifies a change estimate into one of four brackets: trivial, small,
+medium, or large, then returns the recommended MAP workflow depth.
+
+Usage:
+    python3 .map/scripts/classify_scope.py --files 5 --lines 120
+
+Output (JSON, exit 0):
+    {"bracket": "small", "recommended_workflow": "map-plan-light",
+     "estimated_files": 5, "estimated_lines": 120, "auto_enabled": true}
+
+Config keys read from .map/config.yaml (dotted notation):
+    scale.auto                         (default: true)
+    scale.thresholds.trivial.max_files (default: 3)
+    scale.thresholds.trivial.max_lines (default: 50)
+    scale.thresholds.small.max_files   (default: 10)
+    scale.thresholds.small.max_lines   (default: 200)
+    scale.thresholds.medium.max_files  (default: 30)
+    scale.thresholds.medium.max_lines  (default: 1000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+_BRACKET_WORKFLOW: dict[str, str] = {
+    "trivial": "map-fast",
+    "small": "map-plan-light",
+    "medium": "map-efficient",
+    "large": "map-efficient+map-tdd",
+}
+
+_DEFAULTS: dict[str, str] = {
+    "scale.auto": "true",
+    "scale.thresholds.trivial.max_files": "3",
+    "scale.thresholds.trivial.max_lines": "50",
+    "scale.thresholds.small.max_files": "10",
+    "scale.thresholds.small.max_lines": "200",
+    "scale.thresholds.medium.max_files": "30",
+    "scale.thresholds.medium.max_lines": "1000",
+}
+
+
+def _read_config(project_dir: Path) -> dict[str, str]:
+    """Read .map/config.yaml scalar values without external dependencies.
+
+    Supports the same dotted-key YAML subset used by load_map_config().
+    """
+    config_path = project_dir / ".map" / "config.yaml"
+    if not config_path.is_file():
+        return {}
+    try:
+        lines = config_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    values: dict[str, str] = {}
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if not key or not re.fullmatch(r"[A-Za-z0-9_.]+", key):
+            continue
+        value = value.split("#", 1)[0].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def classify(
+    estimated_files: int,
+    estimated_lines: int,
+    project_dir: Path | None = None,
+) -> dict[str, object]:
+    """Classify scope and return a result dict matching ScopeClassification fields."""
+    raw = _read_config(project_dir or Path("."))
+
+    def _int(key: str) -> int:
+        return int(raw.get(key, _DEFAULTS[key]))
+
+    def _bool(key: str) -> bool:
+        return raw.get(key, _DEFAULTS[key]).lower() not in {"false", "0", "no"}
+
+    auto = _bool("scale.auto")
+    trivial_files = _int("scale.thresholds.trivial.max_files")
+    trivial_lines = _int("scale.thresholds.trivial.max_lines")
+    small_files = _int("scale.thresholds.small.max_files")
+    small_lines = _int("scale.thresholds.small.max_lines")
+    medium_files = _int("scale.thresholds.medium.max_files")
+    medium_lines = _int("scale.thresholds.medium.max_lines")
+
+    if estimated_files <= trivial_files and estimated_lines <= trivial_lines:
+        bracket = "trivial"
+    elif estimated_files <= small_files and estimated_lines <= small_lines:
+        bracket = "small"
+    elif estimated_files <= medium_files and estimated_lines <= medium_lines:
+        bracket = "medium"
+    else:
+        bracket = "large"
+
+    return {
+        "bracket": bracket,
+        "recommended_workflow": _BRACKET_WORKFLOW[bracket],
+        "estimated_files": estimated_files,
+        "estimated_lines": estimated_lines,
+        "auto_enabled": auto,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify MAP workflow scope from estimated change size.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--files", type=int, required=True,
+                        help="Estimated number of files to change (>= 0)")
+    parser.add_argument("--lines", type=int, required=True,
+                        help="Estimated lines to add/modify (>= 0)")
+    parser.add_argument("--project-dir", default=".",
+                        help="Project root (default: current directory)")
+    args = parser.parse_args(argv)
+
+    if args.files < 0 or args.lines < 0:
+        print("error: --files and --lines must be >= 0", file=sys.stderr)
+        return 1
+
+    result = classify(args.files, args.lines, Path(args.project_dir))
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mapify_cli/templates/codex/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-plan/SKILL.md
@@ -98,26 +98,18 @@ shell_command:
 - Outcome `map-fast`: recommend `$map-fast` and STOP.
 - Outcome `map-plan`: continue below.
 
-**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, run:
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, estimate the task scope and run:
 
 ```
 shell_command:
-  cmd: |
-    python3 -c "
-import sys; sys.path.insert(0, 'src')
-from pathlib import Path
-from mapify_cli.config.project_config import load_map_config
-cfg = load_map_config(Path('.'))
-print('scale_auto:', cfg.scale_auto)
-print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
-print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
-"
+  cmd: python3 .map/scripts/classify_scope.py --files ESTIMATED_FILES --lines ESTIMATED_LINES
 ```
 
-If `scale_auto: true`, use your estimate of the task scope to surface an advisory (do not block):
-- Estimated ≤ small thresholds → advise re-invoking as `$map-plan --light`.
-- Estimated > medium thresholds → advise re-invoking as `$map-plan --deep`.
-- Otherwise (medium range) → no advisory; standard mode is appropriate.
+If `auto_enabled: true` in the JSON result, surface an advisory based on `bracket` (do not block):
+- `small` → advise re-invoking as `$map-plan --light`.
+- `large` → advise re-invoking as `$map-plan --deep`.
+- `trivial` → advise `$map-fast` instead.
+- `medium` → no advisory; standard mode is appropriate.
 
 ---
 

--- a/src/mapify_cli/templates/map/scripts/classify_scope.py
+++ b/src/mapify_cli/templates/map/scripts/classify_scope.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""classify_scope.py — Scale-adaptive scope classifier for MAP workflows (#287).
+
+Reads scale thresholds from .map/config.yaml (dotted-key notation) and
+classifies a change estimate into one of four brackets: trivial, small,
+medium, or large, then returns the recommended MAP workflow depth.
+
+Usage:
+    python3 .map/scripts/classify_scope.py --files 5 --lines 120
+
+Output (JSON, exit 0):
+    {"bracket": "small", "recommended_workflow": "map-plan-light",
+     "estimated_files": 5, "estimated_lines": 120, "auto_enabled": true}
+
+Config keys read from .map/config.yaml (dotted notation):
+    scale.auto                         (default: true)
+    scale.thresholds.trivial.max_files (default: 3)
+    scale.thresholds.trivial.max_lines (default: 50)
+    scale.thresholds.small.max_files   (default: 10)
+    scale.thresholds.small.max_lines   (default: 200)
+    scale.thresholds.medium.max_files  (default: 30)
+    scale.thresholds.medium.max_lines  (default: 1000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+_BRACKET_WORKFLOW: dict[str, str] = {
+    "trivial": "map-fast",
+    "small": "map-plan-light",
+    "medium": "map-efficient",
+    "large": "map-efficient+map-tdd",
+}
+
+_DEFAULTS: dict[str, str] = {
+    "scale.auto": "true",
+    "scale.thresholds.trivial.max_files": "3",
+    "scale.thresholds.trivial.max_lines": "50",
+    "scale.thresholds.small.max_files": "10",
+    "scale.thresholds.small.max_lines": "200",
+    "scale.thresholds.medium.max_files": "30",
+    "scale.thresholds.medium.max_lines": "1000",
+}
+
+
+def _read_config(project_dir: Path) -> dict[str, str]:
+    """Read .map/config.yaml scalar values without external dependencies.
+
+    Supports the same dotted-key YAML subset used by load_map_config().
+    """
+    config_path = project_dir / ".map" / "config.yaml"
+    if not config_path.is_file():
+        return {}
+    try:
+        lines = config_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    values: dict[str, str] = {}
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if not key or not re.fullmatch(r"[A-Za-z0-9_.]+", key):
+            continue
+        value = value.split("#", 1)[0].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def classify(
+    estimated_files: int,
+    estimated_lines: int,
+    project_dir: Path | None = None,
+) -> dict[str, object]:
+    """Classify scope and return a result dict matching ScopeClassification fields."""
+    raw = _read_config(project_dir or Path("."))
+
+    def _int(key: str) -> int:
+        return int(raw.get(key, _DEFAULTS[key]))
+
+    def _bool(key: str) -> bool:
+        return raw.get(key, _DEFAULTS[key]).lower() not in {"false", "0", "no"}
+
+    auto = _bool("scale.auto")
+    trivial_files = _int("scale.thresholds.trivial.max_files")
+    trivial_lines = _int("scale.thresholds.trivial.max_lines")
+    small_files = _int("scale.thresholds.small.max_files")
+    small_lines = _int("scale.thresholds.small.max_lines")
+    medium_files = _int("scale.thresholds.medium.max_files")
+    medium_lines = _int("scale.thresholds.medium.max_lines")
+
+    if estimated_files <= trivial_files and estimated_lines <= trivial_lines:
+        bracket = "trivial"
+    elif estimated_files <= small_files and estimated_lines <= small_lines:
+        bracket = "small"
+    elif estimated_files <= medium_files and estimated_lines <= medium_lines:
+        bracket = "medium"
+    else:
+        bracket = "large"
+
+    return {
+        "bracket": bracket,
+        "recommended_workflow": _BRACKET_WORKFLOW[bracket],
+        "estimated_files": estimated_files,
+        "estimated_lines": estimated_lines,
+        "auto_enabled": auto,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify MAP workflow scope from estimated change size.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--files", type=int, required=True,
+                        help="Estimated number of files to change (>= 0)")
+    parser.add_argument("--lines", type=int, required=True,
+                        help="Estimated lines to add/modify (>= 0)")
+    parser.add_argument("--project-dir", default=".",
+                        help="Project root (default: current directory)")
+    args = parser.parse_args(argv)
+
+    if args.files < 0 or args.lines < 0:
+        print("error: --files and --lines must be >= 0", file=sys.stderr)
+        return 1
+
+    result = classify(args.files, args.lines, Path(args.project_dir))
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mapify_cli/templates/skills/map-plan/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-plan/SKILL.md
@@ -120,27 +120,18 @@ Outcomes:
 - `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
-**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, query the project's scale-adaptive config:
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, estimate the task's scope (files to change, lines to add/modify) and run:
 
 ```bash
-python3 -c "
-import sys; sys.path.insert(0, 'src')
-from pathlib import Path
-from mapify_cli.config.project_config import load_map_config
-cfg = load_map_config(Path('.'))
-print('scale_auto:', cfg.scale_auto)
-print('trivial:', cfg.scale_trivial_max_files, cfg.scale_trivial_max_lines)
-print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
-print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
-"
+python3 .map/scripts/classify_scope.py --files ESTIMATED_FILES --lines ESTIMATED_LINES
 ```
 
-If `scale_auto: true`, use your estimate of the task's scope to surface an advisory (do not block on this):
+If `auto_enabled: true` in the JSON result, surface an advisory based on `bracket` (do not block):
 
-- Estimated ≤ trivial thresholds → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
-- Estimated ≤ small thresholds → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
-- Estimated > medium thresholds → advise re-invoking as `/map-plan --deep` for full research + architecture review.
-- Otherwise (medium range) → no advisory; standard mode is appropriate.
+- `trivial` → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
+- `small` → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
+- `large` → advise re-invoking as `/map-plan --deep` for full research + architecture review.
+- `medium` → no advisory; standard mode is appropriate.
 
 The advisory is informational — the user's flags or your judgment prevail. If the user accepts, add the flag and restart; otherwise continue in standard mode.
 

--- a/src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-plan/SKILL.md.jinja
@@ -98,26 +98,18 @@ shell_command:
 - Outcome `map-fast`: recommend `$map-fast` and STOP.
 - Outcome `map-plan`: continue below.
 
-**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, run:
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, estimate the task scope and run:
 
 ```
 shell_command:
-  cmd: |
-    python3 -c "
-import sys; sys.path.insert(0, 'src')
-from pathlib import Path
-from mapify_cli.config.project_config import load_map_config
-cfg = load_map_config(Path('.'))
-print('scale_auto:', cfg.scale_auto)
-print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
-print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
-"
+  cmd: python3 .map/scripts/classify_scope.py --files ESTIMATED_FILES --lines ESTIMATED_LINES
 ```
 
-If `scale_auto: true`, use your estimate of the task scope to surface an advisory (do not block):
-- Estimated ≤ small thresholds → advise re-invoking as `$map-plan --light`.
-- Estimated > medium thresholds → advise re-invoking as `$map-plan --deep`.
-- Otherwise (medium range) → no advisory; standard mode is appropriate.
+If `auto_enabled: true` in the JSON result, surface an advisory based on `bracket` (do not block):
+- `small` → advise re-invoking as `$map-plan --light`.
+- `large` → advise re-invoking as `$map-plan --deep`.
+- `trivial` → advise `$map-fast` instead.
+- `medium` → no advisory; standard mode is appropriate.
 
 ---
 

--- a/src/mapify_cli/templates_src/map/scripts/classify_scope.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/classify_scope.py.jinja
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""classify_scope.py — Scale-adaptive scope classifier for MAP workflows (#287).
+
+Reads scale thresholds from .map/config.yaml (dotted-key notation) and
+classifies a change estimate into one of four brackets: trivial, small,
+medium, or large, then returns the recommended MAP workflow depth.
+
+Usage:
+    python3 .map/scripts/classify_scope.py --files 5 --lines 120
+
+Output (JSON, exit 0):
+    {"bracket": "small", "recommended_workflow": "map-plan-light",
+     "estimated_files": 5, "estimated_lines": 120, "auto_enabled": true}
+
+Config keys read from .map/config.yaml (dotted notation):
+    scale.auto                         (default: true)
+    scale.thresholds.trivial.max_files (default: 3)
+    scale.thresholds.trivial.max_lines (default: 50)
+    scale.thresholds.small.max_files   (default: 10)
+    scale.thresholds.small.max_lines   (default: 200)
+    scale.thresholds.medium.max_files  (default: 30)
+    scale.thresholds.medium.max_lines  (default: 1000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+_BRACKET_WORKFLOW: dict[str, str] = {
+    "trivial": "map-fast",
+    "small": "map-plan-light",
+    "medium": "map-efficient",
+    "large": "map-efficient+map-tdd",
+}
+
+_DEFAULTS: dict[str, str] = {
+    "scale.auto": "true",
+    "scale.thresholds.trivial.max_files": "3",
+    "scale.thresholds.trivial.max_lines": "50",
+    "scale.thresholds.small.max_files": "10",
+    "scale.thresholds.small.max_lines": "200",
+    "scale.thresholds.medium.max_files": "30",
+    "scale.thresholds.medium.max_lines": "1000",
+}
+
+
+def _read_config(project_dir: Path) -> dict[str, str]:
+    """Read .map/config.yaml scalar values without external dependencies.
+
+    Supports the same dotted-key YAML subset used by load_map_config().
+    """
+    config_path = project_dir / ".map" / "config.yaml"
+    if not config_path.is_file():
+        return {}
+    try:
+        lines = config_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    values: dict[str, str] = {}
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if not key or not re.fullmatch(r"[A-Za-z0-9_.]+", key):
+            continue
+        value = value.split("#", 1)[0].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def classify(
+    estimated_files: int,
+    estimated_lines: int,
+    project_dir: Path | None = None,
+) -> dict[str, object]:
+    """Classify scope and return a result dict matching ScopeClassification fields."""
+    raw = _read_config(project_dir or Path("."))
+
+    def _int(key: str) -> int:
+        return int(raw.get(key, _DEFAULTS[key]))
+
+    def _bool(key: str) -> bool:
+        return raw.get(key, _DEFAULTS[key]).lower() not in {"false", "0", "no"}
+
+    auto = _bool("scale.auto")
+    trivial_files = _int("scale.thresholds.trivial.max_files")
+    trivial_lines = _int("scale.thresholds.trivial.max_lines")
+    small_files = _int("scale.thresholds.small.max_files")
+    small_lines = _int("scale.thresholds.small.max_lines")
+    medium_files = _int("scale.thresholds.medium.max_files")
+    medium_lines = _int("scale.thresholds.medium.max_lines")
+
+    if estimated_files <= trivial_files and estimated_lines <= trivial_lines:
+        bracket = "trivial"
+    elif estimated_files <= small_files and estimated_lines <= small_lines:
+        bracket = "small"
+    elif estimated_files <= medium_files and estimated_lines <= medium_lines:
+        bracket = "medium"
+    else:
+        bracket = "large"
+
+    return {
+        "bracket": bracket,
+        "recommended_workflow": _BRACKET_WORKFLOW[bracket],
+        "estimated_files": estimated_files,
+        "estimated_lines": estimated_lines,
+        "auto_enabled": auto,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify MAP workflow scope from estimated change size.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--files", type=int, required=True,
+                        help="Estimated number of files to change (>= 0)")
+    parser.add_argument("--lines", type=int, required=True,
+                        help="Estimated lines to add/modify (>= 0)")
+    parser.add_argument("--project-dir", default=".",
+                        help="Project root (default: current directory)")
+    args = parser.parse_args(argv)
+
+    if args.files < 0 or args.lines < 0:
+        print("error: --files and --lines must be >= 0", file=sys.stderr)
+        return 1
+
+    result = classify(args.files, args.lines, Path(args.project_dir))
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-plan/SKILL.md.jinja
@@ -120,27 +120,18 @@ Outcomes:
 - `map-wayfind`: too foggy to specify — you cannot write sharp acceptance criteria because several core decisions are still unresolved and entangled (not merely "needs a little research"). Recommend `/map-wayfind chart "<loose idea>"` to resolve the decision frontier first, then return with `/map-plan --wayfind <slug>`. STOP. (This is the inverse of the Wayfinding Handoff pre-flight: that consumes a finished map; this sends you to create one.)
 - `map-plan`: continue.
 
-**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, query the project's scale-adaptive config:
+**Scale Advisory (standard mode only, when no `--light`/`--deep` flag was given):** After recording a `map-plan` outcome, estimate the task's scope (files to change, lines to add/modify) and run:
 
 ```bash
-python3 -c "
-import sys; sys.path.insert(0, 'src')
-from pathlib import Path
-from mapify_cli.config.project_config import load_map_config
-cfg = load_map_config(Path('.'))
-print('scale_auto:', cfg.scale_auto)
-print('trivial:', cfg.scale_trivial_max_files, cfg.scale_trivial_max_lines)
-print('small:', cfg.scale_small_max_files, cfg.scale_small_max_lines)
-print('medium:', cfg.scale_medium_max_files, cfg.scale_medium_max_lines)
-"
+python3 .map/scripts/classify_scope.py --files ESTIMATED_FILES --lines ESTIMATED_LINES
 ```
 
-If `scale_auto: true`, use your estimate of the task's scope to surface an advisory (do not block on this):
+If `auto_enabled: true` in the JSON result, surface an advisory based on `bracket` (do not block):
 
-- Estimated ≤ trivial thresholds → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
-- Estimated ≤ small thresholds → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
-- Estimated > medium thresholds → advise re-invoking as `/map-plan --deep` for full research + architecture review.
-- Otherwise (medium range) → no advisory; standard mode is appropriate.
+- `trivial` → advise `/map-fast` instead (already covered by the `map-fast` outcome above).
+- `small` → advise re-invoking as `/map-plan --light` for a lighter-weight plan.
+- `large` → advise re-invoking as `/map-plan --deep` for full research + architecture review.
+- `medium` → no advisory; standard mode is appropriate.
 
 The advisory is informational — the user's flags or your judgment prevail. If the user accepts, add the flag and restart; otherwise continue in standard mode.
 

--- a/tests/test_classify_scope_script.py
+++ b/tests/test_classify_scope_script.py
@@ -1,0 +1,249 @@
+"""Tests for the standalone .map/scripts/classify_scope.py script (#287).
+
+The script is rendered from templates_src/map/scripts/classify_scope.py.jinja
+and ships with 'mapify init' so it must work without importing mapify_cli.
+
+Covers:
+  SC1 — default thresholds (no config file) produce correct brackets
+  SC2 — config file with dotted-key overrides is read correctly
+  SC3 — boundary conditions (at-ceiling vs one-over)
+  SC4 — auto_enabled flag respected from config
+  SC5 — subprocess CLI invocation returns valid JSON (exit 0)
+  SC6 — subprocess CLI rejects negative inputs (exit 1)
+  SC7 — rendered script exists in all three output paths
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Locate the rendered script under the dev tree (.map/scripts/)
+_REPO_ROOT = Path(__file__).parent.parent
+_SCRIPT = _REPO_ROOT / ".map" / "scripts" / "classify_scope.py"
+
+
+def _run(files: int, lines: int, project_dir: Path | None = None) -> dict:
+    """Invoke the script as a subprocess and return parsed JSON."""
+    cmd = [sys.executable, str(_SCRIPT), "--files", str(files), "--lines", str(lines)]
+    if project_dir is not None:
+        cmd += ["--project-dir", str(project_dir)]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode == 0, f"script failed:\n{proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    (tmp_path / ".map").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".map" / "config.yaml").write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# SC1 — default thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestSc1DefaultThresholds:
+    def test_zero_zero_is_trivial(self):
+        result = _run(0, 0)
+        assert result["bracket"] == "trivial"
+        assert result["recommended_workflow"] == "map-fast"
+
+    def test_trivial_at_ceiling(self):
+        result = _run(3, 50)
+        assert result["bracket"] == "trivial"
+
+    def test_small_exceeds_trivial_files(self):
+        result = _run(4, 10)
+        assert result["bracket"] == "small"
+        assert result["recommended_workflow"] == "map-plan-light"
+
+    def test_small_at_ceiling(self):
+        result = _run(10, 200)
+        assert result["bracket"] == "small"
+
+    def test_medium_exceeds_small_files(self):
+        result = _run(11, 10)
+        assert result["bracket"] == "medium"
+        assert result["recommended_workflow"] == "map-efficient"
+
+    def test_medium_at_ceiling(self):
+        result = _run(30, 1000)
+        assert result["bracket"] == "medium"
+
+    def test_large_exceeds_medium(self):
+        result = _run(31, 10)
+        assert result["bracket"] == "large"
+        assert result["recommended_workflow"] == "map-efficient+map-tdd"
+
+    def test_large_lines_exceed_medium(self):
+        result = _run(1, 1001)
+        assert result["bracket"] == "large"
+
+
+# ---------------------------------------------------------------------------
+# SC2 — dotted-key config overrides
+# ---------------------------------------------------------------------------
+
+
+class TestSc2ConfigOverrides:
+    def test_trivial_max_files_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.thresholds.trivial.max_files: 1\n")
+        assert _run(1, 10, tmp_path)["bracket"] == "trivial"
+        assert _run(2, 10, tmp_path)["bracket"] == "small"
+
+    def test_trivial_max_lines_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.thresholds.trivial.max_lines: 20\n")
+        assert _run(1, 20, tmp_path)["bracket"] == "trivial"
+        assert _run(1, 21, tmp_path)["bracket"] == "small"
+
+    def test_small_max_files_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.thresholds.small.max_files: 5\n")
+        assert _run(5, 10, tmp_path)["bracket"] == "small"
+        assert _run(6, 10, tmp_path)["bracket"] == "medium"
+
+    def test_medium_max_files_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.thresholds.medium.max_files: 20\n")
+        assert _run(20, 100, tmp_path)["bracket"] == "medium"
+        assert _run(21, 100, tmp_path)["bracket"] == "large"
+
+    def test_absent_config_uses_defaults(self, tmp_path: Path):
+        result = _run(3, 50, tmp_path)
+        assert result["bracket"] == "trivial"
+
+    def test_multiple_overrides(self, tmp_path: Path):
+        _write_config(
+            tmp_path,
+            "scale.thresholds.trivial.max_files: 2\n"
+            "scale.thresholds.trivial.max_lines: 30\n"
+        )
+        assert _run(2, 30, tmp_path)["bracket"] == "trivial"
+        assert _run(3, 30, tmp_path)["bracket"] == "small"
+        assert _run(2, 31, tmp_path)["bracket"] == "small"
+
+
+# ---------------------------------------------------------------------------
+# SC3 — boundary conditions
+# ---------------------------------------------------------------------------
+
+
+class TestSc3BoundaryConditions:
+    @pytest.mark.parametrize(
+        "files, lines, expected",
+        [
+            (3, 50, "trivial"),
+            (4, 50, "small"),
+            (3, 51, "small"),
+            (10, 200, "small"),
+            (11, 200, "medium"),
+            (10, 201, "medium"),
+            (30, 1000, "medium"),
+            (31, 1000, "large"),
+            (30, 1001, "large"),
+        ],
+    )
+    def test_boundary(self, files: int, lines: int, expected: str):
+        assert _run(files, lines)["bracket"] == expected
+
+
+# ---------------------------------------------------------------------------
+# SC4 — auto_enabled flag
+# ---------------------------------------------------------------------------
+
+
+class TestSc4AutoEnabled:
+    def test_auto_true_by_default(self):
+        assert _run(1, 10)["auto_enabled"] is True
+
+    def test_auto_false_from_config(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.auto: false\n")
+        assert _run(1, 10, tmp_path)["auto_enabled"] is False
+
+    def test_auto_true_explicit_in_config(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.auto: true\n")
+        assert _run(1, 10, tmp_path)["auto_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# SC5 — subprocess JSON output contract
+# ---------------------------------------------------------------------------
+
+
+class TestSc5JsonOutput:
+    def test_required_fields_present(self):
+        result = _run(5, 100)
+        for key in ("bracket", "recommended_workflow", "estimated_files", "estimated_lines", "auto_enabled"):
+            assert key in result, f"missing key: {key}"
+
+    def test_estimated_fields_echo_inputs(self):
+        result = _run(7, 123)
+        assert result["estimated_files"] == 7
+        assert result["estimated_lines"] == 123
+
+    def test_recommended_workflow_nonempty_string(self):
+        for files, lines in [(1, 10), (5, 100), (15, 400), (50, 2000)]:
+            r = _run(files, lines)
+            assert isinstance(r["recommended_workflow"], str) and r["recommended_workflow"]
+
+
+# ---------------------------------------------------------------------------
+# SC6 — invalid input rejected
+# ---------------------------------------------------------------------------
+
+
+class TestSc6InvalidInput:
+    def test_negative_files_exits_nonzero(self):
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--files", "-1", "--lines", "10"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode != 0
+
+    def test_negative_lines_exits_nonzero(self):
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--files", "1", "--lines", "-1"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode != 0
+
+    def test_missing_files_arg_exits_nonzero(self):
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--lines", "10"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode != 0
+
+    def test_missing_lines_arg_exits_nonzero(self):
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--files", "5"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# SC7 — rendered script exists in all output paths
+# ---------------------------------------------------------------------------
+
+
+class TestSc7RenderedScriptExists:
+    _EXPECTED_PATHS = [
+        _REPO_ROOT / ".map" / "scripts" / "classify_scope.py",
+        _REPO_ROOT / "src" / "mapify_cli" / "templates" / "map" / "scripts" / "classify_scope.py",
+    ]
+
+    @pytest.mark.parametrize("script_path", _EXPECTED_PATHS)
+    def test_script_exists(self, script_path: Path):
+        assert script_path.exists(), f"rendered script missing: {script_path}"
+
+    def test_rendered_script_is_executable_python(self):
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--help"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode == 0
+        assert "--files" in proc.stdout or "--files" in proc.stderr


### PR DESCRIPTION
## Summary

Slice 3 of issue #287 (scale-adaptive intelligence) — entry-point integration.

- **New script**: `src/mapify_cli/templates_src/map/scripts/classify_scope.py.jinja` — ships as `.map/scripts/classify_scope.py` in user projects. Stdlib-only (no `mapify_cli` import), reads scale thresholds from `.map/config.yaml` using dotted-key YAML parsing identical to `map_orchestrator.py`, accepts `--files N --lines N` and returns JSON with `bracket`, `recommended_workflow`, `estimated_files`, `estimated_lines`, `auto_enabled`.

- **Scale Advisory fix**: Replaced the broken `python3 -c "import sys; sys.path.insert(0, 'src')..."` inline blocks in both the Claude and Codex variants of `map-plan`'s Scale Advisory section. The `sys.path.insert(0, 'src')` hack only worked in the MAP Framework development repo; in user projects (where `mapify_cli` is installed as a package), it would fail. The new form uses the shipped script directly: `python3 .map/scripts/classify_scope.py --files N --lines N`.

- **Tests**: 36 new tests in `tests/test_classify_scope_script.py` covering all classification brackets, config overrides, boundary conditions, auto_enabled flag, JSON output contract, invalid input rejection, and rendered-script presence in all output paths.

## Test results

- All 3886 tests pass (4 skipped, 12 deselected)
- `make check-render` passes
- map-plan SKILL.md: 488 lines (budget: 515)

---
_Generated by [Claude Code](https://claude.ai/code/session_011jmbBkJwJByEJGXFAihgh8)_