### PR TITLE
feat(#414): /map-auto — single-entry autonomous MAP autopilot wrapper

### DIFF
--- a/.claude/skills/map-auto/SKILL.md
+++ b/.claude/skills/map-auto/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: map-auto
+description: |
+  Single-entry autonomous autopilot: routes a task through the existing MAP workflows via `route_task`, then drives the selected chain (map-plan -> map-efficient -> map-check -> map-review, as routed) end-to-end to a committed feature branch in one session, auto-approving routine workflow-control holds and hard-stopping on dangerous_action/safety_guardrail holds. Use when you want the whole pipeline to run unattended from a single task description, without babysitting phase-by-phase invocation. Do NOT use when you want to review or edit the plan before execution (run /map-plan then /map-efficient yourself instead), when the task is trivial (use /map-fast directly), or when you need a PR opened or merged -- the autopilot always stops at a committed branch and never creates or merges a PR.
+disable-model-invocation: true
+argument-hint: "[task description]"
+effort: high
+---
+# /map-auto — Single-Entry Autonomous Autopilot
+
+Purpose: run `/map-auto <task>` once and let it route the task through the existing MAP workflows, then drive the selected chain end-to-end to a committed feature branch in the same session, without per-phase babysitting. `/map-auto` runs autonomously by default the moment it is invoked -- there is no shadow mode, no calibration period, and no opt-in flag to turn this behavior on.
+
+Contrast with `/map-plan` and `/map-efficient`: those workflows expect you to drive each phase yourself. `/map-auto` is a thin router plus chain driver on top of them -- it never reimplements their logic, it only decides which one(s) to run and calls them unmodified, one after another, in the same session.
+
+## Effort and Parallelism Policy
+
+```yaml
+thinking_policy: high/adaptive
+parallel_tool_policy: sequential_by_default
+```
+
+- Use deeper reasoning for the routing decision and for judging whether a phase genuinely failed (worth a bounded re-entry) or is truly stuck (worth aborting to `/map-resume`) -- a wrong call here compounds across an entire unattended chain.
+- Keep routing, hold-decision, phase-record, and phase-invocation calls strictly sequential; a chain driver has no independent work to parallelize across phases.
+- Within a chained phase (e.g. `/map-efficient`), defer to that phase's own parallelism policy -- `/map-auto` does not override it.
+
+## Determinism boundary
+
+All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through the three runner subcommands below: `route_task` (routing decision), `auto_decide_holds` (approval-hold triage), and `record_auto_phase` (phase ledger). Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
+
+## Step 1: Route the Task
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS"
+```
+
+To inspect the recommendation without committing to it (no write beyond the routing artifact itself, no phase started):
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS" --dry-run
+```
+
+`route_task` writes `.map/<branch>/auto-route.json` (schema-validated) and selects exactly one of `map-resume`, `map-check`, `map-fast`, `map-plan`, `map-efficient` via a five-tier precedence engine you do not need to re-derive -- read `selected_route` and `next_command` from the result and act on those fields.
+
+- `status: "refused"` -- an in-progress chain already exists for this branch; follow the returned `next_command` (`/map-resume`) instead of re-routing.
+- `status: "blocked"` -- a hard-stop hold or a `goal_mismatch` verdict blocks the chain; `blocked_by[]` names the pending hold ids, `block_reason` explains why. STOP -- see Hard Stops below.
+- `status: "success"` -- `chain_status` is `"in_progress"` (normal run) or `"recommended_only"` (`--dry-run`); proceed to Step 2 for the selected route.
+
+## Step 2: Decide Holds Before Each Chained Phase
+
+Before invoking each chained workflow, drain auto-approvable holds so the chain does not sit blocked on routine posture/approval/overwrite confirmations:
+
+```bash
+python3 .map/scripts/map_step_runner.py auto_decide_holds
+```
+
+`auto_decide_holds` approves every pending `autonomy_posture`, `plan_approval`, and `template_overwrite` hold on your behalf and returns them in `auto_approved[]`. Any pending `dangerous_action` or `safety_guardrail` hold is returned in `hard_stops[]` and is left untouched -- these two kinds are never auto-decided by any code path this skill invokes.
+
+### Hard Stops (dangerous_action / safety_guardrail)
+
+If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or `auto_decide_holds` returns a non-empty `hard_stops[]`, STOP the autopilot immediately. Surface the hold's reason to the user and wait for an explicit human decision on that hold before resuming (`/map-resume` once it is decided). Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase.
+
+## Step 3: Record Each Phase Boundary
+
+Record every phase transition so `auto-route.json` stays the single source of truth for chain progress:
+
+```bash
+python3 .map/scripts/map_step_runner.py record_auto_phase "<phase>" "<status>" \
+  --evidence-refs "<comma-separated auto-approved hold ids>" \
+  --reason "<why this status>"
+```
+
+`<phase>` is the workflow name being entered/exited (`map-plan`, `map-efficient`, `map-check`, or `map-review`). `<status>` follows the phase's own vocabulary -- use `completed` on a clean phase close and `aborted`/`failed` on a phase you cannot recover; anything else leaves the chain `in_progress`. Pass every hold id that `auto_decide_holds` auto-approved for this phase in `--evidence-refs`, so the approval is recorded twice: once in the hold's own audit note, once in the phase ledger.
+
+**At most one re-entry per phase:** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Inspect ground truth (the phase's own artifacts, test output, Monitor verdict) before spending the single permitted re-entry. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase.
+
+## Chain
+
+Once routed, drive the selected chain by invoking the existing slash workflows exactly as written, one after another in the same session:
+
+```
+route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]
+```
+
+- `map-resume`, `map-check`, and `map-fast` routes are single-phase: run the one workflow, record its result with `record_auto_phase`, and finish.
+- `map-plan` and `map-efficient` routes continue the chain: `map-plan` produces the task plan that `map-efficient` consumes, `map-efficient` implements it, and the chain then continues to `map-check` and `map-review` to close the loop.
+- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps.
+- A `valid=false` Monitor verdict INSIDE a phase is that phase's own hard stop: its owning workflow's existing retry/escalation rules apply unchanged. `/map-auto` never overrides, suppresses, or re-runs past a Monitor rejection on the phase's behalf -- a phase that cannot get past Monitor is a failed phase for the purposes of Step 3's re-entry bound.
+- The autopilot run ends at a committed feature branch. `/map-auto` never opens a pull request, never merges, and never polls CI -- report the committed branch, the phases recorded, and stop.
+
+## Examples
+
+```
+/map-auto add a --verbose flag to the status command
+/map-auto refactor the checkout flow to support partial refunds
+```
+
+## Troubleshooting
+
+- **Issue:** `route_task` returns `status: "refused"`. **Fix:** A chain is already `in_progress` on this branch; run `/map-resume` instead of re-routing.
+- **Issue:** `route_task` or `auto_decide_holds` reports a pending `dangerous_action`/`safety_guardrail` hold. **Fix:** This is a hard stop by design -- surface the reason and wait for an explicit human decision; do not attempt to auto-approve it.
+- **Issue:** `record_auto_phase` returns `status: "refused"` with `chain_status: "aborted"` or `"blocked"`. **Fix:** The chain is terminal; only a new `route_task` call can re-route it explicitly.
+- **Issue:** A chained phase (e.g. `/map-efficient`) fails Monitor repeatedly. **Fix:** Let that phase's own retry/escalation rules run their course; record the outcome via `record_auto_phase` and stop after the single permitted re-entry rather than forcing a third attempt.

--- a/.claude/skills/map-auto/SKILL.md
+++ b/.claude/skills/map-auto/SKILL.md
@@ -25,7 +25,7 @@ parallel_tool_policy: sequential_by_default
 
 ## Determinism boundary
 
-All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through the three runner subcommands below: `route_task` (routing decision), `auto_decide_holds` (approval-hold triage), and `record_auto_phase` (phase ledger). Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
+All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through two runner subcommands below: `route_task` (routing decision) and `record_auto_phase` (phase ledger). `auto_decide_holds` (approval-hold triage) mutates `approval_holds.json` separately — its approvals surface in the `approval_hold` manifest stage, not in `auto-route.json`. Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
 
 ## Step 1: Route the Task
 

--- a/.claude/skills/map-auto/SKILL.md
+++ b/.claude/skills/map-auto/SKILL.md
@@ -45,9 +45,9 @@ python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS" --dry-run
 - `status: "blocked"` -- a hard-stop hold or a `goal_mismatch` verdict blocks the chain; `blocked_by[]` names the pending hold ids, `block_reason` explains why. STOP -- see Hard Stops below.
 - `status: "success"` -- `chain_status` is `"in_progress"` (normal run) or `"recommended_only"` (`--dry-run`); proceed to Step 2 for the selected route.
 
-## Step 2: Decide Holds Before Each Chained Phase
+## Step 2: Decide Holds Around Each Chained Phase
 
-Before invoking each chained workflow, drain auto-approvable holds so the chain does not sit blocked on routine posture/approval/overwrite confirmations:
+Poll `auto_decide_holds` before invoking each chained workflow AND again immediately after it concludes, before recording its outcome in Step 3 -- the second poll catches a hold that was created while the phase was running instead of leaving it for a later, unscheduled check:
 
 ```bash
 python3 .map/scripts/map_step_runner.py auto_decide_holds
@@ -57,7 +57,7 @@ python3 .map/scripts/map_step_runner.py auto_decide_holds
 
 ### Hard Stops (dangerous_action / safety_guardrail)
 
-If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or `auto_decide_holds` returns a non-empty `hard_stops[]`, STOP the autopilot immediately. Surface the hold's reason to the user and wait for an explicit human decision on that hold before resuming (`/map-resume` once it is decided). Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase.
+If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or either `auto_decide_holds` poll returns a non-empty `hard_stops[]`, STOP the autopilot. Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase. A hard stop found by the POST-phase poll means it appeared while the phase was running -- record that before stopping: `record_auto_phase "<phase>" aborted --reason "hard-stop hold pending: <ids>"`. A hard stop found via `route_task`'s `blocked_by[]` or the PRE-phase poll has no phase entry to record yet -- just stop. Either way, surface the hold's reason to the user and wait for an explicit human decision before resuming (`/map-resume` once it is decided).
 
 ## Step 3: Record Each Phase Boundary
 
@@ -71,7 +71,7 @@ python3 .map/scripts/map_step_runner.py record_auto_phase "<phase>" "<status>" \
 
 `<phase>` is the workflow name being entered/exited (`map-plan`, `map-efficient`, `map-check`, or `map-review`). `<status>` follows the phase's own vocabulary -- use `completed` on a clean phase close and `aborted`/`failed` on a phase you cannot recover; anything else leaves the chain `in_progress`. Pass every hold id that `auto_decide_holds` auto-approved for this phase in `--evidence-refs`, so the approval is recorded twice: once in the hold's own audit note, once in the phase ledger.
 
-**At most one re-entry per phase:** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Inspect ground truth (the phase's own artifacts, test output, Monitor verdict) before spending the single permitted re-entry. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase.
+**At most one re-entry per phase (HC-2):** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Before spending the single permitted re-entry, inspect ground truth -- `git status`/`git diff` and the phase's own `step_state.json` (or equivalent phase artifacts, test output, Monitor verdict) -- to confirm the phase genuinely needs a fresh attempt rather than a partial success being misread as a failure. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase. A chain already `chain_status: "aborted"` or `"blocked"` refuses every further `record_auto_phase` call regardless of phase name; a new `route_task` call is the ONLY legitimate way to continue.
 
 ## Chain
 
@@ -83,9 +83,11 @@ route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]
 
 - `map-resume`, `map-check`, and `map-fast` routes are single-phase: run the one workflow, record its result with `record_auto_phase`, and finish.
 - `map-plan` and `map-efficient` routes continue the chain: `map-plan` produces the task plan that `map-efficient` consumes, `map-efficient` implements it, and the chain then continues to `map-check` and `map-review` to close the loop.
-- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps.
+- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps. `/map-auto` never shells out to a separate Claude process, a new Python execution engine, or any other new phase-driving mechanism to do this -- phases are driven ONLY by invoking the existing slash workflows above and the three runner subcommands from Steps 1-3.
 - A `valid=false` Monitor verdict INSIDE a phase is that phase's own hard stop: its owning workflow's existing retry/escalation rules apply unchanged. `/map-auto` never overrides, suppresses, or re-runs past a Monitor rejection on the phase's behalf -- a phase that cannot get past Monitor is a failed phase for the purposes of Step 3's re-entry bound.
 - The autopilot run ends at a committed feature branch. `/map-auto` never opens a pull request, never merges, and never polls CI -- report the committed branch, the phases recorded, and stop.
+
+For the full CLI flag reference, a worked chain walkthrough, the failure-mode table, and recovery procedures, see [auto-reference.md](auto-reference.md).
 
 ## Examples
 

--- a/.claude/skills/map-auto/auto-reference.md
+++ b/.claude/skills/map-auto/auto-reference.md
@@ -1,0 +1,78 @@
+# /map-auto Supporting Reference
+
+This file holds low-frequency `/map-auto` details so `SKILL.md` stays focused on the active route -> holds -> phase-ledger loop.
+
+## CLI Reference
+
+Three runner subcommands back the whole autopilot; `SKILL.md` calls them in order (`route_task` once, then `auto_decide_holds` / `record_auto_phase` per chained phase). No other subcommand drives the chain.
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task <task> [--branch B] [--dry-run]
+python3 .map/scripts/map_step_runner.py auto_decide_holds [--branch B]
+python3 .map/scripts/map_step_runner.py record_auto_phase <phase> <status> [--branch B] \
+  [--evidence-refs a,b,c] [--reason "..."]
+```
+
+- `route_task <task>` -- `<task>` is the free-text task description (quote it). `--branch` defaults to the current branch. `--dry-run` recommends a route without marking the chain `in_progress` (see Dry-run usage below).
+- `auto_decide_holds` -- no positional arguments; only `--branch` (defaults to current branch).
+- `record_auto_phase <phase> <status>` -- `<phase>` is the workflow name (`map-plan`, `map-efficient`, `map-check`, `map-review`); `<status>` is the phase's own outcome word (`completed`, `failed`, `aborted`, or any other phase-specific status, which leaves `chain_status` at `in_progress`). `--evidence-refs` takes a comma-separated list of ids (auto-approved hold ids from the surrounding `auto_decide_holds` calls); `--reason` is a free-text note stored on the ledger entry.
+
+## Chain Walkthrough Example
+
+A `map-efficient` route, condensed (real output trimmed to the fields that matter):
+
+```bash
+$ python3 .map/scripts/map_step_runner.py route_task "add retry to the sync job"
+{"status": "success", "selected_route": "map-efficient", "chain_status": "in_progress", ...}
+
+$ python3 .map/scripts/map_step_runner.py auto_decide_holds
+{"status": "ok", "auto_approved": [{"id": "hold-1", "kind": "plan_approval", ...}], "hard_stops": []}
+
+# -- drive /map-efficient unmodified, in full, per its own SKILL.md --
+
+$ python3 .map/scripts/map_step_runner.py auto_decide_holds
+{"status": "ok", "auto_approved": [], "hard_stops": []}
+
+$ python3 .map/scripts/map_step_runner.py record_auto_phase "map-efficient" "completed" \
+  --evidence-refs "hold-1" --reason "all subtasks closed, make check green"
+{"status": "success", "chain_status": "completed", "phase": "map-efficient", "attempt": 1, ...}
+
+# -- chain then continues to map-check, then map-review, each following the same
+#    poll -> drive -> poll -> record loop, until the last phase records "completed" --
+```
+
+The run ends there: a committed feature branch, `phases[]` in `auto-route.json` holding one entry per phase attempt, and no PR/merge/CI step of any kind.
+
+## Failure-Mode Table
+
+| Failure mode | Trigger | Response |
+|---|---|---|
+| Hard-stop hold | `dangerous_action` or `safety_guardrail` hold pending (at route time or discovered mid-phase) | STOP the autopilot; surface the hold's reason; wait for an explicit human decision; resume via `/map-resume` once it is decided. Never auto-approved by any `/map-auto` code path (INV-2). |
+| Repeated phase failure (HC-2) | A third `record_auto_phase` call for the SAME phase name | Refused outright -- no entry appended; the chain is force-aborted (`chain_status: "aborted"`) with the abort reason persisted in `auto-route.json`. Recover via `/map-resume`; a fresh `route_task` on the aborted branch re-routes and preserves the prior route in `route_history[]`. |
+| `goal_mismatch` | `check_plan_resume` reports the branch already hosts a plan for a DIFFERENT goal | `route_task` refuses to route: `status: "blocked"`, `chain_status: "blocked"`, `block_reason` names the mismatch. The prior spec/task_plan/blueprint artifacts are left untouched -- resolving the mismatch (archive, rename, or confirm intent) is the operator's call. |
+| In-progress re-route | `route_task` called while the branch's `auto-route.json` already has `chain_status: "in_progress"` | Refused: `status: "refused"`, `next_command: "/map-resume"`; the existing artifact is left byte-identical. |
+| `blueprint_unavailable` | `step_state.json` exists but `blueprint.json`'s subtask-id universe can't be read | Routes to `map-resume` rather than guessing "complete" -- recorded as `evidence: [{"signal": "step_state.json", "value": "blueprint_unavailable", ...}]`. |
+
+## Recovery Procedures
+
+- **`/map-resume`** -- the single recovery surface for every stop condition above: a refused re-route, an aborted chain, a hard-stop hold once it is decided, or a phase that failed Monitor past its own retry budget. It reads the branch's existing state (`step_state.json`, `auto-route.json`) and resumes from there; it never re-runs `route_task` on your behalf.
+- **New `route_task` from a terminal chain** -- `chain_status` values `aborted`, `blocked`, `completed`, and `recommended_only` may all be re-routed; only `in_progress` refuses. A re-route overwrites `auto-route.json` but preserves the superseded route in `route_history[]`, so a fresh `route_task "<task>"` call is the ONLY way to move a terminal chain forward -- never hand-edit `chain_status` in the artifact.
+
+## Dry-run Usage
+
+`route_task "<task>" --dry-run` is the whole dry-run surface (Decision 8) -- there is no separate preview command for holds or phases, because neither runs until a real (non-dry-run) `route_task` call marks the chain `in_progress`.
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "add retry to the sync job" --dry-run
+```
+
+- Sets `executed: false` and `chain_status: "recommended_only"` -- the run is a recommendation, not a commitment.
+- Performs no filesystem writes beyond `.map/<branch>/auto-route.json` and its `auto_route` manifest stage entry -- no `record_workflow_fit`, no `create_approval_hold`, nothing else on disk changes (AC-3).
+- A pending hard-stop hold still surfaces: `blocked_by[]` is populated and `chain_status` becomes `"blocked"` even under `--dry-run` -- "blocked" always outranks "recommended_only".
+- Re-running `route_task` (with or without `--dry-run`) after a dry-run is always allowed -- `recommended_only` is not a terminal `chain_status`.
+
+## Troubleshooting
+
+- **Issue:** `record_auto_phase` reports `status: "error"`. **Fix:** No `auto-route.json` exists for this branch yet -- run `route_task` first.
+- **Issue:** Need to inspect the ledger without another CLI call. **Fix:** Read `.map/<branch>/auto-route.json` directly (read-only) -- `phases[]`, `chain_status`, `abort_reason`/`block_reason`, and `route_history[]` are all plain fields; never hand-edit the file.
+- **Issue:** A phase's own Monitor keeps rejecting past what looks like a real fix. **Fix:** That is the chained workflow's own retry/escalation, not `/map-auto`'s -- let it run its course; `/map-auto` only records the outcome once that workflow itself stops.

--- a/.claude/skills/skill-rules.json
+++ b/.claude/skills/skill-rules.json
@@ -452,6 +452,25 @@
           "before.*(map-plan|planning)"
         ]
       }
+    },
+    "map-auto": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "high",
+      "description": "Single-entry autonomous autopilot: routes a task via route_task then drives the selected MAP workflow chain end-to-end to a committed feature branch.",
+      "promptTriggers": {
+        "keywords": [
+          "map-auto",
+          "autopilot",
+          "single-entry workflow",
+          "auto route task"
+        ],
+        "intentPatterns": [
+          "map-auto",
+          "(autopilot|auto).*(task|workflow|route)"
+        ]
+      }
     }
   }
 }

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -465,6 +465,12 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
+# /map-auto (issue #414, ST-005): hold kinds that hard-stop autonomous
+# routing outright -- route_task blocks the chain rather than proceeding
+# when either is pending. ST-006 defines the complementary
+# AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
+HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
+
 # Truncation infrastructure deleted by user directive ("убери транкейт уже
 # вообще"). build_context_block / _budget_review_prompt now emit raw text;
 # operators handle context size via /compact opt-in. The mapify_cli
@@ -14727,18 +14733,56 @@ def route_task(
 
     `executed` and `chain_status` are always set together in one atomic
     artifact write: non-dry-run -> executed=True, chain_status="in_progress";
-    --dry-run -> executed=False, chain_status="recommended_only". Guards that
-    refuse to re-route an in-progress chain, block on a goal mismatch, or
-    surface pending hard-stop holds are added by a later subcommand -- this
-    call always re-routes and overwrites, preserving the prior selected_route
-    in route_history.
+    --dry-run -> executed=False, chain_status="recommended_only" -- UNLESS
+    one of the guards below blocks the chain, in which case executed is
+    forced False regardless of dry_run.
+
+    Three guards run, in this precedence order, BEFORE the normal write
+    (ST-005, INV-6):
+
+      1. In-progress refusal: an existing auto-route.json with
+         chain_status "in_progress" refuses to re-route -- returns
+         status="refused" with a /map-resume pointer, and neither the
+         artifact nor the manifest is touched. chain_status in
+         {recommended_only, blocked, completed, aborted} may be re-routed
+         (the prior selected_route is preserved in route_history).
+      2. Hard-stop holds: a pending dangerous_action or safety_guardrail
+         hold (HARD_STOP_HOLD_KINDS) blocks the chain -- chain_status
+         "blocked", executed False, blocked_by populated with the pending
+         hold ids -- even under --dry-run ("blocked" outranks
+         "recommended_only").
+      3. goal_mismatch block: check_plan_resume's verdict, already surfaced
+         in _select_route's evidence trail (read here, never re-queried),
+         blocks the chain with chain_status "blocked" and a block_reason.
+         The prior spec/task_plan/blueprint artifacts are left untouched --
+         route_task never archives or overwrites them.
+
+    Per Decision 14, route_task writes ONLY auto-route.json and its manifest
+    stage across every branch above -- it never calls record_workflow_fit or
+    create_approval_hold.
     """
     branch_name = branch or get_branch_name()
+    artifact_path = auto_route_artifact_path(branch_name)
+    prior = _read_json_file(artifact_path)
+
+    # Guard 1: refuse to re-route a chain that is already in progress --
+    # the operator must resume it explicitly (/map-resume) instead of this
+    # call silently clobbering the active decision.
+    if isinstance(prior, dict) and prior.get("chain_status") == "in_progress":
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "reason": (
+                f"branch '{branch_name}' has an in-progress /map-auto chain; "
+                "re-routing is refused to avoid clobbering the active run."
+            ),
+            "next_command": "/map-resume",
+        }
+
     selected_route, raw_evidence = _select_route(branch_name, task)
     next_command = _AUTO_ROUTE_NEXT_COMMAND[selected_route]
 
-    artifact_path = auto_route_artifact_path(branch_name)
-    prior = _read_json_file(artifact_path)
     route_history: list[str] = []
     if isinstance(prior, dict):
         prior_history = prior.get("route_history")
@@ -14750,26 +14794,65 @@ def route_task(
 
     executed = not dry_run
     chain_status = "in_progress" if executed else "recommended_only"
+    blocked_by: list[str] = []
+    block_reason = ""
+
+    # Guard 2: pending hard-stop holds block the chain outright, including
+    # under --dry-run -- "blocked" always outranks "recommended_only".
+    pending_holds = get_pending_holds(branch_name)
+    hard_stop_ids = [
+        str(hold["id"])
+        for hold in cast(list[Any], pending_holds.get("holds", []))
+        if isinstance(hold, dict) and hold.get("kind") in HARD_STOP_HOLD_KINDS
+    ]
+    if hard_stop_ids:
+        chain_status = "blocked"
+        executed = False
+        blocked_by = hard_stop_ids
+        block_reason = f"pending hard-stop hold(s): {', '.join(hard_stop_ids)}"
+    else:
+        # Guard 3: a goal_mismatch verdict from check_plan_resume, already
+        # surfaced by _select_route above -- reused, not re-queried --
+        # blocks the chain without touching the prior plan artifacts.
+        mismatch_entry = next(
+            (
+                entry
+                for entry in raw_evidence
+                if entry.get("signal") == "check_plan_resume"
+                and entry.get("value") == "goal_mismatch"
+            ),
+            None,
+        )
+        if mismatch_entry is not None:
+            chain_status = "blocked"
+            executed = False
+            block_reason = (
+                f"check_plan_resume reported goal_mismatch for branch "
+                f"'{branch_name}'; resolve the mismatch (archive/rename the "
+                "prior plan or confirm intent) before routing."
+            )
 
     artifact: dict[str, object] = {
         "schema_version": "1.0",
         "task_summary": _sanitize_for_json(task),
         "selected_route": selected_route,
         "evidence": _auto_route_evidence_for_artifact(raw_evidence),
-        "blocked_by": [],
+        "blocked_by": blocked_by,
         "next_command": next_command,
         "executed": executed,
         "chain_status": chain_status,
         "phases": [],
         "route_history": route_history,
     }
+    if block_reason:
+        artifact["block_reason"] = block_reason
     _write_json_file(artifact_path, artifact)
 
     manifest = load_artifact_manifest(branch_name)
     _set_manifest_stage(
         manifest,
         "auto_route",
-        "recommended" if dry_run else "in_progress",
+        "blocked" if chain_status == "blocked" else ("recommended" if dry_run else "in_progress"),
         artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
         metadata={
             "selected_route": selected_route,
@@ -14779,13 +14862,14 @@ def route_task(
     save_artifact_manifest(manifest, branch_name)
 
     return {
-        "status": "success",
+        "status": "blocked" if chain_status == "blocked" else "success",
         "branch": branch_name,
         "path": str(artifact_path),
         "selected_route": selected_route,
         "chain_status": chain_status,
         "next_command": next_command,
         "executed": executed,
+        "blocked_by": blocked_by,
     }
 
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -14673,6 +14673,122 @@ def _select_route(
     return "map-plan", evidence
 
 
+# /map-auto routing (issue #414): route -> slash command surfaced to the
+# operator as the next step.
+_AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
+    "map-resume": "/map-resume",
+    "map-check": "/map-check",
+    "map-fast": "/map-fast",
+    "map-plan": "/map-plan",
+    "map-efficient": "/map-efficient",
+}
+
+
+def auto_route_artifact_path(branch: str | None = None) -> Path:
+    """Return the branch-scoped /map-auto routing decision artifact path."""
+    return get_branch_dir(branch) / "auto-route.json"
+
+
+def _auto_route_evidence_for_artifact(
+    evidence: list[dict[str, object]],
+) -> list[dict[str, str]]:
+    """Coerce _select_route's evidence into AUTO_ROUTE_SCHEMA's string shape.
+
+    _select_route returns richer Python values (dict, bool, None) per signal
+    for in-process callers; AUTO_ROUTE_SCHEMA (schemas.py) declares
+    evidence[].value as a plain string for the persisted artifact. JSON-encode
+    non-string values so no signal detail is lost while staying schema-valid.
+    """
+    stringified: list[dict[str, str]] = []
+    for entry in evidence:
+        value = entry.get("value")
+        value_str = value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+        stringified.append({
+            "signal": str(entry.get("signal", "")),
+            "value": value_str,
+            "source": str(entry.get("source", "")),
+        })
+    return stringified
+
+
+def route_task(
+    task: str,
+    branch: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Select a route for /map-auto and persist the decision (issue #414).
+
+    Wraps _select_route with the write side of the routing contract: writes
+    .map/<branch>/auto-route.json (all ten AUTO_ROUTE_SCHEMA fields) and
+    registers the `auto_route` manifest stage in the same call, so the route
+    selection is never observable only in stdout. `phases` is always
+    initialized empty here -- record_auto_phase (a later subcommand) is the
+    sole writer of that ledger.
+
+    `executed` and `chain_status` are always set together in one atomic
+    artifact write: non-dry-run -> executed=True, chain_status="in_progress";
+    --dry-run -> executed=False, chain_status="recommended_only". Guards that
+    refuse to re-route an in-progress chain, block on a goal mismatch, or
+    surface pending hard-stop holds are added by a later subcommand -- this
+    call always re-routes and overwrites, preserving the prior selected_route
+    in route_history.
+    """
+    branch_name = branch or get_branch_name()
+    selected_route, raw_evidence = _select_route(branch_name, task)
+    next_command = _AUTO_ROUTE_NEXT_COMMAND[selected_route]
+
+    artifact_path = auto_route_artifact_path(branch_name)
+    prior = _read_json_file(artifact_path)
+    route_history: list[str] = []
+    if isinstance(prior, dict):
+        prior_history = prior.get("route_history")
+        if isinstance(prior_history, list):
+            route_history = [item for item in prior_history if isinstance(item, str)]
+        prior_route = prior.get("selected_route")
+        if isinstance(prior_route, str) and prior_route:
+            route_history.append(prior_route)
+
+    executed = not dry_run
+    chain_status = "in_progress" if executed else "recommended_only"
+
+    artifact: dict[str, object] = {
+        "schema_version": "1.0",
+        "task_summary": _sanitize_for_json(task),
+        "selected_route": selected_route,
+        "evidence": _auto_route_evidence_for_artifact(raw_evidence),
+        "blocked_by": [],
+        "next_command": next_command,
+        "executed": executed,
+        "chain_status": chain_status,
+        "phases": [],
+        "route_history": route_history,
+    }
+    _write_json_file(artifact_path, artifact)
+
+    manifest = load_artifact_manifest(branch_name)
+    _set_manifest_stage(
+        manifest,
+        "auto_route",
+        "recommended" if dry_run else "in_progress",
+        artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+        metadata={
+            "selected_route": selected_route,
+            "chain_status": chain_status,
+        },
+    )
+    save_artifact_manifest(manifest, branch_name)
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "path": str(artifact_path),
+        "selected_route": selected_route,
+        "chain_status": chain_status,
+        "next_command": next_command,
+        "executed": executed,
+    }
+
+
 def record_scope_baseline(branch: str) -> dict:
     """Snapshot the current uncommitted / untracked file set as a baseline
     that validate_mutation_boundary will subtract from `actual` on future
@@ -22008,6 +22124,25 @@ if __name__ == "__main__":
             branch=_rvl_flag("branch") or None,
         )
         print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "route_task" and len(sys.argv) >= 3:
+        # CLI: route_task <task> [--branch B] [--dry-run]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py route_task")
+        _p.add_argument("task", help="Task description text to route")
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _p.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="Recommend a route without marking the chain in_progress",
+        )
+        _a = _p.parse_args(sys.argv[2:])
+        _r = route_task(_a.task, branch=_a.branch, dry_run=_a.dry_run)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
 
     else:
         # Helpful redirect: when the user passes a command that belongs to

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -4856,18 +4856,16 @@ _DONE_PHASE_STATUSES_FOR_COMPLETION = {
 }
 
 
-def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
-    """Return True iff every subtask in subtask_sequence has a "done"-class
-    signal recorded (subtask_results entry OR subtask_phases marker).
+def _done_class_subtask_ids(state: dict[str, object]) -> set[str]:
+    """Return subtask ids with a "done"-class signal recorded in step_state.json
+    (a subtask_results entry OR a subtask_phases done-class marker).
 
-    Mirrors the orchestrator's _completed_subtask_ids_for_deps logic. Used
-    by _derive_terminal_status so a stuck cursor (ST-033 friction) no
-    longer makes write_run_health_report report ``pending`` when 51/51
-    entries actually exist.
+    Shared canonical-completion primitive: used by
+    _state_subtask_coverage_complete below (global "is the whole run done"
+    check) AND by the /map-auto tier 1 routing signal (per-subtask
+    pending/complete split) so both read the identical done-class
+    definition instead of two definitions that could silently drift apart.
     """
-    sequence_value = state.get("subtask_sequence")
-    if not isinstance(sequence_value, list) or not sequence_value:
-        return False
     results_value = state.get("subtask_results")
     results = results_value if isinstance(results_value, dict) else {}
     phases_value = state.get("subtask_phases")
@@ -4882,6 +4880,22 @@ def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
     for sid, phase in phases.items():
         if isinstance(sid, str) and isinstance(phase, str) and phase.lower() in _DONE_PHASE_STATUSES_FOR_COMPLETION:
             completed.add(sid)
+    return completed
+
+
+def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
+    """Return True iff every subtask in subtask_sequence has a "done"-class
+    signal recorded (subtask_results entry OR subtask_phases marker).
+
+    Mirrors the orchestrator's _completed_subtask_ids_for_deps logic. Used
+    by _derive_terminal_status so a stuck cursor (ST-033 friction) no
+    longer makes write_run_health_report report ``pending`` when 51/51
+    entries actually exist.
+    """
+    sequence_value = state.get("subtask_sequence")
+    if not isinstance(sequence_value, list) or not sequence_value:
+        return False
+    completed = _done_class_subtask_ids(state)
     return all(isinstance(sid, str) and sid in completed for sid in sequence_value)
 
 
@@ -14405,6 +14419,258 @@ def check_plan_resume(request: str = "", branch: str | None = None) -> dict:
         },
         "recommendation": recommendation,
     }
+
+
+# /map-auto routing (issue #414): the recommended workflow values a route
+# selector may pick automatically. Values outside this set (direct-edit,
+# map-tdd, map-wayfind) require a human decision and must fall through to a
+# lower-precedence signal instead of being auto-selected.
+_AUTO_ROUTE_TIER2_ALLOWED = frozenset({"map-fast", "map-plan", "map-efficient"})
+
+
+def _blueprint_subtask_ids(blueprint: dict | None) -> set[str]:
+    """Return the set of subtask ids declared in a loaded blueprint.json payload."""
+    if not isinstance(blueprint, dict):
+        return set()
+    subtasks = blueprint.get("subtasks")
+    if not isinstance(subtasks, list):
+        return set()
+    return {
+        subtask["id"]
+        for subtask in subtasks
+        if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
+    }
+
+
+def _tier1_completed_subtask_ids(state: dict[str, object]) -> tuple[set[str], bool]:
+    """Return (completed subtask ids, used_legacy_fallback) for tier 1 routing.
+
+    Prefers the canonical done-class signal (_done_class_subtask_ids, shared
+    with _state_subtask_coverage_complete): a subtask_results status or a
+    subtask_phases marker in the done class. Falls back to legacy
+    completed_steps KEY PRESENCE only when NEITHER canonical field exists in
+    state at all. Key presence alone is not a safe completion signal even in
+    the fallback case's absence check -- update_step_state (the classic,
+    pre-orchestrator writer) inserts a completed_steps[subtask_id] key at
+    the FIRST recorded phase, so "key exists" means "started", not "done".
+    The canonical fields are preferred specifically so a subtask with only
+    an in-progress phase recorded is never misread as complete.
+    """
+    canonical_present = "subtask_results" in state or "subtask_phases" in state
+    if canonical_present:
+        return _done_class_subtask_ids(state), False
+    completed_steps = state.get("completed_steps")
+    if isinstance(completed_steps, dict):
+        return {key for key in completed_steps if isinstance(key, str)}, True
+    return set(), True
+
+
+def _classify_scope_bracket(estimated_files: int, estimated_lines: int) -> str | None:
+    """Call classify_scope.classify() in-process for the auto-route scope tier.
+
+    classify_scope.py ships alongside this script in every generated tree but
+    is not an importable package member, so it is loaded by file location
+    (mirrors the existing lazy schemas-module import pattern in this file)
+    rather than imported at module scope or shelled out to as a subprocess.
+    """
+    try:
+        import importlib.util as _importlib_util
+
+        script_path = Path(__file__).resolve().parent / "classify_scope.py"
+        spec = _importlib_util.spec_from_file_location("classify_scope", script_path)
+        if spec is None or spec.loader is None:
+            return None
+        module = _importlib_util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except (ImportError, OSError):
+        return None
+
+    classify_fn = getattr(module, "classify", None)
+    if not callable(classify_fn):
+        return None
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    result = classify_fn(estimated_files, estimated_lines, project_dir)
+    bracket = result.get("bracket") if isinstance(result, dict) else None
+    return bracket if isinstance(bracket, str) else None
+
+
+def _select_route(
+    branch: str | None,
+    task_text: str,
+    *,
+    estimated_files: int | None = None,
+    estimated_lines: int | None = None,
+) -> tuple[str, list[dict[str, object]]]:
+    """Pure five-tier routing precedence engine for /map-auto (issue #414).
+
+    Reads exactly five existing signals -- step_state.json, workflow-fit.json,
+    check_plan_resume(), a direct blueprint.json stat, and
+    classify_scope.classify() -- and returns the route picked by the
+    highest-precedence signal that fires, plus an evidence trail of every
+    signal consulted (including signals that lost or were absent). Never
+    inspects ``task_text`` itself for keywords; the only tier that reads its
+    content is check_plan_resume() (tier 3), which is one of the five
+    allowed signals. This function only selects a route -- it writes nothing
+    and creates no CLI surface.
+
+    Tiers, in strict precedence order:
+      1. step_state.json exists: pending subtasks (blueprint ids minus the
+         canonical done-class subtask ids) -> map-resume; all complete ->
+         map-check. When blueprint.json is missing/unparseable/empty, the
+         pending set cannot be computed at all -- this fails CLOSED to
+         map-resume (never asserts completion without evidence) rather than
+         guessing.
+      2. workflow-fit.json recommended_workflow, restricted to
+         {map-fast, map-plan, map-efficient} -- any other recorded value
+         (e.g. direct-edit) is recorded in evidence and falls through.
+      3. check_plan_resume(task_text) verdict "resume" (only reachable once
+         step_state.json is confirmed absent): task_plan artifact present
+         AND a direct blueprint.json stat succeeds -> map-efficient;
+         otherwise -> map-plan. A goal_mismatch or no_plan verdict is only
+         surfaced in evidence here -- blocking on it is not this function's
+         responsibility. NOTE: this is the one SANCTIONED exception to
+         "task_text never influences the route" -- check_plan_resume is one
+         of the five allowed signals, and its goal-overlap comparison is
+         supposed to vary with task_text content. That is intentional
+         signal-reading, not the ad-hoc keyword routing this function
+         otherwise forbids (see the invariance test docstrings below).
+      4. classify_scope.classify() bracket "trivial" -> map-fast, only when
+         the caller supplied non-negative estimated_files/estimated_lines;
+         otherwise the tier is recorded as unavailable and skipped rather
+         than guessed.
+      5. Default: map-plan.
+    """
+    branch_name = branch or get_branch_name()
+    branch_dir = get_branch_dir(branch_name)
+    evidence: list[dict[str, object]] = []
+
+    # Tier 1 signal: step_state.json. Always read up front (even when a
+    # later tier would otherwise win) so a conflicting workflow-fit.json
+    # recommendation is still captured in evidence per the losing-signal
+    # requirement below.
+    step_state_path = branch_dir / "step_state.json"
+    state = _read_json_file(step_state_path)
+    step_state_route: str | None = None
+    if state is not None:
+        blueprint = load_blueprint(branch_name)
+        subtask_ids = _blueprint_subtask_ids(blueprint)
+        if not subtask_ids:
+            # Fail closed: with no subtask id universe from blueprint.json,
+            # "pending minus completed" cannot be computed at all. Asserting
+            # "complete" here would be an unevidenced guess, so route back
+            # to resuming the plan instead.
+            step_state_route = "map-resume"
+            evidence.append({
+                "signal": "step_state.json",
+                "value": "blueprint_unavailable",
+                "source": str(step_state_path),
+            })
+        else:
+            completed_ids, used_legacy_fallback = _tier1_completed_subtask_ids(state)
+            pending_ids = subtask_ids - completed_ids
+            completion_source = (
+                "legacy_completed_steps" if used_legacy_fallback else "canonical_done_class"
+            )
+            if pending_ids:
+                step_state_route = "map-resume"
+                evidence.append({
+                    "signal": "step_state.json",
+                    "value": {
+                        "status": "pending",
+                        "pending_subtask_ids": sorted(pending_ids),
+                        "completion_source": completion_source,
+                    },
+                    "source": str(step_state_path),
+                })
+            else:
+                step_state_route = "map-check"
+                evidence.append({
+                    "signal": "step_state.json",
+                    "value": {
+                        "status": "complete",
+                        "subtask_count": len(subtask_ids),
+                        "completion_source": completion_source,
+                    },
+                    "source": str(step_state_path),
+                })
+    else:
+        evidence.append({
+            "signal": "step_state.json",
+            "value": {"status": "absent"},
+            "source": str(step_state_path),
+        })
+
+    # Tier 2 signal: workflow-fit.json. Also always read up front for the
+    # same losing-signal reason as tier 1.
+    workflow_fit_path = branch_dir / "workflow-fit.json"
+    fit_payload = _read_json_file(workflow_fit_path)
+    recommended: str | None = None
+    if fit_payload is not None:
+        raw_recommended = fit_payload.get("recommended_workflow")
+        recommended = raw_recommended if isinstance(raw_recommended, str) else None
+    evidence.append({
+        "signal": "workflow-fit.json",
+        "value": recommended,
+        "source": str(workflow_fit_path),
+    })
+
+    if step_state_route is not None:
+        return step_state_route, evidence
+
+    if recommended is not None and recommended in _AUTO_ROUTE_TIER2_ALLOWED:
+        return recommended, evidence
+
+    # Tier 3 signals: check_plan_resume() verdict, plus a direct
+    # blueprint.json stat (check_plan_resume's own artifacts dict has no
+    # blueprint key). check_plan_resume is allowed to read task_text -- see
+    # the sanctioned-exception note in the docstring above.
+    resume_report = check_plan_resume(task_text, branch=branch_name)
+    verdict = resume_report.get("verdict")
+    evidence.append({
+        "signal": "check_plan_resume",
+        "value": verdict,
+        "source": "check_plan_resume()",
+    })
+    if verdict == "resume":
+        artifacts = resume_report.get("artifacts")
+        has_task_plan = bool(isinstance(artifacts, dict) and artifacts.get("task_plan"))
+        blueprint_path = branch_dir / "blueprint.json"
+        has_blueprint = blueprint_path.exists()
+        evidence.append({
+            "signal": "blueprint.json",
+            "value": has_blueprint,
+            "source": str(blueprint_path),
+        })
+        return ("map-efficient" if (has_task_plan and has_blueprint) else "map-plan"), evidence
+
+    # Tier 4 signal: classify_scope.classify() bracket. Only fires when the
+    # caller supplied a real scope estimate -- there is no sixth signal in
+    # this function's allowed set (e.g. a git diff stat) that could derive
+    # estimated_files/estimated_lines on its own, so an absent estimate is
+    # recorded and the tier is skipped rather than guessed.
+    if (
+        estimated_files is not None
+        and estimated_lines is not None
+        and estimated_files >= 0
+        and estimated_lines >= 0
+    ):
+        bracket = _classify_scope_bracket(estimated_files, estimated_lines)
+        evidence.append({
+            "signal": "classify_scope.classify",
+            "value": {"estimated": True, "bracket": bracket},
+            "source": "classify_scope.classify()",
+        })
+        if bracket == "trivial":
+            return "map-fast", evidence
+    else:
+        evidence.append({
+            "signal": "classify_scope.classify",
+            "value": {"estimated": False},
+            "source": "classify_scope.classify()",
+        })
+
+    # Tier 5: default.
+    return "map-plan", evidence
 
 
 def record_scope_baseline(branch: str) -> dict:

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -242,6 +242,7 @@ ARTIFACT_STAGE_NAMES = (
     "workflow_fit",
     "spec",
     "plan",
+    "auto_route",
     "test_contract",
     "repro_probe",
     "implementation",

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -465,13 +465,13 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
-# /map-auto (issue #414, ): hold kinds that hard-stop autonomous
+# /map-auto (issue #414): hold kinds that hard-stop autonomous
 # routing outright -- route_task blocks the chain rather than proceeding
-# when either is pending. defines the complementary
-# AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
+# when either is pending. The complementary AUTO_APPROVABLE_HOLD_KINDS
+# set is defined immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
-# /map-auto (issue #414, ): hold kinds auto_decide_holds may decide
+# /map-auto (issue #414): hold kinds auto_decide_holds may decide
 # without a human -- workflow-control gates, never safety gates. Together
 # with HARD_STOP_HOLD_KINDS these must exactly partition
 # APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
@@ -14699,7 +14699,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
-# /map-auto phase ledger (issue #414, ): closed status vocabulary for
+# /map-auto phase ledger (issue #414): closed status vocabulary for
 # record_auto_phase's chain_status transitions. A phase status in
 # AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
 # AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
@@ -14709,9 +14709,9 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
 AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
 AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
 
-# at most ONE re-entry per phase -- attempt 1 (first record) plus
-# attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
-# same phase name is refused by record_auto_phase.
+# Chain-level retry bound: at most ONE re-entry per phase -- attempt 1
+# (first record) plus attempt 2 (the single permitted re-entry) are allowed;
+# a 3rd record of the same phase name is refused by record_auto_phase.
 AUTO_PHASE_MAX_ATTEMPTS = 2
 
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -14699,6 +14699,21 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
+# /map-auto phase ledger (issue #414, ST-007): closed status vocabulary for
+# record_auto_phase's chain_status transitions. A phase status in
+# AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
+# AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
+# in_progress. These two sets are intentionally NOT required to partition
+# every possible status string -- callers may pass phase-specific statuses
+# (e.g. "monitor_rejected") that fall through to in_progress.
+AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
+AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
+
+# HC-2: at most ONE re-entry per phase -- attempt 1 (first record) plus
+# attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
+# same phase name is refused by record_auto_phase.
+AUTO_PHASE_MAX_ATTEMPTS = 2
+
 
 def auto_route_artifact_path(branch: str | None = None) -> Path:
     """Return the branch-scoped /map-auto routing decision artifact path."""
@@ -14880,6 +14895,181 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
+    }
+
+
+def record_auto_phase(
+    phase: str,
+    status: str,
+    branch: str | None = None,
+    evidence_refs: list[str] | None = None,
+    reason: str = "",
+) -> dict[str, object]:
+    """Append one entry to auto-route.json's phase ledger (issue #414, ST-007).
+
+    record_auto_phase is the ONLY function that mutates `phases[]` --
+    route_task always initializes it empty and never appends (Decision 11
+    single-writer invariant). Requires an existing auto-route.json (written
+    by route_task); returns status="error" if none is found.
+
+    `attempt` mechanizes HC-2's at-most-one-re-entry bound: it is
+    ``1 + count of prior phases[] entries with the SAME phase name``. A
+    first call for a phase records attempt=1; a re-entry records attempt=2.
+    A THIRD call for the same phase is refused outright -- no entry is
+    appended for that call. Instead the chain is force-aborted: chain_status
+    is set to "aborted" and the abort reason is persisted in the top-level
+    `abort_reason` field (mirroring route_task's `block_reason` field for
+    the "blocked" chain_status -- one field, schema-valid via the schema's
+    `additionalProperties: true`, so the operator sees WHY directly in
+    auto-route.json without needing to scan phases[] for a synthetic entry).
+
+    On every non-refused call, chain_status transitions from the recorded
+    `status` using a closed vocabulary (AUTO_PHASE_TERMINAL_SUCCESS_STATUSES
+    -> "completed", AUTO_PHASE_ABORT_STATUSES -> "aborted", otherwise
+    "in_progress") and the `abort_reason` field is set/cleared to match. The
+    `auto_route` manifest stage is refreshed on every call (refused or not)
+    so progress is observable outside the artifact, with its status
+    mirroring the resulting chain_status.
+
+    `evidence_refs` persists caller-supplied ids (e.g. hold ids
+    auto-approved by `auto_decide_holds`) in the phase entry, giving every
+    auto-approval a second durable recording site alongside the hold's own
+    audit note (INV-4).
+
+    HC-2 fail-closed guard (code review 2): once chain_status is "aborted"
+    (3rd-attempt refusal above) or "blocked" (route_task hard-stop hold),
+    the chain must stay terminal until an explicit NEW route_task call --
+    route_task's own overwrite policy is the only legitimate way out of
+    "aborted"/"blocked". A call naming a DIFFERENT phase must never act as a
+    side door that resurrects the chain by appending a fresh entry and
+    flipping chain_status back to in_progress/completed. This guard runs
+    BEFORE the attempt-counter logic (which only protects the SAME phase
+    name) and mutates nothing on the terminal-state path: no phases[]
+    append, no chain_status change, no abort_reason/block_reason pop, no
+    manifest write.
+    """
+    branch_name = branch or get_branch_name()
+    artifact_path = auto_route_artifact_path(branch_name)
+    artifact = _read_json_file(artifact_path)
+    if artifact is None:
+        return {
+            "status": "error",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "reason": (
+                f"no auto-route.json found for branch '{branch_name}'; "
+                "run route_task first"
+            ),
+        }
+
+    terminal_chain_status = artifact.get("chain_status")
+    if terminal_chain_status in {"aborted", "blocked"}:
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "phase": phase,
+            "chain_status": terminal_chain_status,
+            "reason": (
+                f"branch '{branch_name}' auto-route chain is already "
+                f"'{terminal_chain_status}'; record_auto_phase refuses to "
+                "mutate a terminal chain -- call route_task to re-route "
+                "explicitly."
+            ),
+            "abort_reason": artifact.get("abort_reason"),
+            "block_reason": artifact.get("block_reason"),
+        }
+
+    raw_phases = artifact.get("phases")
+    phases = [entry for entry in raw_phases if isinstance(entry, dict)] if isinstance(
+        raw_phases, list
+    ) else []
+    prior_attempts = sum(1 for entry in phases if entry.get("phase") == phase)
+    attempt = prior_attempts + 1
+
+    manifest = load_artifact_manifest(branch_name)
+
+    if attempt > AUTO_PHASE_MAX_ATTEMPTS:
+        # HC-2 refusal: do not append an entry for this call -- force-abort
+        # the chain instead, with the reason visible at the top level.
+        abort_reason = (
+            f"phase '{phase}' refused at attempt {attempt} (max "
+            f"{AUTO_PHASE_MAX_ATTEMPTS} attempts per HC-2); forcing "
+            "chain_status=aborted."
+        )
+        if reason:
+            abort_reason += f" caller reason: {reason}"
+        abort_reason = _sanitize_for_json(abort_reason)
+
+        artifact["chain_status"] = "aborted"
+        artifact["abort_reason"] = abort_reason
+        _write_json_file(artifact_path, artifact)
+
+        _set_manifest_stage(
+            manifest,
+            "auto_route",
+            "aborted",
+            artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+            metadata={
+                "chain_status": "aborted",
+                "aborted_phase": phase,
+                "attempt": attempt,
+            },
+        )
+        save_artifact_manifest(manifest, branch_name)
+
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "phase": phase,
+            "attempt": attempt,
+            "chain_status": "aborted",
+            "abort_reason": abort_reason,
+        }
+
+    entry: dict[str, object] = {
+        "phase": phase,
+        "status": status,
+        "attempt": attempt,
+        "evidence_refs": list(evidence_refs or []),
+        "reason": _sanitize_for_json(reason),
+        "recorded_at": _utc_timestamp(),
+    }
+    phases.append(entry)
+    artifact["phases"] = phases
+
+    if status in AUTO_PHASE_TERMINAL_SUCCESS_STATUSES:
+        chain_status = "completed"
+    elif status in AUTO_PHASE_ABORT_STATUSES:
+        chain_status = "aborted"
+    else:
+        chain_status = "in_progress"
+    artifact["chain_status"] = chain_status
+    if chain_status == "aborted":
+        artifact["abort_reason"] = _sanitize_for_json(
+            reason or f"phase '{phase}' reported status '{status}'"
+        )
+    else:
+        artifact.pop("abort_reason", None)
+    _write_json_file(artifact_path, artifact)
+
+    _set_manifest_stage(
+        manifest,
+        "auto_route",
+        chain_status,
+        artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+        metadata={"chain_status": chain_status, "phase": phase, "attempt": attempt},
+    )
+    save_artifact_manifest(manifest, branch_name)
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "path": str(artifact_path),
+        "phase": phase,
+        "attempt": attempt,
+        "chain_status": chain_status,
     }
 
 
@@ -22300,6 +22490,35 @@ if __name__ == "__main__":
         )
         _a = _p.parse_args(sys.argv[2:])
         _r = route_task(_a.task, branch=_a.branch, dry_run=_a.dry_run)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
+
+    elif func_name == "record_auto_phase" and len(sys.argv) >= 4:
+        # CLI: record_auto_phase <phase> <status> [--branch B]
+        #        [--evidence-refs a,b,c] [--reason "..."]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py record_auto_phase")
+        _p.add_argument("phase", help="Phase name to record (e.g. map-plan, map-efficient)")
+        _p.add_argument(
+            "status", help="Phase status (e.g. completed, in_progress, failed, aborted)"
+        )
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _p.add_argument(
+            "--evidence-refs",
+            default="",
+            dest="evidence_refs",
+            help="Comma-separated evidence ids (e.g. auto-approved hold ids)",
+        )
+        _p.add_argument(
+            "--reason", default="", help="Reason recorded alongside the phase entry"
+        )
+        _a = _p.parse_args(sys.argv[2:])
+        _refs = [ref.strip() for ref in _a.evidence_refs.split(",") if ref.strip()]
+        _r = record_auto_phase(
+            _a.phase, _a.status, branch=_a.branch, evidence_refs=_refs, reason=_a.reason
+        )
         print(json.dumps(_r, indent=2))
         if _r.get("status") == "error":
             sys.exit(1)

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -471,6 +471,16 @@ APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATE
 # AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
+# /map-auto (issue #414, ST-006): hold kinds auto_decide_holds may decide
+# without a human -- workflow-control gates, never safety gates. Together
+# with HARD_STOP_HOLD_KINDS these must exactly partition
+# APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
+# kind hard-fails a test instead of being silently auto-approved by
+# omission.
+AUTO_APPROVABLE_HOLD_KINDS = frozenset(
+    {"autonomy_posture", "plan_approval", "template_overwrite"}
+)
+
 # Truncation infrastructure deleted by user directive ("убери транкейт уже
 # вообще"). build_context_block / _budget_review_prompt now emit raw text;
 # operators handle context size via /compact opt-in. The mapify_cli
@@ -17754,6 +17764,60 @@ def get_pending_holds(branch: str | None = None) -> dict[str, Any]:
     }
 
 
+def auto_decide_holds(branch: str | None = None) -> dict[str, Any]:
+    """Split pending approval holds into auto-approved and hard-stopped (#414).
+
+    Reads pending holds via `get_pending_holds` and, for each one, decides
+    solely on AUTO_APPROVABLE_HOLD_KINDS membership -- a positive allowlist,
+    never an exclusion of HARD_STOP_HOLD_KINDS. `decide_approval_hold` is
+    therefore only ever reachable from the branch guarded by that allowlist
+    check, so no code path here can transition a dangerous_action or
+    safety_guardrail hold (INV-2), even if hard-stop membership itself were
+    ever misconfigured.
+
+    - Holds whose kind is in AUTO_APPROVABLE_HOLD_KINDS are decided
+      "approved" via the existing `decide_approval_hold(hold_id, "approved",
+      "auto-approved by map-auto", branch)` and collected into
+      `auto_approved[]`.
+    - Holds whose kind is in HARD_STOP_HOLD_KINDS are left untouched
+      (still `pending`) and collected into `hard_stops[]`.
+    """
+    branch_name = branch or get_branch_name()
+    pending = get_pending_holds(branch_name)
+    auto_approved: list[dict[str, str]] = []
+    hard_stops: list[dict[str, str]] = []
+
+    for hold in cast(list[Any], pending.get("holds", [])):
+        if not isinstance(hold, dict):
+            continue
+        hold_id = str(hold.get("id", ""))
+        kind = str(hold.get("kind", ""))
+        if kind in AUTO_APPROVABLE_HOLD_KINDS:
+            decide_approval_hold(hold_id, "approved", "auto-approved by map-auto", branch_name)
+            auto_approved.append(
+                {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+            )
+        elif kind in HARD_STOP_HOLD_KINDS:
+            hard_stops.append(
+                {
+                    "id": hold_id,
+                    "kind": kind,
+                    "reason": "hard-stop hold kind; requires an explicit human decision",
+                }
+            )
+        # Any other kind is left pending and reported in neither bucket --
+        # unreachable while AUTO_APPROVABLE_HOLD_KINDS | HARD_STOP_HOLD_KINDS
+        # == APPROVAL_HOLD_KINDS holds, but fails closed if that invariant
+        # is ever violated.
+
+    return {
+        "status": "ok",
+        "branch": branch_name,
+        "auto_approved": auto_approved,
+        "hard_stops": hard_stops,
+    }
+
+
 # --- Per-subtask git worktree isolation (#284) ---------------------------------
 # Runner-owned explicit worktrees (NOT the harness-native isolation="worktree").
 # llm-council-reviewed design (conv 461b92f9):
@@ -22094,6 +22158,18 @@ if __name__ == "__main__":
         _a = _p.parse_args(sys.argv[2:])
         _r = get_pending_holds(_a.branch)
         print(json.dumps(_r, indent=2))
+
+    elif func_name == "auto_decide_holds":
+        # CLI: auto_decide_holds [--branch B]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py auto_decide_holds")
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _a = _p.parse_args(sys.argv[2:])
+        _r = auto_decide_holds(_a.branch)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
 
     elif func_name == "write_implementer_readiness_review" and len(sys.argv) >= 3:
         # CLI: write_implementer_readiness_review <verdict>

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -465,13 +465,13 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
-# /map-auto (issue #414, ST-005): hold kinds that hard-stop autonomous
+# /map-auto (issue #414, ): hold kinds that hard-stop autonomous
 # routing outright -- route_task blocks the chain rather than proceeding
-# when either is pending. ST-006 defines the complementary
+# when either is pending. defines the complementary
 # AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
-# /map-auto (issue #414, ST-006): hold kinds auto_decide_holds may decide
+# /map-auto (issue #414, ): hold kinds auto_decide_holds may decide
 # without a human -- workflow-control gates, never safety gates. Together
 # with HARD_STOP_HOLD_KINDS these must exactly partition
 # APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
@@ -14699,7 +14699,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
-# /map-auto phase ledger (issue #414, ST-007): closed status vocabulary for
+# /map-auto phase ledger (issue #414, ): closed status vocabulary for
 # record_auto_phase's chain_status transitions. A phase status in
 # AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
 # AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
@@ -14709,7 +14709,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
 AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
 AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
 
-# HC-2: at most ONE re-entry per phase -- attempt 1 (first record) plus
+# at most ONE re-entry per phase -- attempt 1 (first record) plus
 # attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
 # same phase name is refused by record_auto_phase.
 AUTO_PHASE_MAX_ATTEMPTS = 2
@@ -14990,7 +14990,7 @@ def record_auto_phase(
     manifest = load_artifact_manifest(branch_name)
 
     if attempt > AUTO_PHASE_MAX_ATTEMPTS:
-        # HC-2 refusal: do not append an entry for this call -- force-abort
+        # refusal: do not append an entry for this call -- force-abort
         # the chain instead, with the reason visible at the top level.
         abort_reason = (
             f"phase '{phase}' refused at attempt {attempt} (max "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`/map-auto` single-entry autonomous autopilot (#414).** Routes a task through the existing MAP workflows via `route_task`, then drives the selected chain (`map-plan` -> `map-efficient` -> `map-check` -> `map-review`, as routed) to a committed feature branch in one session, auto-approving `autonomy_posture`/`plan_approval`/`template_overwrite` holds and hard-stopping on `dangerous_action`/`safety_guardrail` holds. Routing and phase-ledger state live in `.map/<branch>/auto-route.json` (`AUTO_ROUTE_SCHEMA`), mutated only through `route_task`, `auto_decide_holds`, and `record_auto_phase`. Out of scope for this slice: `/map-auto` never creates a pull request, never polls CI, and never merges — the run ends at the committed branch.
+- **`/map-auto` single-entry autonomous autopilot (#414).** Routes a task through the existing MAP workflows via `route_task`, then drives the selected chain (`map-plan` -> `map-efficient` -> `map-check` -> `map-review`, as routed) to a committed feature branch in one session, auto-approving `autonomy_posture`/`plan_approval`/`template_overwrite` holds and hard-stopping on `dangerous_action`/`safety_guardrail` holds. Routing and phase-ledger state live in `.map/<branch>/auto-route.json` (`AUTO_ROUTE_SCHEMA`), mutated only through `route_task` and `record_auto_phase`; `auto_decide_holds` mutates `approval_holds.json` separately, surfacing its approvals via the `approval_hold` manifest stage. Out of scope for this slice: `/map-auto` never creates a pull request, never polls CI, and never merges — the run ends at the committed branch.
 
 ## [3.25.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/map-auto` single-entry autonomous autopilot (#414).** Routes a task through the existing MAP workflows via `route_task`, then drives the selected chain (`map-plan` -> `map-efficient` -> `map-check` -> `map-review`, as routed) to a committed feature branch in one session, auto-approving `autonomy_posture`/`plan_approval`/`template_overwrite` holds and hard-stopping on `dangerous_action`/`safety_guardrail` holds. Routing and phase-ledger state live in `.map/<branch>/auto-route.json` (`AUTO_ROUTE_SCHEMA`), mutated only through `route_task`, `auto_decide_holds`, and `record_auto_phase`. Out of scope for this slice: `/map-auto` never creates a pull request, never polls CI, and never merges — the run ends at the committed branch.
+
 ## [3.25.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ That's the whole golden path.
 - **Already scoped?** Go straight to `/map-efficient`.
 - **Tiny edit?** `/map-plan` off-ramps you to a direct edit or `/map-fast` instead of forcing full planning.
 - **Too foggy to plan?** `/map-wayfind` resolves open design decisions one at a time on a durable map, then hands settled decisions to `/map-plan`.
+- **Want one entry point?** `/map-auto` routes and drives the chain autonomously; hard-stops only on `dangerous_action`/`safety_guardrail` holds.
 
 > Codex CLI users invoke the same skills with `$`: `$map-plan`, `$map-efficient`, `$map-check`. See the [Usage Guide](docs/USAGE.md#codex-cli-provider).
 
@@ -110,6 +111,7 @@ The DevOpsConf 2026 case study applies this process to a production Kubernetes P
 
 | Command | Use For |
 |---------|---------|
+| `/map-auto` | Single-entry autonomous autopilot: routes a task through existing MAP workflows and drives the chain to a committed branch |
 | `/map-plan` | **Start here** for non-trivial work; clarify behavior and decompose tasks |
 | `/map-wayfind` | Too foggy to plan? Resolve design decisions on a durable map *before* `/map-plan` |
 | `/map-efficient` | **Implement** an approved plan or already-scoped task |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -363,6 +363,71 @@ concurrent sessions clobbering the map). Honesty note: the human-in-the-loop and
 session-limit checks add friction and an audit trail, not a mechanical guarantee that an
 LLM cannot fabricate input — the same layered-defense posture MAP uses elsewhere.
 
+## Single-Entry Autopilot (`/map-auto`)
+
+A manually-invoked skill (issue #414) that routes a task through the existing MAP
+workflows via `route_task`, then drives the selected chain end-to-end to a committed
+feature branch in the same session. `/map-auto` never reimplements
+`/map-plan`/`/map-efficient`/`/map-check`/`/map-review` — it only decides which one(s) to
+run and invokes them unmodified, one after another. It runs autonomously the moment it is
+invoked; there is no shadow mode, calibration period, or opt-in flag.
+
+- **`auto-route.json` artifact** (`.map/<branch>/auto-route.json`, `AUTO_ROUTE_SCHEMA` in
+  `src/mapify_cli/schemas.py`): ten required fields — `schema_version`, `task_summary`,
+  `selected_route` (closed enum: `map-resume`, `map-check`, `map-fast`, `map-plan`,
+  `map-efficient`), `evidence` (structured `{signal, value, source}` entries),
+  `blocked_by`, `next_command`, `executed`, `chain_status` (closed enum:
+  `recommended_only`, `blocked`, `in_progress`, `completed`, `aborted`), `phases` (ledger,
+  appended only by `record_auto_phase`), and `route_history` (prior `selected_route`
+  values preserved across re-routes). `block_reason` and `abort_reason` are additive
+  string fields (`additionalProperties: true`) — `route_task` sets `block_reason` only
+  when it blocks the chain, and `record_auto_phase` sets/pops `abort_reason` to track
+  whether `chain_status` is currently `aborted`; neither is in the required-field list
+  because most runs never reach either terminal state.
+- **Single-writer split**: `route_task` creates or overwrites the whole artifact (subject
+  to its own guards below) and always initializes `phases` empty — it never appends a
+  phase entry. `record_auto_phase` is the ONLY function that appends to `phases[]`; it
+  also owns the `chain_status` transitions into `completed`/`aborted` and the
+  `abort_reason` field. Per Decision 14, `route_task` writes only `auto-route.json` and
+  its manifest stage — it never calls `record_workflow_fit` or `create_approval_hold`.
+- **`auto_route` manifest stage**: registered in `ARTIFACT_STAGE_NAMES` immediately after
+  `plan` (before `test_contract`); `route_task`, `auto_decide_holds`, and
+  `record_auto_phase` each refresh it via `_set_manifest_stage`, so chain progress is
+  observable from `artifact_manifest.json` without reading `auto-route.json` directly.
+- **Guard semantics**: `route_task` runs three guards in precedence order before its
+  normal write — (1) **in-progress refusal**: an existing `chain_status: "in_progress"`
+  refuses to re-route (`status: "refused"`, `next_command: "/map-resume"`, artifact and
+  manifest left untouched); (2) a pending hard-stop hold blocks the chain even under
+  `--dry-run` (see hold-autonomy policy below); (3) **`goal_mismatch` block**:
+  `check_plan_resume`'s verdict blocks the chain (`chain_status: "blocked"`,
+  `block_reason` set) without archiving or overwriting the pre-existing
+  spec/task_plan/blueprint artifacts. Separately, **terminal-chain no-resurrection**:
+  `record_auto_phase` refuses every call once `chain_status` is `aborted` or `blocked`,
+  regardless of phase name, returning the existing `abort_reason`/`block_reason` instead
+  of mutating anything — only a fresh `route_task` call can move a terminal chain
+  forward. `route_task` itself may re-route from any of `recommended_only`, `blocked`,
+  `completed`, or `aborted` (never from `in_progress`), preserving the superseded route
+  in `route_history[]`.
+- **Hold-autonomy policy**: `auto_decide_holds` partitions `APPROVAL_HOLD_KINDS` into two
+  disjoint, exhaustive sets — a test asserts the union covers the whole set with an empty
+  intersection, so a future sixth hold kind hard-fails instead of being silently
+  auto-approved by omission. `AUTO_APPROVABLE_HOLD_KINDS` (`autonomy_posture`,
+  `plan_approval`, `template_overwrite`) are approved automatically via the existing
+  `decide_approval_hold(hold_id, "approved", "auto-approved by map-auto")`, and each
+  approved hold id is dual-recorded — once in the hold's own audit note, once in the
+  consuming `record_auto_phase` call's `evidence_refs`. `HARD_STOP_HOLD_KINDS`
+  (`dangerous_action`, `safety_guardrail`) are never decided by any `/map-auto` code
+  path; they are only ever returned in `hard_stops[]` for a human to act on.
+- **Honesty caveat (spec Decision 4).** As of this slice, no shipped skill prose or hook
+  actually creates any approval hold — the #344 mechanism (see Durable Approval Holds
+  above) is CLI plumbing without live producers. `/map-auto`'s auto-approve path is
+  therefore exercised only by synthetic test holds in this slice, not by any real routing
+  decision that has ever created a hold; wiring a live producer (e.g. a `plan_approval`
+  hold at a `/map-plan` decision point) into an existing workflow is a tracked follow-up,
+  and the auto-approve path must not be read as an active mitigation until that lands.
+- **Out of scope (first slice, HC-1)**: the autopilot run ends at a committed feature
+  branch. `/map-auto` never creates a pull request, never merges, and never polls CI.
+
 ## Cross-cutting Concepts
 
 - **Context Budgeting & Compression**: MAP exposes compression policies and thresholds and treats budget control as a first-class workflow concern. Generated Actor `<map_context>` blocks and `/map-review` reviewer fan-out prompts are capped by deterministic estimated-token budgets before prompt injection so long plans or raw diffs cannot silently crowd out current-subtask, review-bundle, and dependency context. Active budgeted prompt paths append before/after estimates and clipped section labels to `.map/<branch>/token_budget.json` so users can diagnose missing-context reports without transcript inspection.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,9 +391,11 @@ invoked; there is no shadow mode, calibration period, or opt-in flag.
   `abort_reason` field. Per Decision 14, `route_task` writes only `auto-route.json` and
   its manifest stage — it never calls `record_workflow_fit` or `create_approval_hold`.
 - **`auto_route` manifest stage**: registered in `ARTIFACT_STAGE_NAMES` immediately after
-  `plan` (before `test_contract`); `route_task`, `auto_decide_holds`, and
-  `record_auto_phase` each refresh it via `_set_manifest_stage`, so chain progress is
-  observable from `artifact_manifest.json` without reading `auto-route.json` directly.
+  `plan` (before `test_contract`); `route_task` and `record_auto_phase` each refresh it via
+  `_set_manifest_stage`, so chain progress is observable from `artifact_manifest.json`
+  without reading `auto-route.json` directly. (`auto_decide_holds` does not touch this
+  stage — its approvals surface in the `approval_hold` stage via `decide_approval_hold`
+  and in each hold's own record.)
 - **Guard semantics**: `route_task` runs three guards in precedence order before its
   normal write — (1) **in-progress refusal**: an existing `chain_status: "in_progress"`
   refuses to re-route (`status: "refused"`, `next_command: "/map-resume"`, artifact and

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -43,6 +43,26 @@ All state lives in `.map/wayfind/<slug>/state.json` and is mutated only through 
 
 **Sharing / privacy.** Maps are committed by default (decisions are durable, reviewable history). `grilling` transcripts and prose resolutions may contain sensitive content — `chart` warns about this. To keep one map local, add `.map/wayfind/<slug>/.gitignore` with a single `*`.
 
+## Single-entry autopilot (`/map-auto`)
+
+`/map-auto "<task>"` is a thin router plus chain driver on top of the workflows above — it decides which one(s) to run and then drives the selected chain unattended, in the same session, to a committed feature branch. It runs autonomously the moment it is invoked; there is no shadow mode, no calibration period, and no opt-in flag.
+
+Inspect the routing recommendation without committing to it:
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "<task>" --dry-run
+```
+
+A dry run writes only `.map/<branch>/auto-route.json` and its `auto_route` manifest-stage entry — no other file on disk changes, and the chain never starts (`chain_status: "recommended_only"`).
+
+Routing follows a five-tier precedence engine, highest tier first: (1) a `step_state.json` with pending subtasks routes to `/map-resume`, an all-complete one to `/map-check`; (2) a `workflow-fit.json` recommendation of `map-fast`/`map-plan`/`map-efficient` wins as-is; (3) `check_plan_resume`'s `resume` verdict routes to `/map-efficient` when a task plan and `blueprint.json` both exist, otherwise `/map-plan`; (4) a `trivial` scope bracket (only when file/line estimates are supplied) routes to `/map-fast`; (5) the default is `/map-plan`. None of the tiers pattern-match the task text itself.
+
+Once routed, `/map-auto` drives the chain by invoking the existing slash workflows unmodified — `route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]`, as selected — polling `auto_decide_holds` before and after each chained phase and recording every phase boundary with `record_auto_phase`. `auto_decide_holds` auto-approves pending `autonomy_posture`, `plan_approval`, and `template_overwrite` holds on your behalf. A pending `dangerous_action` or `safety_guardrail` hold is always a hard stop — surfaced to you, never auto-decided by any `/map-auto` code path — and the autopilot stops until a human makes the call.
+
+`record_auto_phase` mechanically enforces at most one re-entry per phase (HC-2): a phase's first record is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the same phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Recovery from any stop condition — a refused re-route, an aborted chain, a hard-stop hold once it is decided, or a phase that exhausted its own retry/escalation budget — goes through `/map-resume`; a fresh `route_task` call is the only way to move a terminal chain forward.
+
+**End state:** a committed feature branch. `/map-auto` never opens a pull request, never polls CI, and never merges — it reports the committed branch and the recorded phases, then stops.
+
 ## Canonical Flows
 
 ### Standard flow

--- a/src/mapify_cli/schemas.py
+++ b/src/mapify_cli/schemas.py
@@ -808,6 +808,7 @@ ARTIFACT_MANIFEST_SCHEMA = {
                 "workflow_fit": ARTIFACT_STAGE_SCHEMA,
                 "spec": ARTIFACT_STAGE_SCHEMA,
                 "plan": ARTIFACT_STAGE_SCHEMA,
+                "auto_route": ARTIFACT_STAGE_SCHEMA,
                 "test_contract": ARTIFACT_STAGE_SCHEMA,
                 "repro_probe": ARTIFACT_STAGE_SCHEMA,
                 "implementation": ARTIFACT_STAGE_SCHEMA,
@@ -829,6 +830,8 @@ ARTIFACT_MANIFEST_SCHEMA = {
                 "worktree": ARTIFACT_STAGE_SCHEMA,
                 "context_usefulness": ARTIFACT_STAGE_SCHEMA,
                 "wayfind_handoff": ARTIFACT_STAGE_SCHEMA,
+                "review_verdict_ledger": ARTIFACT_STAGE_SCHEMA,
+                "prd_review": ARTIFACT_STAGE_SCHEMA,
             },
             "required": [
                 "workflow_fit",

--- a/src/mapify_cli/schemas.py
+++ b/src/mapify_cli/schemas.py
@@ -2122,3 +2122,104 @@ PRD_REVIEW_SCHEMA: dict[str, Any] = {
     ],
     "additionalProperties": True,
 }
+
+AUTO_ROUTE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mapframework.dev/schemas/auto-route.json",
+    "title": "MAP Auto Route Decision",
+    "description": (
+        "Autonomous routing decision and phase ledger stored in "
+        ".map/<branch>/auto-route.json (/map-auto)."
+    ),
+    "type": "object",
+    "properties": {
+        "schema_version": {"type": "string"},
+        "task_summary": {"type": "string"},
+        "selected_route": {
+            "type": "string",
+            "enum": [
+                "map-resume",
+                "map-check",
+                "map-fast",
+                "map-plan",
+                "map-efficient",
+            ],
+        },
+        "evidence": {
+            "type": "array",
+            "description": "Structured signals that justified the selected_route.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "signal": {"type": "string"},
+                    "value": {"type": "string"},
+                    "source": {"type": "string"},
+                },
+                "required": ["signal", "value", "source"],
+                "additionalProperties": False,
+            },
+        },
+        "blocked_by": {
+            "type": "array",
+            "description": "Pending hard-stop hold ids blocking the chain, if any.",
+            "items": {"type": "string"},
+        },
+        "next_command": {"type": "string"},
+        "executed": {"type": "boolean"},
+        "chain_status": {
+            "type": "string",
+            "enum": [
+                "recommended_only",
+                "blocked",
+                "in_progress",
+                "completed",
+                "aborted",
+            ],
+        },
+        "phases": {
+            "type": "array",
+            "description": "Phase ledger; appended only by record_auto_phase.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "phase": {"type": "string"},
+                    "status": {"type": "string"},
+                    "attempt": {"type": "integer", "minimum": 1},
+                    "evidence_refs": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "reason": {"type": "string"},
+                    "recorded_at": {"type": "string", "format": "date-time"},
+                },
+                "required": [
+                    "phase",
+                    "status",
+                    "attempt",
+                    "evidence_refs",
+                    "reason",
+                    "recorded_at",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "route_history": {
+            "type": "array",
+            "description": "Prior selected_route values preserved across re-routes.",
+            "items": {"type": "string"},
+        },
+    },
+    "required": [
+        "schema_version",
+        "task_summary",
+        "selected_route",
+        "evidence",
+        "blocked_by",
+        "next_command",
+        "executed",
+        "chain_status",
+        "phases",
+        "route_history",
+    ],
+    "additionalProperties": True,
+}

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -465,6 +465,12 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
+# /map-auto (issue #414, ST-005): hold kinds that hard-stop autonomous
+# routing outright -- route_task blocks the chain rather than proceeding
+# when either is pending. ST-006 defines the complementary
+# AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
+HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
+
 # Truncation infrastructure deleted by user directive ("убери транкейт уже
 # вообще"). build_context_block / _budget_review_prompt now emit raw text;
 # operators handle context size via /compact opt-in. The mapify_cli
@@ -14727,18 +14733,56 @@ def route_task(
 
     `executed` and `chain_status` are always set together in one atomic
     artifact write: non-dry-run -> executed=True, chain_status="in_progress";
-    --dry-run -> executed=False, chain_status="recommended_only". Guards that
-    refuse to re-route an in-progress chain, block on a goal mismatch, or
-    surface pending hard-stop holds are added by a later subcommand -- this
-    call always re-routes and overwrites, preserving the prior selected_route
-    in route_history.
+    --dry-run -> executed=False, chain_status="recommended_only" -- UNLESS
+    one of the guards below blocks the chain, in which case executed is
+    forced False regardless of dry_run.
+
+    Three guards run, in this precedence order, BEFORE the normal write
+    (ST-005, INV-6):
+
+      1. In-progress refusal: an existing auto-route.json with
+         chain_status "in_progress" refuses to re-route -- returns
+         status="refused" with a /map-resume pointer, and neither the
+         artifact nor the manifest is touched. chain_status in
+         {recommended_only, blocked, completed, aborted} may be re-routed
+         (the prior selected_route is preserved in route_history).
+      2. Hard-stop holds: a pending dangerous_action or safety_guardrail
+         hold (HARD_STOP_HOLD_KINDS) blocks the chain -- chain_status
+         "blocked", executed False, blocked_by populated with the pending
+         hold ids -- even under --dry-run ("blocked" outranks
+         "recommended_only").
+      3. goal_mismatch block: check_plan_resume's verdict, already surfaced
+         in _select_route's evidence trail (read here, never re-queried),
+         blocks the chain with chain_status "blocked" and a block_reason.
+         The prior spec/task_plan/blueprint artifacts are left untouched --
+         route_task never archives or overwrites them.
+
+    Per Decision 14, route_task writes ONLY auto-route.json and its manifest
+    stage across every branch above -- it never calls record_workflow_fit or
+    create_approval_hold.
     """
     branch_name = branch or get_branch_name()
+    artifact_path = auto_route_artifact_path(branch_name)
+    prior = _read_json_file(artifact_path)
+
+    # Guard 1: refuse to re-route a chain that is already in progress --
+    # the operator must resume it explicitly (/map-resume) instead of this
+    # call silently clobbering the active decision.
+    if isinstance(prior, dict) and prior.get("chain_status") == "in_progress":
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "reason": (
+                f"branch '{branch_name}' has an in-progress /map-auto chain; "
+                "re-routing is refused to avoid clobbering the active run."
+            ),
+            "next_command": "/map-resume",
+        }
+
     selected_route, raw_evidence = _select_route(branch_name, task)
     next_command = _AUTO_ROUTE_NEXT_COMMAND[selected_route]
 
-    artifact_path = auto_route_artifact_path(branch_name)
-    prior = _read_json_file(artifact_path)
     route_history: list[str] = []
     if isinstance(prior, dict):
         prior_history = prior.get("route_history")
@@ -14750,26 +14794,65 @@ def route_task(
 
     executed = not dry_run
     chain_status = "in_progress" if executed else "recommended_only"
+    blocked_by: list[str] = []
+    block_reason = ""
+
+    # Guard 2: pending hard-stop holds block the chain outright, including
+    # under --dry-run -- "blocked" always outranks "recommended_only".
+    pending_holds = get_pending_holds(branch_name)
+    hard_stop_ids = [
+        str(hold["id"])
+        for hold in cast(list[Any], pending_holds.get("holds", []))
+        if isinstance(hold, dict) and hold.get("kind") in HARD_STOP_HOLD_KINDS
+    ]
+    if hard_stop_ids:
+        chain_status = "blocked"
+        executed = False
+        blocked_by = hard_stop_ids
+        block_reason = f"pending hard-stop hold(s): {', '.join(hard_stop_ids)}"
+    else:
+        # Guard 3: a goal_mismatch verdict from check_plan_resume, already
+        # surfaced by _select_route above -- reused, not re-queried --
+        # blocks the chain without touching the prior plan artifacts.
+        mismatch_entry = next(
+            (
+                entry
+                for entry in raw_evidence
+                if entry.get("signal") == "check_plan_resume"
+                and entry.get("value") == "goal_mismatch"
+            ),
+            None,
+        )
+        if mismatch_entry is not None:
+            chain_status = "blocked"
+            executed = False
+            block_reason = (
+                f"check_plan_resume reported goal_mismatch for branch "
+                f"'{branch_name}'; resolve the mismatch (archive/rename the "
+                "prior plan or confirm intent) before routing."
+            )
 
     artifact: dict[str, object] = {
         "schema_version": "1.0",
         "task_summary": _sanitize_for_json(task),
         "selected_route": selected_route,
         "evidence": _auto_route_evidence_for_artifact(raw_evidence),
-        "blocked_by": [],
+        "blocked_by": blocked_by,
         "next_command": next_command,
         "executed": executed,
         "chain_status": chain_status,
         "phases": [],
         "route_history": route_history,
     }
+    if block_reason:
+        artifact["block_reason"] = block_reason
     _write_json_file(artifact_path, artifact)
 
     manifest = load_artifact_manifest(branch_name)
     _set_manifest_stage(
         manifest,
         "auto_route",
-        "recommended" if dry_run else "in_progress",
+        "blocked" if chain_status == "blocked" else ("recommended" if dry_run else "in_progress"),
         artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
         metadata={
             "selected_route": selected_route,
@@ -14779,13 +14862,14 @@ def route_task(
     save_artifact_manifest(manifest, branch_name)
 
     return {
-        "status": "success",
+        "status": "blocked" if chain_status == "blocked" else "success",
         "branch": branch_name,
         "path": str(artifact_path),
         "selected_route": selected_route,
         "chain_status": chain_status,
         "next_command": next_command,
         "executed": executed,
+        "blocked_by": blocked_by,
     }
 
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -14673,6 +14673,122 @@ def _select_route(
     return "map-plan", evidence
 
 
+# /map-auto routing (issue #414): route -> slash command surfaced to the
+# operator as the next step.
+_AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
+    "map-resume": "/map-resume",
+    "map-check": "/map-check",
+    "map-fast": "/map-fast",
+    "map-plan": "/map-plan",
+    "map-efficient": "/map-efficient",
+}
+
+
+def auto_route_artifact_path(branch: str | None = None) -> Path:
+    """Return the branch-scoped /map-auto routing decision artifact path."""
+    return get_branch_dir(branch) / "auto-route.json"
+
+
+def _auto_route_evidence_for_artifact(
+    evidence: list[dict[str, object]],
+) -> list[dict[str, str]]:
+    """Coerce _select_route's evidence into AUTO_ROUTE_SCHEMA's string shape.
+
+    _select_route returns richer Python values (dict, bool, None) per signal
+    for in-process callers; AUTO_ROUTE_SCHEMA (schemas.py) declares
+    evidence[].value as a plain string for the persisted artifact. JSON-encode
+    non-string values so no signal detail is lost while staying schema-valid.
+    """
+    stringified: list[dict[str, str]] = []
+    for entry in evidence:
+        value = entry.get("value")
+        value_str = value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+        stringified.append({
+            "signal": str(entry.get("signal", "")),
+            "value": value_str,
+            "source": str(entry.get("source", "")),
+        })
+    return stringified
+
+
+def route_task(
+    task: str,
+    branch: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Select a route for /map-auto and persist the decision (issue #414).
+
+    Wraps _select_route with the write side of the routing contract: writes
+    .map/<branch>/auto-route.json (all ten AUTO_ROUTE_SCHEMA fields) and
+    registers the `auto_route` manifest stage in the same call, so the route
+    selection is never observable only in stdout. `phases` is always
+    initialized empty here -- record_auto_phase (a later subcommand) is the
+    sole writer of that ledger.
+
+    `executed` and `chain_status` are always set together in one atomic
+    artifact write: non-dry-run -> executed=True, chain_status="in_progress";
+    --dry-run -> executed=False, chain_status="recommended_only". Guards that
+    refuse to re-route an in-progress chain, block on a goal mismatch, or
+    surface pending hard-stop holds are added by a later subcommand -- this
+    call always re-routes and overwrites, preserving the prior selected_route
+    in route_history.
+    """
+    branch_name = branch or get_branch_name()
+    selected_route, raw_evidence = _select_route(branch_name, task)
+    next_command = _AUTO_ROUTE_NEXT_COMMAND[selected_route]
+
+    artifact_path = auto_route_artifact_path(branch_name)
+    prior = _read_json_file(artifact_path)
+    route_history: list[str] = []
+    if isinstance(prior, dict):
+        prior_history = prior.get("route_history")
+        if isinstance(prior_history, list):
+            route_history = [item for item in prior_history if isinstance(item, str)]
+        prior_route = prior.get("selected_route")
+        if isinstance(prior_route, str) and prior_route:
+            route_history.append(prior_route)
+
+    executed = not dry_run
+    chain_status = "in_progress" if executed else "recommended_only"
+
+    artifact: dict[str, object] = {
+        "schema_version": "1.0",
+        "task_summary": _sanitize_for_json(task),
+        "selected_route": selected_route,
+        "evidence": _auto_route_evidence_for_artifact(raw_evidence),
+        "blocked_by": [],
+        "next_command": next_command,
+        "executed": executed,
+        "chain_status": chain_status,
+        "phases": [],
+        "route_history": route_history,
+    }
+    _write_json_file(artifact_path, artifact)
+
+    manifest = load_artifact_manifest(branch_name)
+    _set_manifest_stage(
+        manifest,
+        "auto_route",
+        "recommended" if dry_run else "in_progress",
+        artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+        metadata={
+            "selected_route": selected_route,
+            "chain_status": chain_status,
+        },
+    )
+    save_artifact_manifest(manifest, branch_name)
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "path": str(artifact_path),
+        "selected_route": selected_route,
+        "chain_status": chain_status,
+        "next_command": next_command,
+        "executed": executed,
+    }
+
+
 def record_scope_baseline(branch: str) -> dict:
     """Snapshot the current uncommitted / untracked file set as a baseline
     that validate_mutation_boundary will subtract from `actual` on future
@@ -22008,6 +22124,25 @@ if __name__ == "__main__":
             branch=_rvl_flag("branch") or None,
         )
         print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "route_task" and len(sys.argv) >= 3:
+        # CLI: route_task <task> [--branch B] [--dry-run]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py route_task")
+        _p.add_argument("task", help="Task description text to route")
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _p.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="Recommend a route without marking the chain in_progress",
+        )
+        _a = _p.parse_args(sys.argv[2:])
+        _r = route_task(_a.task, branch=_a.branch, dry_run=_a.dry_run)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
 
     else:
         # Helpful redirect: when the user passes a command that belongs to

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -4856,18 +4856,16 @@ _DONE_PHASE_STATUSES_FOR_COMPLETION = {
 }
 
 
-def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
-    """Return True iff every subtask in subtask_sequence has a "done"-class
-    signal recorded (subtask_results entry OR subtask_phases marker).
+def _done_class_subtask_ids(state: dict[str, object]) -> set[str]:
+    """Return subtask ids with a "done"-class signal recorded in step_state.json
+    (a subtask_results entry OR a subtask_phases done-class marker).
 
-    Mirrors the orchestrator's _completed_subtask_ids_for_deps logic. Used
-    by _derive_terminal_status so a stuck cursor (ST-033 friction) no
-    longer makes write_run_health_report report ``pending`` when 51/51
-    entries actually exist.
+    Shared canonical-completion primitive: used by
+    _state_subtask_coverage_complete below (global "is the whole run done"
+    check) AND by the /map-auto tier 1 routing signal (per-subtask
+    pending/complete split) so both read the identical done-class
+    definition instead of two definitions that could silently drift apart.
     """
-    sequence_value = state.get("subtask_sequence")
-    if not isinstance(sequence_value, list) or not sequence_value:
-        return False
     results_value = state.get("subtask_results")
     results = results_value if isinstance(results_value, dict) else {}
     phases_value = state.get("subtask_phases")
@@ -4882,6 +4880,22 @@ def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
     for sid, phase in phases.items():
         if isinstance(sid, str) and isinstance(phase, str) and phase.lower() in _DONE_PHASE_STATUSES_FOR_COMPLETION:
             completed.add(sid)
+    return completed
+
+
+def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
+    """Return True iff every subtask in subtask_sequence has a "done"-class
+    signal recorded (subtask_results entry OR subtask_phases marker).
+
+    Mirrors the orchestrator's _completed_subtask_ids_for_deps logic. Used
+    by _derive_terminal_status so a stuck cursor (ST-033 friction) no
+    longer makes write_run_health_report report ``pending`` when 51/51
+    entries actually exist.
+    """
+    sequence_value = state.get("subtask_sequence")
+    if not isinstance(sequence_value, list) or not sequence_value:
+        return False
+    completed = _done_class_subtask_ids(state)
     return all(isinstance(sid, str) and sid in completed for sid in sequence_value)
 
 
@@ -14405,6 +14419,258 @@ def check_plan_resume(request: str = "", branch: str | None = None) -> dict:
         },
         "recommendation": recommendation,
     }
+
+
+# /map-auto routing (issue #414): the recommended workflow values a route
+# selector may pick automatically. Values outside this set (direct-edit,
+# map-tdd, map-wayfind) require a human decision and must fall through to a
+# lower-precedence signal instead of being auto-selected.
+_AUTO_ROUTE_TIER2_ALLOWED = frozenset({"map-fast", "map-plan", "map-efficient"})
+
+
+def _blueprint_subtask_ids(blueprint: dict | None) -> set[str]:
+    """Return the set of subtask ids declared in a loaded blueprint.json payload."""
+    if not isinstance(blueprint, dict):
+        return set()
+    subtasks = blueprint.get("subtasks")
+    if not isinstance(subtasks, list):
+        return set()
+    return {
+        subtask["id"]
+        for subtask in subtasks
+        if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
+    }
+
+
+def _tier1_completed_subtask_ids(state: dict[str, object]) -> tuple[set[str], bool]:
+    """Return (completed subtask ids, used_legacy_fallback) for tier 1 routing.
+
+    Prefers the canonical done-class signal (_done_class_subtask_ids, shared
+    with _state_subtask_coverage_complete): a subtask_results status or a
+    subtask_phases marker in the done class. Falls back to legacy
+    completed_steps KEY PRESENCE only when NEITHER canonical field exists in
+    state at all. Key presence alone is not a safe completion signal even in
+    the fallback case's absence check -- update_step_state (the classic,
+    pre-orchestrator writer) inserts a completed_steps[subtask_id] key at
+    the FIRST recorded phase, so "key exists" means "started", not "done".
+    The canonical fields are preferred specifically so a subtask with only
+    an in-progress phase recorded is never misread as complete.
+    """
+    canonical_present = "subtask_results" in state or "subtask_phases" in state
+    if canonical_present:
+        return _done_class_subtask_ids(state), False
+    completed_steps = state.get("completed_steps")
+    if isinstance(completed_steps, dict):
+        return {key for key in completed_steps if isinstance(key, str)}, True
+    return set(), True
+
+
+def _classify_scope_bracket(estimated_files: int, estimated_lines: int) -> str | None:
+    """Call classify_scope.classify() in-process for the auto-route scope tier.
+
+    classify_scope.py ships alongside this script in every generated tree but
+    is not an importable package member, so it is loaded by file location
+    (mirrors the existing lazy schemas-module import pattern in this file)
+    rather than imported at module scope or shelled out to as a subprocess.
+    """
+    try:
+        import importlib.util as _importlib_util
+
+        script_path = Path(__file__).resolve().parent / "classify_scope.py"
+        spec = _importlib_util.spec_from_file_location("classify_scope", script_path)
+        if spec is None or spec.loader is None:
+            return None
+        module = _importlib_util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except (ImportError, OSError):
+        return None
+
+    classify_fn = getattr(module, "classify", None)
+    if not callable(classify_fn):
+        return None
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    result = classify_fn(estimated_files, estimated_lines, project_dir)
+    bracket = result.get("bracket") if isinstance(result, dict) else None
+    return bracket if isinstance(bracket, str) else None
+
+
+def _select_route(
+    branch: str | None,
+    task_text: str,
+    *,
+    estimated_files: int | None = None,
+    estimated_lines: int | None = None,
+) -> tuple[str, list[dict[str, object]]]:
+    """Pure five-tier routing precedence engine for /map-auto (issue #414).
+
+    Reads exactly five existing signals -- step_state.json, workflow-fit.json,
+    check_plan_resume(), a direct blueprint.json stat, and
+    classify_scope.classify() -- and returns the route picked by the
+    highest-precedence signal that fires, plus an evidence trail of every
+    signal consulted (including signals that lost or were absent). Never
+    inspects ``task_text`` itself for keywords; the only tier that reads its
+    content is check_plan_resume() (tier 3), which is one of the five
+    allowed signals. This function only selects a route -- it writes nothing
+    and creates no CLI surface.
+
+    Tiers, in strict precedence order:
+      1. step_state.json exists: pending subtasks (blueprint ids minus the
+         canonical done-class subtask ids) -> map-resume; all complete ->
+         map-check. When blueprint.json is missing/unparseable/empty, the
+         pending set cannot be computed at all -- this fails CLOSED to
+         map-resume (never asserts completion without evidence) rather than
+         guessing.
+      2. workflow-fit.json recommended_workflow, restricted to
+         {map-fast, map-plan, map-efficient} -- any other recorded value
+         (e.g. direct-edit) is recorded in evidence and falls through.
+      3. check_plan_resume(task_text) verdict "resume" (only reachable once
+         step_state.json is confirmed absent): task_plan artifact present
+         AND a direct blueprint.json stat succeeds -> map-efficient;
+         otherwise -> map-plan. A goal_mismatch or no_plan verdict is only
+         surfaced in evidence here -- blocking on it is not this function's
+         responsibility. NOTE: this is the one SANCTIONED exception to
+         "task_text never influences the route" -- check_plan_resume is one
+         of the five allowed signals, and its goal-overlap comparison is
+         supposed to vary with task_text content. That is intentional
+         signal-reading, not the ad-hoc keyword routing this function
+         otherwise forbids (see the invariance test docstrings below).
+      4. classify_scope.classify() bracket "trivial" -> map-fast, only when
+         the caller supplied non-negative estimated_files/estimated_lines;
+         otherwise the tier is recorded as unavailable and skipped rather
+         than guessed.
+      5. Default: map-plan.
+    """
+    branch_name = branch or get_branch_name()
+    branch_dir = get_branch_dir(branch_name)
+    evidence: list[dict[str, object]] = []
+
+    # Tier 1 signal: step_state.json. Always read up front (even when a
+    # later tier would otherwise win) so a conflicting workflow-fit.json
+    # recommendation is still captured in evidence per the losing-signal
+    # requirement below.
+    step_state_path = branch_dir / "step_state.json"
+    state = _read_json_file(step_state_path)
+    step_state_route: str | None = None
+    if state is not None:
+        blueprint = load_blueprint(branch_name)
+        subtask_ids = _blueprint_subtask_ids(blueprint)
+        if not subtask_ids:
+            # Fail closed: with no subtask id universe from blueprint.json,
+            # "pending minus completed" cannot be computed at all. Asserting
+            # "complete" here would be an unevidenced guess, so route back
+            # to resuming the plan instead.
+            step_state_route = "map-resume"
+            evidence.append({
+                "signal": "step_state.json",
+                "value": "blueprint_unavailable",
+                "source": str(step_state_path),
+            })
+        else:
+            completed_ids, used_legacy_fallback = _tier1_completed_subtask_ids(state)
+            pending_ids = subtask_ids - completed_ids
+            completion_source = (
+                "legacy_completed_steps" if used_legacy_fallback else "canonical_done_class"
+            )
+            if pending_ids:
+                step_state_route = "map-resume"
+                evidence.append({
+                    "signal": "step_state.json",
+                    "value": {
+                        "status": "pending",
+                        "pending_subtask_ids": sorted(pending_ids),
+                        "completion_source": completion_source,
+                    },
+                    "source": str(step_state_path),
+                })
+            else:
+                step_state_route = "map-check"
+                evidence.append({
+                    "signal": "step_state.json",
+                    "value": {
+                        "status": "complete",
+                        "subtask_count": len(subtask_ids),
+                        "completion_source": completion_source,
+                    },
+                    "source": str(step_state_path),
+                })
+    else:
+        evidence.append({
+            "signal": "step_state.json",
+            "value": {"status": "absent"},
+            "source": str(step_state_path),
+        })
+
+    # Tier 2 signal: workflow-fit.json. Also always read up front for the
+    # same losing-signal reason as tier 1.
+    workflow_fit_path = branch_dir / "workflow-fit.json"
+    fit_payload = _read_json_file(workflow_fit_path)
+    recommended: str | None = None
+    if fit_payload is not None:
+        raw_recommended = fit_payload.get("recommended_workflow")
+        recommended = raw_recommended if isinstance(raw_recommended, str) else None
+    evidence.append({
+        "signal": "workflow-fit.json",
+        "value": recommended,
+        "source": str(workflow_fit_path),
+    })
+
+    if step_state_route is not None:
+        return step_state_route, evidence
+
+    if recommended is not None and recommended in _AUTO_ROUTE_TIER2_ALLOWED:
+        return recommended, evidence
+
+    # Tier 3 signals: check_plan_resume() verdict, plus a direct
+    # blueprint.json stat (check_plan_resume's own artifacts dict has no
+    # blueprint key). check_plan_resume is allowed to read task_text -- see
+    # the sanctioned-exception note in the docstring above.
+    resume_report = check_plan_resume(task_text, branch=branch_name)
+    verdict = resume_report.get("verdict")
+    evidence.append({
+        "signal": "check_plan_resume",
+        "value": verdict,
+        "source": "check_plan_resume()",
+    })
+    if verdict == "resume":
+        artifacts = resume_report.get("artifacts")
+        has_task_plan = bool(isinstance(artifacts, dict) and artifacts.get("task_plan"))
+        blueprint_path = branch_dir / "blueprint.json"
+        has_blueprint = blueprint_path.exists()
+        evidence.append({
+            "signal": "blueprint.json",
+            "value": has_blueprint,
+            "source": str(blueprint_path),
+        })
+        return ("map-efficient" if (has_task_plan and has_blueprint) else "map-plan"), evidence
+
+    # Tier 4 signal: classify_scope.classify() bracket. Only fires when the
+    # caller supplied a real scope estimate -- there is no sixth signal in
+    # this function's allowed set (e.g. a git diff stat) that could derive
+    # estimated_files/estimated_lines on its own, so an absent estimate is
+    # recorded and the tier is skipped rather than guessed.
+    if (
+        estimated_files is not None
+        and estimated_lines is not None
+        and estimated_files >= 0
+        and estimated_lines >= 0
+    ):
+        bracket = _classify_scope_bracket(estimated_files, estimated_lines)
+        evidence.append({
+            "signal": "classify_scope.classify",
+            "value": {"estimated": True, "bracket": bracket},
+            "source": "classify_scope.classify()",
+        })
+        if bracket == "trivial":
+            return "map-fast", evidence
+    else:
+        evidence.append({
+            "signal": "classify_scope.classify",
+            "value": {"estimated": False},
+            "source": "classify_scope.classify()",
+        })
+
+    # Tier 5: default.
+    return "map-plan", evidence
 
 
 def record_scope_baseline(branch: str) -> dict:

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -242,6 +242,7 @@ ARTIFACT_STAGE_NAMES = (
     "workflow_fit",
     "spec",
     "plan",
+    "auto_route",
     "test_contract",
     "repro_probe",
     "implementation",

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -465,13 +465,13 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
-# /map-auto (issue #414, ): hold kinds that hard-stop autonomous
+# /map-auto (issue #414): hold kinds that hard-stop autonomous
 # routing outright -- route_task blocks the chain rather than proceeding
-# when either is pending. defines the complementary
-# AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
+# when either is pending. The complementary AUTO_APPROVABLE_HOLD_KINDS
+# set is defined immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
-# /map-auto (issue #414, ): hold kinds auto_decide_holds may decide
+# /map-auto (issue #414): hold kinds auto_decide_holds may decide
 # without a human -- workflow-control gates, never safety gates. Together
 # with HARD_STOP_HOLD_KINDS these must exactly partition
 # APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
@@ -14699,7 +14699,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
-# /map-auto phase ledger (issue #414, ): closed status vocabulary for
+# /map-auto phase ledger (issue #414): closed status vocabulary for
 # record_auto_phase's chain_status transitions. A phase status in
 # AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
 # AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
@@ -14709,9 +14709,9 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
 AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
 AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
 
-# at most ONE re-entry per phase -- attempt 1 (first record) plus
-# attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
-# same phase name is refused by record_auto_phase.
+# Chain-level retry bound: at most ONE re-entry per phase -- attempt 1
+# (first record) plus attempt 2 (the single permitted re-entry) are allowed;
+# a 3rd record of the same phase name is refused by record_auto_phase.
 AUTO_PHASE_MAX_ATTEMPTS = 2
 
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -14699,6 +14699,21 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
+# /map-auto phase ledger (issue #414, ST-007): closed status vocabulary for
+# record_auto_phase's chain_status transitions. A phase status in
+# AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
+# AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
+# in_progress. These two sets are intentionally NOT required to partition
+# every possible status string -- callers may pass phase-specific statuses
+# (e.g. "monitor_rejected") that fall through to in_progress.
+AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
+AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
+
+# HC-2: at most ONE re-entry per phase -- attempt 1 (first record) plus
+# attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
+# same phase name is refused by record_auto_phase.
+AUTO_PHASE_MAX_ATTEMPTS = 2
+
 
 def auto_route_artifact_path(branch: str | None = None) -> Path:
     """Return the branch-scoped /map-auto routing decision artifact path."""
@@ -14880,6 +14895,181 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
+    }
+
+
+def record_auto_phase(
+    phase: str,
+    status: str,
+    branch: str | None = None,
+    evidence_refs: list[str] | None = None,
+    reason: str = "",
+) -> dict[str, object]:
+    """Append one entry to auto-route.json's phase ledger (issue #414, ST-007).
+
+    record_auto_phase is the ONLY function that mutates `phases[]` --
+    route_task always initializes it empty and never appends (Decision 11
+    single-writer invariant). Requires an existing auto-route.json (written
+    by route_task); returns status="error" if none is found.
+
+    `attempt` mechanizes HC-2's at-most-one-re-entry bound: it is
+    ``1 + count of prior phases[] entries with the SAME phase name``. A
+    first call for a phase records attempt=1; a re-entry records attempt=2.
+    A THIRD call for the same phase is refused outright -- no entry is
+    appended for that call. Instead the chain is force-aborted: chain_status
+    is set to "aborted" and the abort reason is persisted in the top-level
+    `abort_reason` field (mirroring route_task's `block_reason` field for
+    the "blocked" chain_status -- one field, schema-valid via the schema's
+    `additionalProperties: true`, so the operator sees WHY directly in
+    auto-route.json without needing to scan phases[] for a synthetic entry).
+
+    On every non-refused call, chain_status transitions from the recorded
+    `status` using a closed vocabulary (AUTO_PHASE_TERMINAL_SUCCESS_STATUSES
+    -> "completed", AUTO_PHASE_ABORT_STATUSES -> "aborted", otherwise
+    "in_progress") and the `abort_reason` field is set/cleared to match. The
+    `auto_route` manifest stage is refreshed on every call (refused or not)
+    so progress is observable outside the artifact, with its status
+    mirroring the resulting chain_status.
+
+    `evidence_refs` persists caller-supplied ids (e.g. hold ids
+    auto-approved by `auto_decide_holds`) in the phase entry, giving every
+    auto-approval a second durable recording site alongside the hold's own
+    audit note (INV-4).
+
+    HC-2 fail-closed guard (code review 2): once chain_status is "aborted"
+    (3rd-attempt refusal above) or "blocked" (route_task hard-stop hold),
+    the chain must stay terminal until an explicit NEW route_task call --
+    route_task's own overwrite policy is the only legitimate way out of
+    "aborted"/"blocked". A call naming a DIFFERENT phase must never act as a
+    side door that resurrects the chain by appending a fresh entry and
+    flipping chain_status back to in_progress/completed. This guard runs
+    BEFORE the attempt-counter logic (which only protects the SAME phase
+    name) and mutates nothing on the terminal-state path: no phases[]
+    append, no chain_status change, no abort_reason/block_reason pop, no
+    manifest write.
+    """
+    branch_name = branch or get_branch_name()
+    artifact_path = auto_route_artifact_path(branch_name)
+    artifact = _read_json_file(artifact_path)
+    if artifact is None:
+        return {
+            "status": "error",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "reason": (
+                f"no auto-route.json found for branch '{branch_name}'; "
+                "run route_task first"
+            ),
+        }
+
+    terminal_chain_status = artifact.get("chain_status")
+    if terminal_chain_status in {"aborted", "blocked"}:
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "phase": phase,
+            "chain_status": terminal_chain_status,
+            "reason": (
+                f"branch '{branch_name}' auto-route chain is already "
+                f"'{terminal_chain_status}'; record_auto_phase refuses to "
+                "mutate a terminal chain -- call route_task to re-route "
+                "explicitly."
+            ),
+            "abort_reason": artifact.get("abort_reason"),
+            "block_reason": artifact.get("block_reason"),
+        }
+
+    raw_phases = artifact.get("phases")
+    phases = [entry for entry in raw_phases if isinstance(entry, dict)] if isinstance(
+        raw_phases, list
+    ) else []
+    prior_attempts = sum(1 for entry in phases if entry.get("phase") == phase)
+    attempt = prior_attempts + 1
+
+    manifest = load_artifact_manifest(branch_name)
+
+    if attempt > AUTO_PHASE_MAX_ATTEMPTS:
+        # HC-2 refusal: do not append an entry for this call -- force-abort
+        # the chain instead, with the reason visible at the top level.
+        abort_reason = (
+            f"phase '{phase}' refused at attempt {attempt} (max "
+            f"{AUTO_PHASE_MAX_ATTEMPTS} attempts per HC-2); forcing "
+            "chain_status=aborted."
+        )
+        if reason:
+            abort_reason += f" caller reason: {reason}"
+        abort_reason = _sanitize_for_json(abort_reason)
+
+        artifact["chain_status"] = "aborted"
+        artifact["abort_reason"] = abort_reason
+        _write_json_file(artifact_path, artifact)
+
+        _set_manifest_stage(
+            manifest,
+            "auto_route",
+            "aborted",
+            artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+            metadata={
+                "chain_status": "aborted",
+                "aborted_phase": phase,
+                "attempt": attempt,
+            },
+        )
+        save_artifact_manifest(manifest, branch_name)
+
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "phase": phase,
+            "attempt": attempt,
+            "chain_status": "aborted",
+            "abort_reason": abort_reason,
+        }
+
+    entry: dict[str, object] = {
+        "phase": phase,
+        "status": status,
+        "attempt": attempt,
+        "evidence_refs": list(evidence_refs or []),
+        "reason": _sanitize_for_json(reason),
+        "recorded_at": _utc_timestamp(),
+    }
+    phases.append(entry)
+    artifact["phases"] = phases
+
+    if status in AUTO_PHASE_TERMINAL_SUCCESS_STATUSES:
+        chain_status = "completed"
+    elif status in AUTO_PHASE_ABORT_STATUSES:
+        chain_status = "aborted"
+    else:
+        chain_status = "in_progress"
+    artifact["chain_status"] = chain_status
+    if chain_status == "aborted":
+        artifact["abort_reason"] = _sanitize_for_json(
+            reason or f"phase '{phase}' reported status '{status}'"
+        )
+    else:
+        artifact.pop("abort_reason", None)
+    _write_json_file(artifact_path, artifact)
+
+    _set_manifest_stage(
+        manifest,
+        "auto_route",
+        chain_status,
+        artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+        metadata={"chain_status": chain_status, "phase": phase, "attempt": attempt},
+    )
+    save_artifact_manifest(manifest, branch_name)
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "path": str(artifact_path),
+        "phase": phase,
+        "attempt": attempt,
+        "chain_status": chain_status,
     }
 
 
@@ -22300,6 +22490,35 @@ if __name__ == "__main__":
         )
         _a = _p.parse_args(sys.argv[2:])
         _r = route_task(_a.task, branch=_a.branch, dry_run=_a.dry_run)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
+
+    elif func_name == "record_auto_phase" and len(sys.argv) >= 4:
+        # CLI: record_auto_phase <phase> <status> [--branch B]
+        #        [--evidence-refs a,b,c] [--reason "..."]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py record_auto_phase")
+        _p.add_argument("phase", help="Phase name to record (e.g. map-plan, map-efficient)")
+        _p.add_argument(
+            "status", help="Phase status (e.g. completed, in_progress, failed, aborted)"
+        )
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _p.add_argument(
+            "--evidence-refs",
+            default="",
+            dest="evidence_refs",
+            help="Comma-separated evidence ids (e.g. auto-approved hold ids)",
+        )
+        _p.add_argument(
+            "--reason", default="", help="Reason recorded alongside the phase entry"
+        )
+        _a = _p.parse_args(sys.argv[2:])
+        _refs = [ref.strip() for ref in _a.evidence_refs.split(",") if ref.strip()]
+        _r = record_auto_phase(
+            _a.phase, _a.status, branch=_a.branch, evidence_refs=_refs, reason=_a.reason
+        )
         print(json.dumps(_r, indent=2))
         if _r.get("status") == "error":
             sys.exit(1)

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -471,6 +471,16 @@ APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATE
 # AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
+# /map-auto (issue #414, ST-006): hold kinds auto_decide_holds may decide
+# without a human -- workflow-control gates, never safety gates. Together
+# with HARD_STOP_HOLD_KINDS these must exactly partition
+# APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
+# kind hard-fails a test instead of being silently auto-approved by
+# omission.
+AUTO_APPROVABLE_HOLD_KINDS = frozenset(
+    {"autonomy_posture", "plan_approval", "template_overwrite"}
+)
+
 # Truncation infrastructure deleted by user directive ("убери транкейт уже
 # вообще"). build_context_block / _budget_review_prompt now emit raw text;
 # operators handle context size via /compact opt-in. The mapify_cli
@@ -17754,6 +17764,60 @@ def get_pending_holds(branch: str | None = None) -> dict[str, Any]:
     }
 
 
+def auto_decide_holds(branch: str | None = None) -> dict[str, Any]:
+    """Split pending approval holds into auto-approved and hard-stopped (#414).
+
+    Reads pending holds via `get_pending_holds` and, for each one, decides
+    solely on AUTO_APPROVABLE_HOLD_KINDS membership -- a positive allowlist,
+    never an exclusion of HARD_STOP_HOLD_KINDS. `decide_approval_hold` is
+    therefore only ever reachable from the branch guarded by that allowlist
+    check, so no code path here can transition a dangerous_action or
+    safety_guardrail hold (INV-2), even if hard-stop membership itself were
+    ever misconfigured.
+
+    - Holds whose kind is in AUTO_APPROVABLE_HOLD_KINDS are decided
+      "approved" via the existing `decide_approval_hold(hold_id, "approved",
+      "auto-approved by map-auto", branch)` and collected into
+      `auto_approved[]`.
+    - Holds whose kind is in HARD_STOP_HOLD_KINDS are left untouched
+      (still `pending`) and collected into `hard_stops[]`.
+    """
+    branch_name = branch or get_branch_name()
+    pending = get_pending_holds(branch_name)
+    auto_approved: list[dict[str, str]] = []
+    hard_stops: list[dict[str, str]] = []
+
+    for hold in cast(list[Any], pending.get("holds", [])):
+        if not isinstance(hold, dict):
+            continue
+        hold_id = str(hold.get("id", ""))
+        kind = str(hold.get("kind", ""))
+        if kind in AUTO_APPROVABLE_HOLD_KINDS:
+            decide_approval_hold(hold_id, "approved", "auto-approved by map-auto", branch_name)
+            auto_approved.append(
+                {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+            )
+        elif kind in HARD_STOP_HOLD_KINDS:
+            hard_stops.append(
+                {
+                    "id": hold_id,
+                    "kind": kind,
+                    "reason": "hard-stop hold kind; requires an explicit human decision",
+                }
+            )
+        # Any other kind is left pending and reported in neither bucket --
+        # unreachable while AUTO_APPROVABLE_HOLD_KINDS | HARD_STOP_HOLD_KINDS
+        # == APPROVAL_HOLD_KINDS holds, but fails closed if that invariant
+        # is ever violated.
+
+    return {
+        "status": "ok",
+        "branch": branch_name,
+        "auto_approved": auto_approved,
+        "hard_stops": hard_stops,
+    }
+
+
 # --- Per-subtask git worktree isolation (#284) ---------------------------------
 # Runner-owned explicit worktrees (NOT the harness-native isolation="worktree").
 # llm-council-reviewed design (conv 461b92f9):
@@ -22094,6 +22158,18 @@ if __name__ == "__main__":
         _a = _p.parse_args(sys.argv[2:])
         _r = get_pending_holds(_a.branch)
         print(json.dumps(_r, indent=2))
+
+    elif func_name == "auto_decide_holds":
+        # CLI: auto_decide_holds [--branch B]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py auto_decide_holds")
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _a = _p.parse_args(sys.argv[2:])
+        _r = auto_decide_holds(_a.branch)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
 
     elif func_name == "write_implementer_readiness_review" and len(sys.argv) >= 3:
         # CLI: write_implementer_readiness_review <verdict>

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -465,13 +465,13 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
-# /map-auto (issue #414, ST-005): hold kinds that hard-stop autonomous
+# /map-auto (issue #414, ): hold kinds that hard-stop autonomous
 # routing outright -- route_task blocks the chain rather than proceeding
-# when either is pending. ST-006 defines the complementary
+# when either is pending. defines the complementary
 # AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
-# /map-auto (issue #414, ST-006): hold kinds auto_decide_holds may decide
+# /map-auto (issue #414, ): hold kinds auto_decide_holds may decide
 # without a human -- workflow-control gates, never safety gates. Together
 # with HARD_STOP_HOLD_KINDS these must exactly partition
 # APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
@@ -14699,7 +14699,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
-# /map-auto phase ledger (issue #414, ST-007): closed status vocabulary for
+# /map-auto phase ledger (issue #414, ): closed status vocabulary for
 # record_auto_phase's chain_status transitions. A phase status in
 # AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
 # AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
@@ -14709,7 +14709,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
 AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
 AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
 
-# HC-2: at most ONE re-entry per phase -- attempt 1 (first record) plus
+# at most ONE re-entry per phase -- attempt 1 (first record) plus
 # attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
 # same phase name is refused by record_auto_phase.
 AUTO_PHASE_MAX_ATTEMPTS = 2
@@ -14990,7 +14990,7 @@ def record_auto_phase(
     manifest = load_artifact_manifest(branch_name)
 
     if attempt > AUTO_PHASE_MAX_ATTEMPTS:
-        # HC-2 refusal: do not append an entry for this call -- force-abort
+        # refusal: do not append an entry for this call -- force-abort
         # the chain instead, with the reason visible at the top level.
         abort_reason = (
             f"phase '{phase}' refused at attempt {attempt} (max "

--- a/src/mapify_cli/templates/skills/map-auto/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-auto/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: map-auto
+description: |
+  Single-entry autonomous autopilot: routes a task through the existing MAP workflows via `route_task`, then drives the selected chain (map-plan -> map-efficient -> map-check -> map-review, as routed) end-to-end to a committed feature branch in one session, auto-approving routine workflow-control holds and hard-stopping on dangerous_action/safety_guardrail holds. Use when you want the whole pipeline to run unattended from a single task description, without babysitting phase-by-phase invocation. Do NOT use when you want to review or edit the plan before execution (run /map-plan then /map-efficient yourself instead), when the task is trivial (use /map-fast directly), or when you need a PR opened or merged -- the autopilot always stops at a committed branch and never creates or merges a PR.
+disable-model-invocation: true
+argument-hint: "[task description]"
+effort: high
+---
+# /map-auto — Single-Entry Autonomous Autopilot
+
+Purpose: run `/map-auto <task>` once and let it route the task through the existing MAP workflows, then drive the selected chain end-to-end to a committed feature branch in the same session, without per-phase babysitting. `/map-auto` runs autonomously by default the moment it is invoked -- there is no shadow mode, no calibration period, and no opt-in flag to turn this behavior on.
+
+Contrast with `/map-plan` and `/map-efficient`: those workflows expect you to drive each phase yourself. `/map-auto` is a thin router plus chain driver on top of them -- it never reimplements their logic, it only decides which one(s) to run and calls them unmodified, one after another, in the same session.
+
+## Effort and Parallelism Policy
+
+```yaml
+thinking_policy: high/adaptive
+parallel_tool_policy: sequential_by_default
+```
+
+- Use deeper reasoning for the routing decision and for judging whether a phase genuinely failed (worth a bounded re-entry) or is truly stuck (worth aborting to `/map-resume`) -- a wrong call here compounds across an entire unattended chain.
+- Keep routing, hold-decision, phase-record, and phase-invocation calls strictly sequential; a chain driver has no independent work to parallelize across phases.
+- Within a chained phase (e.g. `/map-efficient`), defer to that phase's own parallelism policy -- `/map-auto` does not override it.
+
+## Determinism boundary
+
+All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through the three runner subcommands below: `route_task` (routing decision), `auto_decide_holds` (approval-hold triage), and `record_auto_phase` (phase ledger). Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
+
+## Step 1: Route the Task
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS"
+```
+
+To inspect the recommendation without committing to it (no write beyond the routing artifact itself, no phase started):
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS" --dry-run
+```
+
+`route_task` writes `.map/<branch>/auto-route.json` (schema-validated) and selects exactly one of `map-resume`, `map-check`, `map-fast`, `map-plan`, `map-efficient` via a five-tier precedence engine you do not need to re-derive -- read `selected_route` and `next_command` from the result and act on those fields.
+
+- `status: "refused"` -- an in-progress chain already exists for this branch; follow the returned `next_command` (`/map-resume`) instead of re-routing.
+- `status: "blocked"` -- a hard-stop hold or a `goal_mismatch` verdict blocks the chain; `blocked_by[]` names the pending hold ids, `block_reason` explains why. STOP -- see Hard Stops below.
+- `status: "success"` -- `chain_status` is `"in_progress"` (normal run) or `"recommended_only"` (`--dry-run`); proceed to Step 2 for the selected route.
+
+## Step 2: Decide Holds Before Each Chained Phase
+
+Before invoking each chained workflow, drain auto-approvable holds so the chain does not sit blocked on routine posture/approval/overwrite confirmations:
+
+```bash
+python3 .map/scripts/map_step_runner.py auto_decide_holds
+```
+
+`auto_decide_holds` approves every pending `autonomy_posture`, `plan_approval`, and `template_overwrite` hold on your behalf and returns them in `auto_approved[]`. Any pending `dangerous_action` or `safety_guardrail` hold is returned in `hard_stops[]` and is left untouched -- these two kinds are never auto-decided by any code path this skill invokes.
+
+### Hard Stops (dangerous_action / safety_guardrail)
+
+If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or `auto_decide_holds` returns a non-empty `hard_stops[]`, STOP the autopilot immediately. Surface the hold's reason to the user and wait for an explicit human decision on that hold before resuming (`/map-resume` once it is decided). Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase.
+
+## Step 3: Record Each Phase Boundary
+
+Record every phase transition so `auto-route.json` stays the single source of truth for chain progress:
+
+```bash
+python3 .map/scripts/map_step_runner.py record_auto_phase "<phase>" "<status>" \
+  --evidence-refs "<comma-separated auto-approved hold ids>" \
+  --reason "<why this status>"
+```
+
+`<phase>` is the workflow name being entered/exited (`map-plan`, `map-efficient`, `map-check`, or `map-review`). `<status>` follows the phase's own vocabulary -- use `completed` on a clean phase close and `aborted`/`failed` on a phase you cannot recover; anything else leaves the chain `in_progress`. Pass every hold id that `auto_decide_holds` auto-approved for this phase in `--evidence-refs`, so the approval is recorded twice: once in the hold's own audit note, once in the phase ledger.
+
+**At most one re-entry per phase:** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Inspect ground truth (the phase's own artifacts, test output, Monitor verdict) before spending the single permitted re-entry. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase.
+
+## Chain
+
+Once routed, drive the selected chain by invoking the existing slash workflows exactly as written, one after another in the same session:
+
+```
+route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]
+```
+
+- `map-resume`, `map-check`, and `map-fast` routes are single-phase: run the one workflow, record its result with `record_auto_phase`, and finish.
+- `map-plan` and `map-efficient` routes continue the chain: `map-plan` produces the task plan that `map-efficient` consumes, `map-efficient` implements it, and the chain then continues to `map-check` and `map-review` to close the loop.
+- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps.
+- A `valid=false` Monitor verdict INSIDE a phase is that phase's own hard stop: its owning workflow's existing retry/escalation rules apply unchanged. `/map-auto` never overrides, suppresses, or re-runs past a Monitor rejection on the phase's behalf -- a phase that cannot get past Monitor is a failed phase for the purposes of Step 3's re-entry bound.
+- The autopilot run ends at a committed feature branch. `/map-auto` never opens a pull request, never merges, and never polls CI -- report the committed branch, the phases recorded, and stop.
+
+## Examples
+
+```
+/map-auto add a --verbose flag to the status command
+/map-auto refactor the checkout flow to support partial refunds
+```
+
+## Troubleshooting
+
+- **Issue:** `route_task` returns `status: "refused"`. **Fix:** A chain is already `in_progress` on this branch; run `/map-resume` instead of re-routing.
+- **Issue:** `route_task` or `auto_decide_holds` reports a pending `dangerous_action`/`safety_guardrail` hold. **Fix:** This is a hard stop by design -- surface the reason and wait for an explicit human decision; do not attempt to auto-approve it.
+- **Issue:** `record_auto_phase` returns `status: "refused"` with `chain_status: "aborted"` or `"blocked"`. **Fix:** The chain is terminal; only a new `route_task` call can re-route it explicitly.
+- **Issue:** A chained phase (e.g. `/map-efficient`) fails Monitor repeatedly. **Fix:** Let that phase's own retry/escalation rules run their course; record the outcome via `record_auto_phase` and stop after the single permitted re-entry rather than forcing a third attempt.

--- a/src/mapify_cli/templates/skills/map-auto/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-auto/SKILL.md
@@ -25,7 +25,7 @@ parallel_tool_policy: sequential_by_default
 
 ## Determinism boundary
 
-All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through the three runner subcommands below: `route_task` (routing decision), `auto_decide_holds` (approval-hold triage), and `record_auto_phase` (phase ledger). Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
+All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through two runner subcommands below: `route_task` (routing decision) and `record_auto_phase` (phase ledger). `auto_decide_holds` (approval-hold triage) mutates `approval_holds.json` separately — its approvals surface in the `approval_hold` manifest stage, not in `auto-route.json`. Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
 
 ## Step 1: Route the Task
 

--- a/src/mapify_cli/templates/skills/map-auto/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-auto/SKILL.md
@@ -45,9 +45,9 @@ python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS" --dry-run
 - `status: "blocked"` -- a hard-stop hold or a `goal_mismatch` verdict blocks the chain; `blocked_by[]` names the pending hold ids, `block_reason` explains why. STOP -- see Hard Stops below.
 - `status: "success"` -- `chain_status` is `"in_progress"` (normal run) or `"recommended_only"` (`--dry-run`); proceed to Step 2 for the selected route.
 
-## Step 2: Decide Holds Before Each Chained Phase
+## Step 2: Decide Holds Around Each Chained Phase
 
-Before invoking each chained workflow, drain auto-approvable holds so the chain does not sit blocked on routine posture/approval/overwrite confirmations:
+Poll `auto_decide_holds` before invoking each chained workflow AND again immediately after it concludes, before recording its outcome in Step 3 -- the second poll catches a hold that was created while the phase was running instead of leaving it for a later, unscheduled check:
 
 ```bash
 python3 .map/scripts/map_step_runner.py auto_decide_holds
@@ -57,7 +57,7 @@ python3 .map/scripts/map_step_runner.py auto_decide_holds
 
 ### Hard Stops (dangerous_action / safety_guardrail)
 
-If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or `auto_decide_holds` returns a non-empty `hard_stops[]`, STOP the autopilot immediately. Surface the hold's reason to the user and wait for an explicit human decision on that hold before resuming (`/map-resume` once it is decided). Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase.
+If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or either `auto_decide_holds` poll returns a non-empty `hard_stops[]`, STOP the autopilot. Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase. A hard stop found by the POST-phase poll means it appeared while the phase was running -- record that before stopping: `record_auto_phase "<phase>" aborted --reason "hard-stop hold pending: <ids>"`. A hard stop found via `route_task`'s `blocked_by[]` or the PRE-phase poll has no phase entry to record yet -- just stop. Either way, surface the hold's reason to the user and wait for an explicit human decision before resuming (`/map-resume` once it is decided).
 
 ## Step 3: Record Each Phase Boundary
 
@@ -71,7 +71,7 @@ python3 .map/scripts/map_step_runner.py record_auto_phase "<phase>" "<status>" \
 
 `<phase>` is the workflow name being entered/exited (`map-plan`, `map-efficient`, `map-check`, or `map-review`). `<status>` follows the phase's own vocabulary -- use `completed` on a clean phase close and `aborted`/`failed` on a phase you cannot recover; anything else leaves the chain `in_progress`. Pass every hold id that `auto_decide_holds` auto-approved for this phase in `--evidence-refs`, so the approval is recorded twice: once in the hold's own audit note, once in the phase ledger.
 
-**At most one re-entry per phase:** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Inspect ground truth (the phase's own artifacts, test output, Monitor verdict) before spending the single permitted re-entry. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase.
+**At most one re-entry per phase (HC-2):** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Before spending the single permitted re-entry, inspect ground truth -- `git status`/`git diff` and the phase's own `step_state.json` (or equivalent phase artifacts, test output, Monitor verdict) -- to confirm the phase genuinely needs a fresh attempt rather than a partial success being misread as a failure. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase. A chain already `chain_status: "aborted"` or `"blocked"` refuses every further `record_auto_phase` call regardless of phase name; a new `route_task` call is the ONLY legitimate way to continue.
 
 ## Chain
 
@@ -83,9 +83,11 @@ route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]
 
 - `map-resume`, `map-check`, and `map-fast` routes are single-phase: run the one workflow, record its result with `record_auto_phase`, and finish.
 - `map-plan` and `map-efficient` routes continue the chain: `map-plan` produces the task plan that `map-efficient` consumes, `map-efficient` implements it, and the chain then continues to `map-check` and `map-review` to close the loop.
-- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps.
+- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps. `/map-auto` never shells out to a separate Claude process, a new Python execution engine, or any other new phase-driving mechanism to do this -- phases are driven ONLY by invoking the existing slash workflows above and the three runner subcommands from Steps 1-3.
 - A `valid=false` Monitor verdict INSIDE a phase is that phase's own hard stop: its owning workflow's existing retry/escalation rules apply unchanged. `/map-auto` never overrides, suppresses, or re-runs past a Monitor rejection on the phase's behalf -- a phase that cannot get past Monitor is a failed phase for the purposes of Step 3's re-entry bound.
 - The autopilot run ends at a committed feature branch. `/map-auto` never opens a pull request, never merges, and never polls CI -- report the committed branch, the phases recorded, and stop.
+
+For the full CLI flag reference, a worked chain walkthrough, the failure-mode table, and recovery procedures, see [auto-reference.md](auto-reference.md).
 
 ## Examples
 

--- a/src/mapify_cli/templates/skills/map-auto/auto-reference.md
+++ b/src/mapify_cli/templates/skills/map-auto/auto-reference.md
@@ -1,0 +1,78 @@
+# /map-auto Supporting Reference
+
+This file holds low-frequency `/map-auto` details so `SKILL.md` stays focused on the active route -> holds -> phase-ledger loop.
+
+## CLI Reference
+
+Three runner subcommands back the whole autopilot; `SKILL.md` calls them in order (`route_task` once, then `auto_decide_holds` / `record_auto_phase` per chained phase). No other subcommand drives the chain.
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task <task> [--branch B] [--dry-run]
+python3 .map/scripts/map_step_runner.py auto_decide_holds [--branch B]
+python3 .map/scripts/map_step_runner.py record_auto_phase <phase> <status> [--branch B] \
+  [--evidence-refs a,b,c] [--reason "..."]
+```
+
+- `route_task <task>` -- `<task>` is the free-text task description (quote it). `--branch` defaults to the current branch. `--dry-run` recommends a route without marking the chain `in_progress` (see Dry-run usage below).
+- `auto_decide_holds` -- no positional arguments; only `--branch` (defaults to current branch).
+- `record_auto_phase <phase> <status>` -- `<phase>` is the workflow name (`map-plan`, `map-efficient`, `map-check`, `map-review`); `<status>` is the phase's own outcome word (`completed`, `failed`, `aborted`, or any other phase-specific status, which leaves `chain_status` at `in_progress`). `--evidence-refs` takes a comma-separated list of ids (auto-approved hold ids from the surrounding `auto_decide_holds` calls); `--reason` is a free-text note stored on the ledger entry.
+
+## Chain Walkthrough Example
+
+A `map-efficient` route, condensed (real output trimmed to the fields that matter):
+
+```bash
+$ python3 .map/scripts/map_step_runner.py route_task "add retry to the sync job"
+{"status": "success", "selected_route": "map-efficient", "chain_status": "in_progress", ...}
+
+$ python3 .map/scripts/map_step_runner.py auto_decide_holds
+{"status": "ok", "auto_approved": [{"id": "hold-1", "kind": "plan_approval", ...}], "hard_stops": []}
+
+# -- drive /map-efficient unmodified, in full, per its own SKILL.md --
+
+$ python3 .map/scripts/map_step_runner.py auto_decide_holds
+{"status": "ok", "auto_approved": [], "hard_stops": []}
+
+$ python3 .map/scripts/map_step_runner.py record_auto_phase "map-efficient" "completed" \
+  --evidence-refs "hold-1" --reason "all subtasks closed, make check green"
+{"status": "success", "chain_status": "completed", "phase": "map-efficient", "attempt": 1, ...}
+
+# -- chain then continues to map-check, then map-review, each following the same
+#    poll -> drive -> poll -> record loop, until the last phase records "completed" --
+```
+
+The run ends there: a committed feature branch, `phases[]` in `auto-route.json` holding one entry per phase attempt, and no PR/merge/CI step of any kind.
+
+## Failure-Mode Table
+
+| Failure mode | Trigger | Response |
+|---|---|---|
+| Hard-stop hold | `dangerous_action` or `safety_guardrail` hold pending (at route time or discovered mid-phase) | STOP the autopilot; surface the hold's reason; wait for an explicit human decision; resume via `/map-resume` once it is decided. Never auto-approved by any `/map-auto` code path (INV-2). |
+| Repeated phase failure (HC-2) | A third `record_auto_phase` call for the SAME phase name | Refused outright -- no entry appended; the chain is force-aborted (`chain_status: "aborted"`) with the abort reason persisted in `auto-route.json`. Recover via `/map-resume`; a fresh `route_task` on the aborted branch re-routes and preserves the prior route in `route_history[]`. |
+| `goal_mismatch` | `check_plan_resume` reports the branch already hosts a plan for a DIFFERENT goal | `route_task` refuses to route: `status: "blocked"`, `chain_status: "blocked"`, `block_reason` names the mismatch. The prior spec/task_plan/blueprint artifacts are left untouched -- resolving the mismatch (archive, rename, or confirm intent) is the operator's call. |
+| In-progress re-route | `route_task` called while the branch's `auto-route.json` already has `chain_status: "in_progress"` | Refused: `status: "refused"`, `next_command: "/map-resume"`; the existing artifact is left byte-identical. |
+| `blueprint_unavailable` | `step_state.json` exists but `blueprint.json`'s subtask-id universe can't be read | Routes to `map-resume` rather than guessing "complete" -- recorded as `evidence: [{"signal": "step_state.json", "value": "blueprint_unavailable", ...}]`. |
+
+## Recovery Procedures
+
+- **`/map-resume`** -- the single recovery surface for every stop condition above: a refused re-route, an aborted chain, a hard-stop hold once it is decided, or a phase that failed Monitor past its own retry budget. It reads the branch's existing state (`step_state.json`, `auto-route.json`) and resumes from there; it never re-runs `route_task` on your behalf.
+- **New `route_task` from a terminal chain** -- `chain_status` values `aborted`, `blocked`, `completed`, and `recommended_only` may all be re-routed; only `in_progress` refuses. A re-route overwrites `auto-route.json` but preserves the superseded route in `route_history[]`, so a fresh `route_task "<task>"` call is the ONLY way to move a terminal chain forward -- never hand-edit `chain_status` in the artifact.
+
+## Dry-run Usage
+
+`route_task "<task>" --dry-run` is the whole dry-run surface (Decision 8) -- there is no separate preview command for holds or phases, because neither runs until a real (non-dry-run) `route_task` call marks the chain `in_progress`.
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "add retry to the sync job" --dry-run
+```
+
+- Sets `executed: false` and `chain_status: "recommended_only"` -- the run is a recommendation, not a commitment.
+- Performs no filesystem writes beyond `.map/<branch>/auto-route.json` and its `auto_route` manifest stage entry -- no `record_workflow_fit`, no `create_approval_hold`, nothing else on disk changes (AC-3).
+- A pending hard-stop hold still surfaces: `blocked_by[]` is populated and `chain_status` becomes `"blocked"` even under `--dry-run` -- "blocked" always outranks "recommended_only".
+- Re-running `route_task` (with or without `--dry-run`) after a dry-run is always allowed -- `recommended_only` is not a terminal `chain_status`.
+
+## Troubleshooting
+
+- **Issue:** `record_auto_phase` reports `status: "error"`. **Fix:** No `auto-route.json` exists for this branch yet -- run `route_task` first.
+- **Issue:** Need to inspect the ledger without another CLI call. **Fix:** Read `.map/<branch>/auto-route.json` directly (read-only) -- `phases[]`, `chain_status`, `abort_reason`/`block_reason`, and `route_history[]` are all plain fields; never hand-edit the file.
+- **Issue:** A phase's own Monitor keeps rejecting past what looks like a real fix. **Fix:** That is the chained workflow's own retry/escalation, not `/map-auto`'s -- let it run its course; `/map-auto` only records the outcome once that workflow itself stops.

--- a/src/mapify_cli/templates/skills/skill-rules.json
+++ b/src/mapify_cli/templates/skills/skill-rules.json
@@ -452,6 +452,25 @@
           "before.*(map-plan|planning)"
         ]
       }
+    },
+    "map-auto": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "high",
+      "description": "Single-entry autonomous autopilot: routes a task via route_task then drives the selected MAP workflow chain end-to-end to a committed feature branch.",
+      "promptTriggers": {
+        "keywords": [
+          "map-auto",
+          "autopilot",
+          "single-entry workflow",
+          "auto route task"
+        ],
+        "intentPatterns": [
+          "map-auto",
+          "(autopilot|auto).*(task|workflow|route)"
+        ]
+      }
     }
   }
 }

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -465,6 +465,12 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
+# /map-auto (issue #414, ST-005): hold kinds that hard-stop autonomous
+# routing outright -- route_task blocks the chain rather than proceeding
+# when either is pending. ST-006 defines the complementary
+# AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
+HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
+
 # Truncation infrastructure deleted by user directive ("убери транкейт уже
 # вообще"). build_context_block / _budget_review_prompt now emit raw text;
 # operators handle context size via /compact opt-in. The mapify_cli
@@ -14727,18 +14733,56 @@ def route_task(
 
     `executed` and `chain_status` are always set together in one atomic
     artifact write: non-dry-run -> executed=True, chain_status="in_progress";
-    --dry-run -> executed=False, chain_status="recommended_only". Guards that
-    refuse to re-route an in-progress chain, block on a goal mismatch, or
-    surface pending hard-stop holds are added by a later subcommand -- this
-    call always re-routes and overwrites, preserving the prior selected_route
-    in route_history.
+    --dry-run -> executed=False, chain_status="recommended_only" -- UNLESS
+    one of the guards below blocks the chain, in which case executed is
+    forced False regardless of dry_run.
+
+    Three guards run, in this precedence order, BEFORE the normal write
+    (ST-005, INV-6):
+
+      1. In-progress refusal: an existing auto-route.json with
+         chain_status "in_progress" refuses to re-route -- returns
+         status="refused" with a /map-resume pointer, and neither the
+         artifact nor the manifest is touched. chain_status in
+         {recommended_only, blocked, completed, aborted} may be re-routed
+         (the prior selected_route is preserved in route_history).
+      2. Hard-stop holds: a pending dangerous_action or safety_guardrail
+         hold (HARD_STOP_HOLD_KINDS) blocks the chain -- chain_status
+         "blocked", executed False, blocked_by populated with the pending
+         hold ids -- even under --dry-run ("blocked" outranks
+         "recommended_only").
+      3. goal_mismatch block: check_plan_resume's verdict, already surfaced
+         in _select_route's evidence trail (read here, never re-queried),
+         blocks the chain with chain_status "blocked" and a block_reason.
+         The prior spec/task_plan/blueprint artifacts are left untouched --
+         route_task never archives or overwrites them.
+
+    Per Decision 14, route_task writes ONLY auto-route.json and its manifest
+    stage across every branch above -- it never calls record_workflow_fit or
+    create_approval_hold.
     """
     branch_name = branch or get_branch_name()
+    artifact_path = auto_route_artifact_path(branch_name)
+    prior = _read_json_file(artifact_path)
+
+    # Guard 1: refuse to re-route a chain that is already in progress --
+    # the operator must resume it explicitly (/map-resume) instead of this
+    # call silently clobbering the active decision.
+    if isinstance(prior, dict) and prior.get("chain_status") == "in_progress":
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "reason": (
+                f"branch '{branch_name}' has an in-progress /map-auto chain; "
+                "re-routing is refused to avoid clobbering the active run."
+            ),
+            "next_command": "/map-resume",
+        }
+
     selected_route, raw_evidence = _select_route(branch_name, task)
     next_command = _AUTO_ROUTE_NEXT_COMMAND[selected_route]
 
-    artifact_path = auto_route_artifact_path(branch_name)
-    prior = _read_json_file(artifact_path)
     route_history: list[str] = []
     if isinstance(prior, dict):
         prior_history = prior.get("route_history")
@@ -14750,26 +14794,65 @@ def route_task(
 
     executed = not dry_run
     chain_status = "in_progress" if executed else "recommended_only"
+    blocked_by: list[str] = []
+    block_reason = ""
+
+    # Guard 2: pending hard-stop holds block the chain outright, including
+    # under --dry-run -- "blocked" always outranks "recommended_only".
+    pending_holds = get_pending_holds(branch_name)
+    hard_stop_ids = [
+        str(hold["id"])
+        for hold in cast(list[Any], pending_holds.get("holds", []))
+        if isinstance(hold, dict) and hold.get("kind") in HARD_STOP_HOLD_KINDS
+    ]
+    if hard_stop_ids:
+        chain_status = "blocked"
+        executed = False
+        blocked_by = hard_stop_ids
+        block_reason = f"pending hard-stop hold(s): {', '.join(hard_stop_ids)}"
+    else:
+        # Guard 3: a goal_mismatch verdict from check_plan_resume, already
+        # surfaced by _select_route above -- reused, not re-queried --
+        # blocks the chain without touching the prior plan artifacts.
+        mismatch_entry = next(
+            (
+                entry
+                for entry in raw_evidence
+                if entry.get("signal") == "check_plan_resume"
+                and entry.get("value") == "goal_mismatch"
+            ),
+            None,
+        )
+        if mismatch_entry is not None:
+            chain_status = "blocked"
+            executed = False
+            block_reason = (
+                f"check_plan_resume reported goal_mismatch for branch "
+                f"'{branch_name}'; resolve the mismatch (archive/rename the "
+                "prior plan or confirm intent) before routing."
+            )
 
     artifact: dict[str, object] = {
         "schema_version": "1.0",
         "task_summary": _sanitize_for_json(task),
         "selected_route": selected_route,
         "evidence": _auto_route_evidence_for_artifact(raw_evidence),
-        "blocked_by": [],
+        "blocked_by": blocked_by,
         "next_command": next_command,
         "executed": executed,
         "chain_status": chain_status,
         "phases": [],
         "route_history": route_history,
     }
+    if block_reason:
+        artifact["block_reason"] = block_reason
     _write_json_file(artifact_path, artifact)
 
     manifest = load_artifact_manifest(branch_name)
     _set_manifest_stage(
         manifest,
         "auto_route",
-        "recommended" if dry_run else "in_progress",
+        "blocked" if chain_status == "blocked" else ("recommended" if dry_run else "in_progress"),
         artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
         metadata={
             "selected_route": selected_route,
@@ -14779,13 +14862,14 @@ def route_task(
     save_artifact_manifest(manifest, branch_name)
 
     return {
-        "status": "success",
+        "status": "blocked" if chain_status == "blocked" else "success",
         "branch": branch_name,
         "path": str(artifact_path),
         "selected_route": selected_route,
         "chain_status": chain_status,
         "next_command": next_command,
         "executed": executed,
+        "blocked_by": blocked_by,
     }
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -14673,6 +14673,122 @@ def _select_route(
     return "map-plan", evidence
 
 
+# /map-auto routing (issue #414): route -> slash command surfaced to the
+# operator as the next step.
+_AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
+    "map-resume": "/map-resume",
+    "map-check": "/map-check",
+    "map-fast": "/map-fast",
+    "map-plan": "/map-plan",
+    "map-efficient": "/map-efficient",
+}
+
+
+def auto_route_artifact_path(branch: str | None = None) -> Path:
+    """Return the branch-scoped /map-auto routing decision artifact path."""
+    return get_branch_dir(branch) / "auto-route.json"
+
+
+def _auto_route_evidence_for_artifact(
+    evidence: list[dict[str, object]],
+) -> list[dict[str, str]]:
+    """Coerce _select_route's evidence into AUTO_ROUTE_SCHEMA's string shape.
+
+    _select_route returns richer Python values (dict, bool, None) per signal
+    for in-process callers; AUTO_ROUTE_SCHEMA (schemas.py) declares
+    evidence[].value as a plain string for the persisted artifact. JSON-encode
+    non-string values so no signal detail is lost while staying schema-valid.
+    """
+    stringified: list[dict[str, str]] = []
+    for entry in evidence:
+        value = entry.get("value")
+        value_str = value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+        stringified.append({
+            "signal": str(entry.get("signal", "")),
+            "value": value_str,
+            "source": str(entry.get("source", "")),
+        })
+    return stringified
+
+
+def route_task(
+    task: str,
+    branch: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Select a route for /map-auto and persist the decision (issue #414).
+
+    Wraps _select_route with the write side of the routing contract: writes
+    .map/<branch>/auto-route.json (all ten AUTO_ROUTE_SCHEMA fields) and
+    registers the `auto_route` manifest stage in the same call, so the route
+    selection is never observable only in stdout. `phases` is always
+    initialized empty here -- record_auto_phase (a later subcommand) is the
+    sole writer of that ledger.
+
+    `executed` and `chain_status` are always set together in one atomic
+    artifact write: non-dry-run -> executed=True, chain_status="in_progress";
+    --dry-run -> executed=False, chain_status="recommended_only". Guards that
+    refuse to re-route an in-progress chain, block on a goal mismatch, or
+    surface pending hard-stop holds are added by a later subcommand -- this
+    call always re-routes and overwrites, preserving the prior selected_route
+    in route_history.
+    """
+    branch_name = branch or get_branch_name()
+    selected_route, raw_evidence = _select_route(branch_name, task)
+    next_command = _AUTO_ROUTE_NEXT_COMMAND[selected_route]
+
+    artifact_path = auto_route_artifact_path(branch_name)
+    prior = _read_json_file(artifact_path)
+    route_history: list[str] = []
+    if isinstance(prior, dict):
+        prior_history = prior.get("route_history")
+        if isinstance(prior_history, list):
+            route_history = [item for item in prior_history if isinstance(item, str)]
+        prior_route = prior.get("selected_route")
+        if isinstance(prior_route, str) and prior_route:
+            route_history.append(prior_route)
+
+    executed = not dry_run
+    chain_status = "in_progress" if executed else "recommended_only"
+
+    artifact: dict[str, object] = {
+        "schema_version": "1.0",
+        "task_summary": _sanitize_for_json(task),
+        "selected_route": selected_route,
+        "evidence": _auto_route_evidence_for_artifact(raw_evidence),
+        "blocked_by": [],
+        "next_command": next_command,
+        "executed": executed,
+        "chain_status": chain_status,
+        "phases": [],
+        "route_history": route_history,
+    }
+    _write_json_file(artifact_path, artifact)
+
+    manifest = load_artifact_manifest(branch_name)
+    _set_manifest_stage(
+        manifest,
+        "auto_route",
+        "recommended" if dry_run else "in_progress",
+        artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+        metadata={
+            "selected_route": selected_route,
+            "chain_status": chain_status,
+        },
+    )
+    save_artifact_manifest(manifest, branch_name)
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "path": str(artifact_path),
+        "selected_route": selected_route,
+        "chain_status": chain_status,
+        "next_command": next_command,
+        "executed": executed,
+    }
+
+
 def record_scope_baseline(branch: str) -> dict:
     """Snapshot the current uncommitted / untracked file set as a baseline
     that validate_mutation_boundary will subtract from `actual` on future
@@ -22008,6 +22124,25 @@ if __name__ == "__main__":
             branch=_rvl_flag("branch") or None,
         )
         print(json.dumps(result, indent=2, ensure_ascii=True))
+
+    elif func_name == "route_task" and len(sys.argv) >= 3:
+        # CLI: route_task <task> [--branch B] [--dry-run]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py route_task")
+        _p.add_argument("task", help="Task description text to route")
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _p.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="Recommend a route without marking the chain in_progress",
+        )
+        _a = _p.parse_args(sys.argv[2:])
+        _r = route_task(_a.task, branch=_a.branch, dry_run=_a.dry_run)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
 
     else:
         # Helpful redirect: when the user passes a command that belongs to

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -4856,18 +4856,16 @@ _DONE_PHASE_STATUSES_FOR_COMPLETION = {
 }
 
 
-def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
-    """Return True iff every subtask in subtask_sequence has a "done"-class
-    signal recorded (subtask_results entry OR subtask_phases marker).
+def _done_class_subtask_ids(state: dict[str, object]) -> set[str]:
+    """Return subtask ids with a "done"-class signal recorded in step_state.json
+    (a subtask_results entry OR a subtask_phases done-class marker).
 
-    Mirrors the orchestrator's _completed_subtask_ids_for_deps logic. Used
-    by _derive_terminal_status so a stuck cursor (ST-033 friction) no
-    longer makes write_run_health_report report ``pending`` when 51/51
-    entries actually exist.
+    Shared canonical-completion primitive: used by
+    _state_subtask_coverage_complete below (global "is the whole run done"
+    check) AND by the /map-auto tier 1 routing signal (per-subtask
+    pending/complete split) so both read the identical done-class
+    definition instead of two definitions that could silently drift apart.
     """
-    sequence_value = state.get("subtask_sequence")
-    if not isinstance(sequence_value, list) or not sequence_value:
-        return False
     results_value = state.get("subtask_results")
     results = results_value if isinstance(results_value, dict) else {}
     phases_value = state.get("subtask_phases")
@@ -4882,6 +4880,22 @@ def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
     for sid, phase in phases.items():
         if isinstance(sid, str) and isinstance(phase, str) and phase.lower() in _DONE_PHASE_STATUSES_FOR_COMPLETION:
             completed.add(sid)
+    return completed
+
+
+def _state_subtask_coverage_complete(state: dict[str, object]) -> bool:
+    """Return True iff every subtask in subtask_sequence has a "done"-class
+    signal recorded (subtask_results entry OR subtask_phases marker).
+
+    Mirrors the orchestrator's _completed_subtask_ids_for_deps logic. Used
+    by _derive_terminal_status so a stuck cursor (ST-033 friction) no
+    longer makes write_run_health_report report ``pending`` when 51/51
+    entries actually exist.
+    """
+    sequence_value = state.get("subtask_sequence")
+    if not isinstance(sequence_value, list) or not sequence_value:
+        return False
+    completed = _done_class_subtask_ids(state)
     return all(isinstance(sid, str) and sid in completed for sid in sequence_value)
 
 
@@ -14405,6 +14419,258 @@ def check_plan_resume(request: str = "", branch: str | None = None) -> dict:
         },
         "recommendation": recommendation,
     }
+
+
+# /map-auto routing (issue #414): the recommended workflow values a route
+# selector may pick automatically. Values outside this set (direct-edit,
+# map-tdd, map-wayfind) require a human decision and must fall through to a
+# lower-precedence signal instead of being auto-selected.
+_AUTO_ROUTE_TIER2_ALLOWED = frozenset({"map-fast", "map-plan", "map-efficient"})
+
+
+def _blueprint_subtask_ids(blueprint: dict | None) -> set[str]:
+    """Return the set of subtask ids declared in a loaded blueprint.json payload."""
+    if not isinstance(blueprint, dict):
+        return set()
+    subtasks = blueprint.get("subtasks")
+    if not isinstance(subtasks, list):
+        return set()
+    return {
+        subtask["id"]
+        for subtask in subtasks
+        if isinstance(subtask, dict) and isinstance(subtask.get("id"), str)
+    }
+
+
+def _tier1_completed_subtask_ids(state: dict[str, object]) -> tuple[set[str], bool]:
+    """Return (completed subtask ids, used_legacy_fallback) for tier 1 routing.
+
+    Prefers the canonical done-class signal (_done_class_subtask_ids, shared
+    with _state_subtask_coverage_complete): a subtask_results status or a
+    subtask_phases marker in the done class. Falls back to legacy
+    completed_steps KEY PRESENCE only when NEITHER canonical field exists in
+    state at all. Key presence alone is not a safe completion signal even in
+    the fallback case's absence check -- update_step_state (the classic,
+    pre-orchestrator writer) inserts a completed_steps[subtask_id] key at
+    the FIRST recorded phase, so "key exists" means "started", not "done".
+    The canonical fields are preferred specifically so a subtask with only
+    an in-progress phase recorded is never misread as complete.
+    """
+    canonical_present = "subtask_results" in state or "subtask_phases" in state
+    if canonical_present:
+        return _done_class_subtask_ids(state), False
+    completed_steps = state.get("completed_steps")
+    if isinstance(completed_steps, dict):
+        return {key for key in completed_steps if isinstance(key, str)}, True
+    return set(), True
+
+
+def _classify_scope_bracket(estimated_files: int, estimated_lines: int) -> str | None:
+    """Call classify_scope.classify() in-process for the auto-route scope tier.
+
+    classify_scope.py ships alongside this script in every generated tree but
+    is not an importable package member, so it is loaded by file location
+    (mirrors the existing lazy schemas-module import pattern in this file)
+    rather than imported at module scope or shelled out to as a subprocess.
+    """
+    try:
+        import importlib.util as _importlib_util
+
+        script_path = Path(__file__).resolve().parent / "classify_scope.py"
+        spec = _importlib_util.spec_from_file_location("classify_scope", script_path)
+        if spec is None or spec.loader is None:
+            return None
+        module = _importlib_util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except (ImportError, OSError):
+        return None
+
+    classify_fn = getattr(module, "classify", None)
+    if not callable(classify_fn):
+        return None
+    project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    result = classify_fn(estimated_files, estimated_lines, project_dir)
+    bracket = result.get("bracket") if isinstance(result, dict) else None
+    return bracket if isinstance(bracket, str) else None
+
+
+def _select_route(
+    branch: str | None,
+    task_text: str,
+    *,
+    estimated_files: int | None = None,
+    estimated_lines: int | None = None,
+) -> tuple[str, list[dict[str, object]]]:
+    """Pure five-tier routing precedence engine for /map-auto (issue #414).
+
+    Reads exactly five existing signals -- step_state.json, workflow-fit.json,
+    check_plan_resume(), a direct blueprint.json stat, and
+    classify_scope.classify() -- and returns the route picked by the
+    highest-precedence signal that fires, plus an evidence trail of every
+    signal consulted (including signals that lost or were absent). Never
+    inspects ``task_text`` itself for keywords; the only tier that reads its
+    content is check_plan_resume() (tier 3), which is one of the five
+    allowed signals. This function only selects a route -- it writes nothing
+    and creates no CLI surface.
+
+    Tiers, in strict precedence order:
+      1. step_state.json exists: pending subtasks (blueprint ids minus the
+         canonical done-class subtask ids) -> map-resume; all complete ->
+         map-check. When blueprint.json is missing/unparseable/empty, the
+         pending set cannot be computed at all -- this fails CLOSED to
+         map-resume (never asserts completion without evidence) rather than
+         guessing.
+      2. workflow-fit.json recommended_workflow, restricted to
+         {map-fast, map-plan, map-efficient} -- any other recorded value
+         (e.g. direct-edit) is recorded in evidence and falls through.
+      3. check_plan_resume(task_text) verdict "resume" (only reachable once
+         step_state.json is confirmed absent): task_plan artifact present
+         AND a direct blueprint.json stat succeeds -> map-efficient;
+         otherwise -> map-plan. A goal_mismatch or no_plan verdict is only
+         surfaced in evidence here -- blocking on it is not this function's
+         responsibility. NOTE: this is the one SANCTIONED exception to
+         "task_text never influences the route" -- check_plan_resume is one
+         of the five allowed signals, and its goal-overlap comparison is
+         supposed to vary with task_text content. That is intentional
+         signal-reading, not the ad-hoc keyword routing this function
+         otherwise forbids (see the invariance test docstrings below).
+      4. classify_scope.classify() bracket "trivial" -> map-fast, only when
+         the caller supplied non-negative estimated_files/estimated_lines;
+         otherwise the tier is recorded as unavailable and skipped rather
+         than guessed.
+      5. Default: map-plan.
+    """
+    branch_name = branch or get_branch_name()
+    branch_dir = get_branch_dir(branch_name)
+    evidence: list[dict[str, object]] = []
+
+    # Tier 1 signal: step_state.json. Always read up front (even when a
+    # later tier would otherwise win) so a conflicting workflow-fit.json
+    # recommendation is still captured in evidence per the losing-signal
+    # requirement below.
+    step_state_path = branch_dir / "step_state.json"
+    state = _read_json_file(step_state_path)
+    step_state_route: str | None = None
+    if state is not None:
+        blueprint = load_blueprint(branch_name)
+        subtask_ids = _blueprint_subtask_ids(blueprint)
+        if not subtask_ids:
+            # Fail closed: with no subtask id universe from blueprint.json,
+            # "pending minus completed" cannot be computed at all. Asserting
+            # "complete" here would be an unevidenced guess, so route back
+            # to resuming the plan instead.
+            step_state_route = "map-resume"
+            evidence.append({
+                "signal": "step_state.json",
+                "value": "blueprint_unavailable",
+                "source": str(step_state_path),
+            })
+        else:
+            completed_ids, used_legacy_fallback = _tier1_completed_subtask_ids(state)
+            pending_ids = subtask_ids - completed_ids
+            completion_source = (
+                "legacy_completed_steps" if used_legacy_fallback else "canonical_done_class"
+            )
+            if pending_ids:
+                step_state_route = "map-resume"
+                evidence.append({
+                    "signal": "step_state.json",
+                    "value": {
+                        "status": "pending",
+                        "pending_subtask_ids": sorted(pending_ids),
+                        "completion_source": completion_source,
+                    },
+                    "source": str(step_state_path),
+                })
+            else:
+                step_state_route = "map-check"
+                evidence.append({
+                    "signal": "step_state.json",
+                    "value": {
+                        "status": "complete",
+                        "subtask_count": len(subtask_ids),
+                        "completion_source": completion_source,
+                    },
+                    "source": str(step_state_path),
+                })
+    else:
+        evidence.append({
+            "signal": "step_state.json",
+            "value": {"status": "absent"},
+            "source": str(step_state_path),
+        })
+
+    # Tier 2 signal: workflow-fit.json. Also always read up front for the
+    # same losing-signal reason as tier 1.
+    workflow_fit_path = branch_dir / "workflow-fit.json"
+    fit_payload = _read_json_file(workflow_fit_path)
+    recommended: str | None = None
+    if fit_payload is not None:
+        raw_recommended = fit_payload.get("recommended_workflow")
+        recommended = raw_recommended if isinstance(raw_recommended, str) else None
+    evidence.append({
+        "signal": "workflow-fit.json",
+        "value": recommended,
+        "source": str(workflow_fit_path),
+    })
+
+    if step_state_route is not None:
+        return step_state_route, evidence
+
+    if recommended is not None and recommended in _AUTO_ROUTE_TIER2_ALLOWED:
+        return recommended, evidence
+
+    # Tier 3 signals: check_plan_resume() verdict, plus a direct
+    # blueprint.json stat (check_plan_resume's own artifacts dict has no
+    # blueprint key). check_plan_resume is allowed to read task_text -- see
+    # the sanctioned-exception note in the docstring above.
+    resume_report = check_plan_resume(task_text, branch=branch_name)
+    verdict = resume_report.get("verdict")
+    evidence.append({
+        "signal": "check_plan_resume",
+        "value": verdict,
+        "source": "check_plan_resume()",
+    })
+    if verdict == "resume":
+        artifacts = resume_report.get("artifacts")
+        has_task_plan = bool(isinstance(artifacts, dict) and artifacts.get("task_plan"))
+        blueprint_path = branch_dir / "blueprint.json"
+        has_blueprint = blueprint_path.exists()
+        evidence.append({
+            "signal": "blueprint.json",
+            "value": has_blueprint,
+            "source": str(blueprint_path),
+        })
+        return ("map-efficient" if (has_task_plan and has_blueprint) else "map-plan"), evidence
+
+    # Tier 4 signal: classify_scope.classify() bracket. Only fires when the
+    # caller supplied a real scope estimate -- there is no sixth signal in
+    # this function's allowed set (e.g. a git diff stat) that could derive
+    # estimated_files/estimated_lines on its own, so an absent estimate is
+    # recorded and the tier is skipped rather than guessed.
+    if (
+        estimated_files is not None
+        and estimated_lines is not None
+        and estimated_files >= 0
+        and estimated_lines >= 0
+    ):
+        bracket = _classify_scope_bracket(estimated_files, estimated_lines)
+        evidence.append({
+            "signal": "classify_scope.classify",
+            "value": {"estimated": True, "bracket": bracket},
+            "source": "classify_scope.classify()",
+        })
+        if bracket == "trivial":
+            return "map-fast", evidence
+    else:
+        evidence.append({
+            "signal": "classify_scope.classify",
+            "value": {"estimated": False},
+            "source": "classify_scope.classify()",
+        })
+
+    # Tier 5: default.
+    return "map-plan", evidence
 
 
 def record_scope_baseline(branch: str) -> dict:

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -242,6 +242,7 @@ ARTIFACT_STAGE_NAMES = (
     "workflow_fit",
     "spec",
     "plan",
+    "auto_route",
     "test_contract",
     "repro_probe",
     "implementation",

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -465,13 +465,13 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
-# /map-auto (issue #414, ): hold kinds that hard-stop autonomous
+# /map-auto (issue #414): hold kinds that hard-stop autonomous
 # routing outright -- route_task blocks the chain rather than proceeding
-# when either is pending. defines the complementary
-# AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
+# when either is pending. The complementary AUTO_APPROVABLE_HOLD_KINDS
+# set is defined immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
-# /map-auto (issue #414, ): hold kinds auto_decide_holds may decide
+# /map-auto (issue #414): hold kinds auto_decide_holds may decide
 # without a human -- workflow-control gates, never safety gates. Together
 # with HARD_STOP_HOLD_KINDS these must exactly partition
 # APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
@@ -14699,7 +14699,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
-# /map-auto phase ledger (issue #414, ): closed status vocabulary for
+# /map-auto phase ledger (issue #414): closed status vocabulary for
 # record_auto_phase's chain_status transitions. A phase status in
 # AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
 # AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
@@ -14709,9 +14709,9 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
 AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
 AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
 
-# at most ONE re-entry per phase -- attempt 1 (first record) plus
-# attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
-# same phase name is refused by record_auto_phase.
+# Chain-level retry bound: at most ONE re-entry per phase -- attempt 1
+# (first record) plus attempt 2 (the single permitted re-entry) are allowed;
+# a 3rd record of the same phase name is refused by record_auto_phase.
 AUTO_PHASE_MAX_ATTEMPTS = 2
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -14699,6 +14699,21 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
+# /map-auto phase ledger (issue #414, ST-007): closed status vocabulary for
+# record_auto_phase's chain_status transitions. A phase status in
+# AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
+# AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
+# in_progress. These two sets are intentionally NOT required to partition
+# every possible status string -- callers may pass phase-specific statuses
+# (e.g. "monitor_rejected") that fall through to in_progress.
+AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
+AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
+
+# HC-2: at most ONE re-entry per phase -- attempt 1 (first record) plus
+# attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
+# same phase name is refused by record_auto_phase.
+AUTO_PHASE_MAX_ATTEMPTS = 2
+
 
 def auto_route_artifact_path(branch: str | None = None) -> Path:
     """Return the branch-scoped /map-auto routing decision artifact path."""
@@ -14880,6 +14895,181 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
+    }
+
+
+def record_auto_phase(
+    phase: str,
+    status: str,
+    branch: str | None = None,
+    evidence_refs: list[str] | None = None,
+    reason: str = "",
+) -> dict[str, object]:
+    """Append one entry to auto-route.json's phase ledger (issue #414, ST-007).
+
+    record_auto_phase is the ONLY function that mutates `phases[]` --
+    route_task always initializes it empty and never appends (Decision 11
+    single-writer invariant). Requires an existing auto-route.json (written
+    by route_task); returns status="error" if none is found.
+
+    `attempt` mechanizes HC-2's at-most-one-re-entry bound: it is
+    ``1 + count of prior phases[] entries with the SAME phase name``. A
+    first call for a phase records attempt=1; a re-entry records attempt=2.
+    A THIRD call for the same phase is refused outright -- no entry is
+    appended for that call. Instead the chain is force-aborted: chain_status
+    is set to "aborted" and the abort reason is persisted in the top-level
+    `abort_reason` field (mirroring route_task's `block_reason` field for
+    the "blocked" chain_status -- one field, schema-valid via the schema's
+    `additionalProperties: true`, so the operator sees WHY directly in
+    auto-route.json without needing to scan phases[] for a synthetic entry).
+
+    On every non-refused call, chain_status transitions from the recorded
+    `status` using a closed vocabulary (AUTO_PHASE_TERMINAL_SUCCESS_STATUSES
+    -> "completed", AUTO_PHASE_ABORT_STATUSES -> "aborted", otherwise
+    "in_progress") and the `abort_reason` field is set/cleared to match. The
+    `auto_route` manifest stage is refreshed on every call (refused or not)
+    so progress is observable outside the artifact, with its status
+    mirroring the resulting chain_status.
+
+    `evidence_refs` persists caller-supplied ids (e.g. hold ids
+    auto-approved by `auto_decide_holds`) in the phase entry, giving every
+    auto-approval a second durable recording site alongside the hold's own
+    audit note (INV-4).
+
+    HC-2 fail-closed guard (code review 2): once chain_status is "aborted"
+    (3rd-attempt refusal above) or "blocked" (route_task hard-stop hold),
+    the chain must stay terminal until an explicit NEW route_task call --
+    route_task's own overwrite policy is the only legitimate way out of
+    "aborted"/"blocked". A call naming a DIFFERENT phase must never act as a
+    side door that resurrects the chain by appending a fresh entry and
+    flipping chain_status back to in_progress/completed. This guard runs
+    BEFORE the attempt-counter logic (which only protects the SAME phase
+    name) and mutates nothing on the terminal-state path: no phases[]
+    append, no chain_status change, no abort_reason/block_reason pop, no
+    manifest write.
+    """
+    branch_name = branch or get_branch_name()
+    artifact_path = auto_route_artifact_path(branch_name)
+    artifact = _read_json_file(artifact_path)
+    if artifact is None:
+        return {
+            "status": "error",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "reason": (
+                f"no auto-route.json found for branch '{branch_name}'; "
+                "run route_task first"
+            ),
+        }
+
+    terminal_chain_status = artifact.get("chain_status")
+    if terminal_chain_status in {"aborted", "blocked"}:
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "phase": phase,
+            "chain_status": terminal_chain_status,
+            "reason": (
+                f"branch '{branch_name}' auto-route chain is already "
+                f"'{terminal_chain_status}'; record_auto_phase refuses to "
+                "mutate a terminal chain -- call route_task to re-route "
+                "explicitly."
+            ),
+            "abort_reason": artifact.get("abort_reason"),
+            "block_reason": artifact.get("block_reason"),
+        }
+
+    raw_phases = artifact.get("phases")
+    phases = [entry for entry in raw_phases if isinstance(entry, dict)] if isinstance(
+        raw_phases, list
+    ) else []
+    prior_attempts = sum(1 for entry in phases if entry.get("phase") == phase)
+    attempt = prior_attempts + 1
+
+    manifest = load_artifact_manifest(branch_name)
+
+    if attempt > AUTO_PHASE_MAX_ATTEMPTS:
+        # HC-2 refusal: do not append an entry for this call -- force-abort
+        # the chain instead, with the reason visible at the top level.
+        abort_reason = (
+            f"phase '{phase}' refused at attempt {attempt} (max "
+            f"{AUTO_PHASE_MAX_ATTEMPTS} attempts per HC-2); forcing "
+            "chain_status=aborted."
+        )
+        if reason:
+            abort_reason += f" caller reason: {reason}"
+        abort_reason = _sanitize_for_json(abort_reason)
+
+        artifact["chain_status"] = "aborted"
+        artifact["abort_reason"] = abort_reason
+        _write_json_file(artifact_path, artifact)
+
+        _set_manifest_stage(
+            manifest,
+            "auto_route",
+            "aborted",
+            artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+            metadata={
+                "chain_status": "aborted",
+                "aborted_phase": phase,
+                "attempt": attempt,
+            },
+        )
+        save_artifact_manifest(manifest, branch_name)
+
+        return {
+            "status": "refused",
+            "branch": branch_name,
+            "path": str(artifact_path),
+            "phase": phase,
+            "attempt": attempt,
+            "chain_status": "aborted",
+            "abort_reason": abort_reason,
+        }
+
+    entry: dict[str, object] = {
+        "phase": phase,
+        "status": status,
+        "attempt": attempt,
+        "evidence_refs": list(evidence_refs or []),
+        "reason": _sanitize_for_json(reason),
+        "recorded_at": _utc_timestamp(),
+    }
+    phases.append(entry)
+    artifact["phases"] = phases
+
+    if status in AUTO_PHASE_TERMINAL_SUCCESS_STATUSES:
+        chain_status = "completed"
+    elif status in AUTO_PHASE_ABORT_STATUSES:
+        chain_status = "aborted"
+    else:
+        chain_status = "in_progress"
+    artifact["chain_status"] = chain_status
+    if chain_status == "aborted":
+        artifact["abort_reason"] = _sanitize_for_json(
+            reason or f"phase '{phase}' reported status '{status}'"
+        )
+    else:
+        artifact.pop("abort_reason", None)
+    _write_json_file(artifact_path, artifact)
+
+    _set_manifest_stage(
+        manifest,
+        "auto_route",
+        chain_status,
+        artifacts=[_artifact_ref(artifact_path, "auto-route-decision")],
+        metadata={"chain_status": chain_status, "phase": phase, "attempt": attempt},
+    )
+    save_artifact_manifest(manifest, branch_name)
+
+    return {
+        "status": "success",
+        "branch": branch_name,
+        "path": str(artifact_path),
+        "phase": phase,
+        "attempt": attempt,
+        "chain_status": chain_status,
     }
 
 
@@ -22300,6 +22490,35 @@ if __name__ == "__main__":
         )
         _a = _p.parse_args(sys.argv[2:])
         _r = route_task(_a.task, branch=_a.branch, dry_run=_a.dry_run)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
+
+    elif func_name == "record_auto_phase" and len(sys.argv) >= 4:
+        # CLI: record_auto_phase <phase> <status> [--branch B]
+        #        [--evidence-refs a,b,c] [--reason "..."]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py record_auto_phase")
+        _p.add_argument("phase", help="Phase name to record (e.g. map-plan, map-efficient)")
+        _p.add_argument(
+            "status", help="Phase status (e.g. completed, in_progress, failed, aborted)"
+        )
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _p.add_argument(
+            "--evidence-refs",
+            default="",
+            dest="evidence_refs",
+            help="Comma-separated evidence ids (e.g. auto-approved hold ids)",
+        )
+        _p.add_argument(
+            "--reason", default="", help="Reason recorded alongside the phase entry"
+        )
+        _a = _p.parse_args(sys.argv[2:])
+        _refs = [ref.strip() for ref in _a.evidence_refs.split(",") if ref.strip()]
+        _r = record_auto_phase(
+            _a.phase, _a.status, branch=_a.branch, evidence_refs=_refs, reason=_a.reason
+        )
         print(json.dumps(_r, indent=2))
         if _r.get("status") == "error":
             sys.exit(1)

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -471,6 +471,16 @@ APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATE
 # AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
+# /map-auto (issue #414, ST-006): hold kinds auto_decide_holds may decide
+# without a human -- workflow-control gates, never safety gates. Together
+# with HARD_STOP_HOLD_KINDS these must exactly partition
+# APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
+# kind hard-fails a test instead of being silently auto-approved by
+# omission.
+AUTO_APPROVABLE_HOLD_KINDS = frozenset(
+    {"autonomy_posture", "plan_approval", "template_overwrite"}
+)
+
 # Truncation infrastructure deleted by user directive ("убери транкейт уже
 # вообще"). build_context_block / _budget_review_prompt now emit raw text;
 # operators handle context size via /compact opt-in. The mapify_cli
@@ -17754,6 +17764,60 @@ def get_pending_holds(branch: str | None = None) -> dict[str, Any]:
     }
 
 
+def auto_decide_holds(branch: str | None = None) -> dict[str, Any]:
+    """Split pending approval holds into auto-approved and hard-stopped (#414).
+
+    Reads pending holds via `get_pending_holds` and, for each one, decides
+    solely on AUTO_APPROVABLE_HOLD_KINDS membership -- a positive allowlist,
+    never an exclusion of HARD_STOP_HOLD_KINDS. `decide_approval_hold` is
+    therefore only ever reachable from the branch guarded by that allowlist
+    check, so no code path here can transition a dangerous_action or
+    safety_guardrail hold (INV-2), even if hard-stop membership itself were
+    ever misconfigured.
+
+    - Holds whose kind is in AUTO_APPROVABLE_HOLD_KINDS are decided
+      "approved" via the existing `decide_approval_hold(hold_id, "approved",
+      "auto-approved by map-auto", branch)` and collected into
+      `auto_approved[]`.
+    - Holds whose kind is in HARD_STOP_HOLD_KINDS are left untouched
+      (still `pending`) and collected into `hard_stops[]`.
+    """
+    branch_name = branch or get_branch_name()
+    pending = get_pending_holds(branch_name)
+    auto_approved: list[dict[str, str]] = []
+    hard_stops: list[dict[str, str]] = []
+
+    for hold in cast(list[Any], pending.get("holds", [])):
+        if not isinstance(hold, dict):
+            continue
+        hold_id = str(hold.get("id", ""))
+        kind = str(hold.get("kind", ""))
+        if kind in AUTO_APPROVABLE_HOLD_KINDS:
+            decide_approval_hold(hold_id, "approved", "auto-approved by map-auto", branch_name)
+            auto_approved.append(
+                {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+            )
+        elif kind in HARD_STOP_HOLD_KINDS:
+            hard_stops.append(
+                {
+                    "id": hold_id,
+                    "kind": kind,
+                    "reason": "hard-stop hold kind; requires an explicit human decision",
+                }
+            )
+        # Any other kind is left pending and reported in neither bucket --
+        # unreachable while AUTO_APPROVABLE_HOLD_KINDS | HARD_STOP_HOLD_KINDS
+        # == APPROVAL_HOLD_KINDS holds, but fails closed if that invariant
+        # is ever violated.
+
+    return {
+        "status": "ok",
+        "branch": branch_name,
+        "auto_approved": auto_approved,
+        "hard_stops": hard_stops,
+    }
+
+
 # --- Per-subtask git worktree isolation (#284) ---------------------------------
 # Runner-owned explicit worktrees (NOT the harness-native isolation="worktree").
 # llm-council-reviewed design (conv 461b92f9):
@@ -22094,6 +22158,18 @@ if __name__ == "__main__":
         _a = _p.parse_args(sys.argv[2:])
         _r = get_pending_holds(_a.branch)
         print(json.dumps(_r, indent=2))
+
+    elif func_name == "auto_decide_holds":
+        # CLI: auto_decide_holds [--branch B]
+        import argparse as _ap
+
+        _p = _ap.ArgumentParser(prog="map_step_runner.py auto_decide_holds")
+        _p.add_argument("--branch", default=None, help="Branch name (default: current branch)")
+        _a = _p.parse_args(sys.argv[2:])
+        _r = auto_decide_holds(_a.branch)
+        print(json.dumps(_r, indent=2))
+        if _r.get("status") == "error":
+            sys.exit(1)
 
     elif func_name == "write_implementer_readiness_review" and len(sys.argv) >= 3:
         # CLI: write_implementer_readiness_review <verdict>

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -465,13 +465,13 @@ APPROVAL_HOLD_KINDS = frozenset(
 APPROVAL_HOLD_TERMINAL_STATES = frozenset({"approved", "denied", "expired", "cancelled"})
 APPROVAL_HOLD_ALL_STATES = frozenset({"pending"}) | APPROVAL_HOLD_TERMINAL_STATES
 
-# /map-auto (issue #414, ST-005): hold kinds that hard-stop autonomous
+# /map-auto (issue #414, ): hold kinds that hard-stop autonomous
 # routing outright -- route_task blocks the chain rather than proceeding
-# when either is pending. ST-006 defines the complementary
+# when either is pending. defines the complementary
 # AUTO_APPROVABLE_HOLD_KINDS set immediately alongside this one.
 HARD_STOP_HOLD_KINDS = frozenset({"dangerous_action", "safety_guardrail"})
 
-# /map-auto (issue #414, ST-006): hold kinds auto_decide_holds may decide
+# /map-auto (issue #414, ): hold kinds auto_decide_holds may decide
 # without a human -- workflow-control gates, never safety gates. Together
 # with HARD_STOP_HOLD_KINDS these must exactly partition
 # APPROVAL_HOLD_KINDS (disjoint, union == whole set) so a future sixth hold
@@ -14699,7 +14699,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
     "map-efficient": "/map-efficient",
 }
 
-# /map-auto phase ledger (issue #414, ST-007): closed status vocabulary for
+# /map-auto phase ledger (issue #414, ): closed status vocabulary for
 # record_auto_phase's chain_status transitions. A phase status in
 # AUTO_PHASE_TERMINAL_SUCCESS_STATUSES completes the chain; a status in
 # AUTO_PHASE_ABORT_STATUSES aborts it; any other status leaves the chain
@@ -14709,7 +14709,7 @@ _AUTO_ROUTE_NEXT_COMMAND: dict[str, str] = {
 AUTO_PHASE_TERMINAL_SUCCESS_STATUSES = frozenset({"completed"})
 AUTO_PHASE_ABORT_STATUSES = frozenset({"aborted", "failed"})
 
-# HC-2: at most ONE re-entry per phase -- attempt 1 (first record) plus
+# at most ONE re-entry per phase -- attempt 1 (first record) plus
 # attempt 2 (the single permitted re-entry) are allowed; a 3rd record of the
 # same phase name is refused by record_auto_phase.
 AUTO_PHASE_MAX_ATTEMPTS = 2
@@ -14990,7 +14990,7 @@ def record_auto_phase(
     manifest = load_artifact_manifest(branch_name)
 
     if attempt > AUTO_PHASE_MAX_ATTEMPTS:
-        # HC-2 refusal: do not append an entry for this call -- force-abort
+        # refusal: do not append an entry for this call -- force-abort
         # the chain instead, with the reason visible at the top level.
         abort_reason = (
             f"phase '{phase}' refused at attempt {attempt} (max "

--- a/src/mapify_cli/templates_src/skills/map-auto/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-auto/SKILL.md.jinja
@@ -1,0 +1,102 @@
+---
+name: map-auto
+description: |
+  Single-entry autonomous autopilot: routes a task through the existing MAP workflows via `route_task`, then drives the selected chain (map-plan -> map-efficient -> map-check -> map-review, as routed) end-to-end to a committed feature branch in one session, auto-approving routine workflow-control holds and hard-stopping on dangerous_action/safety_guardrail holds. Use when you want the whole pipeline to run unattended from a single task description, without babysitting phase-by-phase invocation. Do NOT use when you want to review or edit the plan before execution (run /map-plan then /map-efficient yourself instead), when the task is trivial (use /map-fast directly), or when you need a PR opened or merged -- the autopilot always stops at a committed branch and never creates or merges a PR.
+disable-model-invocation: true
+argument-hint: "[task description]"
+effort: high
+---
+# /map-auto — Single-Entry Autonomous Autopilot
+
+Purpose: run `/map-auto <task>` once and let it route the task through the existing MAP workflows, then drive the selected chain end-to-end to a committed feature branch in the same session, without per-phase babysitting. `/map-auto` runs autonomously by default the moment it is invoked -- there is no shadow mode, no calibration period, and no opt-in flag to turn this behavior on.
+
+Contrast with `/map-plan` and `/map-efficient`: those workflows expect you to drive each phase yourself. `/map-auto` is a thin router plus chain driver on top of them -- it never reimplements their logic, it only decides which one(s) to run and calls them unmodified, one after another, in the same session.
+
+## Effort and Parallelism Policy
+
+```yaml
+thinking_policy: high/adaptive
+parallel_tool_policy: sequential_by_default
+```
+
+- Use deeper reasoning for the routing decision and for judging whether a phase genuinely failed (worth a bounded re-entry) or is truly stuck (worth aborting to `/map-resume`) -- a wrong call here compounds across an entire unattended chain.
+- Keep routing, hold-decision, phase-record, and phase-invocation calls strictly sequential; a chain driver has no independent work to parallelize across phases.
+- Within a chained phase (e.g. `/map-efficient`), defer to that phase's own parallelism policy -- `/map-auto` does not override it.
+
+## Determinism boundary
+
+All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through the three runner subcommands below: `route_task` (routing decision), `auto_decide_holds` (approval-hold triage), and `record_auto_phase` (phase ledger). Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
+
+## Step 1: Route the Task
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS"
+```
+
+To inspect the recommendation without committing to it (no write beyond the routing artifact itself, no phase started):
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS" --dry-run
+```
+
+`route_task` writes `.map/<branch>/auto-route.json` (schema-validated) and selects exactly one of `map-resume`, `map-check`, `map-fast`, `map-plan`, `map-efficient` via a five-tier precedence engine you do not need to re-derive -- read `selected_route` and `next_command` from the result and act on those fields.
+
+- `status: "refused"` -- an in-progress chain already exists for this branch; follow the returned `next_command` (`/map-resume`) instead of re-routing.
+- `status: "blocked"` -- a hard-stop hold or a `goal_mismatch` verdict blocks the chain; `blocked_by[]` names the pending hold ids, `block_reason` explains why. STOP -- see Hard Stops below.
+- `status: "success"` -- `chain_status` is `"in_progress"` (normal run) or `"recommended_only"` (`--dry-run`); proceed to Step 2 for the selected route.
+
+## Step 2: Decide Holds Before Each Chained Phase
+
+Before invoking each chained workflow, drain auto-approvable holds so the chain does not sit blocked on routine posture/approval/overwrite confirmations:
+
+```bash
+python3 .map/scripts/map_step_runner.py auto_decide_holds
+```
+
+`auto_decide_holds` approves every pending `autonomy_posture`, `plan_approval`, and `template_overwrite` hold on your behalf and returns them in `auto_approved[]`. Any pending `dangerous_action` or `safety_guardrail` hold is returned in `hard_stops[]` and is left untouched -- these two kinds are never auto-decided by any code path this skill invokes.
+
+### Hard Stops (dangerous_action / safety_guardrail)
+
+If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or `auto_decide_holds` returns a non-empty `hard_stops[]`, STOP the autopilot immediately. Surface the hold's reason to the user and wait for an explicit human decision on that hold before resuming (`/map-resume` once it is decided). Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase.
+
+## Step 3: Record Each Phase Boundary
+
+Record every phase transition so `auto-route.json` stays the single source of truth for chain progress:
+
+```bash
+python3 .map/scripts/map_step_runner.py record_auto_phase "<phase>" "<status>" \
+  --evidence-refs "<comma-separated auto-approved hold ids>" \
+  --reason "<why this status>"
+```
+
+`<phase>` is the workflow name being entered/exited (`map-plan`, `map-efficient`, `map-check`, or `map-review`). `<status>` follows the phase's own vocabulary -- use `completed` on a clean phase close and `aborted`/`failed` on a phase you cannot recover; anything else leaves the chain `in_progress`. Pass every hold id that `auto_decide_holds` auto-approved for this phase in `--evidence-refs`, so the approval is recorded twice: once in the hold's own audit note, once in the phase ledger.
+
+**At most one re-entry per phase:** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Inspect ground truth (the phase's own artifacts, test output, Monitor verdict) before spending the single permitted re-entry. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase.
+
+## Chain
+
+Once routed, drive the selected chain by invoking the existing slash workflows exactly as written, one after another in the same session:
+
+```
+route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]
+```
+
+- `map-resume`, `map-check`, and `map-fast` routes are single-phase: run the one workflow, record its result with `record_auto_phase`, and finish.
+- `map-plan` and `map-efficient` routes continue the chain: `map-plan` produces the task plan that `map-efficient` consumes, `map-efficient` implements it, and the chain then continues to `map-check` and `map-review` to close the loop.
+- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps.
+- A `valid=false` Monitor verdict INSIDE a phase is that phase's own hard stop: its owning workflow's existing retry/escalation rules apply unchanged. `/map-auto` never overrides, suppresses, or re-runs past a Monitor rejection on the phase's behalf -- a phase that cannot get past Monitor is a failed phase for the purposes of Step 3's re-entry bound.
+- The autopilot run ends at a committed feature branch. `/map-auto` never opens a pull request, never merges, and never polls CI -- report the committed branch, the phases recorded, and stop.
+
+## Examples
+
+```
+/map-auto add a --verbose flag to the status command
+/map-auto refactor the checkout flow to support partial refunds
+```
+
+## Troubleshooting
+
+- **Issue:** `route_task` returns `status: "refused"`. **Fix:** A chain is already `in_progress` on this branch; run `/map-resume` instead of re-routing.
+- **Issue:** `route_task` or `auto_decide_holds` reports a pending `dangerous_action`/`safety_guardrail` hold. **Fix:** This is a hard stop by design -- surface the reason and wait for an explicit human decision; do not attempt to auto-approve it.
+- **Issue:** `record_auto_phase` returns `status: "refused"` with `chain_status: "aborted"` or `"blocked"`. **Fix:** The chain is terminal; only a new `route_task` call can re-route it explicitly.
+- **Issue:** A chained phase (e.g. `/map-efficient`) fails Monitor repeatedly. **Fix:** Let that phase's own retry/escalation rules run their course; record the outcome via `record_auto_phase` and stop after the single permitted re-entry rather than forcing a third attempt.

--- a/src/mapify_cli/templates_src/skills/map-auto/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-auto/SKILL.md.jinja
@@ -25,7 +25,7 @@ parallel_tool_policy: sequential_by_default
 
 ## Determinism boundary
 
-All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through the three runner subcommands below: `route_task` (routing decision), `auto_decide_holds` (approval-hold triage), and `record_auto_phase` (phase ledger). Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
+All routing and phase-ledger state lives in `.map/<branch>/auto-route.json` and is mutated ONLY through two runner subcommands below: `route_task` (routing decision) and `record_auto_phase` (phase ledger). `auto_decide_holds` (approval-hold triage) mutates `approval_holds.json` separately — its approvals surface in the `approval_hold` manifest stage, not in `auto-route.json`. Never hand-edit `auto-route.json`. Every command prints a JSON result; a non-success `status` means stop and read the message before continuing.
 
 ## Step 1: Route the Task
 

--- a/src/mapify_cli/templates_src/skills/map-auto/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-auto/SKILL.md.jinja
@@ -45,9 +45,9 @@ python3 .map/scripts/map_step_runner.py route_task "$ARGUMENTS" --dry-run
 - `status: "blocked"` -- a hard-stop hold or a `goal_mismatch` verdict blocks the chain; `blocked_by[]` names the pending hold ids, `block_reason` explains why. STOP -- see Hard Stops below.
 - `status: "success"` -- `chain_status` is `"in_progress"` (normal run) or `"recommended_only"` (`--dry-run`); proceed to Step 2 for the selected route.
 
-## Step 2: Decide Holds Before Each Chained Phase
+## Step 2: Decide Holds Around Each Chained Phase
 
-Before invoking each chained workflow, drain auto-approvable holds so the chain does not sit blocked on routine posture/approval/overwrite confirmations:
+Poll `auto_decide_holds` before invoking each chained workflow AND again immediately after it concludes, before recording its outcome in Step 3 -- the second poll catches a hold that was created while the phase was running instead of leaving it for a later, unscheduled check:
 
 ```bash
 python3 .map/scripts/map_step_runner.py auto_decide_holds
@@ -57,7 +57,7 @@ python3 .map/scripts/map_step_runner.py auto_decide_holds
 
 ### Hard Stops (dangerous_action / safety_guardrail)
 
-If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or `auto_decide_holds` returns a non-empty `hard_stops[]`, STOP the autopilot immediately. Surface the hold's reason to the user and wait for an explicit human decision on that hold before resuming (`/map-resume` once it is decided). Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase.
+If `route_task` reports `status: "blocked"` with entries in `blocked_by[]`, or either `auto_decide_holds` poll returns a non-empty `hard_stops[]`, STOP the autopilot. Do not retry, do not reinterpret the hold as auto-approvable, and do not proceed to the next phase. A hard stop found by the POST-phase poll means it appeared while the phase was running -- record that before stopping: `record_auto_phase "<phase>" aborted --reason "hard-stop hold pending: <ids>"`. A hard stop found via `route_task`'s `blocked_by[]` or the PRE-phase poll has no phase entry to record yet -- just stop. Either way, surface the hold's reason to the user and wait for an explicit human decision before resuming (`/map-resume` once it is decided).
 
 ## Step 3: Record Each Phase Boundary
 
@@ -71,7 +71,7 @@ python3 .map/scripts/map_step_runner.py record_auto_phase "<phase>" "<status>" \
 
 `<phase>` is the workflow name being entered/exited (`map-plan`, `map-efficient`, `map-check`, or `map-review`). `<status>` follows the phase's own vocabulary -- use `completed` on a clean phase close and `aborted`/`failed` on a phase you cannot recover; anything else leaves the chain `in_progress`. Pass every hold id that `auto_decide_holds` auto-approved for this phase in `--evidence-refs`, so the approval is recorded twice: once in the hold's own audit note, once in the phase ledger.
 
-**At most one re-entry per phase:** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Inspect ground truth (the phase's own artifacts, test output, Monitor verdict) before spending the single permitted re-entry. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase.
+**At most one re-entry per phase (HC-2):** `record_auto_phase` mechanically enforces this -- the first record of a phase name is `attempt: 1`, a re-entry is `attempt: 2`, and a third call for the SAME phase name is refused and force-aborts the chain (`chain_status: "aborted"`). Before spending the single permitted re-entry, inspect ground truth -- `git status`/`git diff` and the phase's own `step_state.json` (or equivalent phase artifacts, test output, Monitor verdict) -- to confirm the phase genuinely needs a fresh attempt rather than a partial success being misread as a failure. A second failure of the same phase means STOP and hand off to `/map-resume` -- never attempt a third call for that phase. A chain already `chain_status: "aborted"` or `"blocked"` refuses every further `record_auto_phase` call regardless of phase name; a new `route_task` call is the ONLY legitimate way to continue.
 
 ## Chain
 
@@ -83,9 +83,11 @@ route_task -> [map-plan] -> [map-efficient] -> [map-check] -> [map-review]
 
 - `map-resume`, `map-check`, and `map-fast` routes are single-phase: run the one workflow, record its result with `record_auto_phase`, and finish.
 - `map-plan` and `map-efficient` routes continue the chain: `map-plan` produces the task plan that `map-efficient` consumes, `map-efficient` implements it, and the chain then continues to `map-check` and `map-review` to close the loop.
-- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps.
+- Invoke each phase by reading and following its own `SKILL.md` in full, exactly as if the user had typed the corresponding slash command -- do not summarize, skip, or reimplement its internal steps. `/map-auto` never shells out to a separate Claude process, a new Python execution engine, or any other new phase-driving mechanism to do this -- phases are driven ONLY by invoking the existing slash workflows above and the three runner subcommands from Steps 1-3.
 - A `valid=false` Monitor verdict INSIDE a phase is that phase's own hard stop: its owning workflow's existing retry/escalation rules apply unchanged. `/map-auto` never overrides, suppresses, or re-runs past a Monitor rejection on the phase's behalf -- a phase that cannot get past Monitor is a failed phase for the purposes of Step 3's re-entry bound.
 - The autopilot run ends at a committed feature branch. `/map-auto` never opens a pull request, never merges, and never polls CI -- report the committed branch, the phases recorded, and stop.
+
+For the full CLI flag reference, a worked chain walkthrough, the failure-mode table, and recovery procedures, see [auto-reference.md](auto-reference.md).
 
 ## Examples
 

--- a/src/mapify_cli/templates_src/skills/map-auto/auto-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-auto/auto-reference.md.jinja
@@ -1,0 +1,78 @@
+# /map-auto Supporting Reference
+
+This file holds low-frequency `/map-auto` details so `SKILL.md` stays focused on the active route -> holds -> phase-ledger loop.
+
+## CLI Reference
+
+Three runner subcommands back the whole autopilot; `SKILL.md` calls them in order (`route_task` once, then `auto_decide_holds` / `record_auto_phase` per chained phase). No other subcommand drives the chain.
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task <task> [--branch B] [--dry-run]
+python3 .map/scripts/map_step_runner.py auto_decide_holds [--branch B]
+python3 .map/scripts/map_step_runner.py record_auto_phase <phase> <status> [--branch B] \
+  [--evidence-refs a,b,c] [--reason "..."]
+```
+
+- `route_task <task>` -- `<task>` is the free-text task description (quote it). `--branch` defaults to the current branch. `--dry-run` recommends a route without marking the chain `in_progress` (see Dry-run usage below).
+- `auto_decide_holds` -- no positional arguments; only `--branch` (defaults to current branch).
+- `record_auto_phase <phase> <status>` -- `<phase>` is the workflow name (`map-plan`, `map-efficient`, `map-check`, `map-review`); `<status>` is the phase's own outcome word (`completed`, `failed`, `aborted`, or any other phase-specific status, which leaves `chain_status` at `in_progress`). `--evidence-refs` takes a comma-separated list of ids (auto-approved hold ids from the surrounding `auto_decide_holds` calls); `--reason` is a free-text note stored on the ledger entry.
+
+## Chain Walkthrough Example
+
+A `map-efficient` route, condensed (real output trimmed to the fields that matter):
+
+```bash
+$ python3 .map/scripts/map_step_runner.py route_task "add retry to the sync job"
+{"status": "success", "selected_route": "map-efficient", "chain_status": "in_progress", ...}
+
+$ python3 .map/scripts/map_step_runner.py auto_decide_holds
+{"status": "ok", "auto_approved": [{"id": "hold-1", "kind": "plan_approval", ...}], "hard_stops": []}
+
+# -- drive /map-efficient unmodified, in full, per its own SKILL.md --
+
+$ python3 .map/scripts/map_step_runner.py auto_decide_holds
+{"status": "ok", "auto_approved": [], "hard_stops": []}
+
+$ python3 .map/scripts/map_step_runner.py record_auto_phase "map-efficient" "completed" \
+  --evidence-refs "hold-1" --reason "all subtasks closed, make check green"
+{"status": "success", "chain_status": "completed", "phase": "map-efficient", "attempt": 1, ...}
+
+# -- chain then continues to map-check, then map-review, each following the same
+#    poll -> drive -> poll -> record loop, until the last phase records "completed" --
+```
+
+The run ends there: a committed feature branch, `phases[]` in `auto-route.json` holding one entry per phase attempt, and no PR/merge/CI step of any kind.
+
+## Failure-Mode Table
+
+| Failure mode | Trigger | Response |
+|---|---|---|
+| Hard-stop hold | `dangerous_action` or `safety_guardrail` hold pending (at route time or discovered mid-phase) | STOP the autopilot; surface the hold's reason; wait for an explicit human decision; resume via `/map-resume` once it is decided. Never auto-approved by any `/map-auto` code path (INV-2). |
+| Repeated phase failure (HC-2) | A third `record_auto_phase` call for the SAME phase name | Refused outright -- no entry appended; the chain is force-aborted (`chain_status: "aborted"`) with the abort reason persisted in `auto-route.json`. Recover via `/map-resume`; a fresh `route_task` on the aborted branch re-routes and preserves the prior route in `route_history[]`. |
+| `goal_mismatch` | `check_plan_resume` reports the branch already hosts a plan for a DIFFERENT goal | `route_task` refuses to route: `status: "blocked"`, `chain_status: "blocked"`, `block_reason` names the mismatch. The prior spec/task_plan/blueprint artifacts are left untouched -- resolving the mismatch (archive, rename, or confirm intent) is the operator's call. |
+| In-progress re-route | `route_task` called while the branch's `auto-route.json` already has `chain_status: "in_progress"` | Refused: `status: "refused"`, `next_command: "/map-resume"`; the existing artifact is left byte-identical. |
+| `blueprint_unavailable` | `step_state.json` exists but `blueprint.json`'s subtask-id universe can't be read | Routes to `map-resume` rather than guessing "complete" -- recorded as `evidence: [{"signal": "step_state.json", "value": "blueprint_unavailable", ...}]`. |
+
+## Recovery Procedures
+
+- **`/map-resume`** -- the single recovery surface for every stop condition above: a refused re-route, an aborted chain, a hard-stop hold once it is decided, or a phase that failed Monitor past its own retry budget. It reads the branch's existing state (`step_state.json`, `auto-route.json`) and resumes from there; it never re-runs `route_task` on your behalf.
+- **New `route_task` from a terminal chain** -- `chain_status` values `aborted`, `blocked`, `completed`, and `recommended_only` may all be re-routed; only `in_progress` refuses. A re-route overwrites `auto-route.json` but preserves the superseded route in `route_history[]`, so a fresh `route_task "<task>"` call is the ONLY way to move a terminal chain forward -- never hand-edit `chain_status` in the artifact.
+
+## Dry-run Usage
+
+`route_task "<task>" --dry-run` is the whole dry-run surface (Decision 8) -- there is no separate preview command for holds or phases, because neither runs until a real (non-dry-run) `route_task` call marks the chain `in_progress`.
+
+```bash
+python3 .map/scripts/map_step_runner.py route_task "add retry to the sync job" --dry-run
+```
+
+- Sets `executed: false` and `chain_status: "recommended_only"` -- the run is a recommendation, not a commitment.
+- Performs no filesystem writes beyond `.map/<branch>/auto-route.json` and its `auto_route` manifest stage entry -- no `record_workflow_fit`, no `create_approval_hold`, nothing else on disk changes (AC-3).
+- A pending hard-stop hold still surfaces: `blocked_by[]` is populated and `chain_status` becomes `"blocked"` even under `--dry-run` -- "blocked" always outranks "recommended_only".
+- Re-running `route_task` (with or without `--dry-run`) after a dry-run is always allowed -- `recommended_only` is not a terminal `chain_status`.
+
+## Troubleshooting
+
+- **Issue:** `record_auto_phase` reports `status: "error"`. **Fix:** No `auto-route.json` exists for this branch yet -- run `route_task` first.
+- **Issue:** Need to inspect the ledger without another CLI call. **Fix:** Read `.map/<branch>/auto-route.json` directly (read-only) -- `phases[]`, `chain_status`, `abort_reason`/`block_reason`, and `route_history[]` are all plain fields; never hand-edit the file.
+- **Issue:** A phase's own Monitor keeps rejecting past what looks like a real fix. **Fix:** That is the chained workflow's own retry/escalation, not `/map-auto`'s -- let it run its course; `/map-auto` only records the outcome once that workflow itself stops.

--- a/src/mapify_cli/templates_src/skills/skill-rules.json.jinja
+++ b/src/mapify_cli/templates_src/skills/skill-rules.json.jinja
@@ -452,6 +452,25 @@
           "before.*(map-plan|planning)"
         ]
       }
+    },
+    "map-auto": {
+      "type": "manual",
+      "skillClass": "task",
+      "enforcement": "manual",
+      "priority": "high",
+      "description": "Single-entry autonomous autopilot: routes a task via route_task then drives the selected MAP workflow chain end-to-end to a committed feature branch.",
+      "promptTriggers": {
+        "keywords": [
+          "map-auto",
+          "autopilot",
+          "single-entry workflow",
+          "auto route task"
+        ],
+        "intentPatterns": [
+          "map-auto",
+          "(autopilot|auto).*(task|workflow|route)"
+        ]
+      }
     }
   }
 }

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -1,6 +1,7 @@
 """Focused tests for new artifact schemas without importing package extras."""
 
 import importlib.util
+import sys
 from pathlib import Path
 
 SCHEMAS_PATH = Path(__file__).resolve().parents[1] / "src" / "mapify_cli" / "schemas.py"
@@ -8,6 +9,15 @@ SPEC = importlib.util.spec_from_file_location("artifact_schemas", SCHEMAS_PATH)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
+
+# map_step_runner.py is generated (stdlib-only), so importing it here does not
+# pull in package extras — it is the single authority for ARTIFACT_STAGE_NAMES
+# (see architecture-patterns: Contract-First Inter-Component JSON Schemas).
+_RUNNER_SCRIPTS_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "mapify_cli" / "templates" / "map" / "scripts"
+)
+sys.path.insert(0, str(_RUNNER_SCRIPTS_PATH))
+import map_step_runner  # type: ignore[import-not-found]
 
 
 def _minimal_prior_stage_consumption() -> dict:
@@ -815,3 +825,21 @@ def test_validate_auto_route_schema_phases_missing_attempt_fails():
     is_valid = MODULE.validate_artifact(artifact, MODULE.AUTO_ROUTE_SCHEMA)[0]
 
     assert not is_valid
+
+
+def test_artifact_manifest_schema_stages_cover_every_runner_stage_name():
+    """Every stage in map_step_runner's ARTIFACT_STAGE_NAMES authority must be
+    declared in ARTIFACT_MANIFEST_SCHEMA's stages.properties, or a manifest
+    carrying that stage fails schema validation (stages.additionalProperties
+    is False). Prevents this drift class from recurring silently.
+    """
+    schema_stage_names = set(
+        MODULE.ARTIFACT_MANIFEST_SCHEMA["properties"]["stages"]["properties"]
+    )
+    runner_stage_names = set(map_step_runner.ARTIFACT_STAGE_NAMES)
+
+    missing_from_schema = runner_stage_names - schema_stage_names
+    assert not missing_from_schema, (
+        f"Stages present in ARTIFACT_STAGE_NAMES but missing from "
+        f"ARTIFACT_MANIFEST_SCHEMA stages.properties: {sorted(missing_from_schema)}"
+    )

--- a/tests/test_artifact_schemas.py
+++ b/tests/test_artifact_schemas.py
@@ -734,3 +734,84 @@ def test_validate_implementer_readiness_schema_rejects_additional_properties():
     )[0]
 
     assert not is_valid
+
+
+def _minimal_auto_route() -> dict:
+    return {
+        "schema_version": "1.0",
+        "task_summary": "Add AUTO_ROUTE_SCHEMA to schemas.py",
+        "selected_route": "map-efficient",
+        "evidence": [
+            {
+                "signal": "step_state",
+                "value": "pending",
+                "source": ".map/feat-map-auto/step_state.json",
+            }
+        ],
+        "blocked_by": [],
+        "next_command": "/map-efficient",
+        "executed": True,
+        "chain_status": "in_progress",
+        "phases": [
+            {
+                "phase": "plan",
+                "status": "completed",
+                "attempt": 1,
+                "evidence_refs": [],
+                "reason": "",
+                "recorded_at": "2026-08-13T12:00:00Z",
+            }
+        ],
+        "route_history": [],
+    }
+
+
+def test_validate_auto_route_schema_golden():
+    artifact = _minimal_auto_route()
+
+    is_valid, errors = MODULE.validate_artifact(artifact, MODULE.AUTO_ROUTE_SCHEMA)
+    assert is_valid, f"Errors: {errors}"
+
+
+def test_validate_auto_route_schema_rejects_unknown_chain_status():
+    artifact = _minimal_auto_route()
+    artifact["chain_status"] = "not-a-status"
+
+    is_valid = MODULE.validate_artifact(artifact, MODULE.AUTO_ROUTE_SCHEMA)[0]
+
+    assert not is_valid
+
+
+def test_validate_auto_route_schema_rejects_unknown_selected_route():
+    artifact = _minimal_auto_route()
+    artifact["selected_route"] = "map-tdd"
+
+    is_valid = MODULE.validate_artifact(artifact, MODULE.AUTO_ROUTE_SCHEMA)[0]
+
+    assert not is_valid
+
+
+def test_validate_auto_route_schema_evidence_missing_source_fails():
+    artifact = _minimal_auto_route()
+    artifact["evidence"] = [{"signal": "step_state", "value": "pending"}]
+
+    is_valid = MODULE.validate_artifact(artifact, MODULE.AUTO_ROUTE_SCHEMA)[0]
+
+    assert not is_valid
+
+
+def test_validate_auto_route_schema_phases_missing_attempt_fails():
+    artifact = _minimal_auto_route()
+    artifact["phases"] = [
+        {
+            "phase": "plan",
+            "status": "completed",
+            "evidence_refs": [],
+            "reason": "",
+            "recorded_at": "2026-08-13T12:00:00Z",
+        }
+    ]
+
+    is_valid = MODULE.validate_artifact(artifact, MODULE.AUTO_ROUTE_SCHEMA)[0]
+
+    assert not is_valid

--- a/tests/test_map_auto.py
+++ b/tests/test_map_auto.py
@@ -68,30 +68,30 @@ _AC7_MATRIX: dict[str, tuple[set[str], list[str]]] = {
         _STEP_RUNNER_TESTS,
         [
             "test_route_task_dry_run_sets_executed_false_and_recommended_only",
-            "test_vc1_route_task_dry_run_write_isolation",
-            "test_vc2_route_task_never_calls_record_workflow_fit_or_create_approval_hold",
+            "test_route_task_dry_run_write_isolation",
+            "test_route_task_never_calls_record_workflow_fit_or_create_approval_hold",
         ],
     ),
     # (c) hold auto-approve vs hard-stop split.
     "hold_auto_approve_vs_hard_stop": (
         _STEP_RUNNER_TESTS,
         [
-            "test_vc4_auto_approvable_and_hard_stop_kinds_partition_approval_hold_kinds",
-            "test_vc1_auto_decide_holds_approves_every_auto_approvable_kind",
-            "test_vc2_auto_decide_holds_leaves_hard_stop_kinds_pending",
-            "test_vc3_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_kind",
+            "test_auto_approvable_and_hard_stop_kinds_partition_approval_hold_kinds",
+            "test_auto_decide_holds_approves_every_auto_approvable_kind",
+            "test_auto_decide_holds_leaves_hard_stop_kinds_pending",
+            "test_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_kind",
         ],
     ),
     # (d) phase ledger + chain_status transitions + in-progress re-route refusal.
     "phase_ledger_and_reroute_refusal": (
         _STEP_RUNNER_TESTS,
         [
-            "test_vc1_record_auto_phase_appends_one_schema_valid_six_field_entry",
-            "test_vc2_record_auto_phase_terminal_success_status_completes_chain",
-            "test_vc2_record_auto_phase_abort_class_status_aborts_chain",
-            "test_vc3_record_auto_phase_attempt_counter_and_third_attempt_refused",
-            "test_vc3_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched",
-            "test_vc3_route_task_reroutes_when_prior_status_allows",
+            "test_record_auto_phase_appends_one_schema_valid_six_field_entry",
+            "test_record_auto_phase_terminal_success_status_completes_chain",
+            "test_record_auto_phase_abort_class_status_aborts_chain",
+            "test_record_auto_phase_attempt_counter_and_third_attempt_refused",
+            "test_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched",
+            "test_route_task_reroutes_when_prior_status_allows",
         ],
     ),
     # (e) AUTO_ROUTE_SCHEMA golden-artifact validation.
@@ -110,7 +110,7 @@ _AC7_MATRIX: dict[str, tuple[set[str], list[str]]] = {
         _SKILLS_TESTS,
         [
             "test_map_auto_is_default_on_with_no_gating_flag",
-            "test_vc5_skill_body_within_default_budget",
+            "test_skill_body_within_default_budget",
             "test_every_non_high_traffic_skill_body_within_default_budget",
         ],
     ),

--- a/tests/test_map_auto.py
+++ b/tests/test_map_auto.py
@@ -1,0 +1,148 @@
+"""AC-7 matrix-completeness meta-test for the /map-auto autopilot feature.
+
+ST-010 closes AC-7 by proving the test matrix accumulated across ST-001..
+ST-009 is provably complete: each of AC-7's seven required areas must map to
+at least one existing NAMED covering test. This file does NOT duplicate the
+underlying tests -- it only asserts the named tests are still defined in
+their owning suite, so a future rename or deletion of a covering test fails
+this meta-test loudly instead of leaving a silent coverage hole.
+
+Test names are discovered by AST parsing (not import) of the owning test
+modules. AST parsing is chosen over importing the modules because it needs
+no side effects (no sys.path mutation, no pulling in map_step_runner.py or
+package extras) and cannot accidentally re-execute another test module's
+top-level code -- it only reads which `test_*` functions are defined.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_TESTS_DIR = Path(__file__).resolve().parent
+
+
+def _defined_test_names(module_filename: str) -> set[str]:
+    """Return every `test_*` function name defined anywhere in the module
+    (module-level or nested inside a `Test*` class), via AST parsing.
+    """
+    source = (_TESTS_DIR / module_filename).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=module_filename)
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+
+
+_STEP_RUNNER_TESTS = _defined_test_names("test_map_step_runner.py")
+_ARTIFACT_SCHEMA_TESTS = _defined_test_names("test_artifact_schemas.py")
+_SKILLS_TESTS = _defined_test_names("test_skills.py")
+_TEMPLATE_RENDER_TESTS = _defined_test_names("test_template_render.py")
+
+
+# AC-7 area -> (set of test names actually defined in the owning suite(s),
+# list of covering test names this area depends on). Every listed name must
+# be present in the defined-names set -- if a name is renamed or deleted the
+# corresponding area's check fails loudly rather than silently degrading to
+# "at least one other test still covers it".
+_AC7_MATRIX: dict[str, tuple[set[str], list[str]]] = {
+    # (a) routing tiers, incl. 1b complete-state, tier-2 out-of-vocabulary
+    # fallthrough, and tier-3 task_plan-without-blueprint.
+    "routing_tiers": (
+        _STEP_RUNNER_TESTS,
+        [
+            "test_select_route_tier1a_pending_step_state_yields_map_resume",
+            "test_select_route_tier1b_all_complete_step_state_yields_map_check",
+            "test_select_route_tier2_workflow_fit_map_efficient_is_honored",
+            "test_select_route_tier2_out_of_vocabulary_falls_through_and_is_recorded",
+            "test_select_route_tier3_resume_with_blueprint_yields_map_efficient",
+            "test_select_route_tier3b_resume_without_blueprint_yields_map_plan",
+            "test_select_route_tier4_trivial_bracket_yields_map_fast",
+            "test_select_route_tier5_default_bare_branch_yields_map_plan",
+        ],
+    ),
+    # (b) dry-run write isolation.
+    "dry_run_write_isolation": (
+        _STEP_RUNNER_TESTS,
+        [
+            "test_route_task_dry_run_sets_executed_false_and_recommended_only",
+            "test_vc1_route_task_dry_run_write_isolation",
+            "test_vc2_route_task_never_calls_record_workflow_fit_or_create_approval_hold",
+        ],
+    ),
+    # (c) hold auto-approve vs hard-stop split.
+    "hold_auto_approve_vs_hard_stop": (
+        _STEP_RUNNER_TESTS,
+        [
+            "test_vc4_auto_approvable_and_hard_stop_kinds_partition_approval_hold_kinds",
+            "test_vc1_auto_decide_holds_approves_every_auto_approvable_kind",
+            "test_vc2_auto_decide_holds_leaves_hard_stop_kinds_pending",
+            "test_vc3_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_kind",
+        ],
+    ),
+    # (d) phase ledger + chain_status transitions + in-progress re-route refusal.
+    "phase_ledger_and_reroute_refusal": (
+        _STEP_RUNNER_TESTS,
+        [
+            "test_vc1_record_auto_phase_appends_one_schema_valid_six_field_entry",
+            "test_vc2_record_auto_phase_terminal_success_status_completes_chain",
+            "test_vc2_record_auto_phase_abort_class_status_aborts_chain",
+            "test_vc3_record_auto_phase_attempt_counter_and_third_attempt_refused",
+            "test_vc3_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched",
+            "test_vc3_route_task_reroutes_when_prior_status_allows",
+        ],
+    ),
+    # (e) AUTO_ROUTE_SCHEMA golden-artifact validation.
+    "auto_route_schema_golden": (
+        _ARTIFACT_SCHEMA_TESTS,
+        [
+            "test_validate_auto_route_schema_golden",
+            "test_validate_auto_route_schema_rejects_unknown_chain_status",
+            "test_validate_auto_route_schema_rejects_unknown_selected_route",
+            "test_validate_auto_route_schema_evidence_missing_source_fails",
+            "test_validate_auto_route_schema_phases_missing_attempt_fails",
+        ],
+    ),
+    # (f) skill registration + body budget.
+    "skill_registration_and_body_budget": (
+        _SKILLS_TESTS,
+        [
+            "test_map_auto_is_default_on_with_no_gating_flag",
+            "test_vc5_skill_body_within_default_budget",
+            "test_every_non_high_traffic_skill_body_within_default_budget",
+        ],
+    ),
+    # (g) render parity.
+    "render_parity": (
+        _SKILLS_TESTS | _TEMPLATE_RENDER_TESTS,
+        [
+            "test_skill_templates_in_sync",
+            "test_skill_supporting_files_in_sync",
+            "test_real_repo_trees_in_sync",
+        ],
+    ),
+}
+
+
+def test_ac7_matrix_covers_exactly_seven_areas() -> None:
+    """Guard against the matrix itself silently shrinking or growing."""
+    assert len(_AC7_MATRIX) == 7, (
+        f"AC-7 defines exactly seven required test areas; matrix currently "
+        f"has {len(_AC7_MATRIX)}: {sorted(_AC7_MATRIX)}"
+    )
+
+
+@pytest.mark.parametrize("area", sorted(_AC7_MATRIX))
+def test_ac7_area_has_named_covering_tests(area: str) -> None:
+    """VC1 [AC-7]: every area maps to >=1 existing named covering test and
+    fails if any listed covering test has been renamed or deleted."""
+    defined_names, required_names = _AC7_MATRIX[area]
+    assert required_names, f"AC-7 area {area!r} has no required test names configured."
+    missing = [name for name in required_names if name not in defined_names]
+    assert not missing, (
+        f"AC-7 area {area!r} lost covering test(s) {missing} -- restore the "
+        "test, or if it was deliberately renamed, update this matrix. An "
+        "AC-7 area must never silently drop to zero covering tests."
+    )

--- a/tests/test_map_auto.py
+++ b/tests/test_map_auto.py
@@ -42,7 +42,7 @@ _SKILLS_TESTS = _defined_test_names("test_skills.py")
 _TEMPLATE_RENDER_TESTS = _defined_test_names("test_template_render.py")
 
 
-# AC-7 area -> (set of test names actually defined in the owning suite(s),
+# area -> (set of test names actually defined in the owning suite(s),
 # list of covering test names this area depends on). Every listed name must
 # be present in the defined-names set -- if a name is renamed or deleted the
 # corresponding area's check fails loudly rather than silently degrading to

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -1928,7 +1928,7 @@ def _read_auto_route_artifact(branch_workspace: Path) -> dict[str, object]:
     return json.loads((branch_workspace / "auto-route.json").read_text(encoding="utf-8"))
 
 
-def test_vc1_route_task_writes_schema_valid_artifact_and_registers_manifest_stage(
+def test_route_task_writes_schema_valid_artifact_and_registers_manifest_stage(
     branch_workspace,
 ):
     branch = branch_workspace.name
@@ -1955,7 +1955,7 @@ def test_vc1_route_task_writes_schema_valid_artifact_and_registers_manifest_stag
     assert metadata["chain_status"] == artifact["chain_status"]
 
 
-def test_vc2_route_task_non_dry_run_sets_executed_true_and_chain_status_in_progress(
+def test_route_task_non_dry_run_sets_executed_true_and_chain_status_in_progress(
     branch_workspace,
 ):
     branch = branch_workspace.name
@@ -1977,7 +1977,7 @@ def test_route_task_dry_run_sets_executed_false_and_recommended_only(branch_work
     assert artifact["chain_status"] == "recommended_only"
 
 
-def test_vc3_route_task_sanitizes_task_summary_control_characters(branch_workspace):
+def test_route_task_sanitizes_task_summary_control_characters(branch_workspace):
     branch = branch_workspace.name
     dirty_task = "line one\r\nline two\x00\x1f\x7f\ttabbed"
 
@@ -1992,7 +1992,7 @@ def test_vc3_route_task_sanitizes_task_summary_control_characters(branch_workspa
     assert "line two" in task_summary
 
 
-def test_vc4_route_task_phases_empty_and_next_command_matches_selected_route(
+def test_route_task_phases_empty_and_next_command_matches_selected_route(
     branch_workspace,
 ):
     branch = branch_workspace.name
@@ -2022,7 +2022,7 @@ def test_route_task_preserves_route_history_on_second_write(branch_workspace):
     assert artifact["route_history"] == ["map-plan"]
 
 
-# --- route_task guards (issue #414 ST-005: dry-run write isolation,
+# route_task guards (issue #414 : dry-run write isolation,
 # in-progress re-route refusal, hard-stop hold block, goal_mismatch block) -
 
 
@@ -2039,7 +2039,7 @@ def _snapshot_tree(root: Path) -> dict[str, int]:
     }
 
 
-def test_vc1_route_task_dry_run_write_isolation(tmp_path, branch_workspace):
+def test_route_task_dry_run_write_isolation(tmp_path, branch_workspace):
     branch = branch_workspace.name
     before = _snapshot_tree(tmp_path)
 
@@ -2064,7 +2064,7 @@ def test_vc1_route_task_dry_run_write_isolation(tmp_path, branch_workspace):
     assert artifact["chain_status"] == "recommended_only"
 
 
-def test_vc2_route_task_never_calls_record_workflow_fit_or_create_approval_hold(
+def test_route_task_never_calls_record_workflow_fit_or_create_approval_hold(
     branch_workspace, monkeypatch
 ):
     branch = branch_workspace.name
@@ -2111,7 +2111,7 @@ def test_vc2_route_task_never_calls_record_workflow_fit_or_create_approval_hold(
             map_step_runner.route_task("some task", branch=branch, dry_run=dry_run)
 
 
-def test_vc3_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched(
+def test_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched(
     branch_workspace,
 ):
     branch = branch_workspace.name
@@ -2133,7 +2133,7 @@ def test_vc3_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched(
     assert manifest_path.read_bytes() == manifest_before
 
 
-def test_vc3_route_task_reroutes_when_prior_status_allows(branch_workspace):
+def test_route_task_reroutes_when_prior_status_allows(branch_workspace):
     branch = branch_workspace.name
     artifact_path = branch_workspace / "auto-route.json"
 
@@ -2161,7 +2161,7 @@ def test_vc3_route_task_reroutes_when_prior_status_allows(branch_workspace):
         assert artifact["route_history"] == ["map-fast"]
 
 
-def test_vc4_route_task_blocks_on_goal_mismatch_and_leaves_plan_artifacts_untouched(
+def test_route_task_blocks_on_goal_mismatch_and_leaves_plan_artifacts_untouched(
     branch_workspace,
 ):
     branch = branch_workspace.name
@@ -2188,7 +2188,7 @@ def test_vc4_route_task_blocks_on_goal_mismatch_and_leaves_plan_artifacts_untouc
     assert not (branch_workspace / "blueprint.json").exists()
 
 
-def test_vc5_route_task_blocks_on_pending_hard_stop_hold(branch_workspace):
+def test_route_task_blocks_on_pending_hard_stop_hold(branch_workspace):
     branch = branch_workspace.name
     hold_result = map_step_runner.create_approval_hold(
         kind="dangerous_action",
@@ -2208,7 +2208,7 @@ def test_vc5_route_task_blocks_on_pending_hard_stop_hold(branch_workspace):
     assert artifact["chain_status"] == "blocked"
 
 
-def test_vc5_route_task_blocks_on_pending_hard_stop_hold_under_dry_run(branch_workspace):
+def test_route_task_blocks_on_pending_hard_stop_hold_under_dry_run(branch_workspace):
     branch = branch_workspace.name
     hold_result = map_step_runner.create_approval_hold(
         kind="safety_guardrail",
@@ -2226,7 +2226,7 @@ def test_vc5_route_task_blocks_on_pending_hard_stop_hold_under_dry_run(branch_wo
     assert result["blocked_by"] == [hold_id]
 
 
-# --- auto_decide_holds (issue #414 ST-006: auto-approve workflow-control
+# auto_decide_holds (issue #414 : auto-approve workflow-control
 # holds via a positive allowlist; dangerous_action/safety_guardrail can
 # never be decided by this code path) -------------------------------------
 
@@ -2235,7 +2235,7 @@ def _read_approval_holds(branch_workspace: Path) -> dict[str, Any]:
     return json.loads((branch_workspace / "approval_holds.json").read_text(encoding="utf-8"))
 
 
-def test_vc4_auto_approvable_and_hard_stop_kinds_partition_approval_hold_kinds():
+def test_auto_approvable_and_hard_stop_kinds_partition_approval_hold_kinds():
     auto_approvable = map_step_runner.AUTO_APPROVABLE_HOLD_KINDS
     hard_stop = map_step_runner.HARD_STOP_HOLD_KINDS
     assert auto_approvable.isdisjoint(hard_stop)
@@ -2252,7 +2252,7 @@ def test_auto_decide_holds_with_nothing_pending_returns_empty_lists(branch_works
     assert result["hard_stops"] == []
 
 
-def test_vc1_auto_decide_holds_approves_every_auto_approvable_kind(branch_workspace):
+def test_auto_decide_holds_approves_every_auto_approvable_kind(branch_workspace):
     branch = branch_workspace.name
     hold_ids: dict[str, str] = {}
     for kind in sorted(map_step_runner.AUTO_APPROVABLE_HOLD_KINDS):
@@ -2283,7 +2283,7 @@ def test_vc1_auto_decide_holds_approves_every_auto_approvable_kind(branch_worksp
     assert follow_up["pending_count"] == 0
 
 
-def test_vc2_auto_decide_holds_leaves_hard_stop_kinds_pending(branch_workspace):
+def test_auto_decide_holds_leaves_hard_stop_kinds_pending(branch_workspace):
     branch = branch_workspace.name
     hold_ids: dict[str, str] = {}
     for kind in sorted(map_step_runner.HARD_STOP_HOLD_KINDS):
@@ -2309,7 +2309,7 @@ def test_vc2_auto_decide_holds_leaves_hard_stop_kinds_pending(branch_workspace):
         assert hold["decision"] is None
 
 
-def test_vc3_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_kind(
+def test_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_kind(
     branch_workspace, monkeypatch
 ):
     branch = branch_workspace.name
@@ -2343,8 +2343,8 @@ def test_vc3_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_k
     assert len(result["hard_stops"]) == len(map_step_runner.HARD_STOP_HOLD_KINDS)
 
 
-# --- record_auto_phase (issue #414 ST-007: phases[] ledger, attempt
-# counter/HC-2 bound, chain_status transitions, single-writer invariant) ---
+# record_auto_phase (issue #414 : phases ledger, attempt
+# counter/ bound, chain_status transitions, single-writer invariant) ---
 
 
 def test_record_auto_phase_errors_when_no_route_task_has_run(branch_workspace):
@@ -2357,7 +2357,7 @@ def test_record_auto_phase_errors_when_no_route_task_has_run(branch_workspace):
     assert not (branch_workspace / "auto-route.json").exists()
 
 
-def test_vc1_record_auto_phase_appends_one_schema_valid_six_field_entry(branch_workspace):
+def test_record_auto_phase_appends_one_schema_valid_six_field_entry(branch_workspace):
     branch = branch_workspace.name
     map_step_runner.route_task("ship something", branch=branch)
 
@@ -2395,7 +2395,7 @@ def test_vc1_record_auto_phase_appends_one_schema_valid_six_field_entry(branch_w
     assert is_valid, f"Errors: {errors}"
 
 
-def test_vc2_record_auto_phase_terminal_success_status_completes_chain(branch_workspace):
+def test_record_auto_phase_terminal_success_status_completes_chain(branch_workspace):
     branch = branch_workspace.name
     map_step_runner.route_task("ship something", branch=branch)
 
@@ -2413,7 +2413,7 @@ def test_vc2_record_auto_phase_terminal_success_status_completes_chain(branch_wo
     assert stage["metadata"]["chain_status"] == "completed"
 
 
-def test_vc2_record_auto_phase_abort_class_status_aborts_chain(branch_workspace):
+def test_record_auto_phase_abort_class_status_aborts_chain(branch_workspace):
     branch = branch_workspace.name
     map_step_runner.route_task("ship something", branch=branch)
 
@@ -2430,7 +2430,7 @@ def test_vc2_record_auto_phase_abort_class_status_aborts_chain(branch_workspace)
     assert manifest["stages"]["auto_route"]["status"] == "aborted"
 
 
-def test_vc2_record_auto_phase_intermediate_status_stays_in_progress(branch_workspace):
+def test_record_auto_phase_intermediate_status_stays_in_progress(branch_workspace):
     branch = branch_workspace.name
     map_step_runner.route_task("ship something", branch=branch)
 
@@ -2445,7 +2445,7 @@ def test_vc2_record_auto_phase_intermediate_status_stays_in_progress(branch_work
     assert manifest["stages"]["auto_route"]["status"] == "in_progress"
 
 
-def test_vc3_record_auto_phase_attempt_counter_and_third_attempt_refused(branch_workspace):
+def test_record_auto_phase_attempt_counter_and_third_attempt_refused(branch_workspace):
     branch = branch_workspace.name
     map_step_runner.route_task("do the thing", branch=branch)
 
@@ -2577,7 +2577,7 @@ def test_record_auto_phase_refuses_new_phase_after_chain_blocked(branch_workspac
     )
 
 
-def test_vc4_record_auto_phase_persists_auto_approved_hold_ids_in_evidence_refs(
+def test_record_auto_phase_persists_auto_approved_hold_ids_in_evidence_refs(
     branch_workspace,
 ):
     branch = branch_workspace.name
@@ -2607,13 +2607,13 @@ def test_vc4_record_auto_phase_persists_auto_approved_hold_ids_in_evidence_refs(
     assert isinstance(phases, list) and isinstance(phases[0], dict)
     assert phases[0]["evidence_refs"] == [hold_id]
 
-    # Dual record (INV-4): the hold id also persists in the hold's own audit
+    # Dual record : the hold id also persists in the hold's own audit
     # trail, independent of the auto-route.json ledger checked above.
     holds_store = _read_approval_holds(branch_workspace)
     assert holds_store["holds"][hold_id]["decision_note"] == "auto-approved by map-auto"
 
 
-def test_vc5_route_task_leaves_phases_empty_before_any_phase_recorded(branch_workspace):
+def test_route_task_leaves_phases_empty_before_any_phase_recorded(branch_workspace):
     branch = branch_workspace.name
 
     map_step_runner.route_task("ship something", branch=branch)
@@ -2622,7 +2622,7 @@ def test_vc5_route_task_leaves_phases_empty_before_any_phase_recorded(branch_wor
     assert artifact["phases"] == []
 
 
-def test_vc5_record_auto_phase_is_the_sole_phases_mutator_in_source():
+def test_record_auto_phase_is_the_sole_phases_mutator_in_source():
     source = (SCRIPTS_PATH / "map_step_runner.py").read_text(encoding="utf-8")
     mutation_pattern = re.compile(r'artifact\["phases"\]\s*=|phases\.append\(')
 
@@ -3640,7 +3640,7 @@ def test_load_artifact_manifest_normalizes_branch_name(branch_workspace):
     assert manifest["branch"] == branch_workspace.name
 
 
-def test_vc3_set_manifest_stage_auto_route_does_not_raise(branch_workspace):
+def test_set_manifest_stage_auto_route_does_not_raise(branch_workspace):
     del branch_workspace
     manifest = map_step_runner.default_artifact_manifest("test-branch")
 
@@ -3649,7 +3649,7 @@ def test_vc3_set_manifest_stage_auto_route_does_not_raise(branch_workspace):
     assert manifest["stages"]["auto_route"]["status"] == "started"
 
 
-def test_vc3_load_artifact_manifest_backfills_missing_auto_route_stage(branch_workspace):
+def test_load_artifact_manifest_backfills_missing_auto_route_stage(branch_workspace):
     stages_without_auto_route = {
         stage: {
             "status": "not_started",

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2022,6 +2022,210 @@ def test_route_task_preserves_route_history_on_second_write(branch_workspace):
     assert artifact["route_history"] == ["map-plan"]
 
 
+# --- route_task guards (issue #414 ST-005: dry-run write isolation,
+# in-progress re-route refusal, hard-stop hold block, goal_mismatch block) -
+
+
+def _snapshot_tree(root: Path) -> dict[str, int]:
+    """Recursive path -> mtime_ns snapshot of every file under `root`.
+
+    Used to prove a call touches only the files it claims to (VC1's
+    write-isolation assertion) without depending on file content/hashing.
+    """
+    return {
+        str(path.relative_to(root)): path.stat().st_mtime_ns
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_vc1_route_task_dry_run_write_isolation(tmp_path, branch_workspace):
+    branch = branch_workspace.name
+    before = _snapshot_tree(tmp_path)
+
+    map_step_runner.route_task(
+        "just recommend, touch nothing else", branch=branch, dry_run=True
+    )
+
+    after = _snapshot_tree(tmp_path)
+    # Диффим полные dict'ы (path -> mtime_ns): ловим и новые файлы, и
+    # in-place мутации существующих — не только появление новых путей.
+    changed = {
+        path
+        for path in set(before) | set(after)
+        if before.get(path) != after.get(path)
+    }
+    assert changed == {
+        f".map/{branch}/auto-route.json",
+        f".map/{branch}/artifact_manifest.json",
+    }
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["executed"] is False
+    assert artifact["chain_status"] == "recommended_only"
+
+
+def test_vc2_route_task_never_calls_record_workflow_fit_or_create_approval_hold(
+    branch_workspace, monkeypatch
+):
+    branch = branch_workspace.name
+
+    def _boom(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError(f"must not be called: args={args} kwargs={kwargs}")
+
+    monkeypatch.setattr(map_step_runner, "record_workflow_fit", _boom)
+    monkeypatch.setattr(map_step_runner, "create_approval_hold", _boom)
+
+    def _reset_signals() -> None:
+        for name in (
+            "auto-route.json",
+            "blueprint.json",
+            "step_state.json",
+            "workflow-fit.json",
+            f"spec_{branch}.md",
+            f"task_plan_{branch}.md",
+        ):
+            path = branch_workspace / name
+            if path.exists():
+                path.unlink()
+
+    # Representative tier matrix: tier1 pending, tier2 workflow-fit,
+    # tier3 resume, tier5 default -- each run in both dry-run and
+    # non-dry-run mode. Every iteration is reset first so a prior
+    # iteration's in_progress artifact never trips the in-progress refusal
+    # guard before the forbidden-call assertion is exercised.
+    tier_setups = [
+        lambda: (
+            _write_blueprint(branch_workspace, ["ST-001"]),
+            _write_step_state(branch_workspace, {}),
+        ),
+        lambda: _write_workflow_fit(branch_workspace, "map-efficient"),
+        lambda: _write_resumable_plan(
+            branch_workspace, branch, "Implement token authentication middleware"
+        ),
+        lambda: None,  # tier5 default: no signals at all
+    ]
+    for setup in tier_setups:
+        for dry_run in (True, False):
+            _reset_signals()
+            setup()
+            map_step_runner.route_task("some task", branch=branch, dry_run=dry_run)
+
+
+def test_vc3_route_task_refuses_in_progress_chain_and_leaves_artifact_untouched(
+    branch_workspace,
+):
+    branch = branch_workspace.name
+    first = map_step_runner.route_task("first task", branch=branch, dry_run=False)
+    assert first["chain_status"] == "in_progress"
+
+    artifact_path = branch_workspace / "auto-route.json"
+    manifest_path = branch_workspace / "artifact_manifest.json"
+    artifact_before = artifact_path.read_bytes()
+    manifest_before = manifest_path.read_bytes()
+
+    result = map_step_runner.route_task(
+        "a completely different task", branch=branch, dry_run=False
+    )
+
+    assert result["status"] == "refused"
+    assert result["next_command"] == "/map-resume"
+    assert artifact_path.read_bytes() == artifact_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+def test_vc3_route_task_reroutes_when_prior_status_allows(branch_workspace):
+    branch = branch_workspace.name
+    artifact_path = branch_workspace / "auto-route.json"
+
+    for allowed_status in ("recommended_only", "completed", "aborted"):
+        artifact_path.write_text(
+            json.dumps({
+                "schema_version": "1.0",
+                "task_summary": "prior task",
+                "selected_route": "map-fast",
+                "evidence": [],
+                "blocked_by": [],
+                "next_command": "/map-fast",
+                "executed": allowed_status != "recommended_only",
+                "chain_status": allowed_status,
+                "phases": [],
+                "route_history": [],
+            }),
+            encoding="utf-8",
+        )
+
+        result = map_step_runner.route_task("new task", branch=branch, dry_run=True)
+
+        assert result["status"] != "refused", f"status={allowed_status} should re-route"
+        artifact = _read_auto_route_artifact(branch_workspace)
+        assert artifact["route_history"] == ["map-fast"]
+
+
+def test_vc4_route_task_blocks_on_goal_mismatch_and_leaves_plan_artifacts_untouched(
+    branch_workspace,
+):
+    branch = branch_workspace.name
+    goal = "Auditable Graph-Guided Incident Analysis"
+    _write_resumable_plan(branch_workspace, branch, goal)
+    spec_path = branch_workspace / f"spec_{branch}.md"
+    task_plan_path = branch_workspace / f"task_plan_{branch}.md"
+    spec_before = spec_path.read_bytes()
+    task_plan_before = task_plan_path.read_bytes()
+
+    result = map_step_runner.route_task(
+        "Add per-subtask token budget reporting to the statusline meter",
+        branch=branch,
+    )
+
+    assert result["chain_status"] == "blocked"
+    assert result["executed"] is False
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["chain_status"] == "blocked"
+    assert artifact.get("block_reason"), "block reason must be present in the artifact"
+    assert "goal_mismatch" in str(artifact["block_reason"])
+    assert spec_path.read_bytes() == spec_before
+    assert task_plan_path.read_bytes() == task_plan_before
+    assert not (branch_workspace / "blueprint.json").exists()
+
+
+def test_vc5_route_task_blocks_on_pending_hard_stop_hold(branch_workspace):
+    branch = branch_workspace.name
+    hold_result = map_step_runner.create_approval_hold(
+        kind="dangerous_action",
+        reason="Risky shell command flagged",
+        request_summary="rm -rf staging bucket",
+        branch=branch,
+    )
+    hold_id = hold_result["hold_id"]
+
+    result = map_step_runner.route_task("run the cleanup", branch=branch, dry_run=False)
+
+    assert result["chain_status"] == "blocked"
+    assert result["executed"] is False
+    assert result["blocked_by"] == [hold_id]
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["blocked_by"] == [hold_id]
+    assert artifact["chain_status"] == "blocked"
+
+
+def test_vc5_route_task_blocks_on_pending_hard_stop_hold_under_dry_run(branch_workspace):
+    branch = branch_workspace.name
+    hold_result = map_step_runner.create_approval_hold(
+        kind="safety_guardrail",
+        reason="Hook denied a destructive command",
+        request_summary="rm -rf .map",
+        branch=branch,
+    )
+    hold_id = hold_result["hold_id"]
+
+    result = map_step_runner.route_task("run the cleanup", branch=branch, dry_run=True)
+
+    # blocked outranks recommended_only even though dry_run=True was requested.
+    assert result["chain_status"] == "blocked"
+    assert result["executed"] is False
+    assert result["blocked_by"] == [hold_id]
+
+
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):
     blueprint = {
         "summary": "Deliver a user-visible fix",

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2226,6 +2226,123 @@ def test_vc5_route_task_blocks_on_pending_hard_stop_hold_under_dry_run(branch_wo
     assert result["blocked_by"] == [hold_id]
 
 
+# --- auto_decide_holds (issue #414 ST-006: auto-approve workflow-control
+# holds via a positive allowlist; dangerous_action/safety_guardrail can
+# never be decided by this code path) -------------------------------------
+
+
+def _read_approval_holds(branch_workspace: Path) -> dict[str, Any]:
+    return json.loads((branch_workspace / "approval_holds.json").read_text(encoding="utf-8"))
+
+
+def test_vc4_auto_approvable_and_hard_stop_kinds_partition_approval_hold_kinds():
+    auto_approvable = map_step_runner.AUTO_APPROVABLE_HOLD_KINDS
+    hard_stop = map_step_runner.HARD_STOP_HOLD_KINDS
+    assert auto_approvable.isdisjoint(hard_stop)
+    assert auto_approvable | hard_stop == map_step_runner.APPROVAL_HOLD_KINDS
+
+
+def test_auto_decide_holds_with_nothing_pending_returns_empty_lists(branch_workspace):
+    branch = branch_workspace.name
+
+    result = map_step_runner.auto_decide_holds(branch=branch)
+
+    assert result["status"] == "ok"
+    assert result["auto_approved"] == []
+    assert result["hard_stops"] == []
+
+
+def test_vc1_auto_decide_holds_approves_every_auto_approvable_kind(branch_workspace):
+    branch = branch_workspace.name
+    hold_ids: dict[str, str] = {}
+    for kind in sorted(map_step_runner.AUTO_APPROVABLE_HOLD_KINDS):
+        created = map_step_runner.create_approval_hold(
+            kind=kind,
+            reason=f"synthetic {kind} hold for auto_decide_holds test",
+            request_summary=f"synthetic request for {kind}",
+            branch=branch,
+        )
+        hold_ids[kind] = created["hold_id"]
+
+    result = map_step_runner.auto_decide_holds(branch=branch)
+
+    approved_ids = {entry["id"] for entry in result["auto_approved"]}
+    assert approved_ids == set(hold_ids.values())
+    for entry in result["auto_approved"]:
+        assert entry["note"] == "auto-approved by map-auto"
+        assert entry["kind"] in map_step_runner.AUTO_APPROVABLE_HOLD_KINDS
+
+    # Re-read from disk -- the return value alone does not prove persistence.
+    store = _read_approval_holds(branch_workspace)
+    for kind, hold_id in hold_ids.items():
+        hold = store["holds"][hold_id]
+        assert hold["state"] == "approved"
+        assert hold["decision_note"] == "auto-approved by map-auto"
+
+    follow_up = map_step_runner.get_pending_holds(branch)
+    assert follow_up["pending_count"] == 0
+
+
+def test_vc2_auto_decide_holds_leaves_hard_stop_kinds_pending(branch_workspace):
+    branch = branch_workspace.name
+    hold_ids: dict[str, str] = {}
+    for kind in sorted(map_step_runner.HARD_STOP_HOLD_KINDS):
+        created = map_step_runner.create_approval_hold(
+            kind=kind,
+            reason=f"synthetic {kind} hold for auto_decide_holds test",
+            request_summary=f"synthetic request for {kind}",
+            branch=branch,
+        )
+        hold_ids[kind] = created["hold_id"]
+
+    result = map_step_runner.auto_decide_holds(branch=branch)
+
+    hard_stop_ids = {entry["id"] for entry in result["hard_stops"]}
+    assert hard_stop_ids == set(hold_ids.values())
+    assert result["auto_approved"] == []
+
+    # Re-read from disk -- must still be pending, not merely absent from auto_approved.
+    store = _read_approval_holds(branch_workspace)
+    for kind, hold_id in hold_ids.items():
+        hold = store["holds"][hold_id]
+        assert hold["state"] == "pending"
+        assert hold["decision"] is None
+
+
+def test_vc3_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_kind(
+    branch_workspace, monkeypatch
+):
+    branch = branch_workspace.name
+    hard_stop_hold_ids: set[str] = set()
+    for kind in sorted(map_step_runner.APPROVAL_HOLD_KINDS):
+        created = map_step_runner.create_approval_hold(
+            kind=kind,
+            reason=f"synthetic {kind} hold for the mixed-population VC3 test",
+            request_summary=f"synthetic request for {kind}",
+            branch=branch,
+        )
+        if kind in map_step_runner.HARD_STOP_HOLD_KINDS:
+            hard_stop_hold_ids.add(created["hold_id"])
+
+    real_decide_approval_hold = map_step_runner.decide_approval_hold
+
+    def _guarded_decide(
+        hold_id: str, decision: str, note: str = "", branch: str | None = None
+    ) -> dict[str, Any]:
+        if hold_id in hard_stop_hold_ids:
+            raise AssertionError(
+                f"decide_approval_hold must never be invoked on hard-stop hold {hold_id!r}"
+            )
+        return real_decide_approval_hold(hold_id, decision, note, branch)
+
+    monkeypatch.setattr(map_step_runner, "decide_approval_hold", _guarded_decide)
+
+    result = map_step_runner.auto_decide_holds(branch=branch)  # must not raise
+
+    assert len(result["auto_approved"]) == len(map_step_runner.AUTO_APPROVABLE_HOLD_KINDS)
+    assert len(result["hard_stops"]) == len(map_step_runner.HARD_STOP_HOLD_KINDS)
+
+
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):
     blueprint = {
         "summary": "Deliver a user-visible fix",

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -1614,6 +1614,299 @@ def test_check_plan_resume_cli_smoke(tmp_path):
     assert payload["branch"] == branch
 
 
+# --- _select_route (issue #414 /map-auto five-tier routing) ---------------
+
+
+def _route_signal_path(branch: str, name: str) -> str:
+    """Match the relative `.map/<branch>/<name>` path _select_route records."""
+    return str(Path(".map") / branch / name)
+
+
+def _write_blueprint(branch_workspace: Path, subtask_ids: list[str]) -> None:
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps({"subtasks": [{"id": sid} for sid in subtask_ids]}),
+        encoding="utf-8",
+    )
+
+
+def _write_step_state(branch_workspace: Path, completed_steps: dict[str, list[str]]) -> None:
+    (branch_workspace / "step_state.json").write_text(
+        json.dumps({"completed_steps": completed_steps}), encoding="utf-8"
+    )
+
+
+def _write_workflow_fit(branch_workspace: Path, recommended_workflow: str) -> None:
+    (branch_workspace / "workflow-fit.json").write_text(
+        json.dumps({"recommended_workflow": recommended_workflow}), encoding="utf-8"
+    )
+
+
+def _write_resumable_plan(branch_workspace: Path, branch: str, goal: str) -> None:
+    """Seed spec_+task_plan_ (NOT step_state.json) so check_plan_resume can fire."""
+    (branch_workspace / f"spec_{branch}.md").write_text(
+        f"# Spec: {goal}\n\n## Acceptance Criteria\n- AC-1: ...\n", encoding="utf-8"
+    )
+    (branch_workspace / f"task_plan_{branch}.md").write_text(
+        f"# Task Plan: {goal}\n\n## Overview\n- Goal: {goal}\n", encoding="utf-8"
+    )
+
+
+def test_select_route_tier1a_pending_step_state_yields_map_resume(branch_workspace):
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, ["ST-001", "ST-002"])
+    _write_step_state(branch_workspace, {"ST-001": ["actor"]})
+
+    route, evidence = map_step_runner._select_route(branch, "implement feature")
+
+    assert route == "map-resume"
+    entry = next(e for e in evidence if e["signal"] == "step_state.json")
+    assert entry["value"] == {
+        "status": "pending",
+        "pending_subtask_ids": ["ST-002"],
+        "completion_source": "legacy_completed_steps",
+    }
+    assert entry["source"] == _route_signal_path(branch, "step_state.json")
+
+
+def test_select_route_tier1b_all_complete_step_state_yields_map_check(branch_workspace):
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, ["ST-001"])
+    _write_step_state(branch_workspace, {"ST-001": ["actor", "monitor"]})
+
+    route, _ = map_step_runner._select_route(branch, "anything")
+
+    assert route == "map-check"
+    assert route != "map-plan"
+
+
+def test_select_route_tier2_workflow_fit_map_efficient_is_honored(branch_workspace):
+    branch = branch_workspace.name
+    _write_workflow_fit(branch_workspace, "map-efficient")
+
+    route, evidence = map_step_runner._select_route(branch, "some task")
+
+    assert route == "map-efficient"
+    entry = next(e for e in evidence if e["signal"] == "workflow-fit.json")
+    assert entry["value"] == "map-efficient"
+
+
+def test_select_route_tier2_out_of_vocabulary_falls_through_and_is_recorded(branch_workspace):
+    branch = branch_workspace.name
+    _write_workflow_fit(branch_workspace, "direct-edit")
+
+    route, evidence = map_step_runner._select_route(branch, "trivial one-off tweak")
+
+    assert route != "direct-edit"
+    assert route == "map-plan"
+    entry = next(e for e in evidence if e["signal"] == "workflow-fit.json")
+    assert entry["value"] == "direct-edit"
+
+
+def test_select_route_tier3_resume_with_blueprint_yields_map_efficient(branch_workspace):
+    branch = branch_workspace.name
+    goal = "Implement token authentication middleware for the API"
+    _write_resumable_plan(branch_workspace, branch, goal)
+    _write_blueprint(branch_workspace, [])
+
+    route, evidence = map_step_runner._select_route(
+        branch, "Implement token authentication middleware"
+    )
+
+    assert route == "map-efficient"
+    verdict_entry = next(e for e in evidence if e["signal"] == "check_plan_resume")
+    assert verdict_entry["value"] == "resume"
+    blueprint_entry = next(e for e in evidence if e["signal"] == "blueprint.json")
+    assert blueprint_entry["value"] is True
+    assert blueprint_entry["source"] == _route_signal_path(branch, "blueprint.json")
+
+
+def test_select_route_tier3b_resume_without_blueprint_yields_map_plan(branch_workspace):
+    branch = branch_workspace.name
+    goal = "Implement token authentication middleware for the API"
+    _write_resumable_plan(branch_workspace, branch, goal)
+    # Deliberately no blueprint.json.
+
+    route, evidence = map_step_runner._select_route(
+        branch, "Implement token authentication middleware"
+    )
+
+    assert route == "map-plan"
+    blueprint_entry = next(e for e in evidence if e["signal"] == "blueprint.json")
+    assert blueprint_entry["value"] is False
+
+
+def test_select_route_tier4_trivial_bracket_yields_map_fast(branch_workspace):
+    branch = branch_workspace.name
+
+    route, evidence = map_step_runner._select_route(
+        branch, "small fix", estimated_files=1, estimated_lines=10
+    )
+
+    assert route == "map-fast"
+    entry = next(e for e in evidence if e["signal"] == "classify_scope.classify")
+    assert entry["value"] == {"estimated": True, "bracket": "trivial"}
+
+
+def test_select_route_tier4_unavailable_estimate_is_recorded_and_skipped(branch_workspace):
+    branch = branch_workspace.name
+
+    route, evidence = map_step_runner._select_route(branch, "no estimate supplied")
+
+    assert route == "map-plan"
+    entry = next(e for e in evidence if e["signal"] == "classify_scope.classify")
+    assert entry["value"] == {"estimated": False}
+
+
+def test_select_route_tier5_default_bare_branch_yields_map_plan(branch_workspace):
+    branch = branch_workspace.name
+
+    route, evidence = map_step_runner._select_route(branch, "some task with no signals")
+
+    assert route == "map-plan"
+    assert {e["signal"] for e in evidence} == {
+        "step_state.json",
+        "workflow-fit.json",
+        "check_plan_resume",
+        "classify_scope.classify",
+    }
+
+
+def test_select_route_ignores_task_text_content_once_step_state_resolves(branch_workspace):
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, ["ST-001", "ST-002"])
+    _write_step_state(branch_workspace, {"ST-001": ["actor"]})
+
+    route_a, evidence_a = map_step_runner._select_route(
+        branch, "implement rate limiting for the payments API"
+    )
+    route_b, evidence_b = map_step_runner._select_route(
+        branch, "zzz totally unrelated banana fruit salad recipe"
+    )
+
+    assert route_a == route_b == "map-resume"
+    assert evidence_a == evidence_b
+
+
+def test_select_route_step_state_wins_over_conflicting_workflow_fit(branch_workspace):
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, ["ST-001"])
+    _write_step_state(branch_workspace, {})
+    _write_workflow_fit(branch_workspace, "map-fast")
+
+    route, evidence = map_step_runner._select_route(branch, "any task text")
+
+    assert route == "map-resume"
+    workflow_fit_entry = next(e for e in evidence if e["signal"] == "workflow-fit.json")
+    assert workflow_fit_entry == {
+        "signal": "workflow-fit.json",
+        "value": "map-fast",
+        "source": _route_signal_path(branch, "workflow-fit.json"),
+    }
+
+
+def test_select_route_step_state_without_blueprint_fails_closed_to_resume(branch_workspace):
+    """Regression (code-review-1 HIGH): a step_state.json with no usable
+    blueprint.json must never be asserted complete -- that would be an
+    unevidenced guess. Fails closed to map-resume, NOT map-check.
+    """
+    branch = branch_workspace.name
+    _write_step_state(branch_workspace, {})
+    # Deliberately no blueprint.json.
+
+    route, evidence = map_step_runner._select_route(branch, "anything")
+
+    assert route == "map-resume"
+    assert route != "map-check"
+    entry = next(e for e in evidence if e["signal"] == "step_state.json")
+    assert entry["value"] == "blueprint_unavailable"
+
+
+def test_select_route_step_state_with_empty_blueprint_fails_closed_to_resume(branch_workspace):
+    """Regression (code-review-1 HIGH), zero-subtask-ids variant: blueprint.json
+    present but declaring no subtasks is equally unusable as a pending-set
+    universe and must also fail closed to map-resume.
+    """
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, [])
+    _write_step_state(branch_workspace, {})
+
+    route, evidence = map_step_runner._select_route(branch, "anything")
+
+    assert route == "map-resume"
+    entry = next(e for e in evidence if e["signal"] == "step_state.json")
+    assert entry["value"] == "blueprint_unavailable"
+
+
+def test_select_route_started_but_not_done_class_subtask_stays_pending(branch_workspace):
+    """Regression (code-review-1 MEDIUM): completed_steps key presence alone
+    (the first phase landed) must NOT be read as completion once the
+    canonical done-class signal (subtask_results/subtask_phases) is
+    available -- only a done-class status counts. update_step_state inserts
+    the completed_steps key at the FIRST recorded phase, so key-presence
+    conflates "started" with "done".
+    """
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, ["ST-001"])
+    (branch_workspace / "step_state.json").write_text(
+        json.dumps({
+            "completed_steps": {"ST-001": ["actor"]},
+            "subtask_phases": {"ST-001": "actor"},
+        }),
+        encoding="utf-8",
+    )
+
+    route, evidence = map_step_runner._select_route(branch, "anything")
+
+    assert route == "map-resume"
+    entry = next(e for e in evidence if e["signal"] == "step_state.json")
+    assert entry["value"]["status"] == "pending"
+    assert entry["value"]["completion_source"] == "canonical_done_class"
+
+
+def test_select_route_canonical_done_class_result_yields_map_check(branch_workspace):
+    """Companion positive case for the MEDIUM regression: a genuine done-class
+    subtask_results status DOES count as complete via the canonical signal.
+    """
+    branch = branch_workspace.name
+    _write_blueprint(branch_workspace, ["ST-001"])
+    (branch_workspace / "step_state.json").write_text(
+        json.dumps({
+            "completed_steps": {"ST-001": ["actor"]},
+            "subtask_results": {"ST-001": {"status": "valid"}},
+        }),
+        encoding="utf-8",
+    )
+
+    route, evidence = map_step_runner._select_route(branch, "anything")
+
+    assert route == "map-check"
+    entry = next(e for e in evidence if e["signal"] == "step_state.json")
+    assert entry["value"]["completion_source"] == "canonical_done_class"
+
+
+def test_select_route_task_text_sanctioned_exception_drives_tier3_verdict(branch_workspace):
+    """Documents the sanctioned exception (code-review-1 LOW) to task-text
+    invariance: check_plan_resume (tier 3) IS one of the five allowed
+    signals, so its goal-overlap comparison legitimately changes with
+    task_text content -- unlike tier 1, where task_text has zero influence
+    (see test_select_route_ignores_task_text_content_once_step_state_resolves).
+    This is intentional signal-reading, not the keyword routing INV-3 forbids.
+    """
+    branch = branch_workspace.name
+    goal = "Auditable Graph-Guided Incident Analysis"
+    _write_resumable_plan(branch_workspace, branch, goal)
+
+    _, resume_evidence = map_step_runner._select_route(branch, "")
+    _, mismatch_evidence = map_step_runner._select_route(
+        branch, "Add per-subtask token budget reporting to the statusline meter"
+    )
+
+    resume_verdict = next(e for e in resume_evidence if e["signal"] == "check_plan_resume")
+    mismatch_verdict = next(e for e in mismatch_evidence if e["signal"] == "check_plan_resume")
+    assert resume_verdict["value"] == "resume"
+    assert mismatch_verdict["value"] == "goal_mismatch"
+
+
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):
     blueprint = {
         "summary": "Deliver a user-visible fix",

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2615,6 +2615,47 @@ def test_load_artifact_manifest_normalizes_branch_name(branch_workspace):
     assert manifest["branch"] == branch_workspace.name
 
 
+def test_vc3_set_manifest_stage_auto_route_does_not_raise(branch_workspace):
+    del branch_workspace
+    manifest = map_step_runner.default_artifact_manifest("test-branch")
+
+    map_step_runner._set_manifest_stage(manifest, "auto_route", "started")
+
+    assert manifest["stages"]["auto_route"]["status"] == "started"
+
+
+def test_vc3_load_artifact_manifest_backfills_missing_auto_route_stage(branch_workspace):
+    stages_without_auto_route = {
+        stage: {
+            "status": "not_started",
+            "updated_at": "",
+            "artifacts": [],
+            "metadata": {},
+        }
+        for stage in map_step_runner.ARTIFACT_STAGE_NAMES
+        if stage != "auto_route"
+    }
+    (branch_workspace / "artifact_manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "branch": "test-branch",
+                "updated_at": "2026-04-12T00:00:00Z",
+                "stages": stages_without_auto_route,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest = map_step_runner.load_artifact_manifest()
+
+    stage = manifest["stages"]["auto_route"]
+    assert stage["status"] == "not_started"
+    assert stage["artifacts"] == []
+    assert stage["metadata"] == {}
+
+
 def test_build_handoff_bundle_reads_artifacts(branch_workspace):
     """Build handoff bundle reads available artifacts."""
     (branch_workspace / "verification-summary.md").write_text(

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2343,6 +2343,302 @@ def test_vc3_auto_decide_holds_never_invokes_decide_approval_hold_on_hard_stop_k
     assert len(result["hard_stops"]) == len(map_step_runner.HARD_STOP_HOLD_KINDS)
 
 
+# --- record_auto_phase (issue #414 ST-007: phases[] ledger, attempt
+# counter/HC-2 bound, chain_status transitions, single-writer invariant) ---
+
+
+def test_record_auto_phase_errors_when_no_route_task_has_run(branch_workspace):
+    branch = branch_workspace.name
+
+    result = map_step_runner.record_auto_phase("map-plan", "in_progress", branch=branch)
+
+    assert result["status"] == "error"
+    assert "route_task" in result["reason"]
+    assert not (branch_workspace / "auto-route.json").exists()
+
+
+def test_vc1_record_auto_phase_appends_one_schema_valid_six_field_entry(branch_workspace):
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship something", branch=branch)
+
+    result = map_step_runner.record_auto_phase(
+        "map-efficient",
+        "in_progress",
+        branch=branch,
+        evidence_refs=["hold-abc"],
+        reason="starting execution",
+    )
+    assert result["status"] == "success"
+    assert result["attempt"] == 1
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    phases = artifact["phases"]
+    assert isinstance(phases, list) and len(phases) == 1
+    entry = phases[0]
+    assert set(entry.keys()) == {
+        "phase",
+        "status",
+        "attempt",
+        "evidence_refs",
+        "reason",
+        "recorded_at",
+    }
+    assert entry["phase"] == "map-efficient"
+    assert entry["status"] == "in_progress"
+    assert entry["attempt"] == 1
+    assert entry["evidence_refs"] == ["hold-abc"]
+    assert entry["reason"] == "starting execution"
+
+    is_valid, errors = auto_route_schemas_module.validate_artifact(
+        artifact, auto_route_schemas_module.AUTO_ROUTE_SCHEMA
+    )
+    assert is_valid, f"Errors: {errors}"
+
+
+def test_vc2_record_auto_phase_terminal_success_status_completes_chain(branch_workspace):
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship something", branch=branch)
+
+    result = map_step_runner.record_auto_phase("map-check", "completed", branch=branch)
+
+    assert result["chain_status"] == "completed"
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["chain_status"] == "completed"
+    assert "abort_reason" not in artifact
+
+    manifest = map_step_runner.load_artifact_manifest(branch)
+    stage = manifest["stages"]["auto_route"]
+    assert stage["status"] == "completed"
+    assert stage["artifacts"][0]["path"] == result["path"]
+    assert stage["metadata"]["chain_status"] == "completed"
+
+
+def test_vc2_record_auto_phase_abort_class_status_aborts_chain(branch_workspace):
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship something", branch=branch)
+
+    result = map_step_runner.record_auto_phase(
+        "map-efficient", "failed", branch=branch, reason="monitor rejected twice"
+    )
+
+    assert result["chain_status"] == "aborted"
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["chain_status"] == "aborted"
+    assert "monitor rejected twice" in str(artifact["abort_reason"])
+
+    manifest = map_step_runner.load_artifact_manifest(branch)
+    assert manifest["stages"]["auto_route"]["status"] == "aborted"
+
+
+def test_vc2_record_auto_phase_intermediate_status_stays_in_progress(branch_workspace):
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship something", branch=branch)
+
+    result = map_step_runner.record_auto_phase("map-plan", "started", branch=branch)
+
+    assert result["chain_status"] == "in_progress"
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["chain_status"] == "in_progress"
+    assert "abort_reason" not in artifact
+
+    manifest = map_step_runner.load_artifact_manifest(branch)
+    assert manifest["stages"]["auto_route"]["status"] == "in_progress"
+
+
+def test_vc3_record_auto_phase_attempt_counter_and_third_attempt_refused(branch_workspace):
+    branch = branch_workspace.name
+    map_step_runner.route_task("do the thing", branch=branch)
+
+    first = map_step_runner.record_auto_phase("map-plan", "in_progress", branch=branch)
+    assert first["status"] == "success"
+    assert first["attempt"] == 1
+
+    second = map_step_runner.record_auto_phase(
+        "map-plan",
+        "in_progress",
+        branch=branch,
+        reason="re-entry after inspecting ground truth",
+    )
+    assert second["status"] == "success"
+    assert second["attempt"] == 2
+
+    third = map_step_runner.record_auto_phase(
+        "map-plan", "in_progress", branch=branch, reason="second failure of map-plan"
+    )
+    assert third["status"] == "refused"
+    assert third["attempt"] == 3
+    assert third["chain_status"] == "aborted"
+    assert third["abort_reason"]
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    phases = artifact["phases"]
+    assert isinstance(phases, list) and len(phases) == 2, (
+        "the refused third attempt must not append a phases[] entry"
+    )
+    assert artifact["chain_status"] == "aborted"
+    abort_reason = str(artifact.get("abort_reason", ""))
+    assert abort_reason, "abort reason must be visible directly in the artifact"
+    assert "map-plan" in abort_reason
+
+    manifest = map_step_runner.load_artifact_manifest(branch)
+    assert manifest["stages"]["auto_route"]["status"] == "aborted"
+
+
+def test_record_auto_phase_refuses_different_phase_after_chain_aborted(branch_workspace):
+    """Code review 2 (HIGH): the HC-2 attempt guard only protects the SAME
+    phase name -- a call naming a DIFFERENT phase after chain_status became
+    "aborted" must not resurrect the chain. Reproduces the reported repro:
+    abort phase A via the 3rd-attempt refusal, then call phase B and assert
+    nothing changes (no append, chain_status stays aborted, abort_reason
+    intact, manifest stage unchanged).
+    """
+    branch = branch_workspace.name
+    map_step_runner.route_task("do the thing", branch=branch)
+
+    # Drive phase A to the 3rd-attempt refusal -> chain_status "aborted".
+    map_step_runner.record_auto_phase("phase-a", "in_progress", branch=branch)
+    map_step_runner.record_auto_phase("phase-a", "in_progress", branch=branch)
+    aborted = map_step_runner.record_auto_phase("phase-a", "in_progress", branch=branch)
+    assert aborted["chain_status"] == "aborted"
+
+    artifact_before = _read_auto_route_artifact(branch_workspace)
+    assert artifact_before["chain_status"] == "aborted"
+    abort_reason_before = artifact_before["abort_reason"]
+    manifest_before = map_step_runner.load_artifact_manifest(branch)
+    stage_before = manifest_before["stages"]["auto_route"]
+
+    result = map_step_runner.record_auto_phase(
+        "phase-b", "in_progress", branch=branch, reason="different phase, side door attempt"
+    )
+
+    assert result["status"] == "refused"
+    assert result["chain_status"] == "aborted"
+    assert result["abort_reason"] == abort_reason_before
+
+    artifact_after = _read_auto_route_artifact(branch_workspace)
+    assert artifact_after == artifact_before, "no field of the artifact may change"
+    assert artifact_after["chain_status"] == "aborted"
+    assert artifact_after["abort_reason"] == abort_reason_before
+    phases_after = artifact_after["phases"]
+    assert isinstance(phases_after, list) and len(phases_after) == 2, (
+        "phase-b must not be appended to phases[] while the chain is aborted"
+    )
+    assert all(entry["phase"] == "phase-a" for entry in phases_after)
+
+    manifest_after = map_step_runner.load_artifact_manifest(branch)
+    assert manifest_after["stages"]["auto_route"] == stage_before, (
+        "the auto_route manifest stage must not be refreshed on a refused call"
+    )
+
+
+def test_record_auto_phase_refuses_new_phase_after_chain_blocked(branch_workspace):
+    """Code review 2 (HIGH), blocked-chain variant: route_task sets
+    chain_status "blocked" when a hard-stop hold is pending at route time.
+    A subsequent record_auto_phase call for any phase must refuse without
+    mutating the artifact or manifest -- block_reason stays intact.
+    """
+    branch = branch_workspace.name
+    hold_result = map_step_runner.create_approval_hold(
+        kind="dangerous_action",
+        reason="Risky shell command flagged",
+        request_summary="rm -rf staging bucket",
+        branch=branch,
+    )
+    hold_id = hold_result["hold_id"]
+
+    route_result = map_step_runner.route_task("run the cleanup", branch=branch, dry_run=False)
+    assert route_result["chain_status"] == "blocked"
+    assert route_result["blocked_by"] == [hold_id]
+
+    artifact_before = _read_auto_route_artifact(branch_workspace)
+    assert artifact_before["chain_status"] == "blocked"
+    block_reason_before = artifact_before["block_reason"]
+    assert artifact_before["phases"] == []
+    manifest_before = map_step_runner.load_artifact_manifest(branch)
+    stage_before = manifest_before["stages"]["auto_route"]
+
+    result = map_step_runner.record_auto_phase(
+        "map-plan", "in_progress", branch=branch, reason="attempt during blocked chain"
+    )
+
+    assert result["status"] == "refused"
+    assert result["chain_status"] == "blocked"
+    assert result["block_reason"] == block_reason_before
+
+    artifact_after = _read_auto_route_artifact(branch_workspace)
+    assert artifact_after == artifact_before, "no field of the artifact may change"
+    assert artifact_after["chain_status"] == "blocked"
+    assert artifact_after["block_reason"] == block_reason_before
+    assert artifact_after["phases"] == []
+
+    manifest_after = map_step_runner.load_artifact_manifest(branch)
+    assert manifest_after["stages"]["auto_route"] == stage_before, (
+        "the auto_route manifest stage must not be refreshed on a refused call"
+    )
+
+
+def test_vc4_record_auto_phase_persists_auto_approved_hold_ids_in_evidence_refs(
+    branch_workspace,
+):
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship something", branch=branch)
+    created = map_step_runner.create_approval_hold(
+        kind="plan_approval",
+        reason="plan needs sign-off",
+        request_summary="approve blueprint before executing",
+        branch=branch,
+    )
+    hold_id = created["hold_id"]
+
+    decided = map_step_runner.auto_decide_holds(branch=branch)
+    assert hold_id in {entry["id"] for entry in decided["auto_approved"]}
+
+    result = map_step_runner.record_auto_phase(
+        "map-efficient",
+        "in_progress",
+        branch=branch,
+        evidence_refs=[hold_id],
+        reason="auto-approved plan_approval hold before dispatch",
+    )
+    assert result["status"] == "success"
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    phases = artifact["phases"]
+    assert isinstance(phases, list) and isinstance(phases[0], dict)
+    assert phases[0]["evidence_refs"] == [hold_id]
+
+    # Dual record (INV-4): the hold id also persists in the hold's own audit
+    # trail, independent of the auto-route.json ledger checked above.
+    holds_store = _read_approval_holds(branch_workspace)
+    assert holds_store["holds"][hold_id]["decision_note"] == "auto-approved by map-auto"
+
+
+def test_vc5_route_task_leaves_phases_empty_before_any_phase_recorded(branch_workspace):
+    branch = branch_workspace.name
+
+    map_step_runner.route_task("ship something", branch=branch)
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["phases"] == []
+
+
+def test_vc5_record_auto_phase_is_the_sole_phases_mutator_in_source():
+    source = (SCRIPTS_PATH / "map_step_runner.py").read_text(encoding="utf-8")
+    mutation_pattern = re.compile(r'artifact\["phases"\]\s*=|phases\.append\(')
+
+    start = source.index("def record_auto_phase(")
+    end = source.index("\ndef ", start + 1)
+    body = source[start:end]
+
+    all_matches = mutation_pattern.findall(source)
+    body_matches = mutation_pattern.findall(body)
+    assert all_matches, "expected at least one phases[] mutation site in the runner"
+    assert all_matches == body_matches, (
+        "phases[] must be mutated only inside record_auto_phase "
+        "(Decision 11 single-writer invariant)"
+    )
+
+
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):
     blueprint = {
         "summary": "Deliver a user-visible fix",

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -1,5 +1,6 @@
 """Tests for map_step_runner human-readable artifact helpers."""
 
+import importlib.util
 import json
 import os
 import re
@@ -27,6 +28,19 @@ sys.path.insert(0, str(SCRIPTS_PATH))
 from datetime import UTC
 
 import map_step_runner  # type: ignore[import-not-found]
+
+# Load schemas.py by file location (mirrors tests/test_artifact_schemas.py) so
+# validating auto-route.json against AUTO_ROUTE_SCHEMA does not require
+# importing the mapify_cli package and its extras.
+_AUTO_ROUTE_SCHEMAS_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "mapify_cli" / "schemas.py"
+)
+_AUTO_ROUTE_SCHEMAS_SPEC = importlib.util.spec_from_file_location(
+    "map_step_runner_auto_route_schemas", _AUTO_ROUTE_SCHEMAS_PATH
+)
+assert _AUTO_ROUTE_SCHEMAS_SPEC is not None and _AUTO_ROUTE_SCHEMAS_SPEC.loader is not None
+auto_route_schemas_module = importlib.util.module_from_spec(_AUTO_ROUTE_SCHEMAS_SPEC)
+_AUTO_ROUTE_SCHEMAS_SPEC.loader.exec_module(auto_route_schemas_module)
 
 
 def _stub_compute_insight(payload: dict[str, object]):
@@ -1905,6 +1919,107 @@ def test_select_route_task_text_sanctioned_exception_drives_tier3_verdict(branch
     mismatch_verdict = next(e for e in mismatch_evidence if e["signal"] == "check_plan_resume")
     assert resume_verdict["value"] == "resume"
     assert mismatch_verdict["value"] == "goal_mismatch"
+
+
+# --- route_task (issue #414 /map-auto route persistence + manifest stage) --
+
+
+def _read_auto_route_artifact(branch_workspace: Path) -> dict[str, object]:
+    return json.loads((branch_workspace / "auto-route.json").read_text(encoding="utf-8"))
+
+
+def test_vc1_route_task_writes_schema_valid_artifact_and_registers_manifest_stage(
+    branch_workspace,
+):
+    branch = branch_workspace.name
+
+    result = map_step_runner.route_task("plain default-tier task", branch=branch)
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    is_valid, errors = auto_route_schemas_module.validate_artifact(
+        artifact, auto_route_schemas_module.AUTO_ROUTE_SCHEMA
+    )
+    assert is_valid, f"Errors: {errors}"
+
+    manifest = map_step_runner.load_artifact_manifest(branch)
+    stages = manifest["stages"]
+    assert isinstance(stages, dict)
+    auto_route_stage = stages["auto_route"]
+    assert isinstance(auto_route_stage, dict)
+    stage_artifacts = auto_route_stage["artifacts"]
+    assert isinstance(stage_artifacts, list) and stage_artifacts
+    assert stage_artifacts[0]["path"] == result["path"]
+    metadata = auto_route_stage["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["selected_route"] == artifact["selected_route"]
+    assert metadata["chain_status"] == artifact["chain_status"]
+
+
+def test_vc2_route_task_non_dry_run_sets_executed_true_and_chain_status_in_progress(
+    branch_workspace,
+):
+    branch = branch_workspace.name
+
+    map_step_runner.route_task("ship it", branch=branch, dry_run=False)
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["executed"] is True
+    assert artifact["chain_status"] == "in_progress"
+
+
+def test_route_task_dry_run_sets_executed_false_and_recommended_only(branch_workspace):
+    branch = branch_workspace.name
+
+    map_step_runner.route_task("just look", branch=branch, dry_run=True)
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["executed"] is False
+    assert artifact["chain_status"] == "recommended_only"
+
+
+def test_vc3_route_task_sanitizes_task_summary_control_characters(branch_workspace):
+    branch = branch_workspace.name
+    dirty_task = "line one\r\nline two\x00\x1f\x7f\ttabbed"
+
+    map_step_runner.route_task(dirty_task, branch=branch)
+
+    raw_text = (branch_workspace / "auto-route.json").read_text(encoding="utf-8")
+    artifact = json.loads(raw_text)  # must not raise: no raw control bytes on disk
+    task_summary = artifact["task_summary"]
+    assert isinstance(task_summary, str)
+    assert not re.search(r"[\x00-\x1f\x7f]", task_summary)
+    assert "line one" in task_summary
+    assert "line two" in task_summary
+
+
+def test_vc4_route_task_phases_empty_and_next_command_matches_selected_route(
+    branch_workspace,
+):
+    branch = branch_workspace.name
+    _write_workflow_fit(branch_workspace, "map-fast")
+
+    result = map_step_runner.route_task("some task", branch=branch)
+
+    assert result["selected_route"] == "map-fast"
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["phases"] == []
+    assert artifact["next_command"] == "/map-fast"
+    assert result["next_command"] == "/map-fast"
+
+
+def test_route_task_preserves_route_history_on_second_write(branch_workspace):
+    branch = branch_workspace.name
+
+    first = map_step_runner.route_task("first task", branch=branch, dry_run=True)
+    assert first["selected_route"] == "map-plan"
+    assert first["chain_status"] == "recommended_only"
+
+    _write_workflow_fit(branch_workspace, "map-fast")
+    second = map_step_runner.route_task("second task", branch=branch, dry_run=True)
+
+    assert second["selected_route"] == "map-fast"
+    artifact = _read_auto_route_artifact(branch_workspace)
+    assert artifact["route_history"] == ["map-plan"]
 
 
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -997,6 +997,178 @@ class TestSkillStructure:
                     )
 
 
+class TestMapAutoChainSemantics:
+    """ST-009: /map-auto autonomous chain semantics.
+
+    VC1 [HC-1]: run ends at a committed feature branch, never opens/merges a
+    PR, never polls CI. VC2 [INV-5]: a Monitor `valid=false` inside a
+    chained phase is that phase's own hard stop, never overridden. VC3
+    [INV-5]: phases are driven only by the existing slash workflows plus the
+    three runner subcommands -- no new subprocess-driven execution engine.
+    VC4 [HC-1/HC-2]: ground-truth inspection before the single permitted
+    phase re-entry, fail-closed to /map-resume on a second failure, and a
+    terminal chain refuses further appends. VC5 [HC-1]: auto-reference.md
+    exists and is linked from both rendered trees, SKILL.md stays within the
+    default line budget.
+    """
+
+    _FORBIDDEN_PR_PATTERNS = (
+        "gh pr create",
+        "gh pr merge",
+        "git push origin main",
+        "git push origin master",
+    )
+
+    _FORBIDDEN_MONITOR_OVERRIDE_PATTERNS = (
+        "retry past monitor",
+        "suppress the monitor",
+        "re-run past monitor",
+        "bypass monitor",
+        "override monitor",
+        "skip monitor",
+    )
+
+    _FORBIDDEN_EXECUTION_ENGINE_PATTERNS = ("subprocess", "claude -p", "popen")
+
+    @pytest.fixture(
+        params=[
+            Path(".claude/skills/map-auto"),
+            Path("src/mapify_cli/templates/skills/map-auto"),
+        ],
+        ids=["dev", "template"],
+    )
+    def skill_dir(self, request: pytest.FixtureRequest) -> Path:
+        return Path(__file__).parent.parent / request.param
+
+    @pytest.fixture
+    def skill_content(self, skill_dir: Path) -> str:
+        return (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+    @pytest.fixture
+    def reference_content(self, skill_dir: Path) -> str:
+        return (skill_dir / "auto-reference.md").read_text(encoding="utf-8")
+
+    # --- VC1 [HC-1]: no PR/merge instruction; explicit committed-branch end state ---
+
+    def test_vc1_no_pr_or_merge_instruction(
+        self, skill_content: str, reference_content: str
+    ) -> None:
+        combined = (skill_content + "\n" + reference_content).lower()
+        for pattern in self._FORBIDDEN_PR_PATTERNS:
+            assert pattern not in combined, (
+                f"map-auto surfaces must never instruct {pattern!r} -- HC-1 "
+                "requires the run to end at a committed feature branch, "
+                "never a PR/merge."
+            )
+
+    def test_vc1_grep_self_test_detects_synthetic_violation(self) -> None:
+        """Negative-proof: the forbidden-pattern set actually catches a
+        violation, so a typo in the pattern list can't silently pass VC1."""
+        synthetic_bad = "After Monitor passes, run `gh pr create --fill` to open the PR."
+        lowered = synthetic_bad.lower()
+        assert any(pattern in lowered for pattern in self._FORBIDDEN_PR_PATTERNS)
+
+    def test_vc1_states_committed_branch_end_state(self, skill_content: str) -> None:
+        assert "ends at a committed feature branch" in skill_content
+        assert "never opens a pull request" in skill_content
+        assert "never merges" in skill_content
+        assert "never polls CI" in skill_content
+
+    # --- VC2 [INV-5]: Monitor valid=false is a hard stop, never overridden ---
+
+    def test_vc2_monitor_hard_stop_never_overridden(self, skill_content: str) -> None:
+        assert "valid=false" in skill_content
+        assert (
+            "never overrides, suppresses, or re-runs past a Monitor rejection"
+            in skill_content
+        )
+
+    def test_vc2_no_monitor_bypass_instruction(
+        self, skill_content: str, reference_content: str
+    ) -> None:
+        combined = (skill_content + "\n" + reference_content).lower()
+        for pattern in self._FORBIDDEN_MONITOR_OVERRIDE_PATTERNS:
+            assert pattern not in combined, (
+                f"map-auto must never instruct {pattern!r} -- INV-5 requires "
+                "a phase's own Monitor rejection to stand unmodified."
+            )
+
+    # --- VC3 [INV-5]: no new execution engine; existing surfaces only ---
+
+    def test_vc3_no_subprocess_execution_engine(
+        self, skill_content: str, reference_content: str
+    ) -> None:
+        combined = (skill_content + "\n" + reference_content).lower()
+        for pattern in self._FORBIDDEN_EXECUTION_ENGINE_PATTERNS:
+            assert pattern not in combined, (
+                f"map-auto prose must not describe a new phase-driving "
+                f"mechanism ({pattern!r} found) -- INV-5 forbids a new "
+                "execution engine."
+            )
+        assert "never shells out to a separate Claude process" in skill_content
+
+    # --- VC4 [HC-1/HC-2]: ground truth before re-entry; fail-closed recovery ---
+
+    def test_vc4_ground_truth_inspection_before_reentry(self, skill_content: str) -> None:
+        assert "git status" in skill_content
+        assert "git diff" in skill_content
+        assert "step_state.json" in skill_content
+        assert "Before spending the single permitted re-entry" in skill_content
+
+    def test_vc4_second_failure_hands_off_to_map_resume(self, skill_content: str) -> None:
+        assert "STOP and hand off to `/map-resume`" in skill_content
+        assert "never attempt a third call for that phase" in skill_content
+
+    def test_vc4_terminal_chain_refuses_further_appends(self, skill_content: str) -> None:
+        assert "refuses every further `record_auto_phase` call" in skill_content
+        assert (
+            "a new `route_task` call is the ONLY legitimate way to continue"
+            in skill_content
+        )
+
+    # --- VC5 [HC-1]: auto-reference.md exists, linked, render parity, budget ---
+
+    def test_vc5_reference_file_exists_and_linked(
+        self, skill_dir: Path, skill_content: str
+    ) -> None:
+        assert (skill_dir / "auto-reference.md").exists(), (
+            f"{skill_dir}/auto-reference.md must exist in every rendered tree"
+        )
+        assert "[auto-reference.md](auto-reference.md)" in skill_content
+
+    def test_vc5_skill_body_within_default_budget(self, skill_content: str) -> None:
+        assert len(skill_content.splitlines()) <= _DEFAULT_SKILL_BODY_BUDGET, (
+            "map-auto/SKILL.md must stay within the default active-body "
+            f"line budget ({_DEFAULT_SKILL_BODY_BUDGET} lines)."
+        )
+
+    def test_vc5_reference_covers_required_topics(self, reference_content: str) -> None:
+        for marker in (
+            "## CLI Reference",
+            "## Chain Walkthrough Example",
+            "## Failure-Mode Table",
+            "## Recovery Procedures",
+            "## Dry-run Usage",
+        ):
+            assert marker in reference_content, (
+                f"auto-reference.md missing required section: {marker}"
+            )
+        for flag in ("--dry-run", "--evidence-refs", "--reason", "--branch"):
+            assert flag in reference_content, (
+                f"auto-reference.md CLI reference missing real flag: {flag}"
+            )
+        for failure_mode in (
+            "Hard-stop hold",
+            "Repeated phase failure",
+            "goal_mismatch",
+            "In-progress re-route",
+            "blueprint_unavailable",
+        ):
+            assert failure_mode in reference_content, (
+                f"auto-reference.md failure-mode table missing: {failure_mode}"
+            )
+
+
 class TestLightweightWorkflowSkillContracts:
     """Regression tests for action-first lightweight workflow prompts."""
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -126,6 +126,20 @@ HIGH_TRAFFIC_SKILL_BODY_BUDGETS = {
     "map-tdd": 545,
 }
 
+# map-release is NOT "justified high-traffic" like the skills above -- it is a
+# tracked LEGACY oversize with no split-into-reference-file done yet. Keeping
+# it out of HIGH_TRAFFIC_SKILL_BODY_BUDGETS means the naming stays honest: a
+# reader of that dict should only find deliberate, justified higher caps, not
+# an untouched pre-existing violation. The pinned value here is a ratchet --
+# it may only shrink (as map-release gets trimmed/split) and must never grow,
+# so the guard test below still catches any further regression on this file.
+_LEGACY_OVERSIZED_SKILL_BODIES = {
+    "map-release": 1248,  # tracked in #418 -- ratchet: may shrink, must NOT grow;
+    # remove this entry entirely once map-release is split into a compact
+    # active body + reference file (the HIGH_TRAFFIC_COMPACT_SKILL_REFS
+    # pattern already used by map-plan/map-efficient/map-review/map-check).
+}
+
 CLAUDE_MUTATION_BOUNDARY_SURFACES = [
     Path("agents") / "actor.md",
     Path("skills") / "map-fast" / "SKILL.md",
@@ -547,6 +561,63 @@ class TestSkillStructure:
                 reference = reference_file.read_text(encoding="utf-8")
                 assert "## Examples" in reference
                 assert "## Troubleshooting" in reference
+
+    def test_every_non_high_traffic_skill_body_within_default_budget(
+        self, skill_rules, skills_dir, template_skills_dir
+    ):
+        """General body-budget guard (closes the ST-008 Monitor LOW finding).
+
+        Every skill registered in skill-rules.json whose SKILL.md exists and
+        is NOT explicitly exempted via HIGH_TRAFFIC_SKILL_BODY_BUDGETS must
+        keep its rendered active body within the default line budget. Unlike
+        the per-skill budget tests above (map-resume, the
+        HIGH_TRAFFIC_COMPACT_SKILL_REFS set, map-auto), this loop is derived
+        dynamically from skill-rules.json, so it covers map-auto AND every
+        future skill without needing a dedicated per-skill test to be added
+        by hand.
+
+        `_LEGACY_OVERSIZED_SKILL_BODIES` (tracked in #418) is a RATCHET, not
+        an exemption: a skill listed there is pinned to its currently-known
+        line count and may only shrink from here, never grow. It is
+        deliberately kept OUT of HIGH_TRAFFIC_SKILL_BODY_BUDGETS -- that dict
+        is for skills whose higher cap is a justified design choice (multiple
+        review modes, Iron Law enforcement); a legacy oversize that hasn't
+        been split into body + reference file yet is not "justified", so the
+        naming must not conflate the two. Every skill NOT in either dict
+        keeps the strict default budget. A brand-new violation (a skill not
+        already in `_LEGACY_OVERSIZED_SKILL_BODIES`) means it genuinely needs
+        either a HIGH_TRAFFIC_SKILL_BODY_BUDGETS entry (with a justification
+        comment) or a split into a compact body + reference file -- never a
+        silent exemption.
+        """
+        violations: list[str] = []
+        for base_dir in (skills_dir, template_skills_dir):
+            for skill_name in skill_rules.get("skills", {}):
+                if skill_name in HIGH_TRAFFIC_SKILL_BODY_BUDGETS:
+                    continue
+                skill_md = base_dir / skill_name / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+                line_count = len(skill_md.read_text(encoding="utf-8").splitlines())
+                if skill_name in _LEGACY_OVERSIZED_SKILL_BODIES:
+                    pinned = _LEGACY_OVERSIZED_SKILL_BODIES[skill_name]
+                    if line_count > pinned:
+                        violations.append(
+                            f"{skill_md}: {line_count} lines grew past the "
+                            f"pinned legacy ratchet of {pinned} (#418) -- the "
+                            "ratchet may only shrink, never grow"
+                        )
+                    continue
+                if line_count > _DEFAULT_SKILL_BODY_BUDGET:
+                    violations.append(
+                        f"{skill_md}: {line_count} lines "
+                        f"(budget {_DEFAULT_SKILL_BODY_BUDGET})"
+                    )
+        assert not violations, (
+            "Skill(s) exceed their active-body line budget with no "
+            "HIGH_TRAFFIC_SKILL_BODY_BUDGETS or _LEGACY_OVERSIZED_SKILL_BODIES "
+            "coverage: " + "; ".join(violations)
+        )
 
     def test_write_capable_claude_surfaces_have_constraint_first_boundaries(
         self, project_root

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -676,6 +676,37 @@ class TestSkillStructure:
         assert entry.get("enforcement") == "manual"
         assert not entry.get("runtimeEffects")
 
+    def test_map_auto_is_default_on_with_no_gating_flag(
+        self, skill_rules, skills_dir
+    ):
+        """AC-9: /map-auto is available by default -- no shadow mode, calibration
+        gate, or opt-in flag in either the skill-rules entry or the SKILL.md body."""
+        entry = skill_rules.get("skills", {}).get("map-auto")
+        assert entry is not None, "map-auto missing from skill-rules.json"
+        gating_fields = {
+            "disabled",
+            "enabled",
+            "gated",
+            "shadow_mode",
+            "shadowMode",
+            "calibration",
+            "opt_in",
+            "optIn",
+        }
+        present_gating_fields = gating_fields & set(entry.keys())
+        assert not present_gating_fields, (
+            f"map-auto skill-rules entry declares gating field(s) "
+            f"{sorted(present_gating_fields)}; AC-9 requires default-on behavior "
+            "with no shadow mode, calibration gate, or opt-in flag."
+        )
+
+        skill_file = skills_dir / "map-auto" / "SKILL.md"
+        content = skill_file.read_text(encoding="utf-8").lower()
+        assert "enable this first" not in content, (
+            f"{skill_file} contains an 'enable this first' precondition step; "
+            "AC-9 requires /map-auto to run autonomously the moment it is invoked."
+        )
+
     def test_task_skill_class_matches_manual_runtime_metadata(
         self, skills_dir, skill_folders, skill_rules
     ):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1119,9 +1119,9 @@ class TestMapAutoChainSemantics:
     def reference_content(self, skill_dir: Path) -> str:
         return (skill_dir / "auto-reference.md").read_text(encoding="utf-8")
 
-    # --- VC1 [HC-1]: no PR/merge instruction; explicit committed-branch end state ---
+    # no PR/merge instruction; explicit committed-branch end state ---
 
-    def test_vc1_no_pr_or_merge_instruction(
+    def test_no_pr_or_merge_instruction(
         self, skill_content: str, reference_content: str
     ) -> None:
         combined = (skill_content + "\n" + reference_content).lower()
@@ -1132,29 +1132,29 @@ class TestMapAutoChainSemantics:
                 "never a PR/merge."
             )
 
-    def test_vc1_grep_self_test_detects_synthetic_violation(self) -> None:
+    def test_grep_self_test_detects_synthetic_violation(self) -> None:
         """Negative-proof: the forbidden-pattern set actually catches a
         violation, so a typo in the pattern list can't silently pass VC1."""
         synthetic_bad = "After Monitor passes, run `gh pr create --fill` to open the PR."
         lowered = synthetic_bad.lower()
         assert any(pattern in lowered for pattern in self._FORBIDDEN_PR_PATTERNS)
 
-    def test_vc1_states_committed_branch_end_state(self, skill_content: str) -> None:
+    def test_states_committed_branch_end_state(self, skill_content: str) -> None:
         assert "ends at a committed feature branch" in skill_content
         assert "never opens a pull request" in skill_content
         assert "never merges" in skill_content
         assert "never polls CI" in skill_content
 
-    # --- VC2 [INV-5]: Monitor valid=false is a hard stop, never overridden ---
+    # Monitor valid=false is a hard stop, never overridden ---
 
-    def test_vc2_monitor_hard_stop_never_overridden(self, skill_content: str) -> None:
+    def test_monitor_hard_stop_never_overridden(self, skill_content: str) -> None:
         assert "valid=false" in skill_content
         assert (
             "never overrides, suppresses, or re-runs past a Monitor rejection"
             in skill_content
         )
 
-    def test_vc2_no_monitor_bypass_instruction(
+    def test_no_monitor_bypass_instruction(
         self, skill_content: str, reference_content: str
     ) -> None:
         combined = (skill_content + "\n" + reference_content).lower()
@@ -1164,9 +1164,9 @@ class TestMapAutoChainSemantics:
                 "a phase's own Monitor rejection to stand unmodified."
             )
 
-    # --- VC3 [INV-5]: no new execution engine; existing surfaces only ---
+    # no new execution engine; existing surfaces only ---
 
-    def test_vc3_no_subprocess_execution_engine(
+    def test_no_subprocess_execution_engine(
         self, skill_content: str, reference_content: str
     ) -> None:
         combined = (skill_content + "\n" + reference_content).lower()
@@ -1178,28 +1178,28 @@ class TestMapAutoChainSemantics:
             )
         assert "never shells out to a separate Claude process" in skill_content
 
-    # --- VC4 [HC-1/HC-2]: ground truth before re-entry; fail-closed recovery ---
+    # [/]: ground truth before re-entry; fail-closed recovery ---
 
-    def test_vc4_ground_truth_inspection_before_reentry(self, skill_content: str) -> None:
+    def test_ground_truth_inspection_before_reentry(self, skill_content: str) -> None:
         assert "git status" in skill_content
         assert "git diff" in skill_content
         assert "step_state.json" in skill_content
         assert "Before spending the single permitted re-entry" in skill_content
 
-    def test_vc4_second_failure_hands_off_to_map_resume(self, skill_content: str) -> None:
+    def test_second_failure_hands_off_to_map_resume(self, skill_content: str) -> None:
         assert "STOP and hand off to `/map-resume`" in skill_content
         assert "never attempt a third call for that phase" in skill_content
 
-    def test_vc4_terminal_chain_refuses_further_appends(self, skill_content: str) -> None:
+    def test_terminal_chain_refuses_further_appends(self, skill_content: str) -> None:
         assert "refuses every further `record_auto_phase` call" in skill_content
         assert (
             "a new `route_task` call is the ONLY legitimate way to continue"
             in skill_content
         )
 
-    # --- VC5 [HC-1]: auto-reference.md exists, linked, render parity, budget ---
+    # auto-reference.md exists, linked, render parity, budget ---
 
-    def test_vc5_reference_file_exists_and_linked(
+    def test_reference_file_exists_and_linked(
         self, skill_dir: Path, skill_content: str
     ) -> None:
         assert (skill_dir / "auto-reference.md").exists(), (
@@ -1207,13 +1207,13 @@ class TestMapAutoChainSemantics:
         )
         assert "[auto-reference.md](auto-reference.md)" in skill_content
 
-    def test_vc5_skill_body_within_default_budget(self, skill_content: str) -> None:
+    def test_skill_body_within_default_budget(self, skill_content: str) -> None:
         assert len(skill_content.splitlines()) <= _DEFAULT_SKILL_BODY_BUDGET, (
             "map-auto/SKILL.md must stay within the default active-body "
             f"line budget ({_DEFAULT_SKILL_BODY_BUDGET} lines)."
         )
 
-    def test_vc5_reference_covers_required_topics(self, reference_content: str) -> None:
+    def test_reference_covers_required_topics(self, reference_content: str) -> None:
         for marker in (
             "## CLI Reference",
             "## Chain Walkthrough Example",

--- a/tests/test_skills_consistency.py
+++ b/tests/test_skills_consistency.py
@@ -476,15 +476,25 @@ def detect_skill_deps(skill_dir: Path) -> dict[str, set[str]]:
 # ---------------------------------------------------------------------------
 
 
-def test_skill_discovery_non_empty(skill_names: list[str]) -> None:
-    """Guard: skill-rules.json must list exactly 21 skills (prevents vacuous pass).
+def test_skill_discovery_non_empty(skill_names: list[str], skills_dir: Path) -> None:
+    """Guard: skill-rules.json entries == shipped skill dirs (prevents vacuous pass).
 
-    21 = the 16 core MAP skills + map-so-search + map-understand + map-wayfind
-         + map-architecture (#363) + map-prd-review (#413).
+    Derived from the directory tree instead of a hardcoded count so a new skill
+    doesn't break this guard (the old literal was bumped for #363, #413, ...).
+    A dir without a registry entry, or a stale entry without a dir, both fail;
+    an empty discovery on either side fails the non-empty assertions.
     """
-    assert len(skill_names) == 21, (
-        f"Expected 21 skills in skill-rules.json, found {len(skill_names)}: "
-        f"{sorted(skill_names)}"
+    dir_names = {
+        p.name
+        for p in skills_dir.iterdir()
+        if p.is_dir() and (p / "SKILL.md").exists()
+    }
+    assert dir_names, f"empty skill-dir discovery under {skills_dir}"
+    assert skill_names, "empty skills mapping in skill-rules.json"
+    assert set(skill_names) == dir_names, (
+        "skill-rules.json entries and .claude/skills/ dirs diverge: "
+        f"only-in-rules={sorted(set(skill_names) - dir_names)}, "
+        f"only-on-disk={sorted(dir_names - set(skill_names))}"
     )
 
 


### PR DESCRIPTION
## Summary

Ships `/map-auto <task>` (#414) — a thin single-entry autopilot wrapper that routes a task through the existing MAP workflows and drives the selected chain autonomously to a committed feature branch. No new execution engine: Python owns the deterministic triad `route_task` / `auto_decide_holds` / `record_auto_phase` plus `AUTO_ROUTE_SCHEMA`; skill prose chains the existing unmodified workflows.

- **Routing** — state-first five-tier precedence in `_select_route`: (1a) pending `step_state.json` → map-resume; (1b) all-complete → map-check; (2) recorded `workflow-fit.json` iff ∈ {map-fast, map-plan, map-efficient}; (3) `check_plan_resume` resume without step_state: plan+blueprint → map-efficient, else map-plan; (4) trivial scope → map-fast; (5) default map-plan. Losing signals land in `evidence[]`.
- **Hold policy** — `auto_decide_holds` auto-approves the positive allowlist `autonomy_posture`/`plan_approval`/`template_overwrite` via existing `decide_approval_hold` (audit note "auto-approved by map-auto", surfaces in the `approval_hold` manifest stage); `dangerous_action`/`safety_guardrail` are hard stops, never auto-decided. The two sets are test-enforced to exactly partition `APPROVAL_HOLD_KINDS`.
- **State** — schema-validated `.map/<branch>/auto-route.json` (closed `chain_status` vocabulary, `phases[]` ledger, `route_history[]`), new `auto_route` manifest stage. Mutated only by `route_task` and `record_auto_phase`; `auto_decide_holds` writes `approval_holds.json`.
- **Guards** — `route_task --dry-run` write-isolation (mtime-diff-tested), `in_progress` re-route refusal → `/map-resume`, goal_mismatch and hard-stop-hold blocks, C0 sanitization of task text, max ONE re-entry per phase (3rd attempt refused), fail-closed aborts resumable via `/map-resume`.
- **End state** — committed feature branch; PR/CI/merge stay manual (first-slice guardrail).
- **Skill** — `/map-auto` SKILL.md + auto-reference within the always-loaded body budget; AC-7 matrix meta-test pins every acceptance area to named covering tests; docs updated (README, USAGE, ARCHITECTURE, CHANGELOG).

## Validation

- `make check` green at HEAD: 4489 passed / 3 skipped, ruff clean, pyright 0/0/0, `make check-render` parity clean.
- MAP review (monitor + predictor + evaluator + complexity lens): initial REVISE — doc drift (SKILL/CHANGELOG mis-stated `auto_decide_holds` mutating `auto-route.json`) + comment residue from ID-strip — fixed in `1aafa3d`, re-verified by grep + full gate; final verdict PROCEED (ledger-computed).
- Dedicated tests: schema golden artifacts, five-tier routing precedence (incl. fall-through recording), dry-run isolation, in-progress refusal, hold-partition invariant, phase-ledger attempt bound, skill-budget guard, AC-7 matrix meta-test.

## Risks / Follow-up

- No live approval-hold producers exist yet — the auto-approve path is exercised by synthetic test holds; wiring a real producer (e.g. `plan_approval` at a map-plan decision point) is a follow-up.
- map-release skill-body oversize deferred to ratchet issue #418 (pre-existing, unrelated).
- Advisory (non-blocking): `_AUTO_ROUTE_NEXT_COMMAND` identity dict could be an f-string; `_classify_scope_bracket` hand-rolls importlib loading (~-18 lines possible).

Closes #414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/map-auto`, an autonomous entry point that routes tasks through MAP workflows and tracks execution progress.
  * Supports dry-run routing, routine hold approvals, retry limits, and recovery from interrupted phases.
  * Automatically stops when dangerous or safety-related actions require review.
  * Ends with a committed feature branch without creating pull requests or merging changes.

* **Documentation**
  * Added usage guidance, workflow examples, troubleshooting, recovery procedures, and architecture details.

* **Tests**
  * Added comprehensive coverage for routing, hold handling, phase tracking, safeguards, artifacts, and skill consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->