### PR TITLE
feat(wayfind): make one-non-research-resolve-per-session cap opt-in

### DIFF
--- a/.claude/skills/map-wayfind/SKILL.md
+++ b/.claude/skills/map-wayfind/SKILL.md
@@ -92,7 +92,7 @@ Resolve exactly ONE non-research decision, then stop. Five steps.
    ```
 
    With what you learned, keep the map honest: `add_ticket` newly-sharp decisions, `graduate_fog` a fog entry that is now sharp, or `rule_out_of_scope` a ticket/fog that is settled as excluded (exclusions never appear under Decisions).
-5. **Stop.** The runner blocks a second non-research resolve in the same session by design. Report the decision and stop; start a fresh session (or `/map-wayfind handoff <slug>`) to continue.
+5. **Stop.** Resolving one decision at a time keeps the map reviewable — report the decision and stop, then start a fresh session (or `/map-wayfind handoff <slug>`) to continue. By default the runner does NOT hard-cap this; set `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION=1` to re-enable the old one-per-session block.
 
 ## Mode: handoff \<slug\>
 
@@ -107,7 +107,7 @@ This writes `.map/wayfind/<slug>/handoff.md` (+ `handoff.json`) and registers a 
 ## Guardrails
 
 - Do not pre-slice fog: only create a ticket when you can state its question sharply NOW (rubric in the reference). Otherwise keep it as fog.
-- Resolve at most ONE non-research ticket per session; the runner enforces this.
+- Resolve at most ONE non-research ticket per session (recommended discipline; not hard-enforced by default — opt in via `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`).
 - Out-of-scope is an exclusion, not a decision — it never graduates into the plan.
 - No implementation subtasks and no code changes here — that is `/map-plan` + execution.
 - Never write secrets into tickets, resolutions, or the map. Warn about the commit-by-default privacy note in `chart`.
@@ -126,6 +126,6 @@ More worked examples are in [wayfind-reference.md](wayfind-reference.md).
 
 - `emit_wayfind_handoff` returns `not_terminal`: fog, claimed, or unresolved tickets remain — resolve or rule them out, or hand off `--early --confirmed-by-user`.
 - `resolve_ticket` returns `awaiting_human`: it is a `prototype`/`grilling` ticket — record the human answer with `record_human_input` first.
-- `resolve_ticket` returns `session_limit`: you already resolved a non-research ticket this session — start a new session.
+- `resolve_ticket` returns `session_limit`: a per-session cap is active (`WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`, unset/0 = unlimited) — start a new session or raise/unset the cap.
 - `wire_blocking` returns `cycle`: the dependency you added would close a loop — re-check the blocker direction.
 - Full command reference and the fog-sharpness rubric are in [wayfind-reference.md](wayfind-reference.md).

--- a/.claude/skills/map-wayfind/wayfind-reference.md
+++ b/.claude/skills/map-wayfind/wayfind-reference.md
@@ -125,7 +125,7 @@ emit_wayfind_handoff checkout --remaining-risks-json '["fraud rules not yet scop
 
 - **`not_terminal` on handoff** — an item is still open. Run `wayfind_status --slug <slug>`; the error's `open_items` names each blocker. Resolve or `rule_out_of_scope` them, or hand off `--early --confirmed-by-user`.
 - **`awaiting_human`** — a `prototype`/`grilling` ticket needs a recorded human answer first (`record_human_input`).
-- **`session_limit`** — one non-research resolve per session is the rule; mint a fresh session id and continue.
+- **`session_limit`** — a per-session non-research cap is active via `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION` (unset/0 = unlimited, the default); mint a fresh session id and continue, or raise/unset the cap.
 - **`already_claimed` / `blocked` / `not_owner`** — the ticket is taken, has unresolved blockers, or is claimed by another session. Check `map.md`'s Blocked/claimed section.
 - **`stale_revision`** — another session advanced the map; re-read it and retry with the current `--expected-revision`.
 - **`cycle`** — a `wire_blocking` call would create a dependency loop; the blocker relationship is likely backwards.

--- a/.map/scripts/wayfind_runner.py
+++ b/.map/scripts/wayfind_runner.py
@@ -12,9 +12,9 @@ Design contract (mirrors the wider MAP conventions):
   * Every function returns a typed result dict: ``{"status": "success", ...}``
     or ``{"status": "error", "message": ...}``.  Nothing is raised through the
     public API; the CLI turns a non-success status into exit code 1.
-  * Invariants (cycle-freedom, one-non-research-resolve-per-session, HITL gate,
-    terminal-handoff condition) live ABOVE persistence so a future non-local
-    backend cannot bypass them.
+  * Invariants (cycle-freedom, HITL gate, terminal-handoff condition, plus the
+    opt-in one-non-research-resolve-per-session cap) live ABOVE persistence so a
+    future non-local backend cannot bypass them.
 
 The only cross-module dependency is a LAZY import of ``map_step_runner`` inside
 :func:`emit_wayfind_handoff`, used solely to register the ``wayfind_handoff``
@@ -45,6 +45,23 @@ WAYFIND_TICKET_TYPES = frozenset({"research", "prototype", "grilling", "task"})
 HITL_TYPES = frozenset({"prototype", "grilling"})
 # Ticket statuses that count as "closed" for frontier / terminal computations.
 TERMINAL_TICKET_STATUSES = frozenset({"resolved", "out_of_scope"})
+
+# Max non-research ticket resolves allowed per session. 0 (the default) means
+# unlimited — the one-per-session cap is an opt-in workflow discipline, not a
+# hard gate. Set WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION=N (N>=1) to
+# re-enable a cap. The session ledger still records every resolve regardless,
+# so the audit trail is preserved either way.
+_ENV_MAX_NONRESEARCH_PER_SESSION = "WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION"
+
+
+def _max_nonresearch_per_session() -> int:
+    """Resolve the per-session non-research cap; 0 = unlimited (default)."""
+    try:
+        n = int(os.environ.get(_ENV_MAX_NONRESEARCH_PER_SESSION, "0"))
+    except (TypeError, ValueError):
+        return 0
+    return max(0, n)
+
 
 _SLUG_RE = re.compile(r"^[a-z0-9-]{1,50}$")
 
@@ -958,10 +975,12 @@ def resolve_ticket(
 
     is_non_research = ticket.get("type") != "research"
     ledger = _ensure_session(state, session)
-    if is_non_research and int(ledger.get("non_research_resolved", 0)) >= 1:
+    cap = _max_nonresearch_per_session()
+    if is_non_research and cap > 0 and int(ledger.get("non_research_resolved", 0)) >= cap:
         return _err(
-            "this session has already resolved a non-research ticket. Resolve at most "
-            "ONE non-research ticket per session; start a new session to continue.",
+            f"this session has already resolved {cap} non-research ticket(s); the cap "
+            f"is set via {_ENV_MAX_NONRESEARCH_PER_SESSION}. Start a new session to "
+            "continue, or raise/unset the cap.",
             code="session_limit",
         )
 

--- a/src/mapify_cli/templates/map/scripts/wayfind_runner.py
+++ b/src/mapify_cli/templates/map/scripts/wayfind_runner.py
@@ -12,9 +12,9 @@ Design contract (mirrors the wider MAP conventions):
   * Every function returns a typed result dict: ``{"status": "success", ...}``
     or ``{"status": "error", "message": ...}``.  Nothing is raised through the
     public API; the CLI turns a non-success status into exit code 1.
-  * Invariants (cycle-freedom, one-non-research-resolve-per-session, HITL gate,
-    terminal-handoff condition) live ABOVE persistence so a future non-local
-    backend cannot bypass them.
+  * Invariants (cycle-freedom, HITL gate, terminal-handoff condition, plus the
+    opt-in one-non-research-resolve-per-session cap) live ABOVE persistence so a
+    future non-local backend cannot bypass them.
 
 The only cross-module dependency is a LAZY import of ``map_step_runner`` inside
 :func:`emit_wayfind_handoff`, used solely to register the ``wayfind_handoff``
@@ -45,6 +45,23 @@ WAYFIND_TICKET_TYPES = frozenset({"research", "prototype", "grilling", "task"})
 HITL_TYPES = frozenset({"prototype", "grilling"})
 # Ticket statuses that count as "closed" for frontier / terminal computations.
 TERMINAL_TICKET_STATUSES = frozenset({"resolved", "out_of_scope"})
+
+# Max non-research ticket resolves allowed per session. 0 (the default) means
+# unlimited — the one-per-session cap is an opt-in workflow discipline, not a
+# hard gate. Set WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION=N (N>=1) to
+# re-enable a cap. The session ledger still records every resolve regardless,
+# so the audit trail is preserved either way.
+_ENV_MAX_NONRESEARCH_PER_SESSION = "WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION"
+
+
+def _max_nonresearch_per_session() -> int:
+    """Resolve the per-session non-research cap; 0 = unlimited (default)."""
+    try:
+        n = int(os.environ.get(_ENV_MAX_NONRESEARCH_PER_SESSION, "0"))
+    except (TypeError, ValueError):
+        return 0
+    return max(0, n)
+
 
 _SLUG_RE = re.compile(r"^[a-z0-9-]{1,50}$")
 
@@ -958,10 +975,12 @@ def resolve_ticket(
 
     is_non_research = ticket.get("type") != "research"
     ledger = _ensure_session(state, session)
-    if is_non_research and int(ledger.get("non_research_resolved", 0)) >= 1:
+    cap = _max_nonresearch_per_session()
+    if is_non_research and cap > 0 and int(ledger.get("non_research_resolved", 0)) >= cap:
         return _err(
-            "this session has already resolved a non-research ticket. Resolve at most "
-            "ONE non-research ticket per session; start a new session to continue.",
+            f"this session has already resolved {cap} non-research ticket(s); the cap "
+            f"is set via {_ENV_MAX_NONRESEARCH_PER_SESSION}. Start a new session to "
+            "continue, or raise/unset the cap.",
             code="session_limit",
         )
 

--- a/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
@@ -92,7 +92,7 @@ Resolve exactly ONE non-research decision, then stop. Five steps.
    ```
 
    With what you learned, keep the map honest: `add_ticket` newly-sharp decisions, `graduate_fog` a fog entry that is now sharp, or `rule_out_of_scope` a ticket/fog that is settled as excluded (exclusions never appear under Decisions).
-5. **Stop.** The runner blocks a second non-research resolve in the same session by design. Report the decision and stop; start a fresh session (or `/map-wayfind handoff <slug>`) to continue.
+5. **Stop.** Resolving one decision at a time keeps the map reviewable — report the decision and stop, then start a fresh session (or `/map-wayfind handoff <slug>`) to continue. By default the runner does NOT hard-cap this; set `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION=1` to re-enable the old one-per-session block.
 
 ## Mode: handoff \<slug\>
 
@@ -107,7 +107,7 @@ This writes `.map/wayfind/<slug>/handoff.md` (+ `handoff.json`) and registers a 
 ## Guardrails
 
 - Do not pre-slice fog: only create a ticket when you can state its question sharply NOW (rubric in the reference). Otherwise keep it as fog.
-- Resolve at most ONE non-research ticket per session; the runner enforces this.
+- Resolve at most ONE non-research ticket per session (recommended discipline; not hard-enforced by default — opt in via `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`).
 - Out-of-scope is an exclusion, not a decision — it never graduates into the plan.
 - No implementation subtasks and no code changes here — that is `/map-plan` + execution.
 - Never write secrets into tickets, resolutions, or the map. Warn about the commit-by-default privacy note in `chart`.
@@ -126,6 +126,6 @@ More worked examples are in [wayfind-reference.md](wayfind-reference.md).
 
 - `emit_wayfind_handoff` returns `not_terminal`: fog, claimed, or unresolved tickets remain — resolve or rule them out, or hand off `--early --confirmed-by-user`.
 - `resolve_ticket` returns `awaiting_human`: it is a `prototype`/`grilling` ticket — record the human answer with `record_human_input` first.
-- `resolve_ticket` returns `session_limit`: you already resolved a non-research ticket this session — start a new session.
+- `resolve_ticket` returns `session_limit`: a per-session cap is active (`WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`, unset/0 = unlimited) — start a new session or raise/unset the cap.
 - `wire_blocking` returns `cycle`: the dependency you added would close a loop — re-check the blocker direction.
 - Full command reference and the fog-sharpness rubric are in [wayfind-reference.md](wayfind-reference.md).

--- a/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
@@ -125,7 +125,7 @@ emit_wayfind_handoff checkout --remaining-risks-json '["fraud rules not yet scop
 
 - **`not_terminal` on handoff** — an item is still open. Run `wayfind_status --slug <slug>`; the error's `open_items` names each blocker. Resolve or `rule_out_of_scope` them, or hand off `--early --confirmed-by-user`.
 - **`awaiting_human`** — a `prototype`/`grilling` ticket needs a recorded human answer first (`record_human_input`).
-- **`session_limit`** — one non-research resolve per session is the rule; mint a fresh session id and continue.
+- **`session_limit`** — a per-session non-research cap is active via `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION` (unset/0 = unlimited, the default); mint a fresh session id and continue, or raise/unset the cap.
 - **`already_claimed` / `blocked` / `not_owner`** — the ticket is taken, has unresolved blockers, or is claimed by another session. Check `map.md`'s Blocked/claimed section.
 - **`stale_revision`** — another session advanced the map; re-read it and retry with the current `--expected-revision`.
 - **`cycle`** — a `wire_blocking` call would create a dependency loop; the blocker relationship is likely backwards.

--- a/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
@@ -12,9 +12,9 @@ Design contract (mirrors the wider MAP conventions):
   * Every function returns a typed result dict: ``{"status": "success", ...}``
     or ``{"status": "error", "message": ...}``.  Nothing is raised through the
     public API; the CLI turns a non-success status into exit code 1.
-  * Invariants (cycle-freedom, one-non-research-resolve-per-session, HITL gate,
-    terminal-handoff condition) live ABOVE persistence so a future non-local
-    backend cannot bypass them.
+  * Invariants (cycle-freedom, HITL gate, terminal-handoff condition, plus the
+    opt-in one-non-research-resolve-per-session cap) live ABOVE persistence so a
+    future non-local backend cannot bypass them.
 
 The only cross-module dependency is a LAZY import of ``map_step_runner`` inside
 :func:`emit_wayfind_handoff`, used solely to register the ``wayfind_handoff``
@@ -45,6 +45,23 @@ WAYFIND_TICKET_TYPES = frozenset({"research", "prototype", "grilling", "task"})
 HITL_TYPES = frozenset({"prototype", "grilling"})
 # Ticket statuses that count as "closed" for frontier / terminal computations.
 TERMINAL_TICKET_STATUSES = frozenset({"resolved", "out_of_scope"})
+
+# Max non-research ticket resolves allowed per session. 0 (the default) means
+# unlimited — the one-per-session cap is an opt-in workflow discipline, not a
+# hard gate. Set WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION=N (N>=1) to
+# re-enable a cap. The session ledger still records every resolve regardless,
+# so the audit trail is preserved either way.
+_ENV_MAX_NONRESEARCH_PER_SESSION = "WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION"
+
+
+def _max_nonresearch_per_session() -> int:
+    """Resolve the per-session non-research cap; 0 = unlimited (default)."""
+    try:
+        n = int(os.environ.get(_ENV_MAX_NONRESEARCH_PER_SESSION, "0"))
+    except (TypeError, ValueError):
+        return 0
+    return max(0, n)
+
 
 _SLUG_RE = re.compile(r"^[a-z0-9-]{1,50}$")
 
@@ -958,10 +975,12 @@ def resolve_ticket(
 
     is_non_research = ticket.get("type") != "research"
     ledger = _ensure_session(state, session)
-    if is_non_research and int(ledger.get("non_research_resolved", 0)) >= 1:
+    cap = _max_nonresearch_per_session()
+    if is_non_research and cap > 0 and int(ledger.get("non_research_resolved", 0)) >= cap:
         return _err(
-            "this session has already resolved a non-research ticket. Resolve at most "
-            "ONE non-research ticket per session; start a new session to continue.",
+            f"this session has already resolved {cap} non-research ticket(s); the cap "
+            f"is set via {_ENV_MAX_NONRESEARCH_PER_SESSION}. Start a new session to "
+            "continue, or raise/unset the cap.",
             code="session_limit",
         )
 

--- a/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
@@ -92,7 +92,7 @@ Resolve exactly ONE non-research decision, then stop. Five steps.
    ```
 
    With what you learned, keep the map honest: `add_ticket` newly-sharp decisions, `graduate_fog` a fog entry that is now sharp, or `rule_out_of_scope` a ticket/fog that is settled as excluded (exclusions never appear under Decisions).
-5. **Stop.** The runner blocks a second non-research resolve in the same session by design. Report the decision and stop; start a fresh session (or `/map-wayfind handoff <slug>`) to continue.
+5. **Stop.** Resolving one decision at a time keeps the map reviewable — report the decision and stop, then start a fresh session (or `/map-wayfind handoff <slug>`) to continue. By default the runner does NOT hard-cap this; set `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION=1` to re-enable the old one-per-session block.
 
 ## Mode: handoff \<slug\>
 
@@ -107,7 +107,7 @@ This writes `.map/wayfind/<slug>/handoff.md` (+ `handoff.json`) and registers a 
 ## Guardrails
 
 - Do not pre-slice fog: only create a ticket when you can state its question sharply NOW (rubric in the reference). Otherwise keep it as fog.
-- Resolve at most ONE non-research ticket per session; the runner enforces this.
+- Resolve at most ONE non-research ticket per session (recommended discipline; not hard-enforced by default — opt in via `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`).
 - Out-of-scope is an exclusion, not a decision — it never graduates into the plan.
 - No implementation subtasks and no code changes here — that is `/map-plan` + execution.
 - Never write secrets into tickets, resolutions, or the map. Warn about the commit-by-default privacy note in `chart`.
@@ -126,6 +126,6 @@ More worked examples are in [wayfind-reference.md](wayfind-reference.md).
 
 - `emit_wayfind_handoff` returns `not_terminal`: fog, claimed, or unresolved tickets remain — resolve or rule them out, or hand off `--early --confirmed-by-user`.
 - `resolve_ticket` returns `awaiting_human`: it is a `prototype`/`grilling` ticket — record the human answer with `record_human_input` first.
-- `resolve_ticket` returns `session_limit`: you already resolved a non-research ticket this session — start a new session.
+- `resolve_ticket` returns `session_limit`: a per-session cap is active (`WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`, unset/0 = unlimited) — start a new session or raise/unset the cap.
 - `wire_blocking` returns `cycle`: the dependency you added would close a loop — re-check the blocker direction.
 - Full command reference and the fog-sharpness rubric are in [wayfind-reference.md](wayfind-reference.md).

--- a/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
@@ -125,7 +125,7 @@ emit_wayfind_handoff checkout --remaining-risks-json '["fraud rules not yet scop
 
 - **`not_terminal` on handoff** — an item is still open. Run `wayfind_status --slug <slug>`; the error's `open_items` names each blocker. Resolve or `rule_out_of_scope` them, or hand off `--early --confirmed-by-user`.
 - **`awaiting_human`** — a `prototype`/`grilling` ticket needs a recorded human answer first (`record_human_input`).
-- **`session_limit`** — one non-research resolve per session is the rule; mint a fresh session id and continue.
+- **`session_limit`** — a per-session non-research cap is active via `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION` (unset/0 = unlimited, the default); mint a fresh session id and continue, or raise/unset the cap.
 - **`already_claimed` / `blocked` / `not_owner`** — the ticket is taken, has unresolved blockers, or is claimed by another session. Check `map.md`'s Blocked/claimed section.
 - **`stale_revision`** — another session advanced the map; re-read it and retry with the current `--expected-revision`.
 - **`cycle`** — a `wire_blocking` call would create a dependency loop; the blocker relationship is likely backwards.

--- a/tests/test_wayfind_runner.py
+++ b/tests/test_wayfind_runner.py
@@ -423,7 +423,11 @@ class TestEvidencePathContainment:
 
 
 class TestSessionGuardrail:
-    def test_second_non_research_resolve_blocked(self) -> None:
+    def test_second_non_research_resolve_blocked_when_cap_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The one-per-session cap is opt-in via the env var (default = unlimited).
+        monkeypatch.setenv("WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION", "1")
         _create()
         a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
         b = wr.add_ticket("checkout", "B", "task", "Qb?")["ticket_id"]
@@ -431,6 +435,24 @@ class TestSessionGuardrail:
         second = _resolve("checkout", b, "sess-1")
         assert second["status"] == "error"
         assert second["code"] == "session_limit"
+
+    def test_second_non_research_resolve_allowed_by_default(self) -> None:
+        # No cap env → unlimited: a session may resolve many non-research tickets.
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?")["ticket_id"]
+        assert _resolve("checkout", a, "sess-1")["status"] == "success"
+        assert _resolve("checkout", b, "sess-1")["status"] == "success"
+
+    def test_invalid_cap_env_treated_as_unlimited(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION", "not-an-int")
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        b = wr.add_ticket("checkout", "B", "task", "Qb?")["ticket_id"]
+        assert _resolve("checkout", a, "sess-1")["status"] == "success"
+        assert _resolve("checkout", b, "sess-1")["status"] == "success"
 
     def test_two_research_resolves_allowed(self) -> None:
         _create()


### PR DESCRIPTION
Closes #394.

## Problem
`wayfind_runner.py resolve_ticket` hard-blocked the **second** non-research resolve in a session (`code=session_limit`, hard-coded `>= 1`), with no way to disable it. In multi-decision sessions where the operator already has full context loaded, this is pure friction — a new session id per decision. The cap is a workflow discipline, not a correctness invariant.

## Change
- **Default = unlimited.** New `_max_nonresearch_per_session()` reads `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION` (unset / `0` / invalid ⇒ unlimited).
- Guard is now `is_non_research and cap > 0 and resolved >= cap` — opt in with `=N` (N>=1) to restore the old one-per-session block.
- Session ledger still increments `non_research_resolved` on every resolve → **audit trail unchanged**.
- Docs de-claimed: dropped "the runner blocks/enforces by design" in `SKILL.md`, `wayfind-reference.md`, and the runner docstring; now "recommended discipline, opt-in cap".

## Tests
Added to `tests/test_wayfind_runner.py`:
- `test_second_non_research_resolve_blocked_when_cap_set` — env cap=1 still blocks.
- `test_second_non_research_resolve_allowed_by_default` — default allows repeats.
- `test_invalid_cap_env_treated_as_unlimited`.

## Gates
`make render-templates` (jinja is the source of truth) · `make check-render` ✅ · `make lint` (ruff + pyright + lint-hooks) ✅ · `pytest tests/test_wayfind_runner.py` = **52 passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-research ticket resolutions are now unlimited by default within a session.
  * An optional per-session limit can be enabled using `WAYFIND_MAX_NONRESEARCH_RESOLVES_PER_SESSION`.
  * Invalid or unset limit values are treated as unlimited.

* **Documentation**
  * Updated guidance and troubleshooting information to explain configurable session limits and resolution options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->