### PR TITLE
fix(settings): scope secret/credentials deny globs by extension (#397)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,16 @@
   "permissions": {
     "deny": [
       "Edit(./.env*)",
-      "Edit(**/*credentials*)",
-      "Edit(**/*secret*)",
+      "Edit(**/*credentials*.yaml)",
+      "Edit(**/*credentials*.yml)",
+      "Edit(**/*credentials*.json)",
+      "Edit(**/*credentials*.toml)",
+      "Edit(**/*credentials*.env)",
+      "Edit(**/*secret*.yaml)",
+      "Edit(**/*secret*.yml)",
+      "Edit(**/*secret*.json)",
+      "Edit(**/*secret*.toml)",
+      "Edit(**/*secret*.env)",
       "Bash(rm -rf)",
       "Bash(git push --force origin main)",
       "Bash(git push --force origin master)",

--- a/src/mapify_cli/templates/settings.json
+++ b/src/mapify_cli/templates/settings.json
@@ -4,8 +4,16 @@
   "permissions": {
     "deny": [
       "Edit(./.env*)",
-      "Edit(**/*credentials*)",
-      "Edit(**/*secret*)",
+      "Edit(**/*credentials*.yaml)",
+      "Edit(**/*credentials*.yml)",
+      "Edit(**/*credentials*.json)",
+      "Edit(**/*credentials*.toml)",
+      "Edit(**/*credentials*.env)",
+      "Edit(**/*secret*.yaml)",
+      "Edit(**/*secret*.yml)",
+      "Edit(**/*secret*.json)",
+      "Edit(**/*secret*.toml)",
+      "Edit(**/*secret*.env)",
       "Bash(rm -rf)",
       "Bash(git push --force origin main)",
       "Bash(git push --force origin master)",

--- a/src/mapify_cli/templates_src/settings.json.jinja
+++ b/src/mapify_cli/templates_src/settings.json.jinja
@@ -4,8 +4,16 @@
   "permissions": {
     "deny": [
       "Edit(./.env*)",
-      "Edit(**/*credentials*)",
-      "Edit(**/*secret*)",
+      "Edit(**/*credentials*.yaml)",
+      "Edit(**/*credentials*.yml)",
+      "Edit(**/*credentials*.json)",
+      "Edit(**/*credentials*.toml)",
+      "Edit(**/*credentials*.env)",
+      "Edit(**/*secret*.yaml)",
+      "Edit(**/*secret*.yml)",
+      "Edit(**/*secret*.json)",
+      "Edit(**/*secret*.toml)",
+      "Edit(**/*secret*.env)",
       "Bash(rm -rf)",
       "Bash(git push --force origin main)",
       "Bash(git push --force origin master)",

--- a/tests/test_settings_deny_globs.py
+++ b/tests/test_settings_deny_globs.py
@@ -1,0 +1,163 @@
+"""Regression tests for settings.json deny-glob patterns (issue #397).
+
+Verifies that the permission deny rules in the shipped settings.json template
+scope secret/credentials globs by file extension, so that source files whose
+names contain 'secret' or 'credentials' as a substring are NOT blocked by
+the native Claude Code permission layer.
+
+The safety-guardrails.py hook provides a separate, more nuanced layer that
+handles these same concerns with safe-path-prefix allowlisting; these tests
+guard only the coarser settings.json deny-glob layer.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Both copies must be tested — .claude/ is the dev copy, templates/ is what ships.
+SETTINGS_FILES = [
+    REPO_ROOT / ".claude" / "settings.json",
+    REPO_ROOT / "src" / "mapify_cli" / "templates" / "settings.json",
+]
+SETTINGS_IDS = [str(p.relative_to(REPO_ROOT)) for p in SETTINGS_FILES]
+
+
+def _edit_deny_globs(settings_path: Path) -> list[str]:
+    """Return the glob strings from every Edit(...) deny rule in settings.json."""
+    data = json.loads(settings_path.read_text())
+    deny_rules: list[str] = data.get("permissions", {}).get("deny", [])
+    globs: list[str] = []
+    for rule in deny_rules:
+        if rule.startswith("Edit(") and rule.endswith(")"):
+            globs.append(rule[5:-1])
+    return globs
+
+
+# ---------------------------------------------------------------------------
+# Regression: broad globs must be absent (issue #397)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("settings_path", SETTINGS_FILES, ids=SETTINGS_IDS)
+def test_broad_secret_glob_absent(settings_path: Path) -> None:
+    """Edit(**/*secret*) must NOT be in the deny list — it blocks source files."""
+    globs = _edit_deny_globs(settings_path)
+    assert "**/*secret*" not in globs, (
+        f"{settings_path.relative_to(REPO_ROOT)}: "
+        "broad deny glob '**/*secret*' blocks source files like "
+        "secret_service.go — use extension-scoped patterns instead (issue #397)"
+    )
+
+
+@pytest.mark.parametrize("settings_path", SETTINGS_FILES, ids=SETTINGS_IDS)
+def test_broad_credentials_glob_absent(settings_path: Path) -> None:
+    """Edit(**/*credentials*) must NOT be in the deny list — it blocks source files."""
+    globs = _edit_deny_globs(settings_path)
+    assert "**/*credentials*" not in globs, (
+        f"{settings_path.relative_to(REPO_ROOT)}: "
+        "broad deny glob '**/*credentials*' blocks source files — "
+        "use extension-scoped patterns instead (issue #397)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Secret/credentials manifest files are still blocked (extension-scoped globs)
+# ---------------------------------------------------------------------------
+
+_BLOCKED_SECRET_FILES = [
+    # Claude Code's deny globs use **/* which requires at least one path separator;
+    # files at the absolute repo root (no directory) are caught by the
+    # safety-guardrails.py hook instead. These are realistic in-directory paths.
+    "infra/k8s/secret-store.json",
+    "deploy/secret_config.yaml",
+    "k8s/secrets.yaml",
+    "ops/secrets.yml",
+    "config/secrets.json",
+    "deploy/secrets.toml",
+    "envs/secrets.env",
+    "manifests/my_secret.yaml",
+]
+
+_BLOCKED_CREDENTIALS_FILES = [
+    "config/credentials.yaml",
+    "deploy/credentials.yml",
+    "secrets/credentials.json",
+    "config/credentials.toml",
+    "envs/credentials.env",
+    "ops/aws-credentials.yaml",
+    "cfg/gcp_credentials.json",
+]
+
+
+@pytest.mark.parametrize("settings_path", SETTINGS_FILES, ids=SETTINGS_IDS)
+@pytest.mark.parametrize("src_file", _BLOCKED_SECRET_FILES)
+def test_secret_manifest_files_still_blocked(
+    settings_path: Path, src_file: str
+) -> None:
+    """Secret manifest files (.yaml/.json/etc.) must still match a deny glob."""
+    globs = _edit_deny_globs(settings_path)
+    matched = any(fnmatch.fnmatch(src_file, g) for g in globs)
+    assert matched, (
+        f"{settings_path.relative_to(REPO_ROOT)}: secret file {src_file!r} "
+        "is no longer blocked by any Edit deny glob — check extension-scoped patterns"
+    )
+
+
+@pytest.mark.parametrize("settings_path", SETTINGS_FILES, ids=SETTINGS_IDS)
+@pytest.mark.parametrize("src_file", _BLOCKED_CREDENTIALS_FILES)
+def test_credentials_manifest_files_still_blocked(
+    settings_path: Path, src_file: str
+) -> None:
+    """Credential manifest files (.yaml/.json/etc.) must still match a deny glob."""
+    globs = _edit_deny_globs(settings_path)
+    matched = any(fnmatch.fnmatch(src_file, g) for g in globs)
+    assert matched, (
+        f"{settings_path.relative_to(REPO_ROOT)}: credentials file {src_file!r} "
+        "is no longer blocked by any Edit deny glob — check extension-scoped patterns"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source code files with 'secret'/'credentials' in the name are NOT blocked
+# ---------------------------------------------------------------------------
+
+_ALLOWED_SOURCE_FILES = [
+    "lockbox/internal/handler/secret_service.go",
+    "secret_service_test.go",
+    "secret_service_versions.go",
+    "src/credentials_manager.py",
+    "internal/credentials/client.go",
+    "pkg/secrets_injector/main.go",
+    "lib/secrets_vault.ts",
+    "app/secret_store.rb",
+    "credentials_provider.java",
+    "src/secret_helper.rs",
+]
+
+
+@pytest.mark.parametrize("settings_path", SETTINGS_FILES, ids=SETTINGS_IDS)
+@pytest.mark.parametrize("src_file", _ALLOWED_SOURCE_FILES)
+def test_source_files_with_secret_in_name_not_blocked(
+    settings_path: Path, src_file: str
+) -> None:
+    """Source files whose names contain 'secret'/'credentials' must not be blocked.
+
+    Regression for issue #397: Edit(**/*secret*) blocked secret_service.go,
+    secret_service_test.go, and secret_service_versions.go in a secrets-management
+    service codebase — making the agent unable to edit any file with 'secret'
+    in its path.
+    """
+    globs = _edit_deny_globs(settings_path)
+    for glob_pat in globs:
+        assert not fnmatch.fnmatch(src_file, glob_pat), (
+            f"{settings_path.relative_to(REPO_ROOT)}: "
+            f"deny glob {glob_pat!r} blocks source file {src_file!r}. "
+            "Deny rules must only block secret MATERIAL files (by extension), "
+            "not source code that uses 'secret' in identifiers."
+        )


### PR DESCRIPTION
## Summary

Fixes #397 — the broad deny globs `Edit(**/*secret*)` and `Edit(**/*credentials*)` in `settings.json` blocked source files like `secret_service.go`, `secret_service_test.go`, and `secret_service_versions.go` in secrets-management codebases, making the agent unable to edit any file with `secret` or `credentials` in its path.

### Changes

- **`src/mapify_cli/templates_src/settings.json.jinja`** — replaced the two broad substring-match deny globs with 10 extension-scoped patterns (`.yaml`, `.yml`, `.json`, `.toml`, `.env` for both `*secret*` and `*credentials*`). These match secret material files but not source code.
- **`src/mapify_cli/templates/settings.json`** and **`.claude/settings.json`** — regenerated via `make render-templates`; both now carry the narrowed patterns.
- **`tests/test_settings_deny_globs.py`** — new regression test file (54 parametrized cases) that:
  - Asserts the two broad globs are absent from both settings.json copies
  - Asserts secret/credentials manifest files (`.yaml`, `.json`, etc. with a directory component) are still blocked
  - Asserts source files with `secret`/`credentials` in the name (`.go`, `.py`, `.ts`, `.rs`, etc.) are NOT blocked

### Security architecture preserved

The fix mirrors the pattern already established by issue #321 in `safety-guardrails.py`, where the hook regex was similarly narrowed to extension-scoped patterns. The two-layer defense remains intact:

1. **`settings.json` deny rules** (this PR): now blocks only secret-material file extensions
2. **`safety-guardrails.py` hook**: provides finer-grained protection with safe-path-prefix allowlisting for `src/`, `tests/`, `internal/`, etc. — also handles bare filenames at the repo root that the `**/*` glob can't match

### Tests

All 235 tests pass (`make test`). `make check-render` clean. `make lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMPdFPNNytqSSVkgzqysfP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined edit protections for credential and secret configuration files.
  * Source files containing “secret” or “credentials” in their names are no longer unnecessarily blocked.
  * Credential and secret files with supported configuration extensions remain protected.

* **Tests**
  * Added regression coverage to verify the updated edit restrictions across development and shipped settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->