### PR TITLE
feat(wayfind): amend commands for a resolved gist and an out-of-scope reason

### DIFF
--- a/.claude/skills/map-wayfind/wayfind-reference.md
+++ b/.claude/skills/map-wayfind/wayfind-reference.md
@@ -42,6 +42,7 @@ claim_ticket <slug> <ticket_id> <session>              # HITL types return hitl_
 release_ticket <slug> <ticket_id> <session>            # crash/interrupt recovery; owner only
 record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
 resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
+amend_resolution <slug> <ticket_id> [--gist "<corrected one-liner>"] [--resolution-path <path>]  # fix a resolved ticket's gist/path without reopening
 ```
 
 Fog & scope:

--- a/.claude/skills/map-wayfind/wayfind-reference.md
+++ b/.claude/skills/map-wayfind/wayfind-reference.md
@@ -43,6 +43,7 @@ release_ticket <slug> <ticket_id> <session>            # crash/interrupt recover
 record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
 resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
 amend_resolution <slug> <ticket_id> [--gist "<corrected one-liner>"] [--resolution-path <path>]  # fix a resolved ticket's gist/path without reopening
+amend_out_of_scope <slug> (--ticket-id T-003 | --fog-id F-2) [--reason "..."] [--gist "..."]      # fix an out-of-scope entry's reason/gist
 ```
 
 Fog & scope:

--- a/.map/scripts/wayfind_runner.py
+++ b/.map/scripts/wayfind_runner.py
@@ -988,6 +988,76 @@ def resolve_ticket(
     )
 
 
+def amend_resolution(
+    slug: str,
+    ticket_id: str,
+    gist: str | None = None,
+    resolution_path: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    """Correct the one-line gist and/or resolution path of an already-resolved
+    ticket, without reopening it. The gist is baked into the resolution at
+    resolve time; a later realization that the summary is wrong or misleading
+    would otherwise be uncorrectable through the deterministic interface. This
+    touches only free-text resolution metadata — it changes no structural
+    invariant: status, claims, blocking, and ledger counts all stay put.
+
+    Unlike structural mutations, this is allowed on a handed-off map (it uses the
+    pure staleness check, not _mutation_guard): spotting a wrong/misleading gist
+    in the frozen handoff is exactly when you need it. When the map is already
+    handed off, re-run emit_wayfind_handoff afterwards so the frozen artifact
+    picks up the corrected gist — the response flags this via
+    handoff_refresh_needed."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    # Pure staleness check (not _mutation_guard): amending free-text metadata is
+    # the one correction that legitimately applies to a handed-off map.
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("status") != "resolved":
+        return _err(
+            f"ticket {ticket_id!r} is {ticket.get('status')!r}, not resolved; only a "
+            "resolved ticket's gist/resolution can be amended.",
+            code="not_resolved",
+        )
+    if gist is None and resolution_path is None:
+        return _err("nothing to amend: pass --gist and/or --resolution-path.")
+
+    resolution = dict(ticket.get("resolution") or {})
+    if gist is not None:
+        if not _oneline(gist):
+            return _err("gist must be a non-empty one-line summary of the decision.")
+        resolution["gist"] = _oneline(gist)
+    if resolution_path is not None:
+        resolution_file = _resolve_evidence_path(slug, resolution_path)
+        if resolution_file is None or not resolution_file.read_text(
+            encoding="utf-8", errors="replace"
+        ).strip():
+            return _err(
+                f"resolution file {resolution_path!r} must be a non-empty regular file "
+                "INSIDE the map dir (.map/wayfind/<slug>/).",
+                code="missing_resolution",
+            )
+        resolution["path"] = resolution_path
+    ticket["resolution"] = resolution
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        gist=resolution.get("gist"),
+        path=resolution.get("path"),
+        handoff_refresh_needed=state.get("status") == "handed_off",
+        revision=state["revision"],
+    )
+
+
 def wayfind_frontier(slug: str) -> dict[str, Any]:
     """Return open + unblocked + unclaimed tickets (creation order)."""
     state = _load_state(slug)
@@ -1442,6 +1512,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("resolution_path")
     _add_revision_arg(p)
 
+    p = sub.add_parser(
+        "amend_resolution",
+        help="correct a resolved ticket's one-line gist and/or resolution path",
+    )
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("--gist", default=None)
+    p.add_argument("--resolution-path", dest="resolution_path", default=None)
+    _add_revision_arg(p)
+
     p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
     p.add_argument("slug")
 
@@ -1521,6 +1601,14 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.slug,
             args.ticket_id,
             args.session,
+            args.gist,
+            args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "amend_resolution":
+        return amend_resolution(
+            args.slug,
+            args.ticket_id,
             args.gist,
             args.resolution_path,
             args.expected_revision,

--- a/.map/scripts/wayfind_runner.py
+++ b/.map/scripts/wayfind_runner.py
@@ -1058,6 +1058,61 @@ def amend_resolution(
     )
 
 
+def amend_out_of_scope(
+    slug: str,
+    ticket_id: str = "",
+    fog_id: str = "",
+    reason: str | None = None,
+    gist: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    """Correct the free-text reason and/or gist of an existing out-of-scope
+    entry (keyed by the ticket_id or fog_id it was ruled out under). Same
+    rationale and post-handoff semantics as amend_resolution: an exclusion's
+    stated reason is baked at rule_out_of_scope time and surfaces in the frozen
+    handoff, so it needs an in-place correction path that touches no structural
+    invariant. Re-emit the handoff afterwards when handoff_refresh_needed."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if bool(ticket_id) == bool(fog_id):
+        return _err("provide exactly one of --ticket-id or --fog-id.")
+    if reason is None and gist is None:
+        return _err("nothing to amend: pass --reason and/or --gist.")
+
+    key = "ticket_id" if ticket_id else "fog_id"
+    ref = ticket_id or fog_id
+    entry = next(
+        (e for e in state.get("out_of_scope", []) if e.get(key) == ref), None
+    )
+    if entry is None:
+        return _err(
+            f"no out-of-scope entry for {ref!r} in map {slug!r}.", code="not_found"
+        )
+    if reason is not None:
+        if not _oneline(reason):
+            return _err("reason must be a non-empty one-line string.")
+        entry["reason"] = _oneline(reason)
+    if gist is not None:
+        if not _oneline(gist):
+            return _err("gist must be a non-empty one-line string.")
+        entry["gist"] = _oneline(gist)
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ref=ref,
+        reason=entry.get("reason"),
+        gist=entry.get("gist"),
+        handoff_refresh_needed=state.get("status") == "handed_off",
+        revision=state["revision"],
+    )
+
+
 def wayfind_frontier(slug: str) -> dict[str, Any]:
     """Return open + unblocked + unclaimed tickets (creation order)."""
     state = _load_state(slug)
@@ -1522,6 +1577,17 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--resolution-path", dest="resolution_path", default=None)
     _add_revision_arg(p)
 
+    p = sub.add_parser(
+        "amend_out_of_scope",
+        help="correct an out-of-scope entry's reason and/or gist",
+    )
+    p.add_argument("slug")
+    p.add_argument("--ticket-id", dest="ticket_id", default="")
+    p.add_argument("--fog-id", dest="fog_id", default="")
+    p.add_argument("--reason", default=None)
+    p.add_argument("--gist", default=None)
+    _add_revision_arg(p)
+
     p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
     p.add_argument("slug")
 
@@ -1611,6 +1677,15 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.ticket_id,
             args.gist,
             args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "amend_out_of_scope":
+        return amend_out_of_scope(
+            args.slug,
+            args.ticket_id,
+            args.fog_id,
+            args.reason,
+            args.gist,
             args.expected_revision,
         )
     if command == "wayfind_frontier":

--- a/src/mapify_cli/templates/map/scripts/wayfind_runner.py
+++ b/src/mapify_cli/templates/map/scripts/wayfind_runner.py
@@ -988,6 +988,76 @@ def resolve_ticket(
     )
 
 
+def amend_resolution(
+    slug: str,
+    ticket_id: str,
+    gist: str | None = None,
+    resolution_path: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    """Correct the one-line gist and/or resolution path of an already-resolved
+    ticket, without reopening it. The gist is baked into the resolution at
+    resolve time; a later realization that the summary is wrong or misleading
+    would otherwise be uncorrectable through the deterministic interface. This
+    touches only free-text resolution metadata — it changes no structural
+    invariant: status, claims, blocking, and ledger counts all stay put.
+
+    Unlike structural mutations, this is allowed on a handed-off map (it uses the
+    pure staleness check, not _mutation_guard): spotting a wrong/misleading gist
+    in the frozen handoff is exactly when you need it. When the map is already
+    handed off, re-run emit_wayfind_handoff afterwards so the frozen artifact
+    picks up the corrected gist — the response flags this via
+    handoff_refresh_needed."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    # Pure staleness check (not _mutation_guard): amending free-text metadata is
+    # the one correction that legitimately applies to a handed-off map.
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("status") != "resolved":
+        return _err(
+            f"ticket {ticket_id!r} is {ticket.get('status')!r}, not resolved; only a "
+            "resolved ticket's gist/resolution can be amended.",
+            code="not_resolved",
+        )
+    if gist is None and resolution_path is None:
+        return _err("nothing to amend: pass --gist and/or --resolution-path.")
+
+    resolution = dict(ticket.get("resolution") or {})
+    if gist is not None:
+        if not _oneline(gist):
+            return _err("gist must be a non-empty one-line summary of the decision.")
+        resolution["gist"] = _oneline(gist)
+    if resolution_path is not None:
+        resolution_file = _resolve_evidence_path(slug, resolution_path)
+        if resolution_file is None or not resolution_file.read_text(
+            encoding="utf-8", errors="replace"
+        ).strip():
+            return _err(
+                f"resolution file {resolution_path!r} must be a non-empty regular file "
+                "INSIDE the map dir (.map/wayfind/<slug>/).",
+                code="missing_resolution",
+            )
+        resolution["path"] = resolution_path
+    ticket["resolution"] = resolution
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        gist=resolution.get("gist"),
+        path=resolution.get("path"),
+        handoff_refresh_needed=state.get("status") == "handed_off",
+        revision=state["revision"],
+    )
+
+
 def wayfind_frontier(slug: str) -> dict[str, Any]:
     """Return open + unblocked + unclaimed tickets (creation order)."""
     state = _load_state(slug)
@@ -1442,6 +1512,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("resolution_path")
     _add_revision_arg(p)
 
+    p = sub.add_parser(
+        "amend_resolution",
+        help="correct a resolved ticket's one-line gist and/or resolution path",
+    )
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("--gist", default=None)
+    p.add_argument("--resolution-path", dest="resolution_path", default=None)
+    _add_revision_arg(p)
+
     p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
     p.add_argument("slug")
 
@@ -1521,6 +1601,14 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.slug,
             args.ticket_id,
             args.session,
+            args.gist,
+            args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "amend_resolution":
+        return amend_resolution(
+            args.slug,
+            args.ticket_id,
             args.gist,
             args.resolution_path,
             args.expected_revision,

--- a/src/mapify_cli/templates/map/scripts/wayfind_runner.py
+++ b/src/mapify_cli/templates/map/scripts/wayfind_runner.py
@@ -1058,6 +1058,61 @@ def amend_resolution(
     )
 
 
+def amend_out_of_scope(
+    slug: str,
+    ticket_id: str = "",
+    fog_id: str = "",
+    reason: str | None = None,
+    gist: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    """Correct the free-text reason and/or gist of an existing out-of-scope
+    entry (keyed by the ticket_id or fog_id it was ruled out under). Same
+    rationale and post-handoff semantics as amend_resolution: an exclusion's
+    stated reason is baked at rule_out_of_scope time and surfaces in the frozen
+    handoff, so it needs an in-place correction path that touches no structural
+    invariant. Re-emit the handoff afterwards when handoff_refresh_needed."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if bool(ticket_id) == bool(fog_id):
+        return _err("provide exactly one of --ticket-id or --fog-id.")
+    if reason is None and gist is None:
+        return _err("nothing to amend: pass --reason and/or --gist.")
+
+    key = "ticket_id" if ticket_id else "fog_id"
+    ref = ticket_id or fog_id
+    entry = next(
+        (e for e in state.get("out_of_scope", []) if e.get(key) == ref), None
+    )
+    if entry is None:
+        return _err(
+            f"no out-of-scope entry for {ref!r} in map {slug!r}.", code="not_found"
+        )
+    if reason is not None:
+        if not _oneline(reason):
+            return _err("reason must be a non-empty one-line string.")
+        entry["reason"] = _oneline(reason)
+    if gist is not None:
+        if not _oneline(gist):
+            return _err("gist must be a non-empty one-line string.")
+        entry["gist"] = _oneline(gist)
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ref=ref,
+        reason=entry.get("reason"),
+        gist=entry.get("gist"),
+        handoff_refresh_needed=state.get("status") == "handed_off",
+        revision=state["revision"],
+    )
+
+
 def wayfind_frontier(slug: str) -> dict[str, Any]:
     """Return open + unblocked + unclaimed tickets (creation order)."""
     state = _load_state(slug)
@@ -1522,6 +1577,17 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--resolution-path", dest="resolution_path", default=None)
     _add_revision_arg(p)
 
+    p = sub.add_parser(
+        "amend_out_of_scope",
+        help="correct an out-of-scope entry's reason and/or gist",
+    )
+    p.add_argument("slug")
+    p.add_argument("--ticket-id", dest="ticket_id", default="")
+    p.add_argument("--fog-id", dest="fog_id", default="")
+    p.add_argument("--reason", default=None)
+    p.add_argument("--gist", default=None)
+    _add_revision_arg(p)
+
     p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
     p.add_argument("slug")
 
@@ -1611,6 +1677,15 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.ticket_id,
             args.gist,
             args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "amend_out_of_scope":
+        return amend_out_of_scope(
+            args.slug,
+            args.ticket_id,
+            args.fog_id,
+            args.reason,
+            args.gist,
             args.expected_revision,
         )
     if command == "wayfind_frontier":

--- a/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
@@ -42,6 +42,7 @@ claim_ticket <slug> <ticket_id> <session>              # HITL types return hitl_
 release_ticket <slug> <ticket_id> <session>            # crash/interrupt recovery; owner only
 record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
 resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
+amend_resolution <slug> <ticket_id> [--gist "<corrected one-liner>"] [--resolution-path <path>]  # fix a resolved ticket's gist/path without reopening
 ```
 
 Fog & scope:

--- a/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/wayfind-reference.md
@@ -43,6 +43,7 @@ release_ticket <slug> <ticket_id> <session>            # crash/interrupt recover
 record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
 resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
 amend_resolution <slug> <ticket_id> [--gist "<corrected one-liner>"] [--resolution-path <path>]  # fix a resolved ticket's gist/path without reopening
+amend_out_of_scope <slug> (--ticket-id T-003 | --fog-id F-2) [--reason "..."] [--gist "..."]      # fix an out-of-scope entry's reason/gist
 ```
 
 Fog & scope:

--- a/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
@@ -988,6 +988,76 @@ def resolve_ticket(
     )
 
 
+def amend_resolution(
+    slug: str,
+    ticket_id: str,
+    gist: str | None = None,
+    resolution_path: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    """Correct the one-line gist and/or resolution path of an already-resolved
+    ticket, without reopening it. The gist is baked into the resolution at
+    resolve time; a later realization that the summary is wrong or misleading
+    would otherwise be uncorrectable through the deterministic interface. This
+    touches only free-text resolution metadata — it changes no structural
+    invariant: status, claims, blocking, and ledger counts all stay put.
+
+    Unlike structural mutations, this is allowed on a handed-off map (it uses the
+    pure staleness check, not _mutation_guard): spotting a wrong/misleading gist
+    in the frozen handoff is exactly when you need it. When the map is already
+    handed off, re-run emit_wayfind_handoff afterwards so the frozen artifact
+    picks up the corrected gist — the response flags this via
+    handoff_refresh_needed."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    # Pure staleness check (not _mutation_guard): amending free-text metadata is
+    # the one correction that legitimately applies to a handed-off map.
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    ticket = state.get("tickets", {}).get(ticket_id)
+    if ticket is None:
+        return _err(f"no ticket {ticket_id!r} in map {slug!r}.", code="not_found")
+    if ticket.get("status") != "resolved":
+        return _err(
+            f"ticket {ticket_id!r} is {ticket.get('status')!r}, not resolved; only a "
+            "resolved ticket's gist/resolution can be amended.",
+            code="not_resolved",
+        )
+    if gist is None and resolution_path is None:
+        return _err("nothing to amend: pass --gist and/or --resolution-path.")
+
+    resolution = dict(ticket.get("resolution") or {})
+    if gist is not None:
+        if not _oneline(gist):
+            return _err("gist must be a non-empty one-line summary of the decision.")
+        resolution["gist"] = _oneline(gist)
+    if resolution_path is not None:
+        resolution_file = _resolve_evidence_path(slug, resolution_path)
+        if resolution_file is None or not resolution_file.read_text(
+            encoding="utf-8", errors="replace"
+        ).strip():
+            return _err(
+                f"resolution file {resolution_path!r} must be a non-empty regular file "
+                "INSIDE the map dir (.map/wayfind/<slug>/).",
+                code="missing_resolution",
+            )
+        resolution["path"] = resolution_path
+    ticket["resolution"] = resolution
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ticket_id=ticket_id,
+        gist=resolution.get("gist"),
+        path=resolution.get("path"),
+        handoff_refresh_needed=state.get("status") == "handed_off",
+        revision=state["revision"],
+    )
+
+
 def wayfind_frontier(slug: str) -> dict[str, Any]:
     """Return open + unblocked + unclaimed tickets (creation order)."""
     state = _load_state(slug)
@@ -1442,6 +1512,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("resolution_path")
     _add_revision_arg(p)
 
+    p = sub.add_parser(
+        "amend_resolution",
+        help="correct a resolved ticket's one-line gist and/or resolution path",
+    )
+    p.add_argument("slug")
+    p.add_argument("ticket_id")
+    p.add_argument("--gist", default=None)
+    p.add_argument("--resolution-path", dest="resolution_path", default=None)
+    _add_revision_arg(p)
+
     p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
     p.add_argument("slug")
 
@@ -1521,6 +1601,14 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.slug,
             args.ticket_id,
             args.session,
+            args.gist,
+            args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "amend_resolution":
+        return amend_resolution(
+            args.slug,
+            args.ticket_id,
             args.gist,
             args.resolution_path,
             args.expected_revision,

--- a/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
@@ -1058,6 +1058,61 @@ def amend_resolution(
     )
 
 
+def amend_out_of_scope(
+    slug: str,
+    ticket_id: str = "",
+    fog_id: str = "",
+    reason: str | None = None,
+    gist: str | None = None,
+    expected_revision: int | None = None,
+) -> dict[str, Any]:
+    """Correct the free-text reason and/or gist of an existing out-of-scope
+    entry (keyed by the ticket_id or fog_id it was ruled out under). Same
+    rationale and post-handoff semantics as amend_resolution: an exclusion's
+    stated reason is baked at rule_out_of_scope time and surfaces in the frozen
+    handoff, so it needs an in-place correction path that touches no structural
+    invariant. Re-emit the handoff afterwards when handoff_refresh_needed."""
+    state = _load_state(slug)
+    if state is None:
+        return _err(f"no map with slug {slug!r}.", code="not_found")
+    guard = _revision_guard(state, expected_revision)
+    if guard is not None:
+        return guard
+    if bool(ticket_id) == bool(fog_id):
+        return _err("provide exactly one of --ticket-id or --fog-id.")
+    if reason is None and gist is None:
+        return _err("nothing to amend: pass --reason and/or --gist.")
+
+    key = "ticket_id" if ticket_id else "fog_id"
+    ref = ticket_id or fog_id
+    entry = next(
+        (e for e in state.get("out_of_scope", []) if e.get(key) == ref), None
+    )
+    if entry is None:
+        return _err(
+            f"no out-of-scope entry for {ref!r} in map {slug!r}.", code="not_found"
+        )
+    if reason is not None:
+        if not _oneline(reason):
+            return _err("reason must be a non-empty one-line string.")
+        entry["reason"] = _oneline(reason)
+    if gist is not None:
+        if not _oneline(gist):
+            return _err("gist must be a non-empty one-line string.")
+        entry["gist"] = _oneline(gist)
+
+    _recompute_status(state)
+    _save_state(state)
+    return _ok(
+        slug=slug,
+        ref=ref,
+        reason=entry.get("reason"),
+        gist=entry.get("gist"),
+        handoff_refresh_needed=state.get("status") == "handed_off",
+        revision=state["revision"],
+    )
+
+
 def wayfind_frontier(slug: str) -> dict[str, Any]:
     """Return open + unblocked + unclaimed tickets (creation order)."""
     state = _load_state(slug)
@@ -1522,6 +1577,17 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--resolution-path", dest="resolution_path", default=None)
     _add_revision_arg(p)
 
+    p = sub.add_parser(
+        "amend_out_of_scope",
+        help="correct an out-of-scope entry's reason and/or gist",
+    )
+    p.add_argument("slug")
+    p.add_argument("--ticket-id", dest="ticket_id", default="")
+    p.add_argument("--fog-id", dest="fog_id", default="")
+    p.add_argument("--reason", default=None)
+    p.add_argument("--gist", default=None)
+    _add_revision_arg(p)
+
     p = sub.add_parser("wayfind_frontier", help="list open+unblocked+unclaimed tickets")
     p.add_argument("slug")
 
@@ -1611,6 +1677,15 @@ def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
             args.ticket_id,
             args.gist,
             args.resolution_path,
+            args.expected_revision,
+        )
+    if command == "amend_out_of_scope":
+        return amend_out_of_scope(
+            args.slug,
+            args.ticket_id,
+            args.fog_id,
+            args.reason,
+            args.gist,
             args.expected_revision,
         )
     if command == "wayfind_frontier":

--- a/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
@@ -42,6 +42,7 @@ claim_ticket <slug> <ticket_id> <session>              # HITL types return hitl_
 release_ticket <slug> <ticket_id> <session>            # crash/interrupt recovery; owner only
 record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
 resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
+amend_resolution <slug> <ticket_id> [--gist "<corrected one-liner>"] [--resolution-path <path>]  # fix a resolved ticket's gist/path without reopening
 ```
 
 Fog & scope:

--- a/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/wayfind-reference.md.jinja
@@ -43,6 +43,7 @@ release_ticket <slug> <ticket_id> <session>            # crash/interrupt recover
 record_human_input <slug> <ticket_id> <session> <path> # verbatim human answer (file must be non-empty)
 resolve_ticket <slug> <ticket_id> <session> "<gist>" <resolution_path>
 amend_resolution <slug> <ticket_id> [--gist "<corrected one-liner>"] [--resolution-path <path>]  # fix a resolved ticket's gist/path without reopening
+amend_out_of_scope <slug> (--ticket-id T-003 | --fog-id F-2) [--reason "..."] [--gist "..."]      # fix an out-of-scope entry's reason/gist
 ```
 
 Fog & scope:

--- a/tests/test_wayfind_runner.py
+++ b/tests/test_wayfind_runner.py
@@ -560,3 +560,58 @@ class TestCli:
     def test_unknown_subcommand_exits_nonzero(self, repo: Path) -> None:
         result = self._run(repo, "bogus_command")
         assert result.returncode != 0
+
+
+class TestAmendResolution:
+    def test_amend_gist_of_resolved_ticket(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        assert _resolve("checkout", a, "sess-1", gist="old gist")["status"] == "success"
+        amended = wr.amend_resolution("checkout", a, gist="new corrected gist")
+        assert amended["status"] == "success"
+        assert amended["gist"] == "new corrected gist"
+        # persisted
+        ticket = wr.show_ticket("checkout", a)["ticket"]
+        assert ticket["resolution"]["gist"] == "new corrected gist"
+        assert ticket["status"] == "resolved"  # not reopened
+
+    def test_amend_open_ticket_rejected(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        result = wr.amend_resolution("checkout", a, gist="x")
+        assert result["status"] == "error"
+        assert result["code"] == "not_resolved"
+
+    def test_amend_nothing_rejected(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        _resolve("checkout", a, "sess-1")
+        result = wr.amend_resolution("checkout", a)
+        assert result["status"] == "error"
+
+    def test_amend_resolution_path_must_exist(self) -> None:
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        _resolve("checkout", a, "sess-1")
+        result = wr.amend_resolution(
+            "checkout", a, resolution_path="resolutions/does-not-exist.md"
+        )
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
+    def test_amend_allowed_on_handed_off_map(self) -> None:
+        # A wrong gist spotted in the frozen handoff must be correctable; other
+        # structural mutations stay blocked on a handed-off map.
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        _resolve("checkout", a, "sess-1", gist="wrong gist")
+        emitted = wr.emit_wayfind_handoff("checkout", "[]")
+        assert emitted["status"] == "success"
+        amended = wr.amend_resolution("checkout", a, gist="right gist")
+        assert amended["status"] == "success"
+        assert amended["handoff_refresh_needed"] is True
+        assert wr.show_ticket("checkout", a)["ticket"]["resolution"]["gist"] == "right gist"
+        # structural mutation still blocked while handed off
+        blocked = wr.add_ticket("checkout", "B", "task", "Qb?")
+        assert blocked["status"] == "error"
+        assert blocked["code"] == "handed_off"

--- a/tests/test_wayfind_runner.py
+++ b/tests/test_wayfind_runner.py
@@ -599,6 +599,38 @@ class TestAmendResolution:
         assert result["status"] == "error"
         assert result["code"] == "missing_resolution"
 
+    def test_amend_out_of_scope_reason(self) -> None:
+        _create(fog_json='["vague concern"]')  # creates F-1
+        ruled = wr.rule_out_of_scope("checkout", "wrong reason", fog_id="F-1")
+        assert ruled["status"] == "success"
+        amended = wr.amend_out_of_scope("checkout", fog_id="F-1", reason="right reason")
+        assert amended["status"] == "success"
+        assert amended["reason"] == "right reason"
+        oos = wr._load_state("checkout")["out_of_scope"]
+        assert oos[0]["reason"] == "right reason"
+
+    def test_amend_out_of_scope_requires_exactly_one_ref(self) -> None:
+        _create(fog_json='["vague concern"]')
+        wr.rule_out_of_scope("checkout", "reason", fog_id="F-1")
+        both = wr.amend_out_of_scope(
+            "checkout", ticket_id="T-001", fog_id="F-1", reason="x"
+        )
+        assert both["status"] == "error"
+        neither = wr.amend_out_of_scope("checkout", reason="x")
+        assert neither["status"] == "error"
+
+    def test_amend_out_of_scope_unknown_ref(self) -> None:
+        _create()
+        result = wr.amend_out_of_scope("checkout", fog_id="F-9", reason="x")
+        assert result["status"] == "error"
+        assert result["code"] == "not_found"
+
+    def test_amend_out_of_scope_nothing_rejected(self) -> None:
+        _create(fog_json='["vague concern"]')
+        wr.rule_out_of_scope("checkout", "reason", fog_id="F-1")
+        result = wr.amend_out_of_scope("checkout", fog_id="F-1")
+        assert result["status"] == "error"
+
     def test_amend_allowed_on_handed_off_map(self) -> None:
         # A wrong gist spotted in the frozen handoff must be correctable; other
         # structural mutations stay blocked on a handed-off map.


### PR DESCRIPTION
## Problem
Free-text summaries baked at write-time were uncorrectable through the deterministic interface (`state.json` is never hand-edited):
- a resolved ticket's **gist** (set at `resolve_ticket`, shown in `map.md` + the frozen `handoff.md` decision table), and
- an **out-of-scope entry's reason/gist** (set at `rule_out_of_scope`, shown in the handoff's Out of Scope section).

`release_ticket` only clears a claim; `resolve_ticket`/`rule_out_of_scope` won't touch already-terminal items. The only recourse was a whole new map for a wording fix. Hit both live while wayfinding.

## Change — two in-place amend commands
- **`amend_resolution <slug> <ticket_id> [--gist ...] [--resolution-path ...]`** — corrects a resolved ticket's gist/path.
- **`amend_out_of_scope <slug> (--ticket-id T | --fog-id F) [--reason ...] [--gist ...]`** — corrects an out-of-scope entry's reason/gist.

Both:
- touch **no structural invariant** — status, claims, blocking, ledger counts unchanged;
- are **allowed on a handed-off map** (pure staleness check, like `emit_wayfind_handoff`) and return **`handoff_refresh_needed: true`** so the caller re-emits the handoff;
- validate inputs (`not_resolved` / `not_found` / exactly-one-ref / non-empty).

## Tests
9 new cases across both commands. Gates: `make check-render` ✅, `make lint` (ruff+pyright+lint-hooks) ✅, `pytest tests/test_wayfind_runner.py` = **59 passed**.

Independent of #394/#395 (opt-in session cap) — branched off `main`.