### PR TITLE
fix: atomic writes for review-verdict-ledger and review-objections (#409)

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -564,7 +564,7 @@ def _is_non_negative_int(value: object) -> bool:
     return type(value) is int and value >= 0
 
 
-def _write_json_file(path: Path, payload: dict) -> None:
+def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_file = path.with_suffix(".tmp")
@@ -7897,9 +7897,7 @@ def record_review_objection(
     # stacking, so the registry cannot be worn down by repetition.
     existing = [o for o in existing if o.get("finding_id") != finding_id]
     existing.append(record)
-    objections_path.write_text(
-        json.dumps(existing, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(objections_path, existing)
 
     return {
         "status": "success",
@@ -8046,9 +8044,7 @@ def write_review_verdict_ledger(
     )
 
     # Write JSON
-    json_path.write_text(
-        json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(json_path, ledger)
 
     # Write Markdown summary
     verdict = str(ledger.get("computed_verdict", "BLOCK"))

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -564,7 +564,7 @@ def _is_non_negative_int(value: object) -> bool:
     return type(value) is int and value >= 0
 
 
-def _write_json_file(path: Path, payload: dict) -> None:
+def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_file = path.with_suffix(".tmp")
@@ -7897,9 +7897,7 @@ def record_review_objection(
     # stacking, so the registry cannot be worn down by repetition.
     existing = [o for o in existing if o.get("finding_id") != finding_id]
     existing.append(record)
-    objections_path.write_text(
-        json.dumps(existing, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(objections_path, existing)
 
     return {
         "status": "success",
@@ -8046,9 +8044,7 @@ def write_review_verdict_ledger(
     )
 
     # Write JSON
-    json_path.write_text(
-        json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(json_path, ledger)
 
     # Write Markdown summary
     verdict = str(ledger.get("computed_verdict", "BLOCK"))

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -564,7 +564,7 @@ def _is_non_negative_int(value: object) -> bool:
     return type(value) is int and value >= 0
 
 
-def _write_json_file(path: Path, payload: dict) -> None:
+def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_file = path.with_suffix(".tmp")
@@ -7897,9 +7897,7 @@ def record_review_objection(
     # stacking, so the registry cannot be worn down by repetition.
     existing = [o for o in existing if o.get("finding_id") != finding_id]
     existing.append(record)
-    objections_path.write_text(
-        json.dumps(existing, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(objections_path, existing)
 
     return {
         "status": "success",
@@ -8046,9 +8044,7 @@ def write_review_verdict_ledger(
     )
 
     # Write JSON
-    json_path.write_text(
-        json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(json_path, ledger)
 
     # Write Markdown summary
     verdict = str(ledger.get("computed_verdict", "BLOCK"))

--- a/tests/test_review_verdict_ledger.py
+++ b/tests/test_review_verdict_ledger.py
@@ -1187,3 +1187,65 @@ def test_unrecognized_previous_verdict_is_not_copied_into_the_journal(branch_wor
     )
     assert payload["journal"]["previous_verdict"] is None
     assert payload["journal"]["matches_previous"] is None
+
+
+# ---------------------------------------------------------------------------
+# Atomic write regression tests (issue #409)
+# ---------------------------------------------------------------------------
+
+
+def test_write_review_verdict_ledger_uses_atomic_write(branch_workspace):
+    """write_review_verdict_ledger must use _write_json_file (atomic .tmp -> replace).
+
+    A non-atomic write_text() call would leave the ledger in an inconsistent
+    state if the process is killed mid-write.  We verify the ledger JSON is
+    parseable immediately after a successful call (no truncation) and that
+    no residual .tmp file was left behind.
+    """
+    del branch_workspace
+
+    map_step_runner.write_review_verdict_ledger(
+        monitor_json=json.dumps(_monitor_no_issues()),
+    )
+
+    ledger_path = Path(".map/test-branch/review-verdict-ledger.json")
+    tmp_path = ledger_path.with_suffix(".tmp")
+    assert ledger_path.exists(), "ledger JSON must be written"
+    assert not tmp_path.exists(), "no residual .tmp file should remain after atomic write"
+    # Confirm the file is valid JSON (not truncated)
+    payload = json.loads(ledger_path.read_text(encoding="utf-8"))
+    assert "computed_verdict" in payload
+
+
+def test_record_review_objection_uses_atomic_write(branch_workspace):
+    """record_review_objection must use _write_json_file for the objections list.
+
+    Validates that a second objection (replacing the first) leaves a valid JSON
+    array with no residual .tmp file.
+    """
+    del branch_workspace
+    _seed_ledger_with_security_finding()
+
+    map_step_runner.record_review_objection(
+        "RVF-001", "quote_absent", "searched the diff, the quoted line is absent"
+    )
+
+    objections_path = Path(".map/test-branch/review-objections.json")
+    tmp_path = objections_path.with_suffix(".tmp")
+    assert objections_path.exists(), "objections file must be written"
+    assert not tmp_path.exists(), "no residual .tmp file should remain after atomic write"
+    records = json.loads(objections_path.read_text(encoding="utf-8"))
+    assert isinstance(records, list) and len(records) == 1
+    assert records[0]["channel"] == "quote_absent"
+
+
+def test_write_json_file_accepts_list_payload(branch_workspace):
+    """_write_json_file must accept a list payload (widened from dict-only)."""
+    workspace = branch_workspace
+    test_path = workspace / "test-list.json"
+    sample: list = [{"a": 1}, {"b": 2}]
+
+    map_step_runner._write_json_file(test_path, sample)  # type: ignore[attr-defined]
+
+    assert test_path.exists()
+    assert json.loads(test_path.read_text(encoding="utf-8")) == sample


### PR DESCRIPTION
## Summary

Fixes #409 — two non-atomic `write_text()` calls in `map_step_runner.py.jinja` that could corrupt JSON files if the process was killed mid-write.

- **`write_review_verdict_ledger`**: replaced `json_path.write_text(json.dumps(ledger, ...) + "\n", ...)` with `_write_json_file(json_path, ledger)` (atomic `.tmp` → `os.replace()`).
- **`record_review_objection`**: replaced `objections_path.write_text(json.dumps(existing, ...) + "\n", ...)` with `_write_json_file(objections_path, existing)`.
- **`_write_json_file`**: widened `payload: dict` to `payload: dict | list` so it can handle the objections store (which stores a list). The implementation was already generic — only the annotation was narrow.

Templates re-rendered (`make render-templates`) to propagate changes to all generated trees.

## Tests

Three regression tests added to `tests/test_review_verdict_ledger.py`:

- `test_write_review_verdict_ledger_uses_atomic_write` — verifies no residual `.tmp` file remains and the ledger JSON is valid after a write.
- `test_record_review_objection_uses_atomic_write` — verifies no residual `.tmp` file remains and the objections file is a valid JSON array.
- `test_write_json_file_accepts_list_payload` — directly exercises the widened list-payload path.

`make check` passes: 4385 tests (3 new), ruff/mypy/pyright clean, check-render passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZu8kwg8saVCk7i55Wf9Hd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving review verdict and objection records.
  * Prevented incomplete or temporary files from being left behind during JSON updates.
  * Added support for preserving list-based JSON data.

* **Tests**
  * Added coverage verifying saved records remain valid and parseable after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->