### PR TITLE
fix(release): bump pypi-publish action to v1.14.2; fix empty release-notes excerpt

### DIFF
--- a/.claude/skills/map-release/SKILL.md
+++ b/.claude/skills/map-release/SKILL.md
@@ -594,7 +594,7 @@ case "$USER_RESPONSE" in
     echo "════════════════════════════════════════════════════════"
     echo "CHANGELOG EXCERPT:"
     echo "════════════════════════════════════════════════════════"
-    awk "/## \[$TAG_VERSION\]/,/## \[/" CHANGELOG.md | sed '$d'
+    awk -v ver="$TAG_VERSION" 'index($0, "## [" ver "]") == 1 {f=1; next} /^## \[/ {f=0} f' CHANGELOG.md
 
     # Ask again after review
     # (recursive call to AskUserQuestion)

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -122,8 +122,9 @@ assignees: ''
 
 - [ ] Extract CHANGELOG excerpt for release notes:
   ```bash
-  # BSD/macOS compatible (uses awk instead of sed, sed '$d' instead of head -n -1)
-  awk '/## \[{{VERSION}}\]/,/## \[/' CHANGELOG.md | sed '$d'
+  # BSD/macOS compatible. NB: a two-address awk range (/start/,/end/) collapses
+  # to one line here — the version heading matches both patterns; use a flag.
+  awk '/^## \[{{VERSION}}\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md
   ```
 - [ ] Review release notes content
 - [ ] Add any additional context (migration notes, breaking changes, etc.)
@@ -134,7 +135,7 @@ assignees: ''
   ```bash
   gh release create v{{VERSION}} \
     --title "MAP Framework v{{VERSION}}" \
-    --notes "$(awk '/## \[{{VERSION}}\]/,/## \[/' CHANGELOG.md | sed '$d')"
+    --notes "$(awk '/^## \[{{VERSION}}\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)"
   ```
 - [ ] Verify release created: `gh release view v{{VERSION}}`
 - [ ] Release appears on GitHub releases page: https://github.com/azalio/map-framework/releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         echo "✓ Package validation passed"
 
     - name: Publish to PyPI using OIDC
-      uses: pypa/gh-action-pypi-publish@v1.13.0
+      uses: pypa/gh-action-pypi-publish@v1.14.2
       with:
         skip-existing: true
 
@@ -102,7 +102,10 @@ jobs:
       id: changelog
       run: |
         VERSION="${{ steps.get_version.outputs.VERSION }}"
-        EXCERPT=$(awk "/^## \[${VERSION}\]/,/^## \[/" CHANGELOG.md | sed '1d;$d')
+        # NB: a two-address awk range (/start/,/end/) collapses to a single line
+        # here — the "## [X.Y.Z]" heading matches both patterns at once. Use an
+        # explicit flag; 'next' keeps the heading itself out of the range.
+        EXCERPT=$(awk -v ver="$VERSION" 'index($0, "## [" ver "]") == 1 {f=1; next} /^## \[/ {f=0} f' CHANGELOG.md)
         if [ -z "$EXCERPT" ]; then
           echo "::warning::No changelog excerpt found for version ${VERSION}"
           EXCERPT="See CHANGELOG.md for details."

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -110,7 +110,7 @@ jobs:
         echo "✓ Package validation passed"
 
     - name: Publish to TestPyPI using OIDC
-      uses: pypa/gh-action-pypi-publish@v1.13.0
+      uses: pypa/gh-action-pypi-publish@v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Role-local persistent memory for learning agents (#379).**
 
 ### Fixed
+- **PyPI publish action bumped to v1.14.2 so uploads accept Metadata-Version 2.5.**
+  `pypa/gh-action-pypi-publish@v1.13.0` bundles an older twine that rejected the
+  3.25.0 wheel with `InvalidDistribution: '2.5' is not a valid metadata version`
+  even after the repo's own `twine check` step was fixed; v1.14.2 ships twine v7
+  with core-metadata 2.5 support. Applied in `release.yml` and `test-pypi.yml`.
+- **GitHub Release notes are no longer an empty stub.** The changelog-excerpt
+  extraction used a two-address awk range whose start and end patterns both match
+  the `## [X.Y.Z]` heading line, collapsing the range to that single line and
+  yielding an empty excerpt — every past GitHub Release body fell back to
+  "See CHANGELOG.md for details.". Replaced with an explicit flag state machine
+  in `release.yml`, the release-checklist issue template, and the map-release
+  skill.
 - **Atomic writes for `review-verdict-ledger.json` and `review-objections.json` (#409).**
   Both files were written with non-atomic `write_text()` and could be corrupted by a
   mid-write kill; they now go through `_write_json_file()` (temp file + `os.replace`).

--- a/src/mapify_cli/templates/skills/map-release/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-release/SKILL.md
@@ -594,7 +594,7 @@ case "$USER_RESPONSE" in
     echo "════════════════════════════════════════════════════════"
     echo "CHANGELOG EXCERPT:"
     echo "════════════════════════════════════════════════════════"
-    awk "/## \[$TAG_VERSION\]/,/## \[/" CHANGELOG.md | sed '$d'
+    awk -v ver="$TAG_VERSION" 'index($0, "## [" ver "]") == 1 {f=1; next} /^## \[/ {f=0} f' CHANGELOG.md
 
     # Ask again after review
     # (recursive call to AskUserQuestion)

--- a/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
@@ -594,7 +594,7 @@ case "$USER_RESPONSE" in
     echo "════════════════════════════════════════════════════════"
     echo "CHANGELOG EXCERPT:"
     echo "════════════════════════════════════════════════════════"
-    awk "/## \[$TAG_VERSION\]/,/## \[/" CHANGELOG.md | sed '$d'
+    awk -v ver="$TAG_VERSION" 'index($0, "## [" ver "]") == 1 {f=1; next} /^## \[/ {f=0} f' CHANGELOG.md
 
     # Ask again after review
     # (recursive call to AskUserQuestion)


### PR DESCRIPTION
## Summary
Release run 31590633496 for v3.25.0 failed at **Publish to PyPI using OIDC**; nothing was published (verified: 3.25.0 absent on PyPI, no GitHub Release).

## Root causes
1. `pypa/gh-action-pypi-publish@v1.13.0` bundles an older twine that rejects Metadata-Version 2.5 wheels — the action runs its **own** internal `twine check`, so the #411 fix to the repo's check step didn't reach it. Upstream v1.14.2 ships twine v7 with core-metadata 2.5 support (upstream PR pypa/gh-action-pypi-publish#416).
2. Same-class awk bug as documented in learned error-patterns: the changelog-excerpt extraction `awk "/^## \[VERSION\]/,/^## \[/"` collapses to one line (the heading matches both patterns) → every GitHub Release body was the stub "See CHANGELOG.md for details." (verified on v3.24.1). Fixed with a flag state machine in `release.yml`, the release-checklist issue template, and the map-release skill (jinja source + rendered trees; `make check-render` green).

## Verification
- Old awk on current CHANGELOG → 0 lines; new awk → 17 entries.
- `make check-render` ✅, `pytest tests/test_template_render.py tests/test_skills.py` → 359 passed.

## Release plan after merge
v3.25.0 tag will be moved to the merged HEAD and re-pushed (nothing was published, so the version number is unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)