### PR TITLE
docs(map-wayfind): document wayfind_status with --slug, not a positional

### DIFF
--- a/.claude/skills/map-wayfind/SKILL.md
+++ b/.claude/skills/map-wayfind/SKILL.md
@@ -61,7 +61,7 @@ Start a new map. Six steps, mirroring the way a good architect opens a foggy pro
 
    In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
 5. **Kick off research.** For each `research` ticket, `claim_ticket` it FIRST — `resolve_ticket` requires the ticket to be claimed by your session, so an unclaimed dispatch-then-resolve returns `not_owner`. Serialize these claim mutations, then you MAY dispatch research-agent subagents in parallel to gather findings; each writes to `resolutions/<ticket>.md`, after which you `resolve_ticket` it (research resolves are exempt from the one-per-session limit).
-6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
+6. **Stop.** Show `wayfind_status --slug <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
 
 ## Mode: work \<slug\> [ticket]
 
@@ -96,7 +96,7 @@ Resolve exactly ONE non-research decision, then stop. Five steps.
 
 ## Mode: handoff \<slug\>
 
-When `wayfind_status <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
+When `wayfind_status --slug <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
 
 ```bash
 python3 .map/scripts/wayfind_runner.py emit_wayfind_handoff <slug> --remaining-risks-json '["..."]'

--- a/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-wayfind/SKILL.md
@@ -61,7 +61,7 @@ Start a new map. Six steps, mirroring the way a good architect opens a foggy pro
 
    In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
 5. **Kick off research.** For each `research` ticket, `claim_ticket` it FIRST — `resolve_ticket` requires the ticket to be claimed by your session, so an unclaimed dispatch-then-resolve returns `not_owner`. Serialize these claim mutations, then you MAY dispatch research-agent subagents in parallel to gather findings; each writes to `resolutions/<ticket>.md`, after which you `resolve_ticket` it (research resolves are exempt from the one-per-session limit).
-6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
+6. **Stop.** Show `wayfind_status --slug <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
 
 ## Mode: work \<slug\> [ticket]
 
@@ -96,7 +96,7 @@ Resolve exactly ONE non-research decision, then stop. Five steps.
 
 ## Mode: handoff \<slug\>
 
-When `wayfind_status <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
+When `wayfind_status --slug <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
 
 ```bash
 python3 .map/scripts/wayfind_runner.py emit_wayfind_handoff <slug> --remaining-risks-json '["..."]'

--- a/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-wayfind/SKILL.md.jinja
@@ -61,7 +61,7 @@ Start a new map. Six steps, mirroring the way a good architect opens a foggy pro
 
    In a second pass, wire dependencies with `wire_blocking` (rejects cycles and unknown ids).
 5. **Kick off research.** For each `research` ticket, `claim_ticket` it FIRST — `resolve_ticket` requires the ticket to be claimed by your session, so an unclaimed dispatch-then-resolve returns `not_owner`. Serialize these claim mutations, then you MAY dispatch research-agent subagents in parallel to gather findings; each writes to `resolutions/<ticket>.md`, after which you `resolve_ticket` it (research resolves are exempt from the one-per-session limit).
-6. **Stop.** Show `wayfind_status <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
+6. **Stop.** Show `wayfind_status --slug <slug>` and tell the user to run `/map-wayfind work <slug>` to resolve the frontier.
 
 ## Mode: work \<slug\> [ticket]
 
@@ -96,7 +96,7 @@ Resolve exactly ONE non-research decision, then stop. Five steps.
 
 ## Mode: handoff \<slug\>
 
-When `wayfind_status <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
+When `wayfind_status --slug <slug>` reports `handoff_eligible: true` (fog empty, no active claims, every ticket resolved or out-of-scope):
 
 ```bash
 python3 .map/scripts/wayfind_runner.py emit_wayfind_handoff <slug> --remaining-risks-json '["..."]'


### PR DESCRIPTION
The `/map-wayfind` skill body told the operator to run `wayfind_status <slug>` in two places, but the CLI declares that argument as `--slug`. Following the skill verbatim fails:

```
wayfind_runner.py: error: unrecognized arguments: review-verdict-ledger
```

Hit while actually charting a map — both affected lines are on the happy path: the `chart` step that shows the map after creation, and the handoff-eligibility check in `handoff` mode.

`wayfind-reference.md` already documented `wayfind_status [--slug <slug>]` correctly, so only the always-loaded skill body was wrong — which is the copy an operator follows.

## Scope check

Compared every wayfind command documented in `SKILL.md` and `wayfind-reference.md` against its argparse definition in `wayfind_runner.py.jinja`: `create_wayfind_map`, `add_ticket`, `wire_blocking`, `claim_ticket`, `record_human_input`, `resolve_ticket`, `add_fog`, `graduate_fog`, `rule_out_of_scope`, `emit_wayfind_handoff` all match their parsers. `wayfind_status` was the only mismatch.

## Verification

Edited `templates_src/**/*.jinja` and re-rendered; `make check-render` reports the generated trees match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `wayfind_status` command examples to use the explicit `--slug <slug>` option.
  * Aligned guidance across generated and source documentation for chart stopping and handoff eligibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->