### PR TITLE
fix: gate .claude/settings.json parity via check-render (#390)

### DIFF
--- a/src/mapify_cli/delivery/template_renderer.py
+++ b/src/mapify_cli/delivery/template_renderer.py
@@ -62,7 +62,6 @@ _STRAY_TOKENS = ("[%", "<%", "[#")
 _CLAUDE_SHIPPED_ONLY: frozenset[str] = frozenset(
     {
         "CLAUDE.md",
-        "settings.json",
         "workflow-rules.json",
         "ralph-loop-config.json",
         "hooks/README.md",
@@ -262,8 +261,12 @@ def _build_claude_resolver(
         (``map/`` prefix remaps to ``.map/`` in the dev tree)
 
     * hooks/README.md, rules/learned/README.md, CLAUDE.md,
-      settings.json, workflow-rules.json, ralph-loop-config.json
+      workflow-rules.json, ralph-loop-config.json
       → ``src/mapify_cli/templates/<rel>`` ONLY (shipped-only — no dev dest)
+
+    * settings.json
+      → BOTH ``src/mapify_cli/templates/settings.json`` AND ``.claude/settings.json``
+        (dual-dest so ``check-render`` gates both and drift is caught; issue #390)
 
     A rendered file mapping to 0 destinations is simply not written live
     (future use; not used for CLAUDE provider currently).

--- a/tests/test_template_render.py
+++ b/tests/test_template_render.py
@@ -479,9 +479,10 @@ _CLAUDE_ROOT = _REPO_ROOT / ".claude"
 _MAP_ROOT = _REPO_ROOT / ".map"
 
 # Shipped-only relative paths (no .claude/ destination)
+# Note: settings.json is intentionally NOT in this list — it is dual-dest
+# (templates/ AND .claude/) so check-render gates both copies (issue #390).
 _SHIPPED_ONLY_RELS = [
     "CLAUDE.md",
-    "settings.json",
     "workflow-rules.json",
     "ralph-loop-config.json",
     "hooks/README.md",
@@ -670,6 +671,44 @@ class TestRenderRepoTreesClaude:
             assert claude_path not in written_strs, (
                 f"Shipped-only file was incorrectly written to .claude/: {claude_path}"
             )
+
+    @_skip_no_templates_src
+    def test_settings_json_written_to_both_destinations(self) -> None:
+        """settings.json is dual-dest: renders to templates/ AND .claude/ (issue #390).
+
+        This gates the parity that check-render now enforces: a change to
+        settings.json.jinja must propagate to BOTH destinations or check-render
+        reports stale files.
+        """
+        result = render_repo_trees(
+            "claude", dry_run=False, repo_root=_REPO_ROOT, templates_src_root=_TEMPLATES_SRC
+        )
+        written_strs = [str(p) for p in result]
+        templates_path = str(_TEMPLATES_DEST / "settings.json")
+        claude_path = str(_CLAUDE_ROOT / "settings.json")
+        assert templates_path in written_strs, (
+            "settings.json was NOT written to templates/ — check renderer destination map"
+        )
+        assert claude_path in written_strs, (
+            "settings.json was NOT written to .claude/ — shipped-only classification "
+            "must be removed (issue #390 regression)"
+        )
+
+    @_skip_no_templates_src
+    def test_settings_json_dev_shipped_parity(self) -> None:
+        """Parity gate: .claude/settings.json must byte-match templates/settings.json.
+
+        Catches drift between the dev copy and the shipped mirror before it
+        reaches a real user session (issue #390).
+        """
+        dev_file = _CLAUDE_ROOT / "settings.json"
+        shipped_file = _TEMPLATES_DEST / "settings.json"
+        assert dev_file.exists(), f".claude/settings.json missing: {dev_file}"
+        assert shipped_file.exists(), f"templates/settings.json missing: {shipped_file}"
+        assert dev_file.read_bytes() == shipped_file.read_bytes(), (
+            "Parity FAILED: .claude/settings.json differs from templates/settings.json. "
+            "Run 'make render-templates' to sync (issue #390)."
+        )
 
     @_skip_no_templates_src
     def test_vc1_map_scripts_remap(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #390: `check-render` did not cover `.claude/settings.json` because `settings.json` was classified as shipped-only (rendered to `src/mapify_cli/templates/` only, never to `.claude/`). This allowed the dev copy to silently drift from the jinja source with no gate catching it.

## Changes

- **`src/mapify_cli/delivery/template_renderer.py`**: Remove `"settings.json"` from `_CLAUDE_SHIPPED_ONLY`. It is now dual-dest: rendered to both `src/mapify_cli/templates/settings.json` AND `.claude/settings.json`. `diff_rendered_trees` (the `check-render` gate) now automatically byte-compares both copies against a fresh jinja render.

- **`tests/test_template_render.py`**:
  - Remove `"settings.json"` from `_SHIPPED_ONLY_RELS` (matching the renderer change)
  - Add `test_settings_json_written_to_both_destinations`: asserts dual-dest write
  - Add `test_settings_json_dev_shipped_parity`: explicit byte-compare parity gate

## Verification

- Artificial drift in `.claude/settings.json` is now caught by `make check-render`:
  ```
  ❌ Generated trees are stale — run 'make render-templates' and commit:
    stale: /home/user/map-framework/.claude/settings.json
  ```
- `make check` passes: 4105 passed, 4 skipped
- `make lint` passes: ruff, mypy, pyright all clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMPQtQRaorWL7Has6CqkLM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Claude configuration handling so `settings.json` is now available in both shipped templates and the development configuration directory.
  * Ensured both copies remain synchronized for consistent behavior across environments.
* **Tests**
  * Added coverage verifying that `settings.json` is written to both destinations and remains identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->