### PR TITLE
fix(#404): preserve non-English Monitor feedback in retry artifacts

### DIFF
--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -469,7 +469,12 @@ def _is_blocker_feedback_line(line: str) -> bool:
 
 
 def _filter_blocker_retry_feedback(feedback: str) -> str:
-    """Forward only BLOCKER-class feedback into the next Actor retry."""
+    """Forward Monitor feedback into the next Actor retry.
+
+    Uses the keyword filter as a ranking hint only: lines matching BLOCKER terms
+    are surfaced first, but the complete original text is always preserved so
+    non-English or differently-phrased feedback is never silently dropped.
+    """
     if not feedback.strip():
         return ""
 
@@ -485,15 +490,25 @@ def _filter_blocker_retry_feedback(feedback: str) -> str:
                 *kept_lines,
                 "",
                 "Actor may re-add or expand code only by naming the BLOCKER item it addresses.",
+                "",
+                "Full Monitor feedback:",
+                feedback.rstrip(),
             ]
         )
 
-    return (
-        "Monitor returned valid=false, but no BLOCKER-class feedback was detected. "
-        "Re-check the contract, build/test output, security, data-loss paths, and "
-        "required behavior before expanding scope. Do not add code for style, "
-        "volume, docs-only, cosmetic, or nice-to-have feedback."
+    # No BLOCKER keywords matched (may be non-English or use non-standard phrasing).
+    # Forward the complete original text so the defect description is never lost.
+    _header = (
+        "Monitor returned valid=false. Forwarding complete feedback"
+        " (keyword classification did not match — may be non-English"
+        " or use non-standard phrasing):"
     )
+    _footer = (
+        "Re-check the contract, build/test output, security, data-loss paths,"
+        " and required behavior before expanding scope. Do not add code for style,"
+        " volume, docs-only, cosmetic, or nice-to-have feedback."
+    )
+    return f"{_header}\n\n{feedback.rstrip()}\n\n{_footer}"
 
 
 def _latest_numbered_artifact(plan_dir: Path, prefix: str) -> Path | None:

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -469,7 +469,12 @@ def _is_blocker_feedback_line(line: str) -> bool:
 
 
 def _filter_blocker_retry_feedback(feedback: str) -> str:
-    """Forward only BLOCKER-class feedback into the next Actor retry."""
+    """Forward Monitor feedback into the next Actor retry.
+
+    Uses the keyword filter as a ranking hint only: lines matching BLOCKER terms
+    are surfaced first, but the complete original text is always preserved so
+    non-English or differently-phrased feedback is never silently dropped.
+    """
     if not feedback.strip():
         return ""
 
@@ -485,15 +490,25 @@ def _filter_blocker_retry_feedback(feedback: str) -> str:
                 *kept_lines,
                 "",
                 "Actor may re-add or expand code only by naming the BLOCKER item it addresses.",
+                "",
+                "Full Monitor feedback:",
+                feedback.rstrip(),
             ]
         )
 
-    return (
-        "Monitor returned valid=false, but no BLOCKER-class feedback was detected. "
-        "Re-check the contract, build/test output, security, data-loss paths, and "
-        "required behavior before expanding scope. Do not add code for style, "
-        "volume, docs-only, cosmetic, or nice-to-have feedback."
+    # No BLOCKER keywords matched (may be non-English or use non-standard phrasing).
+    # Forward the complete original text so the defect description is never lost.
+    _header = (
+        "Monitor returned valid=false. Forwarding complete feedback"
+        " (keyword classification did not match — may be non-English"
+        " or use non-standard phrasing):"
     )
+    _footer = (
+        "Re-check the contract, build/test output, security, data-loss paths,"
+        " and required behavior before expanding scope. Do not add code for style,"
+        " volume, docs-only, cosmetic, or nice-to-have feedback."
+    )
+    return f"{_header}\n\n{feedback.rstrip()}\n\n{_footer}"
 
 
 def _latest_numbered_artifact(plan_dir: Path, prefix: str) -> Path | None:

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -469,7 +469,12 @@ def _is_blocker_feedback_line(line: str) -> bool:
 
 
 def _filter_blocker_retry_feedback(feedback: str) -> str:
-    """Forward only BLOCKER-class feedback into the next Actor retry."""
+    """Forward Monitor feedback into the next Actor retry.
+
+    Uses the keyword filter as a ranking hint only: lines matching BLOCKER terms
+    are surfaced first, but the complete original text is always preserved so
+    non-English or differently-phrased feedback is never silently dropped.
+    """
     if not feedback.strip():
         return ""
 
@@ -485,15 +490,25 @@ def _filter_blocker_retry_feedback(feedback: str) -> str:
                 *kept_lines,
                 "",
                 "Actor may re-add or expand code only by naming the BLOCKER item it addresses.",
+                "",
+                "Full Monitor feedback:",
+                feedback.rstrip(),
             ]
         )
 
-    return (
-        "Monitor returned valid=false, but no BLOCKER-class feedback was detected. "
-        "Re-check the contract, build/test output, security, data-loss paths, and "
-        "required behavior before expanding scope. Do not add code for style, "
-        "volume, docs-only, cosmetic, or nice-to-have feedback."
+    # No BLOCKER keywords matched (may be non-English or use non-standard phrasing).
+    # Forward the complete original text so the defect description is never lost.
+    _header = (
+        "Monitor returned valid=false. Forwarding complete feedback"
+        " (keyword classification did not match — may be non-English"
+        " or use non-standard phrasing):"
     )
+    _footer = (
+        "Re-check the contract, build/test output, security, data-loss paths,"
+        " and required behavior before expanding scope. Do not add code for style,"
+        " volume, docs-only, cosmetic, or nice-to-have feedback."
+    )
+    return f"{_header}\n\n{feedback.rstrip()}\n\n{_footer}"
 
 
 def _latest_numbered_artifact(plan_dir: Path, prefix: str) -> Path | None:

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -2020,18 +2020,43 @@ class TestMonitorFailed:
         assert "Missing Reset()" in content
         assert "retry 1" in content
 
-    def test_feedback_file_forwards_only_blocker_items(self, branch_dir, tmp_path):
+    def test_feedback_file_highlights_blocker_items_and_preserves_full_text(
+        self, branch_dir, tmp_path
+    ):
+        # BLOCKER lines are surfaced first; the complete original text is always
+        # included in the "Full Monitor feedback" section so no content is dropped.
         self._make_monitor_state(tmp_path, branch_dir)
         feedback = "BLOCKER: build failed in src/app.py\nNON-BLOCKING: docs could mention another example\nnice-to-have: style could be more elegant\nMissing required test for handled timeout path"
 
         result = map_orchestrator.monitor_failed(branch_dir, feedback)
 
         content = Path(result["feedback_file"]).read_text()
+        # Blocker items appear in the highlighted section
         assert "build failed" in content
         assert "Missing required test" in content
-        assert "docs could mention" not in content
-        assert "style could be more elegant" not in content
         assert "Actor may re-add or expand code only by naming" in content
+        # Full original text is preserved — non-blocking lines are NOT dropped
+        assert "docs could mention" in content
+        assert "style could be more elegant" in content
+        assert "Full Monitor feedback:" in content
+
+    def test_feedback_file_non_english_feedback_preserved(self, branch_dir, tmp_path):
+        # Russian/non-English feedback must NOT be replaced by a generic placeholder.
+        # It should be forwarded in full because no English keyword will match it.
+        self._make_monitor_state(tmp_path, branch_dir)
+        ru_feedback = (
+            "caBundle.enabled=false ломает компонент: Bundle не рендерится, но 6 ссылок на "
+            "bundle-ConfigMap остаются в трёх Deployment -> поды в ContainerCreating."
+        )
+
+        result = map_orchestrator.monitor_failed(branch_dir, ru_feedback)
+
+        content = Path(result["feedback_file"]).read_text()
+        # The Russian defect description must survive into the retry artifact
+        assert "ломает компонент" in content
+        assert "ContainerCreating" in content
+        # Must NOT be replaced by the old generic English-only placeholder
+        assert "no BLOCKER-class feedback was detected" not in content
 
     def test_feedback_file_none_when_empty(self, branch_dir, tmp_path):
         self._make_monitor_state(tmp_path, branch_dir)
@@ -2677,7 +2702,10 @@ class TestWaveMonitorFailed:
         content = Path(result["feedback_file"]).read_text()
         assert "type mismatch" in content
 
-    def test_wave_feedback_forwards_only_blocker_items(self, branch_dir, tmp_path):
+    def test_wave_feedback_highlights_blocker_items_and_preserves_full_text(
+        self, branch_dir, tmp_path
+    ):
+        # BLOCKER lines are surfaced first; full original text is always preserved.
         self._make_wave_state(tmp_path, branch_dir)
         feedback = "CRITICAL: security regression in auth flow\nNON-BLOCKING: documentation could be longer\ncosmetic: volume is high"
 
@@ -2685,8 +2713,25 @@ class TestWaveMonitorFailed:
 
         content = Path(result["feedback_file"]).read_text()
         assert "security regression" in content
-        assert "documentation could be longer" not in content
-        assert "volume is high" not in content
+        # Full original text preserved — non-blocking lines are NOT dropped
+        assert "documentation could be longer" in content
+        assert "volume is high" in content
+        assert "Full Monitor feedback:" in content
+
+    def test_wave_feedback_non_english_preserved(self, branch_dir, tmp_path):
+        # Non-English feedback must be forwarded in full, not replaced by a placeholder.
+        self._make_wave_state(tmp_path, branch_dir)
+        ru_feedback = (
+            "YAML-якоря не выживают при слиянии Helm-значений: три Deployment "
+            "ссылаются на несуществующий ConfigMap."
+        )
+
+        result = map_orchestrator.wave_monitor_failed("ST-001", branch_dir, ru_feedback)
+
+        content = Path(result["feedback_file"]).read_text()
+        assert "YAML-якоря" in content
+        assert "ConfigMap" in content
+        assert "no BLOCKER-class feedback was detected" not in content
 
     def test_feedback_file_none_when_empty(self, branch_dir, tmp_path):
         self._make_wave_state(tmp_path, branch_dir)


### PR DESCRIPTION
## Summary

Fixes #404 — `_filter_blocker_retry_feedback` used English-only keyword lists as a hard **gate**: any feedback whose lines matched no BLOCKER term was silently replaced by a generic placeholder, making non-English (e.g. Russian) Monitor feedback permanently invisible to the Actor retry.

The root cause: `.map/scripts/map_orchestrator.py` `BLOCKER_FEEDBACK_TERMS` / `NON_BLOCKING_FEEDBACK_TERMS` are English-only literals, and `_filter_blocker_retry_feedback` returned a generic placeholder when `kept_lines` was empty — dropping the operator's original text entirely.

## Changes

**`src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja`** (source of truth) and its two rendered copies:

- `_filter_blocker_retry_feedback` now uses the keyword filter as a **ranking hint**, not a gate:
  - **BLOCKER keywords match**: highlight those lines at the top + append a `"Full Monitor feedback:"` section with the complete original text.
  - **No keywords match** (non-English / non-standard phrasing): forward the full original text with a note that classification did not match, instead of the old English-only placeholder.

**`tests/test_map_orchestrator.py`**:

- `test_feedback_file_forwards_only_blocker_items` → renamed and updated: blocker lines are still highlighted, but non-blocking lines are now present in the full-feedback section (intentional behavior change).
- `test_wave_feedback_forwards_only_blocker_items` → same update.
- `test_feedback_file_non_english_feedback_preserved` — new regression test: Russian-language feedback survives into the retry artifact unchanged.
- `test_wave_feedback_non_english_preserved` — same for the wave path.

## Test plan

- [x] `uv run ruff check src/ tests/` — 0 errors
- [x] `uv run python -m pyright src/` — 0 errors, 0 warnings
- [x] `uv run pytest tests/ -x -q` — 4320 passed, 4 skipped
- [x] `make check` — exit 0
- [x] `make check-render` — no diff (rendered copies match jinja source)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnGW5EaWsfZ5rKNKmSiiDX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retry guidance now preserves complete monitoring feedback instead of omitting non-blocking details.
  * Critical blocker messages are highlighted first for easier troubleshooting.
  * Feedback without identified blockers now includes guidance to verify required behavior while avoiding cosmetic changes.

* **Tests**
  * Expanded coverage for wave-monitor failures, blocker highlighting, full feedback preservation, and non-English text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->