### PR TITLE
fix: remove stale Write(...)/Glob(**) permission rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Stale `Write(...)`/`Glob(**)` permission rules no longer emit startup warnings.** Claude Code now matches all file-editing tools (Edit/Write/NotebookEdit) against `Edit(path)` rules only, and all file-reading tools against `Read(path)` rules only. Two shipped surfaces predated that consolidation: `settings.json.jinja`'s 6 redundant `Write(...)` deny/allow entries (already covered by existing `Edit(...)` rules) were removed, and `configure_global_permissions()`'s `Glob(**)` entry (written into the user's global `~/.claude/settings.json` on every `mapify init`) was changed to `Read(**)`, with a one-time migration that also heals any already-installed stale `Glob(**)` rule.
+
 ## [3.23.0] - 2026-07-18
 
 ### Added

--- a/src/mapify_cli/config/settings.py
+++ b/src/mapify_cli/config/settings.py
@@ -2,10 +2,9 @@
 
 import json
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any
 
 from mapify_cli.cli_ui import console
-
 
 # ---------------------------------------------------------------------------
 # Autonomy posture (opt-in via `mapify init --autonomy`)
@@ -118,7 +117,7 @@ def configure_global_permissions() -> None:
             "Bash(chmod +x *)",
             "Read(//Users/**)",
             "Read(//private/tmp/**)",
-            "Glob(**)",
+            "Read(**)",
         ],
         "deny": [],
     }
@@ -140,11 +139,21 @@ def configure_global_permissions() -> None:
     if "permissions" not in settings:
         settings["permissions"] = default_permissions
     else:
+        allow_list = settings["permissions"].setdefault("allow", [])
+
+        # Migrate the stale "Glob(**)" rule: Claude Code now matches all
+        # file-reading tools against Read(path) rules only, so a previously
+        # installed "Glob(**)" silently stopped being enforced (startup
+        # warning only). The append-if-missing loop below never removes
+        # stale entries, so heal already-materialized global settings here.
+        if "Glob(**)" in allow_list:
+            allow_list.remove("Glob(**)")
+
         # Add new permissions if they don't exist
-        existing_allow = set(settings["permissions"].get("allow", []))
+        existing_allow = set(allow_list)
         for perm in default_permissions["allow"]:
             if perm not in existing_allow:
-                settings["permissions"].setdefault("allow", []).append(perm)
+                allow_list.append(perm)
 
     # Write back
     with open(settings_file, "w") as f:
@@ -157,7 +166,7 @@ def configure_global_permissions() -> None:
 
 
 def create_or_merge_project_settings_local(
-    project_path: Path, *, autonomy: Optional[bool] = None
+    project_path: Path, *, autonomy: bool | None = None
 ) -> None:
     """Create/merge .claude/settings.local.json with safe project allowlist.
 
@@ -187,7 +196,7 @@ def create_or_merge_project_settings_local(
     settings_file = project_path / ".claude" / "settings.local.json"
     settings_file.parent.mkdir(parents=True, exist_ok=True)
 
-    default_permissions: Dict[str, Any] = {
+    default_permissions: dict[str, Any] = {
         "allow": [
             # SourceCraft MCP helpers (project-scoped)
             "mcp__sourcecraft__list_pull_request_comments",
@@ -266,7 +275,7 @@ def create_or_merge_project_settings_local(
         )
 
 
-def _apply_autonomy(settings: Dict[str, Any], permissions: Dict[str, Any]) -> None:
+def _apply_autonomy(settings: dict[str, Any], permissions: dict[str, Any]) -> None:
     """Add the broad allow + git deny entries and the autonomy sentinel."""
     allow = permissions.setdefault("allow", [])
     for entry in _AUTONOMY_ALLOW:
@@ -285,7 +294,7 @@ def _apply_autonomy(settings: Dict[str, Any], permissions: Dict[str, Any]) -> No
         mapify_meta["autonomy"] = True
 
 
-def _remove_autonomy(settings: Dict[str, Any], permissions: Dict[str, Any]) -> None:
+def _remove_autonomy(settings: dict[str, Any], permissions: dict[str, Any]) -> None:
     """Remove the autonomy allow/deny entries and the sentinel (teardown)."""
     if isinstance(permissions.get("allow"), list):
         permissions["allow"] = [

--- a/src/mapify_cli/config/settings.py
+++ b/src/mapify_cli/config/settings.py
@@ -147,7 +147,7 @@ def configure_global_permissions() -> None:
         # warning only). The append-if-missing loop below never removes
         # stale entries, so heal already-materialized global settings here.
         if "Glob(**)" in allow_list:
-            allow_list.remove("Glob(**)")
+            allow_list[:] = [perm for perm in allow_list if perm != "Glob(**)"]
 
         # Add new permissions if they don't exist
         existing_allow = set(allow_list)

--- a/src/mapify_cli/templates/settings.json
+++ b/src/mapify_cli/templates/settings.json
@@ -3,9 +3,6 @@
   "description": "MAP Framework project-level settings with security guardrails",
   "permissions": {
     "deny": [
-      "Write(./.env*)",
-      "Write(**/*credentials*)",
-      "Write(**/*secret*)",
       "Edit(./.env*)",
       "Edit(**/*credentials*)",
       "Edit(**/*secret*)",
@@ -18,9 +15,6 @@
       "Edit(.claude/agents/*)",
       "Edit(.claude/commands/*)",
       "Edit(.claude/references/*)",
-      "Write(.claude/agents/*)",
-      "Write(.claude/commands/*)",
-      "Write(.claude/references/*)",
       "Bash(mapify *)",
       "Bash(pytest *)",
       "Bash(make lint)",

--- a/src/mapify_cli/templates_src/settings.json.jinja
+++ b/src/mapify_cli/templates_src/settings.json.jinja
@@ -3,9 +3,6 @@
   "description": "MAP Framework project-level settings with security guardrails",
   "permissions": {
     "deny": [
-      "Write(./.env*)",
-      "Write(**/*credentials*)",
-      "Write(**/*secret*)",
       "Edit(./.env*)",
       "Edit(**/*credentials*)",
       "Edit(**/*secret*)",
@@ -18,9 +15,6 @@
       "Edit(.claude/agents/*)",
       "Edit(.claude/commands/*)",
       "Edit(.claude/references/*)",
-      "Write(.claude/agents/*)",
-      "Write(.claude/commands/*)",
-      "Write(.claude/references/*)",
       "Bash(mapify *)",
       "Bash(pytest *)",
       "Bash(make lint)",

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -15,7 +15,6 @@ from typer.testing import CliRunner
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 import mapify_cli
-from mapify_cli.delivery import create_map_tools
 from mapify_cli import (
     app,
     build_standard_mcp_servers,
@@ -35,6 +34,7 @@ from mapify_cli import (
     read_project_mcp_json,
     write_project_mcp_json,
 )
+from mapify_cli.delivery import create_map_tools
 
 runner = CliRunner()
 
@@ -369,8 +369,9 @@ class TestInitCommand:
         - mcp_config.json is created with the default server set (deepwiki removed)
         """
         # Use fresh CliRunner to avoid state pollution from previous tests
-        from typer.testing import CliRunner as FreshRunner
         import sys
+
+        from typer.testing import CliRunner as FreshRunner
 
         fresh_runner = FreshRunner()
 
@@ -709,6 +710,50 @@ class TestAutonomyPosture:
         assert ".claude/settings.local.json" in (
             tmp_path / ".gitignore"
         ).read_text().splitlines()
+
+
+class TestConfigureGlobalPermissions:
+    """Claude Code matches all file-reading tools against Read(path) rules only;
+    a stale Glob(**) rule is never enforced and only emits a startup warning."""
+
+    def _global_settings_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        return tmp_path / ".claude" / "settings.json"
+
+    def test_fresh_install_writes_read_not_glob(self, tmp_path, monkeypatch):
+        from mapify_cli.config.settings import configure_global_permissions
+
+        settings_path = self._global_settings_path(tmp_path, monkeypatch)
+        configure_global_permissions()
+
+        allow = json.loads(settings_path.read_text())["permissions"]["allow"]
+        assert "Read(**)" in allow
+        assert "Glob(**)" not in allow
+
+    def test_existing_stale_glob_rule_is_migrated(self, tmp_path, monkeypatch):
+        from mapify_cli.config.settings import configure_global_permissions
+
+        settings_path = self._global_settings_path(tmp_path, monkeypatch)
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps({"permissions": {"allow": ["Glob(**)"], "deny": []}})
+        )
+
+        configure_global_permissions()
+
+        allow = json.loads(settings_path.read_text())["permissions"]["allow"]
+        assert "Read(**)" in allow
+        assert "Glob(**)" not in allow
+
+    def test_migration_is_idempotent(self, tmp_path, monkeypatch):
+        from mapify_cli.config.settings import configure_global_permissions
+
+        settings_path = self._global_settings_path(tmp_path, monkeypatch)
+        configure_global_permissions()
+        configure_global_permissions()
+
+        allow = json.loads(settings_path.read_text())["permissions"]["allow"]
+        assert allow.count("Read(**)") == 1
 
     def test_init_default_no_autonomy_sentinel(self, tmp_path):
         os.chdir(tmp_path)

--- a/tests/test_mapify_cli.py
+++ b/tests/test_mapify_cli.py
@@ -745,6 +745,25 @@ class TestConfigureGlobalPermissions:
         assert "Read(**)" in allow
         assert "Glob(**)" not in allow
 
+    def test_existing_duplicate_stale_glob_rules_are_all_migrated(
+        self, tmp_path, monkeypatch
+    ):
+        from mapify_cli.config.settings import configure_global_permissions
+
+        settings_path = self._global_settings_path(tmp_path, monkeypatch)
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(
+            json.dumps(
+                {"permissions": {"allow": ["Glob(**)", "Glob(**)"], "deny": []}}
+            )
+        )
+
+        configure_global_permissions()
+
+        allow = json.loads(settings_path.read_text())["permissions"]["allow"]
+        assert allow.count("Glob(**)") == 0
+        assert allow.count("Read(**)") == 1
+
     def test_migration_is_idempotent(self, tmp_path, monkeypatch):
         from mapify_cli.config.settings import configure_global_permissions
 


### PR DESCRIPTION
## Summary
- Claude Code now matches all file-editing tools (Edit/Write/NotebookEdit) against `Edit(path)` rules only, and all file-reading tools against `Read(path)` rules only — pre-consolidation rules only emit a startup warning.
- Removed 6 redundant `Write(...)` deny/allow entries from `settings.json.jinja` (project-level shipped settings); `Edit(...)` already covers the same paths.
- Fixed `configure_global_permissions()` (writes to the user's global `~/.claude/settings.json` on every `mapify init`): `Glob(**)` → `Read(**)`, plus a one-time migration that heals an already-installed stale `Glob(**)` rule (the append-only merge never fixed it before).

## Test plan
- [x] `make render-templates` + `make check-render` — generated trees match
- [x] `uv run pytest tests/` — full suite green (4090 passed, 3 skipped)
- [x] New regression tests for `configure_global_permissions` (fresh install, migration of existing stale rule, idempotency)
- [x] `pyright src/mapify_cli/config/settings.py` — 0 errors/warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated permission rules so edit and read operations match the appropriate controls.
  * Prevented stale permission settings from generating startup warnings.
  * Automatically migrated outdated broad file-access rules to the newer read-only pattern.
  * Added safeguards against destructive file and Git operations.
* **Tests**
  * Added coverage for fresh permission setup and repeatable migration of existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->