### PR TITLE
fix: catch OSError in wayfind_runner evidence reads + extend .env deny glob to subdirs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
   "description": "MAP Framework project-level settings with security guardrails",
   "permissions": {
     "deny": [
-      "Edit(./.env*)",
+      "Edit(**/.env*)",
       "Edit(**/*credentials*.yaml)",
       "Edit(**/*credentials*.yml)",
       "Edit(**/*credentials*.json)",

--- a/.map/scripts/wayfind_runner.py
+++ b/.map/scripts/wayfind_runner.py
@@ -130,6 +130,14 @@ def _resolve_evidence_path(slug: str, rel: str) -> Path | None:
     return candidate
 
 
+def _safe_read(path: Path) -> str:
+    """Read a file's text, returning empty string on OSError."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
 # ---------------------------------------------------------------------------
 # State load / save + derived views
 # ---------------------------------------------------------------------------
@@ -908,9 +916,7 @@ def record_human_input(
     # in state.json doubles as a correct link target from the co-located views;
     # containment is enforced so absolute/../ paths cannot claim provenance.
     input_path = _resolve_evidence_path(slug, path)
-    if input_path is None or not input_path.read_text(
-        encoding="utf-8", errors="replace"
-    ).strip():
+    if input_path is None or not _safe_read(input_path).strip():
         return _err(
             f"human input file {path!r} must be a non-empty regular file INSIDE the map "
             "dir (.map/wayfind/<slug>/). Save the human's verbatim answer there first.",
@@ -956,9 +962,7 @@ def resolve_ticket(
     # value is a correct link target from the co-located map.md / handoff.md views;
     # containment is enforced so absolute/../ paths cannot stand in as a resolution.
     resolution_file = _resolve_evidence_path(slug, resolution_path)
-    if resolution_file is None or not resolution_file.read_text(
-        encoding="utf-8", errors="replace"
-    ).strip():
+    if resolution_file is None or not _safe_read(resolution_file).strip():
         return _err(
             f"resolution file {resolution_path!r} must be a non-empty regular file INSIDE "
             "the map dir (.map/wayfind/<slug>/). Write the prose resolution first.",
@@ -1054,9 +1058,7 @@ def amend_resolution(
         resolution["gist"] = _oneline(gist)
     if resolution_path is not None:
         resolution_file = _resolve_evidence_path(slug, resolution_path)
-        if resolution_file is None or not resolution_file.read_text(
-            encoding="utf-8", errors="replace"
-        ).strip():
+        if resolution_file is None or not _safe_read(resolution_file).strip():
             return _err(
                 f"resolution file {resolution_path!r} must be a non-empty regular file "
                 "INSIDE the map dir (.map/wayfind/<slug>/).",

--- a/src/mapify_cli/templates/map/scripts/wayfind_runner.py
+++ b/src/mapify_cli/templates/map/scripts/wayfind_runner.py
@@ -130,6 +130,14 @@ def _resolve_evidence_path(slug: str, rel: str) -> Path | None:
     return candidate
 
 
+def _safe_read(path: Path) -> str:
+    """Read a file's text, returning empty string on OSError."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
 # ---------------------------------------------------------------------------
 # State load / save + derived views
 # ---------------------------------------------------------------------------
@@ -908,9 +916,7 @@ def record_human_input(
     # in state.json doubles as a correct link target from the co-located views;
     # containment is enforced so absolute/../ paths cannot claim provenance.
     input_path = _resolve_evidence_path(slug, path)
-    if input_path is None or not input_path.read_text(
-        encoding="utf-8", errors="replace"
-    ).strip():
+    if input_path is None or not _safe_read(input_path).strip():
         return _err(
             f"human input file {path!r} must be a non-empty regular file INSIDE the map "
             "dir (.map/wayfind/<slug>/). Save the human's verbatim answer there first.",
@@ -956,9 +962,7 @@ def resolve_ticket(
     # value is a correct link target from the co-located map.md / handoff.md views;
     # containment is enforced so absolute/../ paths cannot stand in as a resolution.
     resolution_file = _resolve_evidence_path(slug, resolution_path)
-    if resolution_file is None or not resolution_file.read_text(
-        encoding="utf-8", errors="replace"
-    ).strip():
+    if resolution_file is None or not _safe_read(resolution_file).strip():
         return _err(
             f"resolution file {resolution_path!r} must be a non-empty regular file INSIDE "
             "the map dir (.map/wayfind/<slug>/). Write the prose resolution first.",
@@ -1054,9 +1058,7 @@ def amend_resolution(
         resolution["gist"] = _oneline(gist)
     if resolution_path is not None:
         resolution_file = _resolve_evidence_path(slug, resolution_path)
-        if resolution_file is None or not resolution_file.read_text(
-            encoding="utf-8", errors="replace"
-        ).strip():
+        if resolution_file is None or not _safe_read(resolution_file).strip():
             return _err(
                 f"resolution file {resolution_path!r} must be a non-empty regular file "
                 "INSIDE the map dir (.map/wayfind/<slug>/).",

--- a/src/mapify_cli/templates/settings.json
+++ b/src/mapify_cli/templates/settings.json
@@ -3,7 +3,7 @@
   "description": "MAP Framework project-level settings with security guardrails",
   "permissions": {
     "deny": [
-      "Edit(./.env*)",
+      "Edit(**/.env*)",
       "Edit(**/*credentials*.yaml)",
       "Edit(**/*credentials*.yml)",
       "Edit(**/*credentials*.json)",

--- a/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja
@@ -130,6 +130,14 @@ def _resolve_evidence_path(slug: str, rel: str) -> Path | None:
     return candidate
 
 
+def _safe_read(path: Path) -> str:
+    """Read a file's text, returning empty string on OSError."""
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
 # ---------------------------------------------------------------------------
 # State load / save + derived views
 # ---------------------------------------------------------------------------
@@ -908,9 +916,7 @@ def record_human_input(
     # in state.json doubles as a correct link target from the co-located views;
     # containment is enforced so absolute/../ paths cannot claim provenance.
     input_path = _resolve_evidence_path(slug, path)
-    if input_path is None or not input_path.read_text(
-        encoding="utf-8", errors="replace"
-    ).strip():
+    if input_path is None or not _safe_read(input_path).strip():
         return _err(
             f"human input file {path!r} must be a non-empty regular file INSIDE the map "
             "dir (.map/wayfind/<slug>/). Save the human's verbatim answer there first.",
@@ -956,9 +962,7 @@ def resolve_ticket(
     # value is a correct link target from the co-located map.md / handoff.md views;
     # containment is enforced so absolute/../ paths cannot stand in as a resolution.
     resolution_file = _resolve_evidence_path(slug, resolution_path)
-    if resolution_file is None or not resolution_file.read_text(
-        encoding="utf-8", errors="replace"
-    ).strip():
+    if resolution_file is None or not _safe_read(resolution_file).strip():
         return _err(
             f"resolution file {resolution_path!r} must be a non-empty regular file INSIDE "
             "the map dir (.map/wayfind/<slug>/). Write the prose resolution first.",
@@ -1054,9 +1058,7 @@ def amend_resolution(
         resolution["gist"] = _oneline(gist)
     if resolution_path is not None:
         resolution_file = _resolve_evidence_path(slug, resolution_path)
-        if resolution_file is None or not resolution_file.read_text(
-            encoding="utf-8", errors="replace"
-        ).strip():
+        if resolution_file is None or not _safe_read(resolution_file).strip():
             return _err(
                 f"resolution file {resolution_path!r} must be a non-empty regular file "
                 "INSIDE the map dir (.map/wayfind/<slug>/).",

--- a/src/mapify_cli/templates_src/settings.json.jinja
+++ b/src/mapify_cli/templates_src/settings.json.jinja
@@ -3,7 +3,7 @@
   "description": "MAP Framework project-level settings with security guardrails",
   "permissions": {
     "deny": [
-      "Edit(./.env*)",
+      "Edit(**/.env*)",
       "Edit(**/*credentials*.yaml)",
       "Edit(**/*credentials*.yml)",
       "Edit(**/*credentials*.json)",

--- a/tests/test_settings_deny_globs.py
+++ b/tests/test_settings_deny_globs.py
@@ -161,3 +161,35 @@ def test_source_files_with_secret_in_name_not_blocked(
             "Deny rules must only block secret MATERIAL files (by extension), "
             "not source code that uses 'secret' in identifiers."
         )
+
+
+# ---------------------------------------------------------------------------
+# .env files are blocked (both root-level and in subdirectories)
+# ---------------------------------------------------------------------------
+
+# Subdirectory .env files — blocked by Edit(**/.env*) but NOT by the old Edit(./.env*).
+# Root-level .env protection comes from safety-guardrails.py, not these settings.json globs.
+_BLOCKED_SUBDIRECTORY_ENV_FILES = [
+    "backend/.env",
+    "services/api/.env",
+    "services/api/.env.local",
+    "apps/web/.env.production",
+    "apps/web/.env.development",
+]
+
+
+@pytest.mark.parametrize("settings_path", SETTINGS_FILES, ids=SETTINGS_IDS)
+@pytest.mark.parametrize("env_file", _BLOCKED_SUBDIRECTORY_ENV_FILES)
+def test_subdirectory_env_files_blocked(settings_path: Path, env_file: str) -> None:
+    """Subdirectory .env* files must match a deny glob.
+
+    Regression for the bug where Edit(./.env*) only matched at the root level
+    while Edit(**/.env*) was the intent — subdirectory .env files like
+    backend/.env were not blocked by the settings.json layer.
+    """
+    globs = _edit_deny_globs(settings_path)
+    matched = any(fnmatch.fnmatch(env_file, g) for g in globs)
+    assert matched, (
+        f"{settings_path.relative_to(REPO_ROOT)}: .env file {env_file!r} "
+        "is not blocked by any Edit deny glob — use Edit(**/.env*) not Edit(./.env*)"
+    )

--- a/tests/test_wayfind_runner.py
+++ b/tests/test_wayfind_runner.py
@@ -492,6 +492,23 @@ class TestSessionGuardrail:
         assert result["status"] == "error"
         assert result["code"] == "missing_input"
 
+    def test_record_human_input_unreadable_file_returns_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When _safe_read catches an OSError it returns ""; the public API must
+        # surface a structured error instead of propagating the exception.
+        _create()
+        tid = wr.add_ticket("checkout", "Grill", "grilling", "What?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        rel = f"resolutions/{tid}.human.md"
+        p = Path(".map/wayfind/checkout") / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("content", encoding="utf-8")
+        monkeypatch.setattr(wr, "_safe_read", lambda _p: "")
+        result = wr.record_human_input("checkout", tid, "sess-1", rel)
+        assert result["status"] == "error"
+        assert result["code"] == "missing_input"
+
 
 # ---------------------------------------------------------------------------
 # 8. Views / files
@@ -508,6 +525,23 @@ class TestViews:
         empty.parent.mkdir(parents=True, exist_ok=True)
         empty.write_text("", encoding="utf-8")
         result = wr.resolve_ticket("checkout", tid, "sess-1", "g", empty_rel)
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
+    def test_unreadable_resolution_blocks_resolve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # _safe_read swallows OSError → returns ""; resolve_ticket must treat
+        # this as a missing/unreadable file and return a structured error.
+        _create()
+        tid = wr.add_ticket("checkout", "T", "task", "Q?")["ticket_id"]
+        wr.claim_ticket("checkout", tid, "sess-1")
+        rel = f"resolutions/{tid}.md"
+        p = Path(".map/wayfind/checkout") / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("content", encoding="utf-8")
+        monkeypatch.setattr(wr, "_safe_read", lambda _p: "")
+        result = wr.resolve_ticket("checkout", tid, "sess-1", "g", rel)
         assert result["status"] == "error"
         assert result["code"] == "missing_resolution"
 
@@ -621,6 +655,23 @@ class TestAmendResolution:
         assert result["status"] == "error"
         assert result["code"] == "missing_resolution"
 
+    def test_amend_resolution_unreadable_file_returns_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # _safe_read swallows OSError → returns ""; amend_resolution must treat
+        # this as a missing/unreadable file and return a structured error.
+        _create()
+        a = wr.add_ticket("checkout", "A", "task", "Qa?")["ticket_id"]
+        _resolve("checkout", a, "sess-1")
+        rel = f"resolutions/{a}.amended.md"
+        p = Path(".map/wayfind/checkout") / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("amended resolution", encoding="utf-8")
+        monkeypatch.setattr(wr, "_safe_read", lambda _p: "")
+        result = wr.amend_resolution("checkout", a, resolution_path=rel)
+        assert result["status"] == "error"
+        assert result["code"] == "missing_resolution"
+
     def test_amend_out_of_scope_reason(self) -> None:
         _create(fog_json='["vague concern"]')  # creates F-1
         ruled = wr.rule_out_of_scope("checkout", "wrong reason", fog_id="F-1")
@@ -669,3 +720,27 @@ class TestAmendResolution:
         blocked = wr.add_ticket("checkout", "B", "task", "Qb?")
         assert blocked["status"] == "error"
         assert blocked["code"] == "handed_off"
+
+
+# ---------------------------------------------------------------------------
+# _safe_read unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafeRead:
+    def test_safe_read_returns_content_normally(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("hello world", encoding="utf-8")
+        assert wr._safe_read(f) == "hello world"
+
+    def test_safe_read_returns_empty_string_on_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        f = tmp_path / "test.md"
+        f.write_text("content", encoding="utf-8")
+
+        def raise_oserror(*args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", raise_oserror)
+        assert wr._safe_read(f) == ""


### PR DESCRIPTION
Closes #400

## Bug 1: OSError escaped the public API in `wayfind_runner.py` (3 sites)

**Module docstring guarantees: "Nothing is raised through the public API."**

`_resolve_evidence_path()` correctly returns `None` for missing files, but three public-API call sites called `read_text()` directly on the returned path. If a file passed `is_file()` but was unreadable (permission denied, stale NFS mount), `OSError` propagated out of the API — violating the documented guarantee.

**Fix:** Add `_safe_read(path)` helper that catches `OSError` and returns `""`. Update all three call sites (`record_human_input`, `resolve_ticket`, `amend_resolution`) to use it.

```python
def _safe_read(path: Path) -> str:
    """Read a file's text, returning empty string on OSError."""
    try:
        return path.read_text(encoding="utf-8", errors="replace")
    except OSError:
        return ""
```

## Bug 2: `settings.json` `.env*` deny glob only matched root-level files

All other deny rules use `**` globbing. The `.env` rule used `./` which scoped it to the project root only — subdirectory `.env` files (`backend/.env`, `services/api/.env`, etc.) were not blocked by this settings.json layer.

```diff
- "Edit(./.env*)",
+ "Edit(**/.env*)",
```

Note: root-level `.env` protection comes from `safety-guardrails.py` (via `_DEFAULT_DANGEROUS_FILE_MARKERS`); the settings.json layer now also covers subdirectories consistently with all other deny rules.

## Files changed

| File | Change |
|------|--------|
| `src/mapify_cli/templates_src/map/scripts/wayfind_runner.py.jinja` | Add `_safe_read()`, update 3 call sites |
| `src/mapify_cli/templates_src/settings.json.jinja` | Fix `.env*` deny glob scope |
| Generated trees (`.map/`, `.claude/`, `templates/`) | Propagated via `make render-templates` |
| `tests/test_wayfind_runner.py` | `TestSafeRead` unit tests + 3 caller integration tests |
| `tests/test_settings_deny_globs.py` | Regression tests for subdirectory `.env` blocking |

## Test results

```
4230 passed, 4 skipped in 144s — make check clean
ruff: All checks passed
mypy: Success: no issues found in 85 source files
pyright: 0 errors, 0 warnings, 0 informations
make check-render: ✅ Generated trees match templates_src
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMyK7VDuXj2z2vSrggEHA8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable or invalid evidence files, providing consistent validation errors instead of unexpected failures.
  * Preserved support for files with decoding issues through safer file reading.

* **Security**
  * Expanded edit protections to cover `.env` files in nested directories, not just the project root.

* **Tests**
  * Added coverage for nested `.env` protection and unreadable resolution, amendment, and human-input files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->