### PR TITLE
fix: promote class-scoped instance-method fixture to module scope

### DIFF
--- a/tests/test_agent_memory.py
+++ b/tests/test_agent_memory.py
@@ -297,29 +297,31 @@ class TestMergeAgentMemoryGitignore:
 # AC8: workflow-gate is_exempt_path exemptions
 # ---------------------------------------------------------------------------
 
+
+@pytest.fixture(scope="module")
+def is_exempt_path():
+    import importlib.util
+    import sys as _sys
+
+    gate_path = _PROJECT_ROOT / ".claude" / "hooks" / "workflow-gate.py"
+    assert gate_path.exists(), f"workflow-gate.py not found at {gate_path}"
+
+    prev = _sys.dont_write_bytecode
+    _sys.dont_write_bytecode = True
+    try:
+        spec = importlib.util.spec_from_file_location("workflow_gate", gate_path)
+        assert spec is not None
+        mod = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    finally:
+        _sys.dont_write_bytecode = prev
+
+    return mod.is_exempt_path
+
+
 class TestWorkflowGateExemptions:
     """Load the rendered workflow-gate.py and test is_exempt_path directly."""
-
-    @pytest.fixture(scope="class")
-    def is_exempt_path(self):
-        import importlib.util
-        import sys as _sys
-
-        gate_path = _PROJECT_ROOT / ".claude" / "hooks" / "workflow-gate.py"
-        assert gate_path.exists(), f"workflow-gate.py not found at {gate_path}"
-
-        prev = _sys.dont_write_bytecode
-        _sys.dont_write_bytecode = True
-        try:
-            spec = importlib.util.spec_from_file_location("workflow_gate", gate_path)
-            assert spec is not None
-            mod = importlib.util.module_from_spec(spec)
-            assert spec.loader is not None
-            spec.loader.exec_module(mod)  # type: ignore[union-attr]
-        finally:
-            _sys.dont_write_bytecode = prev
-
-        return mod.is_exempt_path
 
     def test_agent_memory_project_md_is_exempt(self, is_exempt_path):
         p = str(_PROJECT_ROOT / ".claude" / "agent-memory" / "lessons.md")


### PR DESCRIPTION
## Summary

- `is_exempt_path` in `TestWorkflowGateExemptions` was a `scope="class"` fixture defined as an instance method, triggering `PytestRemovedIn10Warning`
- pytest 10 will turn this into an error: instance attributes set in a class-scoped instance-method fixture are invisible to test methods (each test gets a new instance, fixture runs once per class)
- The fixture has no class-local state — it loads `workflow-gate.py` once and returns `is_exempt_path`
- Promoted to a module-level `@pytest.fixture(scope="module")` — semantically identical, zero warning, pytest-10-safe

## Test plan

- [ ] `uv run pytest tests/test_agent_memory.py -v -W error::pytest.PytestRemovedIn10Warning` — 30 passed, 0 warnings
- [ ] `make check` — 4135 passed, 4 skipped, 0 warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUNo4q48npeLTnhW8Q2Aj1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture organization and reuse.
  * Preserved existing workflow exemption test behavior while updating fixture scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->