### PR TITLE
fix: 5 bugs — scope classifier crash, config dead-toggle, verdict validation, governance category drift

### DIFF
--- a/.map/scripts/classify_scope.py
+++ b/.map/scripts/classify_scope.py
@@ -47,10 +47,23 @@ _DEFAULTS: dict[str, str] = {
 }
 
 
+_SNAKE_ALIASES: dict[str, str] = {
+    "scale_auto": "scale.auto",
+    "scale_trivial_max_files": "scale.thresholds.trivial.max_files",
+    "scale_trivial_max_lines": "scale.thresholds.trivial.max_lines",
+    "scale_small_max_files": "scale.thresholds.small.max_files",
+    "scale_small_max_lines": "scale.thresholds.small.max_lines",
+    "scale_medium_max_files": "scale.thresholds.medium.max_files",
+    "scale_medium_max_lines": "scale.thresholds.medium.max_lines",
+}
+
+
 def _read_config(project_dir: Path) -> dict[str, str]:
     """Read .map/config.yaml scalar values without external dependencies.
 
-    Supports the same dotted-key YAML subset used by load_map_config().
+    Supports both the dotted-key form used in the config template (e.g.
+    ``scale.thresholds.trivial.max_files``) and the snake_case form that
+    ``load_map_config()`` aliases (e.g. ``scale_trivial_max_files``).
     """
     config_path = project_dir / ".map" / "config.yaml"
     if not config_path.is_file():
@@ -72,6 +85,11 @@ def _read_config(project_dir: Path) -> dict[str, str]:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
             value = value[1:-1]
         values[key] = value
+    # Accept snake_case aliases (e.g. scale_trivial_max_files) in addition to
+    # the canonical dotted form so both config styles are honoured.
+    for snake, dotted in _SNAKE_ALIASES.items():
+        if snake in values and dotted not in values:
+            values[dotted] = values[snake]
     return values
 
 
@@ -84,7 +102,16 @@ def classify(
     raw = _read_config(project_dir or Path("."))
 
     def _int(key: str) -> int:
-        return int(raw.get(key, _DEFAULTS[key]))
+        raw_val = raw.get(key, _DEFAULTS[key])
+        try:
+            return int(raw_val)
+        except ValueError:
+            print(
+                f"warning: classify_scope: invalid integer {raw_val!r} for config "
+                f"key {key!r}; using default {_DEFAULTS[key]}",
+                file=sys.stderr,
+            )
+            return int(_DEFAULTS[key])
 
     def _bool(key: str) -> bool:
         return raw.get(key, _DEFAULTS[key]).lower() not in {"false", "0", "no"}

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -2841,6 +2841,16 @@ def write_implementer_readiness_review(
             normalized_question["spec_reference"] = spec_reference
         blocking_questions.append(normalized_question)
 
+    if verdict == "needs_clarification" and not blocking_questions:
+        return {
+            "status": "error",
+            "message": (
+                "blocking_questions must be non-empty when verdict is "
+                "'needs_clarification'. Provide at least one question (with "
+                "category) that must be answered before implementation can proceed."
+            ),
+        }
+
     non_blocking_risks: list[str] = []
     for i, risk in enumerate(parsed_non_blocking_risks):
         if not isinstance(risk, str):

--- a/src/mapify_cli/config/project_config.py
+++ b/src/mapify_cli/config/project_config.py
@@ -543,6 +543,28 @@ def load_map_config(project_path: Path) -> MapConfig:
         # Clamp max_wave_retries to [1, 10]; non-int/bool → default 3.
         cfg.max_wave_retries = clamp_max_wave_retries(cfg.max_wave_retries)
 
+        # Scale threshold fields must be >= 1; a value <= 0 makes one or more
+        # scope brackets unreachable (e.g. estimated_files <= -1 is always False).
+        _scale_defaults: dict[str, int] = {
+            "scale_trivial_max_files": 3,
+            "scale_trivial_max_lines": 50,
+            "scale_small_max_files": 10,
+            "scale_small_max_lines": 200,
+            "scale_medium_max_files": 30,
+            "scale_medium_max_lines": 1000,
+        }
+        for _sf, _default in _scale_defaults.items():
+            _val = getattr(cfg, _sf)
+            if _val < 1:
+                logger.warning(
+                    "%s must be >= 1 in %s (got %d). Using default %d.",
+                    _sf,
+                    config_file,
+                    _val,
+                    _default,
+                )
+                setattr(cfg, _sf, _default)
+
         return cfg
 
     except yaml.YAMLError as e:

--- a/src/mapify_cli/delivery/governance_report.py
+++ b/src/mapify_cli/delivery/governance_report.py
@@ -189,6 +189,14 @@ _SKILL_META: dict[str, tuple[str, str]] = {
         "context",
         "Opt-in read-only prior-art search against Stack Overflow for Agents (SOFA)",
     ),
+    "map-wayfind": (
+        "oversight",
+        "Decision-frontier wayfinding: resolve open design decisions on a durable map before /map-plan",
+    ),
+    "map-architecture": (
+        "context",
+        "Opt-in proactive architecture-deepening report: rank codebase hotspots by design friction",
+    ),
 }
 
 #: Default categories for known references (enforcement = "prompt-only")

--- a/src/mapify_cli/templates/map/scripts/classify_scope.py
+++ b/src/mapify_cli/templates/map/scripts/classify_scope.py
@@ -47,10 +47,23 @@ _DEFAULTS: dict[str, str] = {
 }
 
 
+_SNAKE_ALIASES: dict[str, str] = {
+    "scale_auto": "scale.auto",
+    "scale_trivial_max_files": "scale.thresholds.trivial.max_files",
+    "scale_trivial_max_lines": "scale.thresholds.trivial.max_lines",
+    "scale_small_max_files": "scale.thresholds.small.max_files",
+    "scale_small_max_lines": "scale.thresholds.small.max_lines",
+    "scale_medium_max_files": "scale.thresholds.medium.max_files",
+    "scale_medium_max_lines": "scale.thresholds.medium.max_lines",
+}
+
+
 def _read_config(project_dir: Path) -> dict[str, str]:
     """Read .map/config.yaml scalar values without external dependencies.
 
-    Supports the same dotted-key YAML subset used by load_map_config().
+    Supports both the dotted-key form used in the config template (e.g.
+    ``scale.thresholds.trivial.max_files``) and the snake_case form that
+    ``load_map_config()`` aliases (e.g. ``scale_trivial_max_files``).
     """
     config_path = project_dir / ".map" / "config.yaml"
     if not config_path.is_file():
@@ -72,6 +85,11 @@ def _read_config(project_dir: Path) -> dict[str, str]:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
             value = value[1:-1]
         values[key] = value
+    # Accept snake_case aliases (e.g. scale_trivial_max_files) in addition to
+    # the canonical dotted form so both config styles are honoured.
+    for snake, dotted in _SNAKE_ALIASES.items():
+        if snake in values and dotted not in values:
+            values[dotted] = values[snake]
     return values
 
 
@@ -84,7 +102,16 @@ def classify(
     raw = _read_config(project_dir or Path("."))
 
     def _int(key: str) -> int:
-        return int(raw.get(key, _DEFAULTS[key]))
+        raw_val = raw.get(key, _DEFAULTS[key])
+        try:
+            return int(raw_val)
+        except ValueError:
+            print(
+                f"warning: classify_scope: invalid integer {raw_val!r} for config "
+                f"key {key!r}; using default {_DEFAULTS[key]}",
+                file=sys.stderr,
+            )
+            return int(_DEFAULTS[key])
 
     def _bool(key: str) -> bool:
         return raw.get(key, _DEFAULTS[key]).lower() not in {"false", "0", "no"}

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -2841,6 +2841,16 @@ def write_implementer_readiness_review(
             normalized_question["spec_reference"] = spec_reference
         blocking_questions.append(normalized_question)
 
+    if verdict == "needs_clarification" and not blocking_questions:
+        return {
+            "status": "error",
+            "message": (
+                "blocking_questions must be non-empty when verdict is "
+                "'needs_clarification'. Provide at least one question (with "
+                "category) that must be answered before implementation can proceed."
+            ),
+        }
+
     non_blocking_risks: list[str] = []
     for i, risk in enumerate(parsed_non_blocking_risks):
         if not isinstance(risk, str):

--- a/src/mapify_cli/templates_src/map/scripts/classify_scope.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/classify_scope.py.jinja
@@ -47,10 +47,23 @@ _DEFAULTS: dict[str, str] = {
 }
 
 
+_SNAKE_ALIASES: dict[str, str] = {
+    "scale_auto": "scale.auto",
+    "scale_trivial_max_files": "scale.thresholds.trivial.max_files",
+    "scale_trivial_max_lines": "scale.thresholds.trivial.max_lines",
+    "scale_small_max_files": "scale.thresholds.small.max_files",
+    "scale_small_max_lines": "scale.thresholds.small.max_lines",
+    "scale_medium_max_files": "scale.thresholds.medium.max_files",
+    "scale_medium_max_lines": "scale.thresholds.medium.max_lines",
+}
+
+
 def _read_config(project_dir: Path) -> dict[str, str]:
     """Read .map/config.yaml scalar values without external dependencies.
 
-    Supports the same dotted-key YAML subset used by load_map_config().
+    Supports both the dotted-key form used in the config template (e.g.
+    ``scale.thresholds.trivial.max_files``) and the snake_case form that
+    ``load_map_config()`` aliases (e.g. ``scale_trivial_max_files``).
     """
     config_path = project_dir / ".map" / "config.yaml"
     if not config_path.is_file():
@@ -72,6 +85,11 @@ def _read_config(project_dir: Path) -> dict[str, str]:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
             value = value[1:-1]
         values[key] = value
+    # Accept snake_case aliases (e.g. scale_trivial_max_files) in addition to
+    # the canonical dotted form so both config styles are honoured.
+    for snake, dotted in _SNAKE_ALIASES.items():
+        if snake in values and dotted not in values:
+            values[dotted] = values[snake]
     return values
 
 
@@ -84,7 +102,16 @@ def classify(
     raw = _read_config(project_dir or Path("."))
 
     def _int(key: str) -> int:
-        return int(raw.get(key, _DEFAULTS[key]))
+        raw_val = raw.get(key, _DEFAULTS[key])
+        try:
+            return int(raw_val)
+        except ValueError:
+            print(
+                f"warning: classify_scope: invalid integer {raw_val!r} for config "
+                f"key {key!r}; using default {_DEFAULTS[key]}",
+                file=sys.stderr,
+            )
+            return int(_DEFAULTS[key])
 
     def _bool(key: str) -> bool:
         return raw.get(key, _DEFAULTS[key]).lower() not in {"false", "0", "no"}

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -2841,6 +2841,16 @@ def write_implementer_readiness_review(
             normalized_question["spec_reference"] = spec_reference
         blocking_questions.append(normalized_question)
 
+    if verdict == "needs_clarification" and not blocking_questions:
+        return {
+            "status": "error",
+            "message": (
+                "blocking_questions must be non-empty when verdict is "
+                "'needs_clarification'. Provide at least one question (with "
+                "category) that must be answered before implementation can proceed."
+            ),
+        }
+
     non_blocking_risks: list[str] = []
     for i, risk in enumerate(parsed_non_blocking_risks):
         if not isinstance(risk, str):

--- a/tests/test_classify_scope_script.py
+++ b/tests/test_classify_scope_script.py
@@ -253,3 +253,61 @@ class TestSc7RenderedScriptExists:
         )
         assert proc.returncode == 0
         assert "--files" in proc.stdout or "--files" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# SC8 — snake_case aliases accepted alongside dotted-key form
+# ---------------------------------------------------------------------------
+
+
+class TestSc8SnakeCaseAliases:
+    """Config keys may be written as snake_case (scale_trivial_max_files) instead of
+    the canonical dotted form (scale.thresholds.trivial.max_files); both must work."""
+
+    def test_snake_trivial_max_files_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale_trivial_max_files: 1\n")
+        assert _run(1, 10, tmp_path)["bracket"] == "trivial"
+        assert _run(2, 10, tmp_path)["bracket"] == "small"
+
+    def test_snake_trivial_max_lines_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale_trivial_max_lines: 20\n")
+        assert _run(1, 20, tmp_path)["bracket"] == "trivial"
+        assert _run(1, 21, tmp_path)["bracket"] == "small"
+
+    def test_snake_small_max_files_override(self, tmp_path: Path):
+        _write_config(tmp_path, "scale_small_max_files: 5\n")
+        assert _run(5, 10, tmp_path)["bracket"] == "small"
+        assert _run(6, 10, tmp_path)["bracket"] == "medium"
+
+    def test_snake_auto_false(self, tmp_path: Path):
+        _write_config(tmp_path, "scale_auto: false\n")
+        assert _run(1, 10, tmp_path)["auto_enabled"] is False
+
+    def test_dotted_takes_precedence_over_snake(self, tmp_path: Path):
+        # Both forms present: dotted wins (written first, snake is not applied)
+        _write_config(
+            tmp_path,
+            "scale.thresholds.trivial.max_files: 2\nscale_trivial_max_files: 10\n"
+        )
+        # With max_files=2 (from dotted), files=3 must be "small", not "trivial"
+        assert _run(3, 10, tmp_path)["bracket"] == "small"
+
+
+# ---------------------------------------------------------------------------
+# SC9 — invalid config integer value falls back to default, does not crash
+# ---------------------------------------------------------------------------
+
+
+class TestSc9InvalidConfigValue:
+    def test_non_integer_config_value_uses_default(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.thresholds.trivial.max_files: many\n")
+        # Must not crash; falls back to default (3), so 3 files → trivial
+        result = _run(3, 10, tmp_path)
+        assert result["bracket"] == "trivial"
+        assert result["bracket"] in {"trivial", "small", "medium", "large"}
+
+    def test_float_config_value_uses_default(self, tmp_path: Path):
+        _write_config(tmp_path, "scale.thresholds.trivial.max_lines: 50.5\n")
+        # int("50.5") raises ValueError; must fall back to default 50
+        result = _run(3, 50, tmp_path)
+        assert result["bracket"] == "trivial"

--- a/tests/test_governance_report.py
+++ b/tests/test_governance_report.py
@@ -183,6 +183,42 @@ class TestBuildGovernanceReport:
         mp = next(a for a in report.assets if a.name == "map-plan")
         assert mp.category == "charter"
 
+    def test_map_wayfind_classified_as_oversight(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        skills = claude / "skills"
+        skills.mkdir(parents=True)
+        _make_skill_rules(skills, {
+            "map-wayfind": {
+                "type": "manual",
+                "skillClass": "task",
+                "description": "Decision-frontier wayfinding",
+            }
+        })
+        _make_skill_dir(skills, "map-wayfind")
+        report = build_governance_report(tmp_path)
+        asset = next(a for a in report.assets if a.name == "map-wayfind")
+        assert asset.category == "oversight", (
+            "map-wayfind must be classified as 'oversight', not the generic 'harness' fallback"
+        )
+
+    def test_map_architecture_classified_as_context(self, tmp_path: Path) -> None:
+        claude = tmp_path / ".claude"
+        skills = claude / "skills"
+        skills.mkdir(parents=True)
+        _make_skill_rules(skills, {
+            "map-architecture": {
+                "type": "manual",
+                "skillClass": "task",
+                "description": "Architecture-deepening report",
+            }
+        })
+        _make_skill_dir(skills, "map-architecture")
+        report = build_governance_report(tmp_path)
+        asset = next(a for a in report.assets if a.name == "map-architecture")
+        assert asset.category == "context", (
+            "map-architecture must be classified as 'context', not the generic 'harness' fallback"
+        )
+
     def test_asset_paths_are_relative_to_project(self, map_project: Path) -> None:
         report = build_governance_report(map_project)
         for asset in report.assets:

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -15256,3 +15256,21 @@ def test_write_implementer_readiness_review_rejects_question_extra_keys(
     assert "unsupported fields" in result["message"]
     assert "owner" in result["message"]
     assert not (branch_workspace / "implementation-readiness.json").exists()
+
+
+def test_write_implementer_readiness_review_needs_clarification_requires_blocking_questions(
+    branch_workspace,
+):
+    # needs_clarification with zero blocking_questions must be rejected — an artifact
+    # whose verdict is "needs_clarification" but has no questions blocks callers
+    # with no actionable information.
+    result = map_step_runner.write_implementer_readiness_review(
+        verdict="needs_clarification",
+        blocking_questions_json="[]",
+        summary="Something is unclear.",
+    )
+
+    assert result["status"] == "error"
+    assert "blocking_questions" in result["message"].lower()
+    assert "needs_clarification" in result["message"]
+    assert not (branch_workspace / "implementation-readiness.json").exists()

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -630,3 +630,58 @@ class TestVc9DefaultConfigCompleteness:
             f"generate_default_config() is missing documentation for: {missing}. "
             "Each MapConfig alias must have a corresponding commented block (#340)."
         )
+
+
+# ---------------------------------------------------------------------------
+# Scale threshold range validation
+# ---------------------------------------------------------------------------
+
+
+class TestScaleThresholdRangeValidation:
+    """Scale threshold fields must be >= 1; a value <= 0 makes scope brackets
+    unreachable (e.g. estimated_files <= -1 is always False for real inputs)."""
+
+    def _write_config(self, tmp_path: Path, body: str) -> None:
+        (tmp_path / ".map").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".map" / "config.yaml").write_text(body, encoding="utf-8")
+
+    def test_negative_trivial_max_files_falls_back_to_default(
+        self, tmp_path: Path
+    ) -> None:
+        self._write_config(tmp_path, "scale.thresholds.trivial.max_files: -1\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.scale_trivial_max_files == 3, (
+            "scale_trivial_max_files: -1 must fall back to default 3; "
+            "a negative value makes the trivial bracket unreachable."
+        )
+
+    def test_zero_trivial_max_lines_falls_back_to_default(
+        self, tmp_path: Path
+    ) -> None:
+        self._write_config(tmp_path, "scale.thresholds.trivial.max_lines: 0\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.scale_trivial_max_lines == 50
+
+    def test_negative_small_max_files_falls_back_to_default(
+        self, tmp_path: Path
+    ) -> None:
+        self._write_config(tmp_path, "scale.thresholds.small.max_files: -5\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.scale_small_max_files == 10
+
+    def test_negative_medium_max_lines_falls_back_to_default(
+        self, tmp_path: Path
+    ) -> None:
+        self._write_config(tmp_path, "scale.thresholds.medium.max_lines: -100\n")
+        cfg = load_map_config(tmp_path)
+        assert cfg.scale_medium_max_lines == 1000
+
+    def test_valid_positive_values_accepted(self, tmp_path: Path) -> None:
+        self._write_config(
+            tmp_path,
+            "scale.thresholds.trivial.max_files: 5\n"
+            "scale.thresholds.small.max_files: 15\n",
+        )
+        cfg = load_map_config(tmp_path)
+        assert cfg.scale_trivial_max_files == 5
+        assert cfg.scale_small_max_files == 15


### PR DESCRIPTION
## Summary

Five bugs found during a proactive code review (no open issues existed at run time).

### Bug 1 — `classify_scope.py`: uncaught `ValueError` crash on non-integer config values

`_int()` called `int(raw_val)` with no exception handling. A config file containing `scale.thresholds.trivial.max_files: many` (or any float like `50.5`) would crash the script with a raw Python traceback instead of a useful error. Now catches `ValueError`, prints a warning to stderr, and falls back to the documented default.

### Bug 2 — `classify_scope.py`: snake_case config keys silently ignored

`_read_config()` only recognised the dotted canonical form (`scale.thresholds.trivial.max_files`). `load_map_config()` in `project_config.py` also accepts the snake_case alias form (`scale_trivial_max_files`) via its explicit alias loop (lines 381–387). A user who wrote the snake_case form in `.map/config.yaml` — which `load_map_config` accepted and propagated — got silently ignored by `classify_scope.py`, which fell back to hardcoded defaults with no warning. Added a `_SNAKE_ALIASES` dict and alias resolution step, mirroring `load_map_config`'s pattern.

### Bug 3 — `project_config.py`: no range validation for `scale_*` threshold fields

All six `scale_trivial/small/medium_max_files/lines` fields were loaded without range checks. A value ≤ 0 makes one or more scope brackets permanently unreachable (`estimated_files <= -1` is always `False`). Other numeric fields (`compression_threshold_tokens`, `worktree_max_deletions`, `review_cross_ai_timeout_seconds`) already have equivalent guards. Added >= 1 validation with warning + fallback to defaults, consistent with the existing pattern.

### Bug 4 — `map_step_runner.py`: `needs_clarification` verdict accepted with zero blocking questions

`accepted_with_risk` correctly required a non-empty `acceptance_rationale`. `needs_clarification` had no parallel requirement: passing `--blocking-questions '[]'` produced a `"needs_clarification"` artifact with `blocking_questions_count=0` that would hard-stop callers (via `proceed: False`) with nothing actionable to show. Added validation requiring at least one blocking question when verdict is `needs_clarification`.

### Bug 5 — `governance_report.py`: `map-wayfind` and `map-architecture` misclassified

`_SKILL_META` was missing entries for two installed skills added after the initial table was written. Both fell through to the generic fallback which assigns `"harness"`. Correct categories: `map-wayfind` → `"oversight"` (pause/decision authority); `map-architecture` → `"context"` (provides architectural context for decisions).

## Test plan

- [ ] `tests/test_classify_scope_script.py` — SC8 (snake_case aliases) and SC9 (invalid integer falls back to default) test classes added
- [ ] `tests/test_project_config.py` — `TestScaleThresholdRangeValidation` class added (5 cases)
- [ ] `tests/test_map_step_runner.py` — `test_write_implementer_readiness_review_needs_clarification_requires_blocking_questions` added
- [ ] `tests/test_governance_report.py` — `test_map_wayfind_classified_as_oversight` and `test_map_architecture_classified_as_context` added
- [ ] Full suite: **4215 passed, 4 skipped** (no regressions)
- [ ] `ruff check src/ tests/` — clean
- [ ] `python -m pyright src/` — 0 errors, 0 warnings
- [ ] `make check-render` — generated trees match templates_src

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaRu2rqMuzg23p9FrUjTX8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for snake_case configuration aliases alongside dotted configuration keys.
  * Added metadata classifications for map-wayfind and map-architecture skills.
* **Bug Fixes**
  * Invalid numeric configuration values now warn and safely use defaults instead of stopping processing.
  * Invalid scale thresholds below 1 now revert to their defaults.
  * Clarification decisions now require at least one blocking question; invalid submissions return a clear error without creating an artifact.
* **Tests**
  * Added coverage for configuration aliases, validation, fallback behavior, classifications, and clarification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->