### PR TITLE
fix(map-review): accept documented PROCEED/REVISE/BLOCK gate verdicts (#388)

### DIFF
--- a/.agents/skills/map-review/review-reference.md
+++ b/.agents/skills/map-review/review-reference.md
@@ -300,10 +300,17 @@ python3 .map/scripts/map_step_runner.py write_learning_handoff \
 This preserves `active-issues`, `pr-draft`, and `learning-handoff` flows.
 
 If edits are needed (REVISE/BLOCK), write the stage gate so the owning
-workflow can continue:
+workflow can continue. Positional arguments are
+`<stage> <verdict> <source_artifact> <notes>` — the summary is the FOURTH
+argument, not the third. The runner normalizes `PROCEED` -> `ready`,
+`REVISE` -> `needs-revision`, `BLOCK` -> `blocked`:
 
 ```bash
-python3 .map/scripts/map_step_runner.py write_stage_gate review "$FINAL_VERDICT" "$REVIEW_SUMMARY"
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  "$FINAL_VERDICT" \
+  code-review-001.md \
+  "$REVIEW_SUMMARY"
 ```
 
 Set `RUN_HEALTH_STATUS` from verdict:

--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -473,12 +473,22 @@ Choose exactly one:
 - `REVISE`: actionable changes are required before review can pass.
 - `BLOCK`: external, safety, or correctness blocker prevents review completion.
 
+The runner stores gate verdicts as `ready` / `needs-revision` / `blocked` and
+normalizes `PROCEED` -> `ready`, `REVISE` -> `needs-revision`, `BLOCK` -> `blocked`,
+so either spelling is accepted by `write_stage_gate`.
+
 ## Workflow Gate Unlock (REVISE/BLOCK only)
 
-If edits are needed, write the stage gate so the owning workflow can continue:
+If edits are needed, write the stage gate so the owning workflow can continue.
+Positional arguments are `<stage> <verdict> <source_artifact> <notes>` — the
+summary is the FOURTH argument, not the third:
 
 ```bash
-python3 .map/scripts/map_step_runner.py write_stage_gate review "$FINAL_VERDICT" "$REVIEW_SUMMARY"
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  "$FINAL_VERDICT" \
+  code-review-001.md \
+  "$REVIEW_SUMMARY"
 ```
 
 ## Handoff Artifact Update

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -230,6 +230,14 @@ def _effective_compression_threshold(policy: str, threshold: int) -> int | None:
     return threshold
 
 GATE_VERDICTS = {"ready", "needs-revision", "blocked"}
+# Review skills document their verdict domain as PROCEED/REVISE/BLOCK; accept
+# those spellings (and the underscore variant) and normalize to GATE_VERDICTS.
+GATE_VERDICT_ALIASES = {
+    "proceed": "ready",
+    "revise": "needs-revision",
+    "needs_revision": "needs-revision",
+    "block": "blocked",
+}
 ARTIFACT_STAGE_NAMES = (
     "workflow_fit",
     "spec",
@@ -7088,6 +7096,13 @@ def write_pr_draft(
     return {"status": "success", "path": str(pr_file)}
 
 
+def normalize_gate_verdict(value: str) -> str | None:
+    """Normalize a gate verdict spelling; return None when unrecognized."""
+    candidate = (value or "").strip().lower()
+    candidate = GATE_VERDICT_ALIASES.get(candidate, candidate)
+    return candidate if candidate in GATE_VERDICTS else None
+
+
 def write_plan_review(
     summary: str = "",
     high: str = "",
@@ -7099,12 +7114,13 @@ def write_plan_review(
     branch: str | None = None,
 ) -> dict:
     """Write the next staged planning review artifact."""
-    recommendation = recommendation.strip().lower()
-    if recommendation not in GATE_VERDICTS:
+    normalized_recommendation = normalize_gate_verdict(recommendation)
+    if normalized_recommendation is None:
         return {
             "status": "error",
-            "message": f"Invalid recommendation: {recommendation}",
+            "message": f"Invalid recommendation: {recommendation.strip().lower()}",
         }
+    recommendation = normalized_recommendation
 
     artifact = next_numbered_artifact_path("plan-review", branch)
     review_file = Path(artifact["path"])
@@ -7145,9 +7161,13 @@ def write_stage_gate(
     branch: str | None = None,
 ) -> dict:
     """Write a machine-readable gate artifact for a workflow stage."""
-    verdict = verdict.strip().lower()
-    if verdict not in GATE_VERDICTS:
-        return {"status": "error", "message": f"Invalid verdict: {verdict}"}
+    normalized_verdict = normalize_gate_verdict(verdict)
+    if normalized_verdict is None:
+        return {
+            "status": "error",
+            "message": f"Invalid verdict: {verdict.strip().lower()}",
+        }
+    verdict = normalized_verdict
 
     normalized_stage = stage.strip().lower().replace("_", "-")
     gate_file = get_branch_dir(branch) / f"{normalized_stage}-gate.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`map-review` closeout no longer errors on its own documented verdicts (closes #388).** `map-review`'s SKILL.md documents `PROCEED | REVISE | BLOCK`, but `write_stage_gate` only accepted `{ready, needs-revision, blocked}`, so following the skill verbatim always failed with `Invalid verdict: revise`. `write_stage_gate` and `write_plan_review` now normalize `PROCEED -> ready`, `REVISE -> needs-revision`, `BLOCK -> blocked` (via a shared `normalize_gate_verdict` helper); unknown verdicts still error. Also fixed the secondary arity mismatch: the Gate Unlock call site passed the review summary as the THIRD positional arg, silently landing it in `source_artifact` instead of `notes` — both call sites in `SKILL.md` and the Codex `review-reference.md` port now pass `<stage> <verdict> <source_artifact> <notes>`.
+
 ## [3.24.0] - 2026-07-25
 
 ### Added

--- a/src/mapify_cli/templates/codex/skills/map-review/review-reference.md
+++ b/src/mapify_cli/templates/codex/skills/map-review/review-reference.md
@@ -300,10 +300,17 @@ python3 .map/scripts/map_step_runner.py write_learning_handoff \
 This preserves `active-issues`, `pr-draft`, and `learning-handoff` flows.
 
 If edits are needed (REVISE/BLOCK), write the stage gate so the owning
-workflow can continue:
+workflow can continue. Positional arguments are
+`<stage> <verdict> <source_artifact> <notes>` — the summary is the FOURTH
+argument, not the third. The runner normalizes `PROCEED` -> `ready`,
+`REVISE` -> `needs-revision`, `BLOCK` -> `blocked`:
 
 ```bash
-python3 .map/scripts/map_step_runner.py write_stage_gate review "$FINAL_VERDICT" "$REVIEW_SUMMARY"
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  "$FINAL_VERDICT" \
+  code-review-001.md \
+  "$REVIEW_SUMMARY"
 ```
 
 Set `RUN_HEALTH_STATUS` from verdict:

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -230,6 +230,14 @@ def _effective_compression_threshold(policy: str, threshold: int) -> int | None:
     return threshold
 
 GATE_VERDICTS = {"ready", "needs-revision", "blocked"}
+# Review skills document their verdict domain as PROCEED/REVISE/BLOCK; accept
+# those spellings (and the underscore variant) and normalize to GATE_VERDICTS.
+GATE_VERDICT_ALIASES = {
+    "proceed": "ready",
+    "revise": "needs-revision",
+    "needs_revision": "needs-revision",
+    "block": "blocked",
+}
 ARTIFACT_STAGE_NAMES = (
     "workflow_fit",
     "spec",
@@ -7088,6 +7096,13 @@ def write_pr_draft(
     return {"status": "success", "path": str(pr_file)}
 
 
+def normalize_gate_verdict(value: str) -> str | None:
+    """Normalize a gate verdict spelling; return None when unrecognized."""
+    candidate = (value or "").strip().lower()
+    candidate = GATE_VERDICT_ALIASES.get(candidate, candidate)
+    return candidate if candidate in GATE_VERDICTS else None
+
+
 def write_plan_review(
     summary: str = "",
     high: str = "",
@@ -7099,12 +7114,13 @@ def write_plan_review(
     branch: str | None = None,
 ) -> dict:
     """Write the next staged planning review artifact."""
-    recommendation = recommendation.strip().lower()
-    if recommendation not in GATE_VERDICTS:
+    normalized_recommendation = normalize_gate_verdict(recommendation)
+    if normalized_recommendation is None:
         return {
             "status": "error",
-            "message": f"Invalid recommendation: {recommendation}",
+            "message": f"Invalid recommendation: {recommendation.strip().lower()}",
         }
+    recommendation = normalized_recommendation
 
     artifact = next_numbered_artifact_path("plan-review", branch)
     review_file = Path(artifact["path"])
@@ -7145,9 +7161,13 @@ def write_stage_gate(
     branch: str | None = None,
 ) -> dict:
     """Write a machine-readable gate artifact for a workflow stage."""
-    verdict = verdict.strip().lower()
-    if verdict not in GATE_VERDICTS:
-        return {"status": "error", "message": f"Invalid verdict: {verdict}"}
+    normalized_verdict = normalize_gate_verdict(verdict)
+    if normalized_verdict is None:
+        return {
+            "status": "error",
+            "message": f"Invalid verdict: {verdict.strip().lower()}",
+        }
+    verdict = normalized_verdict
 
     normalized_stage = stage.strip().lower().replace("_", "-")
     gate_file = get_branch_dir(branch) / f"{normalized_stage}-gate.json"

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -473,12 +473,22 @@ Choose exactly one:
 - `REVISE`: actionable changes are required before review can pass.
 - `BLOCK`: external, safety, or correctness blocker prevents review completion.
 
+The runner stores gate verdicts as `ready` / `needs-revision` / `blocked` and
+normalizes `PROCEED` -> `ready`, `REVISE` -> `needs-revision`, `BLOCK` -> `blocked`,
+so either spelling is accepted by `write_stage_gate`.
+
 ## Workflow Gate Unlock (REVISE/BLOCK only)
 
-If edits are needed, write the stage gate so the owning workflow can continue:
+If edits are needed, write the stage gate so the owning workflow can continue.
+Positional arguments are `<stage> <verdict> <source_artifact> <notes>` — the
+summary is the FOURTH argument, not the third:
 
 ```bash
-python3 .map/scripts/map_step_runner.py write_stage_gate review "$FINAL_VERDICT" "$REVIEW_SUMMARY"
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  "$FINAL_VERDICT" \
+  code-review-001.md \
+  "$REVIEW_SUMMARY"
 ```
 
 ## Handoff Artifact Update

--- a/src/mapify_cli/templates_src/codex/skills/map-review/review-reference.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-review/review-reference.md.jinja
@@ -300,10 +300,17 @@ python3 .map/scripts/map_step_runner.py write_learning_handoff \
 This preserves `active-issues`, `pr-draft`, and `learning-handoff` flows.
 
 If edits are needed (REVISE/BLOCK), write the stage gate so the owning
-workflow can continue:
+workflow can continue. Positional arguments are
+`<stage> <verdict> <source_artifact> <notes>` — the summary is the FOURTH
+argument, not the third. The runner normalizes `PROCEED` -> `ready`,
+`REVISE` -> `needs-revision`, `BLOCK` -> `blocked`:
 
 ```bash
-python3 .map/scripts/map_step_runner.py write_stage_gate review "$FINAL_VERDICT" "$REVIEW_SUMMARY"
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  "$FINAL_VERDICT" \
+  code-review-001.md \
+  "$REVIEW_SUMMARY"
 ```
 
 Set `RUN_HEALTH_STATUS` from verdict:

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -230,6 +230,14 @@ def _effective_compression_threshold(policy: str, threshold: int) -> int | None:
     return threshold
 
 GATE_VERDICTS = {"ready", "needs-revision", "blocked"}
+# Review skills document their verdict domain as PROCEED/REVISE/BLOCK; accept
+# those spellings (and the underscore variant) and normalize to GATE_VERDICTS.
+GATE_VERDICT_ALIASES = {
+    "proceed": "ready",
+    "revise": "needs-revision",
+    "needs_revision": "needs-revision",
+    "block": "blocked",
+}
 ARTIFACT_STAGE_NAMES = (
     "workflow_fit",
     "spec",
@@ -7088,6 +7096,13 @@ def write_pr_draft(
     return {"status": "success", "path": str(pr_file)}
 
 
+def normalize_gate_verdict(value: str) -> str | None:
+    """Normalize a gate verdict spelling; return None when unrecognized."""
+    candidate = (value or "").strip().lower()
+    candidate = GATE_VERDICT_ALIASES.get(candidate, candidate)
+    return candidate if candidate in GATE_VERDICTS else None
+
+
 def write_plan_review(
     summary: str = "",
     high: str = "",
@@ -7099,12 +7114,13 @@ def write_plan_review(
     branch: str | None = None,
 ) -> dict:
     """Write the next staged planning review artifact."""
-    recommendation = recommendation.strip().lower()
-    if recommendation not in GATE_VERDICTS:
+    normalized_recommendation = normalize_gate_verdict(recommendation)
+    if normalized_recommendation is None:
         return {
             "status": "error",
-            "message": f"Invalid recommendation: {recommendation}",
+            "message": f"Invalid recommendation: {recommendation.strip().lower()}",
         }
+    recommendation = normalized_recommendation
 
     artifact = next_numbered_artifact_path("plan-review", branch)
     review_file = Path(artifact["path"])
@@ -7145,9 +7161,13 @@ def write_stage_gate(
     branch: str | None = None,
 ) -> dict:
     """Write a machine-readable gate artifact for a workflow stage."""
-    verdict = verdict.strip().lower()
-    if verdict not in GATE_VERDICTS:
-        return {"status": "error", "message": f"Invalid verdict: {verdict}"}
+    normalized_verdict = normalize_gate_verdict(verdict)
+    if normalized_verdict is None:
+        return {
+            "status": "error",
+            "message": f"Invalid verdict: {verdict.strip().lower()}",
+        }
+    verdict = normalized_verdict
 
     normalized_stage = stage.strip().lower().replace("_", "-")
     gate_file = get_branch_dir(branch) / f"{normalized_stage}-gate.json"

--- a/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
@@ -473,12 +473,22 @@ Choose exactly one:
 - `REVISE`: actionable changes are required before review can pass.
 - `BLOCK`: external, safety, or correctness blocker prevents review completion.
 
+The runner stores gate verdicts as `ready` / `needs-revision` / `blocked` and
+normalizes `PROCEED` -> `ready`, `REVISE` -> `needs-revision`, `BLOCK` -> `blocked`,
+so either spelling is accepted by `write_stage_gate`.
+
 ## Workflow Gate Unlock (REVISE/BLOCK only)
 
-If edits are needed, write the stage gate so the owning workflow can continue:
+If edits are needed, write the stage gate so the owning workflow can continue.
+Positional arguments are `<stage> <verdict> <source_artifact> <notes>` — the
+summary is the FOURTH argument, not the third:
 
 ```bash
-python3 .map/scripts/map_step_runner.py write_stage_gate review "$FINAL_VERDICT" "$REVIEW_SUMMARY"
+python3 .map/scripts/map_step_runner.py write_stage_gate \
+  review \
+  "$FINAL_VERDICT" \
+  code-review-001.md \
+  "$REVIEW_SUMMARY"
 ```
 
 ## Handoff Artifact Update

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3159,6 +3159,34 @@ class TestWriteStageGate:
                 res["status"] == "success"
             ), f"Expected success for verdict={verdict!r}"
 
+    def test_skill_documented_verdicts_normalized(self, branch_workspace):
+        """map-review's PROCEED/REVISE/BLOCK spellings map onto GATE_VERDICTS.
+
+        Regression: issue #388 — following map-review/SKILL.md verbatim errored
+        out with "Invalid verdict: revise" at the closeout step.
+        """
+        for spelled, expected in (
+            ("PROCEED", "ready"),
+            ("REVISE", "needs-revision"),
+            ("BLOCK", "blocked"),
+        ):
+            result = map_step_runner.write_stage_gate("review", spelled)
+            assert result["status"] == "success", f"rejected verdict={spelled!r}"
+            assert result["verdict"] == expected
+            data = json.loads(
+                (branch_workspace / "review-gate.json").read_text(encoding="utf-8")
+            )
+            assert data["verdict"] == expected
+
+    def test_plan_review_recommendation_normalized(self, branch_workspace):
+        """write_plan_review accepts the same documented verdict spellings."""
+        del branch_workspace
+        result = map_step_runner.write_plan_review(recommendation="REVISE")
+
+        assert result["status"] == "success"
+        content = Path(result["path"]).read_text(encoding="utf-8")
+        assert "- needs-revision" in content
+
     def test_source_artifact_optional(self, branch_workspace):
         """Omitting source_artifact stores None in the JSON payload."""
         map_step_runner.write_stage_gate("plan", "ready")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -19,6 +19,7 @@ Validates that shipped skills keep a clean, Claude-compatible metadata surface:
 
 import json
 import re
+import shlex
 from pathlib import Path
 from typing import ClassVar
 
@@ -181,6 +182,30 @@ def _has_json_contract_backing(context: str) -> bool:
         JSON_CONTRACT_REFERENCE_PATTERN.search(context)
         or EVIDENCE_FIRST_JSON_PATTERN.search(context)
     )
+
+
+def _shell_invocations(content: str, subcommand: str) -> list[list[str]]:
+    """Return the positional args of every shell call to ``subcommand``.
+
+    Joins backslash-continued lines so multi-line runner invocations are parsed
+    as one command; returns the tokens that follow ``subcommand``.
+    """
+    invocations: list[list[str]] = []
+    lines = content.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if f" {subcommand}" not in line:
+            index += 1
+            continue
+        command = line
+        while command.rstrip().endswith("\\") and index + 1 < len(lines):
+            index += 1
+            command = command.rstrip().removesuffix("\\") + " " + lines[index].strip()
+        tokens = shlex.split(command, comments=True)
+        invocations.append(tokens[tokens.index(subcommand) + 1 :])
+        index += 1
+    return invocations
 
 
 class TestSkillStructure:
@@ -1682,6 +1707,28 @@ class TestMapReviewSkillBundleWiring:
         )
         assert "learning-handoff" in skill_md, (
             "map-review/SKILL.md is missing learning-handoff reference — learning handoff flow was removed"
+        )
+
+    def test_map_review_skill_stage_gate_calls_use_consistent_arg_positions(
+        self, skill_md
+    ):
+        """Regression #388: every write_stage_gate call passes 4 positional args.
+
+        The gate-unlock call used to pass the summary as the THIRD argument, so
+        it silently landed in ``source_artifact`` instead of ``notes``.
+        """
+        calls = _shell_invocations(skill_md, "write_stage_gate")
+        assert calls, "map-review/SKILL.md has no write_stage_gate invocation"
+        for args in calls:
+            assert len(args) == 4, (
+                "write_stage_gate must be called as "
+                f"<stage> <verdict> <source_artifact> <notes>; got {args}"
+            )
+
+    def test_map_review_skill_documents_verdict_normalization(self, skill_md):
+        """Regression #388: SKILL.md must state how PROCEED/REVISE/BLOCK map to gates."""
+        assert "needs-revision" in skill_md, (
+            "map-review/SKILL.md must document the runner's gate verdict spellings"
         )
 
     def test_map_review_skill_documents_detached_flag(self, skill_md):


### PR DESCRIPTION
Closes #388.

## Problem

`map-review`'s SKILL.md documents the final verdict domain as `PROCEED | REVISE | BLOCK`, but `map_step_runner.write_stage_gate` only accepted `{ready, needs-revision, blocked}`. Following the skill verbatim always failed at closeout:

```
$ python3 .map/scripts/map_step_runner.py write_stage_gate review REVISE "<summary>"
{ "status": "error", "message": "Invalid verdict: revise" }
```

Secondary mismatch in the same skill: the Gate Unlock call passed the summary as the THIRD positional arg (`source_artifact`), while the Handoff example passed 4 args — so even a correctly-spelled verdict silently put the summary in the wrong field.

## Fix

- `GATE_VERDICT_ALIASES` + `normalize_gate_verdict()` in `map_step_runner`, used by both `write_stage_gate` and `write_plan_review`: `PROCEED -> ready`, `REVISE -> needs-revision`, `BLOCK -> blocked` (plus the `needs_revision` underscore variant). Unknown verdicts still error.
- Both `write_stage_gate` call sites in `map-review/SKILL.md` and the Codex `review-reference.md` port now pass `<stage> <verdict> <source_artifact> <notes>`, and the skill documents the mapping.

## Verification

- New regression tests: `TestWriteStageGate::test_skill_documented_verdicts_normalized`, `test_plan_review_recommendation_normalized`, and a SKILL.md guard `test_map_review_skill_stage_gate_calls_use_consistent_arg_positions` (negative-proofed — reverting the call site to the 3-arg form turns it red).
- End-to-end CLI repro against a scratch repo now writes `{"verdict": "needs-revision", "source_artifact": "code-review-001.md", "notes": "needs work"}`.
- `make check`: ruff + mypy + pyright (0/0/0) + 4104 tests passed + `check-render` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stage-gate submissions so review summaries and source artifacts are recorded in the proper fields.
  * Added support for common verdict spellings, including `PROCEED`, `REVISE`, and `BLOCK`, with consistent status normalization.
  * Invalid verdicts now produce clearer validation errors.

* **Documentation**
  * Updated map-review guidance and examples to reflect the corrected argument order and verdict mappings.

* **Tests**
  * Added coverage for verdict normalization and stage-gate argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->