### PR TITLE
feat: role-local persistent memory for learning agents (#379)

### DIFF
--- a/.claude/hooks/workflow-gate.py
+++ b/.claude/hooks/workflow-gate.py
@@ -190,7 +190,18 @@ def is_exempt_path(file_path: str) -> bool:
     # rules written by ``/map-learn``. The exemption is restricted to ``*.md`` files to
     # prevent the directory from quietly broadening into a general bypass for arbitrary
     # file types (executables, configs, secrets-bearing JSON, etc.).
-    return bool(len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"))
+    if len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"):
+        return True
+    # POLICY: ``.claude/agent-memory/`` and ``.claude/agent-memory-local/`` are the
+    # destinations for role-local persistent memory written by learning agents (e.g.
+    # reflector). Exemption is restricted to ``*.md`` files only — the same narrow
+    # scope as the ``rules/learned/`` exemption above.
+    return (
+        len(parts) >= 3
+        and parts[0] == ".claude"
+        and parts[1] in ("agent-memory", "agent-memory-local")
+        and parts[-1].endswith(".md")
+    )
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/.codex/hooks/workflow-gate.py
+++ b/.codex/hooks/workflow-gate.py
@@ -190,7 +190,18 @@ def is_exempt_path(file_path: str) -> bool:
     # rules written by ``/map-learn``. The exemption is restricted to ``*.md`` files to
     # prevent the directory from quietly broadening into a general bypass for arbitrary
     # file types (executables, configs, secrets-bearing JSON, etc.).
-    return bool(len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"))
+    if len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"):
+        return True
+    # POLICY: ``.claude/agent-memory/`` and ``.claude/agent-memory-local/`` are the
+    # destinations for role-local persistent memory written by learning agents (e.g.
+    # reflector). Exemption is restricted to ``*.md`` files only — the same narrow
+    # scope as the ``rules/learned/`` exemption above.
+    return (
+        len(parts) >= 3
+        and parts[0] == ".claude"
+        and parts[1] in ("agent-memory", "agent-memory-local")
+        and parts[-1].endswith(".md")
+    )
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/src/mapify_cli/__init__.py
+++ b/src/mapify_cli/__init__.py
@@ -770,6 +770,18 @@ def init(
             "See docs/USAGE.md."
         ),
     ),
+    agent_memory: str = typer.Option(
+        "off",
+        "--agent-memory",
+        help=(
+            "Role-local persistent memory for the reflector learning agent "
+            "(opt-in, off by default). Adds a `memory:` frontmatter field to "
+            ".claude/agents/reflector.md and writes "
+            "claude_agents.persistent_memory=<level> to .map/config.yaml. "
+            "Allowed: off, local (user-local, NOT committed), "
+            "project (project-scoped, committed). See docs/USAGE.md."
+        ),
+    ),
     autonomy: bool | None = typer.Option(
         None,
         "--autonomy/--no-autonomy",
@@ -853,6 +865,14 @@ def init(
     if compression_threshold is not None and compression_threshold <= 0:
         console.print(
             "[red]Error:[/red] --compression-threshold must be > 0"
+        )
+        raise typer.Exit(1)
+
+    from mapify_cli.config.project_config import VALID_AGENT_MEMORY_LEVELS
+    if agent_memory not in VALID_AGENT_MEMORY_LEVELS:
+        console.print(
+            f"[red]Error:[/red] Invalid --agent-memory '{agent_memory}'. "
+            f"Valid: {', '.join(sorted(VALID_AGENT_MEMORY_LEVELS))}"
         )
         raise typer.Exit(1)
 
@@ -975,6 +995,7 @@ def init(
         tracker.start("map-config")
         try:
             from mapify_cli.config.project_config import (
+                apply_agent_memory_overrides,
                 apply_compression_overrides,
                 apply_sofa_overrides,
                 write_default_config,
@@ -994,6 +1015,8 @@ def init(
                 from mapify_cli.delivery.file_copier import merge_sofa_gitignore
 
                 merge_sofa_gitignore(project_path)
+            if agent_memory != "off":
+                apply_agent_memory_overrides(config_path, agent_memory)
             tracker.complete(
                 "map-config", str(config_path.relative_to(project_path))
             )
@@ -1029,6 +1052,7 @@ def init(
         tracker.start("map-config")
         try:
             from mapify_cli.config.project_config import (
+                apply_agent_memory_overrides,
                 apply_compression_overrides,
                 apply_sofa_overrides,
                 write_default_config,
@@ -1048,6 +1072,16 @@ def init(
                 from mapify_cli.delivery.file_copier import merge_sofa_gitignore
 
                 merge_sofa_gitignore(project_path)
+            if agent_memory != "off":
+                apply_agent_memory_overrides(config_path, agent_memory)
+                from mapify_cli.delivery.file_copier import (
+                    apply_reflector_memory_field,
+                    merge_agent_memory_gitignore,
+                )
+
+                apply_reflector_memory_field(project_path, agent_memory)
+                if agent_memory == "local":
+                    merge_agent_memory_gitignore(project_path)
             tracker.complete("map-config", str(config_path.relative_to(project_path)))
         except Exception as e:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
             tracker.error("map-config", f"skipped: {e}")

--- a/src/mapify_cli/config/project_config.py
+++ b/src/mapify_cli/config/project_config.py
@@ -19,6 +19,7 @@ VALID_MINIMALITY = frozenset({"off", "lite", "full", "ultra"})
 VALID_PROMPT_LAYERING = frozenset({"docs_first", "stable_first"})
 VALID_WORKTREE_ISOLATION = frozenset({"off", "auto", "required"})
 VALID_WAVE_MODE = frozenset({"off", "auto", "on"})
+VALID_AGENT_MEMORY_LEVELS = frozenset({"off", "local", "project"})
 
 # Cross-AI peer review (#288): external AI CLI runtimes map-review can dispatch
 # to. Keep in sync with CROSS_AI_RUNTIMES in the rendered step runner
@@ -129,6 +130,17 @@ class MapConfig:
     # Enable via `mapify init --sofa` or by setting `sofa.enabled: true` in
     # .map/config.yaml. When enabled, the map-so-search skill is available.
     sofa_enabled: bool = False
+
+    # Role-local persistent memory for learning agents (#379). Enables the
+    # Claude Code `memory:` frontmatter on the reflector agent so it can retain
+    # lessons across sessions. Enum values:
+    #   "off"     — no memory field added (default; behaviour unchanged)
+    #   "local"   — user-local memory: .claude/agent-memory-local/ (not committed)
+    #   "project" — project-scoped memory: .claude/agent-memory/ (committed)
+    # Enable via `mapify init --agent-memory local|project` or set
+    # `claude_agents.persistent_memory: local|project` in .map/config.yaml.
+    # Dotted YAML key: `claude_agents.persistent_memory` (aliased in load_map_config).
+    claude_agents_persistent_memory: str = "off"
 
     # Strip MAP-internal workflow IDs (ST-/AC-/VC-/INV-/HC-) from run-changed
     # code at workflow completion (Stop hook `scrub-internal-ids.py`). On by
@@ -373,6 +385,7 @@ def load_map_config(project_path: Path) -> MapConfig:
             ("scale.thresholds.small.max_lines", "scale_small_max_lines"),
             ("scale.thresholds.medium.max_files", "scale_medium_max_files"),
             ("scale.thresholds.medium.max_lines", "scale_medium_max_lines"),
+            ("claude_agents.persistent_memory", "claude_agents_persistent_memory"),
         ):
             if dotted in data and field_name not in data:
                 data[field_name] = data.pop(dotted)
@@ -513,6 +526,16 @@ def load_map_config(project_path: Path) -> MapConfig:
             )
             cfg.execution_wave_mode = "auto"
 
+        if cfg.claude_agents_persistent_memory not in VALID_AGENT_MEMORY_LEVELS:
+            logger.warning(
+                "Invalid claude_agents_persistent_memory %r in %s (expected one of %s). "
+                "Using default 'off'.",
+                cfg.claude_agents_persistent_memory,
+                config_file,
+                ", ".join(sorted(VALID_AGENT_MEMORY_LEVELS)),
+            )
+            cfg.claude_agents_persistent_memory = "off"
+
         # Clamp max_actors to [1, 8]; non-int/bool → default 4.
         # retry_degraded_once and concurrent_dispatch are plain bools handled by
         # the generic type-check loop.
@@ -648,6 +671,15 @@ minimality: lite
 # Stack Overflow for Agents (SOFA) integration — opt-in, off by default.
 # Enable via `mapify init --sofa` or uncomment the line below.
 # sofa.enabled: false
+
+# Role-local persistent memory for learning agents (#379) — opt-in, off by default.
+# Adds the Claude Code `memory:` frontmatter to the reflector agent so it retains
+# lessons across sessions. Enable via `mapify init --agent-memory local|project`
+# or uncomment and set one of the values below.
+#   off     — no memory (default; behaviour unchanged)
+#   local   — user-local memory: .claude/agent-memory-local/ (NOT committed)
+#   project — project-scoped memory: .claude/agent-memory/ (committed, shared)
+# claude_agents.persistent_memory: off
 
 # Cross-AI peer review (#288) — opt-in, OFF by default. When enabled AND you run
 # `map-review --cross-ai <runtime>`, the review is dispatched to an INDEPENDENT
@@ -831,6 +863,39 @@ def apply_sofa_overrides(config_path: Path) -> None:
         return f"{body}{sep}{new_line}\n"
 
     text = _set("sofa.enabled", "true", text)
+    config_path.write_text(text, encoding="utf-8")
+
+
+def apply_agent_memory_overrides(config_path: Path, level: str) -> None:
+    """Write claude_agents.persistent_memory=<level> into an existing .map/config.yaml.
+
+    Called by ``mapify init`` when the user passes ``--agent-memory``. Replaces
+    the commented placeholder line so the value becomes active without duplicating
+    keys. Callers should skip this function when ``level`` is ``"off"``.
+
+    Args:
+        config_path: path to the .map/config.yaml produced by ``write_default_config``.
+        level: one of "off", "local", "project" (caller is responsible for validation).
+    """
+    if not config_path.is_file():
+        return
+
+    text = config_path.read_text(encoding="utf-8")
+
+    def _set(key: str, value: str, body: str) -> str:
+        import re
+
+        active_re = re.compile(rf"(?m)^{re.escape(key)}\s*:.*$")
+        commented_re = re.compile(rf"(?m)^#\s*{re.escape(key)}\s*:.*$")
+        new_line = f"{key}: {value}"
+        if active_re.search(body):
+            return active_re.sub(new_line, body, count=1)
+        if commented_re.search(body):
+            return commented_re.sub(new_line, body, count=1)
+        sep = "" if body.endswith("\n") else "\n"
+        return f"{body}{sep}{new_line}\n"
+
+    text = _set("claude_agents.persistent_memory", level, text)
     config_path.write_text(text, encoding="utf-8")
 
 

--- a/src/mapify_cli/delivery/file_copier.py
+++ b/src/mapify_cli/delivery/file_copier.py
@@ -498,6 +498,98 @@ def merge_sofa_gitignore(project_path: Path) -> int:
     return 1
 
 
+_AGENT_MEMORY_LOCAL_GITIGNORE_MARKER = "# map:agent-memory-local"
+_AGENT_MEMORY_LOCAL_GITIGNORE_BLOCK = (
+    "# map:agent-memory-local — user-local agent memory (opt-in); never commit.\n"
+    ".claude/agent-memory-local/\n"
+)
+
+
+def merge_agent_memory_gitignore(project_path: Path) -> int:
+    """Idempotently add .claude/agent-memory-local/ to the repo-root .gitignore.
+
+    Only called when ``--agent-memory local`` is used. The project-scoped level
+    (``--agent-memory project``) writes to ``.claude/agent-memory/`` which IS
+    intended to be committed, so no gitignore entry is needed for it.
+
+    Returns 1 when the file was created or modified, 0 when already up-to-date.
+    """
+    gitignore = project_path / ".gitignore"
+
+    if not gitignore.exists():
+        gitignore.write_text(_AGENT_MEMORY_LOCAL_GITIGNORE_BLOCK)
+        return 1
+
+    existing = gitignore.read_text()
+
+    # OR-not-AND idempotency guard: skip if our marker OR the exact path is
+    # already present (prevents duplicates when user already has the line).
+    ignored_lines = {line.strip() for line in existing.splitlines()}
+    if (
+        _AGENT_MEMORY_LOCAL_GITIGNORE_MARKER in existing
+        or ".claude/agent-memory-local/" in ignored_lines
+    ):
+        return 0
+
+    separator = "" if existing.endswith("\n") else "\n"
+    gitignore.write_text(existing + separator + _AGENT_MEMORY_LOCAL_GITIGNORE_BLOCK)
+    return 1
+
+
+def apply_reflector_memory_field(project_path: Path, level: str) -> int:
+    """Add or update the ``memory:`` frontmatter field in the installed reflector.md.
+
+    Called post-install when ``--agent-memory`` is ``"local"`` or ``"project"``.
+    Idempotent: if the field already exists with the correct value it is left
+    unchanged; if it exists with a different value it is replaced.
+
+    Args:
+        project_path: root of the target project (installed ``.claude/`` lives here).
+        level: ``"local"`` or ``"project"`` (caller is responsible for validation;
+               ``"off"`` callers must not invoke this function).
+
+    Returns:
+        1 if the file was modified, 0 if already up-to-date or not found.
+    """
+    import re
+
+    reflector_path = project_path / ".claude" / "agents" / "reflector.md"
+    if not reflector_path.exists():
+        return 0
+
+    text = reflector_path.read_text(encoding="utf-8")
+
+    # Determine the correct memory field value based on level.
+    # "local"   → memory: user_local   (maps to .claude/agent-memory-local/)
+    # "project" → memory: project      (maps to .claude/agent-memory/)
+    memory_value = "user_local" if level == "local" else "project"
+    new_field_line = f"memory: {memory_value}"
+
+    # If a `memory:` line already exists in the frontmatter, replace it.
+    existing_memory_re = re.compile(r"(?m)^memory\s*:.*$")
+    if existing_memory_re.search(text):
+        updated = existing_memory_re.sub(new_field_line, text, count=1)
+        if updated == text:
+            return 0  # already up-to-date
+        reflector_path.write_text(updated, encoding="utf-8")
+        return 1
+
+    # Inject the `memory:` line into the YAML frontmatter, just before the
+    # closing `---` delimiter. This preserves the existing frontmatter structure.
+    # Match the opening `---\n ... \n---` block.
+    frontmatter_re = re.compile(r"^(---\n.*?\n)(---)", re.DOTALL)
+    m = frontmatter_re.match(text)
+    if not m:
+        # No frontmatter — prepend a minimal one.
+        updated = f"---\n{new_field_line}\n---\n{text}"
+    else:
+        # Insert before the closing `---`.
+        updated = text[: m.start(2)] + new_field_line + "\n" + text[m.start(2) :]
+
+    reflector_path.write_text(updated, encoding="utf-8")
+    return 1
+
+
 def create_commands_dir(project_path: Path) -> None:
     """Create commands directory with README pointing at skill-backed surfaces."""
     commands_dir = project_path / ".claude" / "commands"

--- a/src/mapify_cli/templates/codex/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/codex/hooks/workflow-gate.py
@@ -190,7 +190,18 @@ def is_exempt_path(file_path: str) -> bool:
     # rules written by ``/map-learn``. The exemption is restricted to ``*.md`` files to
     # prevent the directory from quietly broadening into a general bypass for arbitrary
     # file types (executables, configs, secrets-bearing JSON, etc.).
-    return bool(len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"))
+    if len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"):
+        return True
+    # POLICY: ``.claude/agent-memory/`` and ``.claude/agent-memory-local/`` are the
+    # destinations for role-local persistent memory written by learning agents (e.g.
+    # reflector). Exemption is restricted to ``*.md`` files only — the same narrow
+    # scope as the ``rules/learned/`` exemption above.
+    return (
+        len(parts) >= 3
+        and parts[0] == ".claude"
+        and parts[1] in ("agent-memory", "agent-memory-local")
+        and parts[-1].endswith(".md")
+    )
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/src/mapify_cli/templates/hooks/workflow-gate.py
+++ b/src/mapify_cli/templates/hooks/workflow-gate.py
@@ -190,7 +190,18 @@ def is_exempt_path(file_path: str) -> bool:
     # rules written by ``/map-learn``. The exemption is restricted to ``*.md`` files to
     # prevent the directory from quietly broadening into a general bypass for arbitrary
     # file types (executables, configs, secrets-bearing JSON, etc.).
-    return bool(len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"))
+    if len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"):
+        return True
+    # POLICY: ``.claude/agent-memory/`` and ``.claude/agent-memory-local/`` are the
+    # destinations for role-local persistent memory written by learning agents (e.g.
+    # reflector). Exemption is restricted to ``*.md`` files only — the same narrow
+    # scope as the ``rules/learned/`` exemption above.
+    return (
+        len(parts) >= 3
+        and parts[0] == ".claude"
+        and parts[1] in ("agent-memory", "agent-memory-local")
+        and parts[-1].endswith(".md")
+    )
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/src/mapify_cli/templates_src/codex/hooks/workflow-gate.py.jinja
+++ b/src/mapify_cli/templates_src/codex/hooks/workflow-gate.py.jinja
@@ -190,7 +190,18 @@ def is_exempt_path(file_path: str) -> bool:
     # rules written by ``/map-learn``. The exemption is restricted to ``*.md`` files to
     # prevent the directory from quietly broadening into a general bypass for arbitrary
     # file types (executables, configs, secrets-bearing JSON, etc.).
-    return bool(len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"))
+    if len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"):
+        return True
+    # POLICY: ``.claude/agent-memory/`` and ``.claude/agent-memory-local/`` are the
+    # destinations for role-local persistent memory written by learning agents (e.g.
+    # reflector). Exemption is restricted to ``*.md`` files only — the same narrow
+    # scope as the ``rules/learned/`` exemption above.
+    return (
+        len(parts) >= 3
+        and parts[0] == ".claude"
+        and parts[1] in ("agent-memory", "agent-memory-local")
+        and parts[-1].endswith(".md")
+    )
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/src/mapify_cli/templates_src/hooks/workflow-gate.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/workflow-gate.py.jinja
@@ -190,7 +190,18 @@ def is_exempt_path(file_path: str) -> bool:
     # rules written by ``/map-learn``. The exemption is restricted to ``*.md`` files to
     # prevent the directory from quietly broadening into a general bypass for arbitrary
     # file types (executables, configs, secrets-bearing JSON, etc.).
-    return bool(len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"))
+    if len(parts) >= 4 and parts[:3] == (".claude", "rules", "learned") and parts[-1].endswith(".md"):
+        return True
+    # POLICY: ``.claude/agent-memory/`` and ``.claude/agent-memory-local/`` are the
+    # destinations for role-local persistent memory written by learning agents (e.g.
+    # reflector). Exemption is restricted to ``*.md`` files only — the same narrow
+    # scope as the ``rules/learned/`` exemption above.
+    return (
+        len(parts) >= 3
+        and parts[0] == ".claude"
+        and parts[1] in ("agent-memory", "agent-memory-local")
+        and parts[-1].endswith(".md")
+    )
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -1,0 +1,344 @@
+"""
+Tests for role-local persistent memory for learning agents (#379).
+
+Covers:
+  AC1 - VALID_AGENT_MEMORY_LEVELS frozenset contains exactly {"off","local","project"}
+  AC2 - MapConfig.claude_agents_persistent_memory defaults to "off"
+  AC3 - load_map_config honours dotted key claude_agents.persistent_memory
+  AC4 - load_map_config rejects invalid values and falls back to "off"
+  AC5 - apply_agent_memory_overrides writes the key into config.yaml
+  AC6 - apply_reflector_memory_field injects memory: into reflector.md frontmatter
+  AC7 - merge_agent_memory_gitignore idempotently adds agent-memory-local to .gitignore
+  AC8 - workflow-gate is_exempt_path allows *.md writes in agent-memory dirs
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    """Write a minimal .map/config.yaml and return its path."""
+    map_dir = tmp_path / ".map"
+    map_dir.mkdir(parents=True, exist_ok=True)
+    cfg = map_dir / "config.yaml"
+    cfg.write_text(body, encoding="utf-8")
+    return cfg
+
+
+def _minimal_reflector(tmp_path: Path, extra_frontmatter: str = "") -> Path:
+    """Write a minimal reflector.md in the installed location and return its path."""
+    agents_dir = tmp_path / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    path = agents_dir / "reflector.md"
+    fm = f"name: reflector\ndescription: Test reflector\n{extra_frontmatter}".strip()
+    path.write_text(f"---\n{fm}\n---\n\n# Body\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# AC1: frozenset definition
+# ---------------------------------------------------------------------------
+
+class TestValidAgentMemoryLevels:
+    def test_frozenset_exact_members(self):
+        from mapify_cli.config.project_config import VALID_AGENT_MEMORY_LEVELS
+
+        assert VALID_AGENT_MEMORY_LEVELS == frozenset({"off", "local", "project"})
+
+    def test_frozenset_is_frozenset(self):
+        from mapify_cli.config.project_config import VALID_AGENT_MEMORY_LEVELS
+
+        assert isinstance(VALID_AGENT_MEMORY_LEVELS, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# AC2: MapConfig default
+# ---------------------------------------------------------------------------
+
+class TestMapConfigDefault:
+    def test_default_is_off(self):
+        from mapify_cli.config.project_config import MapConfig
+
+        cfg = MapConfig()
+        assert cfg.claude_agents_persistent_memory == "off"
+
+    def test_load_no_file_returns_default(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        cfg = load_map_config(tmp_path)
+        assert cfg.claude_agents_persistent_memory == "off"
+
+
+# ---------------------------------------------------------------------------
+# AC3: load_map_config dotted alias
+# ---------------------------------------------------------------------------
+
+class TestLoadMapConfigAlias:
+    def test_dotted_key_local(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        _write_config(tmp_path, "claude_agents.persistent_memory: local\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.claude_agents_persistent_memory == "local"
+
+    def test_dotted_key_project(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        _write_config(tmp_path, "claude_agents.persistent_memory: project\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.claude_agents_persistent_memory == "project"
+
+    def test_dotted_key_off(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        _write_config(tmp_path, "claude_agents.persistent_memory: 'off'\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.claude_agents_persistent_memory == "off"
+
+    def test_flat_key_also_works(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        _write_config(tmp_path, "claude_agents_persistent_memory: local\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.claude_agents_persistent_memory == "local"
+
+
+# ---------------------------------------------------------------------------
+# AC4: invalid value falls back to "off"
+# ---------------------------------------------------------------------------
+
+class TestLoadMapConfigValidation:
+    def test_invalid_value_falls_back_to_off(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        _write_config(tmp_path, "claude_agents.persistent_memory: global\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.claude_agents_persistent_memory == "off"
+
+    def test_empty_string_invalid_falls_back(self, tmp_path: Path):
+        from mapify_cli.config.project_config import load_map_config
+
+        _write_config(tmp_path, "claude_agents.persistent_memory: ''\n")
+        cfg = load_map_config(tmp_path)
+        # Empty string is not in VALID_AGENT_MEMORY_LEVELS → fallback
+        assert cfg.claude_agents_persistent_memory == "off"
+
+
+# ---------------------------------------------------------------------------
+# AC5: apply_agent_memory_overrides
+# ---------------------------------------------------------------------------
+
+class TestApplyAgentMemoryOverrides:
+    def test_writes_local_into_config(self, tmp_path: Path):
+        from mapify_cli.config.project_config import (
+            apply_agent_memory_overrides,
+            generate_default_config,
+        )
+
+        cfg_path = _write_config(tmp_path, generate_default_config())
+        apply_agent_memory_overrides(cfg_path, "local")
+        text = cfg_path.read_text()
+        assert "claude_agents.persistent_memory: local" in text
+
+    def test_writes_project_into_config(self, tmp_path: Path):
+        from mapify_cli.config.project_config import (
+            apply_agent_memory_overrides,
+            generate_default_config,
+        )
+
+        cfg_path = _write_config(tmp_path, generate_default_config())
+        apply_agent_memory_overrides(cfg_path, "project")
+        text = cfg_path.read_text()
+        assert "claude_agents.persistent_memory: project" in text
+
+    def test_idempotent_same_value(self, tmp_path: Path):
+        from mapify_cli.config.project_config import (
+            apply_agent_memory_overrides,
+            generate_default_config,
+        )
+
+        cfg_path = _write_config(tmp_path, generate_default_config())
+        apply_agent_memory_overrides(cfg_path, "local")
+        apply_agent_memory_overrides(cfg_path, "local")
+        text = cfg_path.read_text()
+        assert text.count("claude_agents.persistent_memory: local") == 1
+
+    def test_replace_existing_active_entry(self, tmp_path: Path):
+        from mapify_cli.config.project_config import apply_agent_memory_overrides
+
+        cfg_path = _write_config(
+            tmp_path,
+            "claude_agents.persistent_memory: local\n",
+        )
+        apply_agent_memory_overrides(cfg_path, "project")
+        text = cfg_path.read_text()
+        assert "claude_agents.persistent_memory: project" in text
+        assert "claude_agents.persistent_memory: local" not in text
+
+    def test_no_file_is_noop(self, tmp_path: Path):
+        from mapify_cli.config.project_config import apply_agent_memory_overrides
+
+        nonexistent = tmp_path / "nonexistent.yaml"
+        apply_agent_memory_overrides(nonexistent, "local")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# AC6: apply_reflector_memory_field
+# ---------------------------------------------------------------------------
+
+class TestApplyReflectorMemoryField:
+    def test_local_injects_user_local(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import apply_reflector_memory_field
+
+        _minimal_reflector(tmp_path)
+        result = apply_reflector_memory_field(tmp_path, "local")
+        assert result == 1
+        text = (tmp_path / ".claude" / "agents" / "reflector.md").read_text()
+        assert "memory: user_local" in text
+
+    def test_project_injects_project(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import apply_reflector_memory_field
+
+        _minimal_reflector(tmp_path)
+        result = apply_reflector_memory_field(tmp_path, "project")
+        assert result == 1
+        text = (tmp_path / ".claude" / "agents" / "reflector.md").read_text()
+        assert "memory: project" in text
+
+    def test_memory_inside_frontmatter(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import apply_reflector_memory_field
+
+        _minimal_reflector(tmp_path)
+        apply_reflector_memory_field(tmp_path, "local")
+        text = (tmp_path / ".claude" / "agents" / "reflector.md").read_text()
+        # memory: line must appear inside the frontmatter block (before closing ---)
+        fm_end = text.index("\n---", 4)
+        frontmatter = text[:fm_end]
+        assert "memory: user_local" in frontmatter
+
+    def test_replaces_existing_memory_field(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import apply_reflector_memory_field
+
+        _minimal_reflector(tmp_path, extra_frontmatter="memory: user_local")
+        result = apply_reflector_memory_field(tmp_path, "project")
+        assert result == 1
+        text = (tmp_path / ".claude" / "agents" / "reflector.md").read_text()
+        assert "memory: project" in text
+        assert "memory: user_local" not in text
+
+    def test_idempotent_same_value(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import apply_reflector_memory_field
+
+        _minimal_reflector(tmp_path, extra_frontmatter="memory: user_local")
+        result = apply_reflector_memory_field(tmp_path, "local")
+        assert result == 0  # already up-to-date
+
+    def test_missing_reflector_returns_zero(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import apply_reflector_memory_field
+
+        result = apply_reflector_memory_field(tmp_path, "local")
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# AC7: merge_agent_memory_gitignore
+# ---------------------------------------------------------------------------
+
+class TestMergeAgentMemoryGitignore:
+    def test_creates_gitignore_if_absent(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import merge_agent_memory_gitignore
+
+        result = merge_agent_memory_gitignore(tmp_path)
+        assert result == 1
+        assert (tmp_path / ".gitignore").exists()
+        text = (tmp_path / ".gitignore").read_text()
+        assert ".claude/agent-memory-local/" in text
+
+    def test_appends_to_existing_gitignore(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import merge_agent_memory_gitignore
+
+        gi = tmp_path / ".gitignore"
+        gi.write_text("*.pyc\n")
+        result = merge_agent_memory_gitignore(tmp_path)
+        assert result == 1
+        text = gi.read_text()
+        assert "*.pyc" in text
+        assert ".claude/agent-memory-local/" in text
+
+    def test_idempotent_marker_present(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import merge_agent_memory_gitignore
+
+        gi = tmp_path / ".gitignore"
+        gi.write_text("# map:agent-memory-local\n.claude/agent-memory-local/\n")
+        result = merge_agent_memory_gitignore(tmp_path)
+        assert result == 0
+        assert gi.read_text().count(".claude/agent-memory-local/") == 1
+
+    def test_idempotent_line_present_without_marker(self, tmp_path: Path):
+        from mapify_cli.delivery.file_copier import merge_agent_memory_gitignore
+
+        gi = tmp_path / ".gitignore"
+        gi.write_text(".claude/agent-memory-local/\n")
+        result = merge_agent_memory_gitignore(tmp_path)
+        assert result == 0
+        assert gi.read_text().count(".claude/agent-memory-local/") == 1
+
+
+# ---------------------------------------------------------------------------
+# AC8: workflow-gate is_exempt_path exemptions
+# ---------------------------------------------------------------------------
+
+class TestWorkflowGateExemptions:
+    """Load the rendered workflow-gate.py and test is_exempt_path directly."""
+
+    @pytest.fixture(scope="class")
+    def is_exempt_path(self):
+        import importlib.util
+        import sys as _sys
+
+        gate_path = _PROJECT_ROOT / ".claude" / "hooks" / "workflow-gate.py"
+        assert gate_path.exists(), f"workflow-gate.py not found at {gate_path}"
+
+        prev = _sys.dont_write_bytecode
+        _sys.dont_write_bytecode = True
+        try:
+            spec = importlib.util.spec_from_file_location("workflow_gate", gate_path)
+            assert spec is not None
+            mod = importlib.util.module_from_spec(spec)
+            assert spec.loader is not None
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        finally:
+            _sys.dont_write_bytecode = prev
+
+        return mod.is_exempt_path
+
+    def test_agent_memory_project_md_is_exempt(self, is_exempt_path):
+        p = str(_PROJECT_ROOT / ".claude" / "agent-memory" / "lessons.md")
+        assert is_exempt_path(p) is True
+
+    def test_agent_memory_local_md_is_exempt(self, is_exempt_path):
+        p = str(_PROJECT_ROOT / ".claude" / "agent-memory-local" / "lessons.md")
+        assert is_exempt_path(p) is True
+
+    def test_agent_memory_non_md_not_exempt(self, is_exempt_path):
+        p = str(_PROJECT_ROOT / ".claude" / "agent-memory" / "script.py")
+        assert is_exempt_path(p) is False
+
+    def test_agent_memory_local_non_md_not_exempt(self, is_exempt_path):
+        p = str(_PROJECT_ROOT / ".claude" / "agent-memory-local" / "config.json")
+        assert is_exempt_path(p) is False
+
+    def test_random_claude_dir_not_exempt(self, is_exempt_path):
+        p = str(_PROJECT_ROOT / ".claude" / "some-dir" / "file.md")
+        # only agent-memory and agent-memory-local are exempt; other dirs are not
+        # (unless covered by an existing exemption like rules/learned)
+        assert is_exempt_path(p) is False


### PR DESCRIPTION
## Summary

Implements the first implementation slice from issue #379: a config flag that enables role-local persistent memory for the reflector learning agent.

- **`VALID_AGENT_MEMORY_LEVELS`** frozenset `{"off", "local", "project"}` and `MapConfig.claude_agents_persistent_memory` field (default `"off"`)
- **`load_map_config`**: dotted-alias `claude_agents.persistent_memory` → snake_case field, enum validation (invalid values fall back to `"off"`)
- **`apply_agent_memory_overrides(config_path, level)`**: writes `claude_agents.persistent_memory: <level>` into `.map/config.yaml`, replacing any existing active or commented placeholder
- **`apply_reflector_memory_field(project_path, level)`**: injects `memory: user_local` or `memory: project` into the installed `reflector.md` YAML frontmatter after `mapify init`; idempotent; replaces an existing `memory:` value when level changes
- **`merge_agent_memory_gitignore(project_path)`**: idempotently adds `.claude/agent-memory-local/` to `.gitignore` when `--agent-memory local` is used (the `project` level writes to a committable path and needs no gitignore entry)
- **`--agent-memory off|local|project`** CLI option on `mapify init`, wired into both the Claude and Codex provider paths
- **`workflow-gate.py.jinja`** (claude + codex): exempts `*.md` files under `.claude/agent-memory/` and `.claude/agent-memory-local/` from the edit gate so learning agents can write memory artifacts without being blocked

## Tests

`tests/test_agent_memory.py` — 30 tests covering AC1–AC8:
- AC1: `VALID_AGENT_MEMORY_LEVELS` members and type
- AC2: `MapConfig` default and `load_map_config` no-file default
- AC3: dotted alias `claude_agents.persistent_memory` (local / project / off / flat key)
- AC4: invalid values fall back to `"off"`
- AC5: `apply_agent_memory_overrides` (write, idempotency, replace, no-file noop)
- AC6: `apply_reflector_memory_field` (inject, replace, idempotency, missing file)
- AC7: `merge_agent_memory_gitignore` (create, append, idempotency)
- AC8: `is_exempt_path` exemptions for `agent-memory/*.md` and `agent-memory-local/*.md`

All 222 tests in the affected test files pass (`test_agent_memory`, `test_template_render`, `test_workflow_gate`, `test_project_config`). Full suite passes except one pre-existing failure in `test_skills_eval_trajectory_gates::test_run_verification_pass` (confirmed pre-existing on `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuTBauPXxMq2eBcfSwckDw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `mapify init --agent-memory` with `off`, `local`, and `project` options.
  - Configures persistent learning-agent memory and updates related project files automatically.
  - Supports local memory exclusions in `.gitignore`.
  - Allows approved Markdown memory files through workflow checks.

- **Bug Fixes**
  - Invalid memory settings now safely fall back to `off`.

- **Tests**
  - Added comprehensive coverage for configuration, installation, persistence, exclusions, and idempotent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->