### PR TITLE
fix: close all four open bug issues (#423, #424, #425, #426)

### DIFF
--- a/.agents/skills/map-efficient/SKILL.md
+++ b/.agents/skills/map-efficient/SKILL.md
@@ -100,7 +100,7 @@ if [ -f "$STATE_FILE" ]; then
   echo "Existing step_state.json found; continuing with get_next_step."
 elif [ -f "$PLAN_FILE" ]; then
   RESUME_RESULT=$(python3 .map/scripts/map_orchestrator.py resume_from_plan)
-  RESUME_STATUS=$(echo "$RESUME_RESULT" | jq -r '.status')
+  RESUME_STATUS=$(printf '%s' "$RESUME_RESULT" | jq -r '.status')
   if [ "$RESUME_STATUS" != "success" ]; then
     echo "resume_from_plan failed: $RESUME_RESULT" >&2
     exit 1
@@ -120,9 +120,9 @@ fi
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 echo "$NEXT_STEP"
 ```
 

--- a/.agents/skills/map-efficient/efficient-reference.md
+++ b/.agents/skills/map-efficient/efficient-reference.md
@@ -86,7 +86,7 @@ python3 .map/scripts/map_step_runner.py validate_flaky_test_triage
 # Preferred close — the verdict path. Monitor emits valid:false plus
 # disposition {kind: deferred_nondeterministic, check_id: ...}; close 2.4 with
 # the same disposition piped through (see "Verdict-path route" below).
-echo "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
+printf '%s' "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
   validate_step 2.4 --disposition deferred_nondeterministic \
   --check-id "pytest::test_name" --monitor-envelope -
 ```

--- a/.agents/skills/map-review/SKILL.md
+++ b/.agents/skills/map-review/SKILL.md
@@ -117,10 +117,15 @@ fully-committed branch — the normal `/map-check` → `/map-review` state —
 `git diff HEAD` is empty and under-reports the review scope to zero (#426).
 
 ```bash
-BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
-       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
-git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
-git --no-pager diff "${BASE:-HEAD}"...HEAD
+BASE=""
+for ref in origin/main origin/master main master; do
+  git rev-parse --verify --quiet "$ref" >/dev/null && { BASE="$ref"; break; }
+done
+# No default-branch ref: diff the working tree. NEVER "HEAD...HEAD" — that range
+# is always empty and re-creates the very bug this step fixes.
+[ -n "$BASE" ] && RANGE="$BASE...HEAD" || RANGE="HEAD"
+git --no-pager diff --stat "$RANGE"
+git --no-pager diff "$RANGE"
 git status          # uncommitted work in progress — secondary signal
 ```
 

--- a/.agents/skills/map-review/SKILL.md
+++ b/.agents/skills/map-review/SKILL.md
@@ -112,9 +112,16 @@ otherwise) and mode semantics.
 
 ### Step A.1: Gather changes
 
+Diff against the **merge-base with the default branch**, not `HEAD`. On a
+fully-committed branch — the normal `/map-check` → `/map-review` state —
+`git diff HEAD` is empty and under-reports the review scope to zero (#426).
+
 ```bash
-git diff HEAD
-git status
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
+git --no-pager diff "${BASE:-HEAD}"...HEAD
+git status          # uncommitted work in progress — secondary signal
 ```
 
 ### Step A.1b: Load canonical review context (bundle + handoff)

--- a/.claude/agents/final-verifier.md
+++ b/.claude/agents/final-verifier.md
@@ -5,8 +5,17 @@ description: Adversarial verifier with Root Cause Analysis (Ralph Loop)
 # gate before merge — false negatives here ship bugs to production.
 model: opus
 effort: high
-version: 1.1.0
-last_updated: 2026-04-28
+# 2026-08-14 (#424): a final-verifier run edited generated trees and committed
+# them mid-audit, despite the prompt contract being APPROVED/REJECTED-only.
+# Write stays allowed — the verifier legitimately writes .map/<branch>/
+# final_verification.json + progress markdown — but Edit and nested Agent are
+# denied at the harness level. Bash git mutations are blocked by the
+# safety-guardrails PreToolUse hook, which keys on agent_type.
+disallowedTools:
+  - Edit
+  - Agent
+version: 1.2.0
+last_updated: 2026-08-14
 ---
 
 # IDENTITY

--- a/.claude/agents/final-verifier.md
+++ b/.claude/agents/final-verifier.md
@@ -7,12 +7,16 @@ model: opus
 effort: high
 # 2026-08-14 (#424): a final-verifier run edited generated trees and committed
 # them mid-audit, despite the prompt contract being APPROVED/REJECTED-only.
-# Write stays allowed — the verifier legitimately writes .map/<branch>/
-# final_verification.json + progress markdown — but Edit and nested Agent are
-# denied at the harness level. Bash git mutations are blocked by the
-# safety-guardrails PreToolUse hook, which keys on agent_type.
+# Nested Agent is denied at the harness level. Edit/Write are NOT denied here:
+# this agent's own contract requires an in-place append to
+# .map/<branch>/progress_<branch>.md and a `[ ]` -> `[x]` update in the
+# task-plan Acceptance Criteria table — forcing those through whole-file Write
+# would drop surrounding content. The boundary is enforced by scope instead:
+# the safety-guardrails PreToolUse hook keys on agent_type and confines every
+# verifier Edit/Write/MultiEdit to `.map/` (normalized, so `.map/../src` cannot
+# escape) while blocking all git-mutating Bash. Runner-owned state inside
+# `.map/` stays protected for everyone by the workflow-gate tamper detector.
 disallowedTools:
-  - Edit
   - Agent
 version: 1.2.0
 last_updated: 2026-08-14

--- a/.claude/hooks/safety-guardrails.py
+++ b/.claude/hooks/safety-guardrails.py
@@ -5,6 +5,9 @@ Safety Guardrails - PreToolUse Hook
 Merged hook that blocks:
 - Access to sensitive files (.env, credentials, private keys)
 - Dangerous shell commands (rm -rf /, force push, etc.)
+- Branch mutation from verifier-class subagents (#424): no git commit/push/reset
+  and no Edit/Write outside `.map/` when `agent_type` names a read-and-report
+  agent. Reads are never restricted.
 
 Trigger: Edit|Write|Bash
 Exit codes:
@@ -226,6 +229,117 @@ def check_autonomy_git_block(command: str) -> tuple[bool, str]:
     return True, ""
 
 
+# =============================================================================
+# Verifier-class capability boundary (#424)
+# =============================================================================
+
+# Agents dispatched with a read-and-report contract. They legitimately write
+# their own review artifacts under `.map/<branch>/`, but must never mutate
+# source or the branch — a final-verifier run once hand-edited generated trees
+# and committed them mid-audit, then reported "working tree clean" for its own
+# post-commit state, masking the breakage from the orchestrating session.
+VERIFIER_AGENT_TYPES = frozenset(
+    {
+        "final-verifier",
+        "monitor",
+        "evaluator",
+        "predictor",
+        "documentation-reviewer",
+    }
+)
+
+# Write scope a verifier keeps: its own branch-scoped artifact directory.
+VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
+
+# git subcommands that mutate the index, the worktree, or history.
+_GIT_MUTATING_SUBCOMMANDS = (
+    "add",
+    "am",
+    "apply",
+    "branch",
+    "checkout",
+    "cherry-pick",
+    "clean",
+    "commit",
+    "merge",
+    "mv",
+    "push",
+    "rebase",
+    "reset",
+    "restore",
+    "revert",
+    "rm",
+    "stash",
+    "switch",
+    "tag",
+    "worktree",
+)
+
+
+def _normalize_agent_type(raw: object) -> str:
+    """Strip plugin scoping (`plugin:pkg:monitor` -> `monitor`) and lowercase."""
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip().split(":")[-1].lower()
+
+
+def is_verifier_agent(agent_type: object) -> bool:
+    """True when the tool call originates from a read-and-report agent."""
+    return _normalize_agent_type(agent_type) in VERIFIER_AGENT_TYPES
+
+
+def check_verifier_command(command: str) -> tuple[bool, str]:
+    """Block git mutations from a verifier-class agent. Returns (is_safe, reason).
+
+    Same token-anchored matching as the autonomy block so `bash -c 'git commit'`
+    and `git -C <path> commit` are caught too. Read-only git (status, diff, log,
+    show, rev-parse, ls-files) stays allowed — it is how a verifier gathers
+    evidence.
+    """
+    if not command:
+        return True, ""
+
+    import re
+
+    pattern = re.compile(
+        r"(?:^|[\s;&|`'\"()])"
+        r"git\s+"
+        r"(?:-\S+\s+|-C\s+\S+\s+|-c\s+\S+\s+)*"
+        r"(?:" + "|".join(_GIT_MUTATING_SUBCOMMANDS) + r")"
+        r"(?:$|[\s;&|`'\"()])",
+        re.IGNORECASE,
+    )
+    match = pattern.search(command)
+    if match:
+        return (
+            False,
+            (
+                f"Blocked: verifier-class agents must not mutate the branch "
+                f"(matched `{match.group(0).strip()}`). Report the finding in your "
+                "verdict instead — the orchestrating session owns all git writes."
+            ),
+        )
+    return True, ""
+
+
+def check_verifier_path(path: str) -> tuple[bool, str]:
+    """Confine verifier writes to `.map/`. Returns (is_safe, reason)."""
+    if not path:
+        return True, ""
+    normalized = path.replace("\\", "/")
+    normalized = normalized.removeprefix("./")
+    if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
+        return True, ""
+    return (
+        False,
+        (
+            f"Blocked: verifier-class agents may only write under `.map/`; "
+            f"refused write to {path}. Report the required change in your verdict "
+            "instead of applying it."
+        ),
+    )
+
+
 def deny(reason: str) -> None:
     """Deny tool execution using structured PreToolUse decision control."""
     print(
@@ -251,6 +365,8 @@ def main() -> None:
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
+    # `agent_type` is present only when the hook fires inside a subagent.
+    verifier = is_verifier_agent(input_data.get("agent_type"))
 
     # Check file-based tools
     if tool_name in ("Edit", "Write", "Read", "MultiEdit"):
@@ -258,6 +374,11 @@ def main() -> None:
         is_safe, reason = check_file_safety(file_path)
         if not is_safe:
             deny(f"{reason} (tool={tool_name})")
+        # Reads stay unrestricted — a verifier must be able to read everything.
+        if verifier and tool_name in ("Edit", "Write", "MultiEdit"):
+            is_safe, reason = check_verifier_path(file_path)
+            if not is_safe:
+                deny(f"{reason} (tool={tool_name})")
 
     # Check bash commands
     elif tool_name == "Bash":
@@ -265,6 +386,10 @@ def main() -> None:
         is_safe, reason = check_command_safety(command)
         if not is_safe:
             deny(f"{reason} (tool={tool_name})")
+        if verifier:
+            is_safe, reason = check_verifier_command(command)
+            if not is_safe:
+                deny(reason)
         is_safe, reason = check_autonomy_git_block(command)
         if not is_safe:
             deny(reason)

--- a/.claude/hooks/safety-guardrails.py
+++ b/.claude/hooks/safety-guardrails.py
@@ -248,8 +248,10 @@ VERIFIER_AGENT_TYPES = frozenset(
     }
 )
 
-# Write scope a verifier keeps: its own branch-scoped artifact directory.
-VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
+# Write scope a verifier keeps: the project-root `.map/` artifact tree, and only
+# that one. Resolved against CLAUDE_PROJECT_DIR at call time — see
+# check_verifier_path.
+VERIFIER_WRITABLE_DIRNAME = ".map"
 
 # git subcommands that mutate the index, the worktree, refs, history, or config.
 # `pull`/`fetch`/`submodule` are included because they move the very refs the
@@ -338,29 +340,32 @@ def check_verifier_command(command: str) -> tuple[bool, str]:
 
 
 def check_verifier_path(path: str) -> tuple[bool, str]:
-    """Confine verifier writes to `.map/`. Returns (is_safe, reason).
+    """Confine verifier writes to the PROJECT-ROOT `.map/`. Returns (is_safe, reason).
 
-    The path is normalized BEFORE the prefix check: a raw text comparison accepts
-    `.map/../src/mapify_cli/cli.py`, which starts with `.map/` yet resolves outside
-    the allowed workspace.
+    Containment is decided on the resolved path, never on path text. A textual
+    check is bypassable three ways, all of which land outside the artifact tree:
+    `.map/../src/cli.py` (starts with the prefix), `src/.map/payload.py` (contains
+    `/.map/`), and `/elsewhere/.map/x` (an unrelated project's directory).
 
-    This is the outer boundary only. Runner-owned state inside `.map/`
+    This is the outer boundary only. Runner-owned state INSIDE `.map/`
     (`.map/scripts/**`, `step_state.json`, `approval_holds.json`, …) is separately
     protected from direct hand-editing by the workflow-gate state-tamper detector,
     which applies to every caller, not just verifiers.
     """
     if not path:
         return True, ""
-    normalized = os.path.normpath(path.replace("\\", "/")).replace("\\", "/")
-    normalized = normalized.removeprefix("./")
-    if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    map_root = os.path.realpath(os.path.join(project_dir, VERIFIER_WRITABLE_DIRNAME))
+    candidate = path if os.path.isabs(path) else os.path.join(project_dir, path)
+    resolved = os.path.realpath(candidate)
+    if resolved == map_root or resolved.startswith(map_root + os.sep):
         return True, ""
     return (
         False,
         (
-            f"Blocked: verifier-class agents may only write under `.map/`; "
-            f"refused write to {path}. Report the required change in your verdict "
-            "instead of applying it."
+            f"Blocked: verifier-class agents may only write under the project's "
+            f"`{VERIFIER_WRITABLE_DIRNAME}/` artifact tree; refused write to {path}. "
+            "Report the required change in your verdict instead of applying it."
         ),
     )
 

--- a/.claude/hooks/safety-guardrails.py
+++ b/.claude/hooks/safety-guardrails.py
@@ -251,7 +251,11 @@ VERIFIER_AGENT_TYPES = frozenset(
 # Write scope a verifier keeps: its own branch-scoped artifact directory.
 VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
 
-# git subcommands that mutate the index, the worktree, or history.
+# git subcommands that mutate the index, the worktree, refs, history, or config.
+# `pull`/`fetch`/`submodule` are included because they move the very refs the
+# verifier is auditing; `config`/`update-ref`/`symbolic-ref`/`filter-branch`/`notes`
+# because they rewrite repository state out from under the audit. A verifier needs
+# none of them — the list is deliberately fail-closed.
 _GIT_MUTATING_SUBCOMMANDS = (
     "add",
     "am",
@@ -261,17 +265,28 @@ _GIT_MUTATING_SUBCOMMANDS = (
     "cherry-pick",
     "clean",
     "commit",
+    "config",
+    "fetch",
+    "filter-branch",
+    "gc",
     "merge",
     "mv",
+    "notes",
+    "prune",
+    "pull",
     "push",
     "rebase",
     "reset",
     "restore",
     "revert",
     "rm",
+    "sparse-checkout",
     "stash",
+    "submodule",
     "switch",
+    "symbolic-ref",
     "tag",
+    "update-ref",
     "worktree",
 )
 
@@ -323,10 +338,20 @@ def check_verifier_command(command: str) -> tuple[bool, str]:
 
 
 def check_verifier_path(path: str) -> tuple[bool, str]:
-    """Confine verifier writes to `.map/`. Returns (is_safe, reason)."""
+    """Confine verifier writes to `.map/`. Returns (is_safe, reason).
+
+    The path is normalized BEFORE the prefix check: a raw text comparison accepts
+    `.map/../src/mapify_cli/cli.py`, which starts with `.map/` yet resolves outside
+    the allowed workspace.
+
+    This is the outer boundary only. Runner-owned state inside `.map/`
+    (`.map/scripts/**`, `step_state.json`, `approval_holds.json`, …) is separately
+    protected from direct hand-editing by the workflow-gate state-tamper detector,
+    which applies to every caller, not just verifiers.
+    """
     if not path:
         return True, ""
-    normalized = path.replace("\\", "/")
+    normalized = os.path.normpath(path.replace("\\", "/")).replace("\\", "/")
     normalized = normalized.removeprefix("./")
     if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
         return True, ""

--- a/.claude/references/bash-guidelines.md
+++ b/.claude/references/bash-guidelines.md
@@ -39,6 +39,33 @@ head -n 10 logfile.txt  # Direct file read is OK
 
 ---
 
+## ⚠️ CRITICAL: Never pipe a captured variable through `echo`
+
+zsh (the default macOS shell) has a builtin `echo` that interprets backslash
+escapes without `-E`. Piping captured JSON through it turns the `\n`/`\t`
+escapes inside JSON string values into raw C0 control bytes, and `jq` aborts
+with `control characters from U+0000 through U+001F must be escaped`. Inside
+`$(...)` the failure is swallowed, so the variable lands **empty** and the
+recipe writes an empty-bodied artifact with exit 0.
+
+```bash
+# ❌ BAD - mangles escapes under zsh; SUMMARY silently ends up empty
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+NORM=$(echo "$TOOL_OUT" | while IFS= read -r line; do ...; done)
+
+# ✅ GOOD - printf emits the bytes verbatim
+SUMMARY=$(printf '%s' "$BUNDLE" | jq -r '.summary')
+
+# ✅ GOOD - keep the trailing newline when a `while read` loop consumes it,
+#           otherwise the last line is dropped
+NORM=$(printf '%s\n' "$TOOL_OUT" | while IFS= read -r line; do ...; done)
+```
+
+The convention is enforced by `tests/test_shell_json_pipes.py`, which scans every
+shipped recipe and handler for the banned form.
+
+---
+
 ## When Checking Command Output
 
 ### Pattern 1: Run Commands Directly

--- a/.claude/skills/map-efficient/SKILL.md
+++ b/.claude/skills/map-efficient/SKILL.md
@@ -115,7 +115,7 @@ if [ -f "$STATE_FILE" ]; then
   echo "Existing step_state.json found — proceeding straight to Step 1 get_next_step."
 elif [ -f "$PLAN_FILE" ]; then
   RESUME_RESULT=$(python3 .map/scripts/map_orchestrator.py resume_from_plan)
-  RESUME_STATUS=$(echo "$RESUME_RESULT" | jq -r '.status')
+  RESUME_STATUS=$(printf '%s' "$RESUME_RESULT" | jq -r '.status')
   if [ "$RESUME_STATUS" = "success" ]; then
     echo "Resumed from /map-plan artifacts."
   else
@@ -141,10 +141,10 @@ fi
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-INSTRUCTION=$(echo "$NEXT_STEP" | jq -r '.instruction')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+INSTRUCTION=$(printf '%s' "$NEXT_STEP" | jq -r '.instruction')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 ```
 
 If `IS_COMPLETE=true`, skip to final verification.

--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -39,7 +39,7 @@ python3 .map/scripts/map_step_runner.py validate_flaky_test_triage
 # disposition {kind: deferred_nondeterministic, check_id: ...}; close 2.4 with
 # the same disposition piped through. The orchestrator routes to deferral ONLY
 # when the sidecar + envelope back it (see "Verdict-path route" below).
-echo "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
+printf '%s' "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
   validate_step 2.4 --disposition deferred_nondeterministic \
   --check-id "pytest::test_name" --monitor-envelope -
 ```
@@ -292,7 +292,7 @@ Before invoking Monitor, validate Actor's response is JSON with required
 keys (`files_changed`, `tests_run`):
 
 ```bash
-echo "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
+printf '%s' "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
     detect_truncated_agent_output --agent actor
 ```
 

--- a/.claude/skills/map-efficient/efficient-reference.md
+++ b/.claude/skills/map-efficient/efficient-reference.md
@@ -315,11 +315,11 @@ If `truncated: true`:
 confirmed intact, run:
 
 ```bash
-FILES_DECLARED=$(echo "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
+FILES_DECLARED=$(printf '%s' "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
 MISMATCH=$(detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" \
   --declared "$FILES_DECLARED")
 echo "$MISMATCH"
-STATUS_MISMATCH=$(echo "$MISMATCH" | jq -r '.status_mismatch')
+STATUS_MISMATCH=$(printf '%s' "$MISMATCH" | jq -r '.status_mismatch')
 ```
 
 - `status_mismatch == true` — Actor declared files it did not write (mid-edit
@@ -344,8 +344,8 @@ Monitor failure), after `monitor_failed`:
 #    test_failure, gate_failure}. Exit 0 always — this is a sensor, not a gate.
 REC=$(python3 .map/scripts/map_step_runner.py record_failure_signature \
   "$MONITOR_FEEDBACK" "$SUBTASK_ID" --source monitor_rejection)
-ARMED=$(echo "$REC" | jq -r '.armed')
-ESCALATE=$(echo "$REC" | jq -r '.escalation_recommended')
+ARMED=$(printf '%s' "$REC" | jq -r '.armed')
+ESCALATE=$(printf '%s' "$REC" | jq -r '.escalation_recommended')
 
 # 2. If armed (same normalized failure >= 2x), prepend the hard constraint to
 #    the TOP of the next Actor prompt. Pass --quarantine-active when CLEAN_RETRY
@@ -380,7 +380,7 @@ fi
       build_escalation_outcome "$SUBTASK_ID" repeated_failure)
     #  Pass --quarantine-active on a CLEAN_RETRY iteration: it returns
     #  status:"deferred" so the one-shot reset runs before any terminal stop.
-    STATUS=$(echo "$OUT" | jq -r '.status')
+    STATUS=$(printf '%s' "$OUT" | jq -r '.status')
     #  status:"escalated"-> surface OUT.blocker_summary + OUT.recommended_action
     #    to the user and STOP (outcome:"BLOCKED", .map/<branch>/escalation_*.md).
     #  status:"not_escalated" -> the LATEST failure was a NEW signature; the
@@ -418,7 +418,7 @@ Before dispatching Monitor, run the blast-radius detector:
 BLAST=$(python3 .map/scripts/map_step_runner.py \
   detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID")
 echo "$BLAST"   # inspect changed_symbols / external_callers / reason
-GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
+GATE=$(printf '%s' "$BLAST" | jq -r '.recommended_gate')
 ```
 
 - `recommended_gate == "validate_callers"` — the subtask changed a
@@ -449,7 +449,7 @@ scoped run is safe:
 RISK=$(python3 .map/scripts/map_step_runner.py \
   detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID")
 echo "$RISK"   # inspect shared_source_files / prior_owners / reason
-GATE=$(echo "$RISK" | jq -r '.recommended_gate')
+GATE=$(printf '%s' "$RISK" | jq -r '.recommended_gate')
 ```
 
 - `recommended_gate == "full_suite"` — the current diff overlaps a file a

--- a/.claude/skills/map-release/release-reference.md
+++ b/.claude/skills/map-release/release-reference.md
@@ -277,7 +277,7 @@ CURRENT_BRANCH=$(git branch --show-current)
 [[ "$CURRENT_BRANCH" != "main" ]] && echo "❌ ABORT: Not on main branch" && exit 1
 
 LATEST_RUN=$(gh run list --branch main --limit 1 --json conclusion,status,createdAt,headBranch --jq '.[0]')
-RUN_CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
+RUN_CONCLUSION=$(printf '%s' "$LATEST_RUN" | jq -r '.conclusion')
 [[ "$RUN_CONCLUSION" != "success" ]] && echo "❌ ABORT: Latest CI did not succeed" && exit 1
 
 LAST_TAG=$(git tag --sort=-version:refname | head -1)
@@ -324,13 +324,13 @@ echo "Waiting for release workflow to start..."
 sleep 10
 
 RELEASE_RUN=$(gh run list --workflow=release.yml --limit 1 --json databaseId,status,conclusion,createdAt)
-RUN_ID=$(echo "$RELEASE_RUN" | jq -r '.[0].databaseId')
+RUN_ID=$(printf '%s' "$RELEASE_RUN" | jq -r '.[0].databaseId')
 
 if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
   echo "⚠️  Workflow not started yet; retrying in 30s..."
   sleep 30
   RELEASE_RUN=$(gh run list --workflow=release.yml --limit 1 --json databaseId,status,conclusion,createdAt)
-  RUN_ID=$(echo "$RELEASE_RUN" | jq -r '.[0].databaseId')
+  RUN_ID=$(printf '%s' "$RELEASE_RUN" | jq -r '.[0].databaseId')
 fi
 
 echo "Workflow URL: https://github.com/azalio/map-framework/actions/runs/$RUN_ID"

--- a/.claude/skills/map-resume/SKILL.md
+++ b/.claude/skills/map-resume/SKILL.md
@@ -189,9 +189,9 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 
 # Get next step from orchestrator (reads step_state.json internally)
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 ```
 
 **Then follow the same phase routing as /map-efficient:**

--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -270,10 +270,15 @@ fully-committed branch — the normal `/map-check` → `/map-review` state —
 `git diff HEAD` is empty and under-reports the review scope to zero (#426).
 
 ```bash
-BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
-       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
-git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
-git --no-pager diff "${BASE:-HEAD}"...HEAD
+BASE=""
+for ref in origin/main origin/master main master; do
+  git rev-parse --verify --quiet "$ref" >/dev/null && { BASE="$ref"; break; }
+done
+# No default-branch ref: diff the working tree. NEVER "HEAD...HEAD" — that range
+# is always empty and re-creates the very bug this step fixes.
+[ -n "$BASE" ] && RANGE="$BASE...HEAD" || RANGE="HEAD"
+git --no-pager diff --stat "$RANGE"
+git --no-pager diff "$RANGE"
 git status          # uncommitted work in progress — secondary signal
 ```
 

--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -265,9 +265,16 @@ Mode semantics:
 
 ### Step A.1: Gather changes
 
+Diff against the **merge-base with the default branch**, not `HEAD`. On a
+fully-committed branch — the normal `/map-check` → `/map-review` state —
+`git diff HEAD` is empty and under-reports the review scope to zero (#426).
+
 ```bash
-git diff HEAD
-git status
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
+git --no-pager diff "${BASE:-HEAD}"...HEAD
+git status          # uncommitted work in progress — secondary signal
 ```
 
 ### Step A.1b: Load canonical review context (bundle + handoff)

--- a/.claude/skills/map-review/SKILL.md
+++ b/.claude/skills/map-review/SKILL.md
@@ -276,7 +276,7 @@ Run this before any reviewer agent:
 
 ```bash
 BUNDLE_JSON=$(python3 .map/scripts/map_step_runner.py create_review_bundle)
-BUNDLE_JSON_PATH=$(echo "$BUNDLE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['bundle_path_json'])")
+BUNDLE_JSON_PATH=$(printf '%s' "$BUNDLE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['bundle_path_json'])")
 ```
 
 This creates `.map/<branch>/review-bundle.json` and `.map/<branch>/review-bundle.md`. These are PRIMARY review context. The bundle includes prior-stage consumption status; missing inputs are review evidence, not invisible setup noise.
@@ -288,9 +288,9 @@ DETACHED_PATH=""
 if [ "$DETACHED_FLAG" = "true" ]; then
   # EC-15: prepare detached review once; compare runs reuse the same path.
   DETACHED_JSON=$(python3 .map/scripts/map_step_runner.py prepare_detached_review "$BUNDLE_JSON_PATH")
-  DETACHED_STATUS=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))")
-  DETACHED_PATH=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('worktree_path') or '')")
-  DETACHED_REASON=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reason') or '')")
+  DETACHED_STATUS=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))")
+  DETACHED_PATH=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('worktree_path') or '')")
+  DETACHED_REASON=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reason') or '')")
 fi
 ```
 

--- a/.claude/skills/map-task/SKILL.md
+++ b/.claude/skills/map-task/SKILL.md
@@ -80,10 +80,10 @@ if [ -f ".map/${BRANCH}/test_handoff_${SUBTASK_ID}.json" ] && [ -f ".map/${BRANC
 else
   RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID")
 fi
-STATUS=$(echo "$RESULT" | jq -r '.status')
+STATUS=$(printf '%s' "$RESULT" | jq -r '.status')
 
 if [ "$STATUS" = "error" ]; then
-  echo "$RESULT" | jq -r '.message'
+  printf '%s' "$RESULT" | jq -r '.message'
   exit 1
 fi
 ```
@@ -125,7 +125,7 @@ Follow the same state machine loop as `/map-efficient`. Call `get_next_step` and
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
@@ -170,10 +170,10 @@ python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "comp
 2. Get overall plan progress:
 ```bash
 PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
-TOTAL=$(echo "$PROGRESS" | jq -r '.total')
-DONE=$(echo "$PROGRESS" | jq -r '.completed_count')
-REMAINING=$(echo "$PROGRESS" | jq -r '.pending_count')
-SUGGESTED=$(echo "$PROGRESS" | jq -r '.suggested_next')
+TOTAL=$(printf '%s' "$PROGRESS" | jq -r '.total')
+DONE=$(printf '%s' "$PROGRESS" | jq -r '.completed_count')
+REMAINING=$(printf '%s' "$PROGRESS" | jq -r '.pending_count')
+SUGGESTED=$(printf '%s' "$PROGRESS" | jq -r '.suggested_next')
 ```
 
 3. Display completion report with remaining subtasks:

--- a/.claude/skills/map-tdd/SKILL.md
+++ b/.claude/skills/map-tdd/SKILL.md
@@ -115,10 +115,10 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 
 ```bash
 RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID" --tdd)
-STATUS=$(echo "$RESULT" | jq -r '.status')
+STATUS=$(printf '%s' "$RESULT" | jq -r '.status')
 
 if [ "$STATUS" = "error" ]; then
-  echo "$RESULT" | jq -r '.message'
+  printf '%s' "$RESULT" | jq -r '.message'
   # If no plan: "Run /map-plan first"
   # If subtask not found: shows available IDs
   exit 1
@@ -185,7 +185,7 @@ Call `get_next_step` and execute based on the returned phase.
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -64,8 +64,8 @@ USAGE FROM map-efficient.md:
   ```bash
   # Get next step
   NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-  STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-  INSTRUCTION=$(echo "$NEXT_STEP" | jq -r '.instruction')
+  STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+  INSTRUCTION=$(printf '%s' "$NEXT_STEP" | jq -r '.instruction')
 
   # Execute step based on phase...
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -363,12 +363,25 @@ ACCEPTANCE_COVERAGE_BLOCK_RE = re.compile(
     + re.escape(ACCEPTANCE_COVERAGE_BLOCK_END),
     re.DOTALL,
 )
-# Structural fallback for artifacts written BEFORE the sentinels existed (every
-# already-installed repo has them on disk). Spans the heading up to the next
-# `## ` heading or end of text — the non-greedy body plus the lookahead also
-# handles pr-draft.md, where the whole summary is flattened onto one line.
-ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE = re.compile(
-    r"##\s+Acceptance Coverage.*?(?=##\s+|\Z)", re.DOTALL
+# Fallback for artifacts written BEFORE the sentinels existed (every already-installed
+# repo has them on disk). Deliberately NOT a heading-to-heading span: when the block is
+# the last section — or when pr-draft.md has flattened every newline into a space so no
+# later `## ` is recognisable — a span would swallow the rest of the file and drop
+# genuine citations. These patterns match the generated block's own line grammar
+# instead, so only report-authored text is ever removed.
+ACCEPTANCE_COVERAGE_LEGACY_LINE_RES = (
+    # The per-requirement rows — the only part that carries tags. The evidence
+    # tail is a bounded, comma-separated label list (labels never contain spaces),
+    # NOT `[^\n]*`: an open-ended tail would run past the last row and swallow
+    # whatever prose follows it on a flattened line.
+    re.compile(
+        r"-\s*\[[a-z_]+\]\s*\S+\s+owned by\s+\S+;\s*evidence:\s*"
+        r"[\w:./-]+(?:,\s*[\w:./-]+)*"
+    ),
+    re.compile(r"-\s*Covered tags:\s*\d+/\d+"),
+    re.compile(r"-\s*Missing evidence:\s*\d+"),
+    re.compile(r"-\s*Uncovered:\s*\d+\s*\([^)]*\)"),
+    re.compile(r"##\s+Acceptance Coverage"),
 )
 REVIEW_PROMPT_DEFAULT_BUDGET_TOKENS = 12_000
 REVIEW_PROMPT_MIN_BUDGET_TOKENS = 1_024
@@ -4690,10 +4703,13 @@ def _strip_generated_coverage_blocks(text: str) -> str:
 
     The coverage report must never count its own output as evidence — see
     ACCEPTANCE_COVERAGE_BLOCK_START. Sentinel-delimited blocks are removed exactly;
-    unmarked legacy blocks fall back to the section-heading span.
+    unmarked legacy blocks are removed line-by-line so nothing beyond the report's
+    own output is ever discarded.
     """
     stripped = ACCEPTANCE_COVERAGE_BLOCK_RE.sub(" ", text)
-    return ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE.sub(" ", stripped)
+    for pattern in ACCEPTANCE_COVERAGE_LEGACY_LINE_RES:
+        stripped = pattern.sub(" ", stripped)
+    return stripped
 
 
 def _extract_acceptance_tags(text: object) -> set[str]:
@@ -4875,6 +4891,7 @@ def build_acceptance_coverage_report(
         )
 
     covered = sum(1 for item in requirements if item["status"] == "covered")
+    planned_only = sum(1 for item in requirements if item["status"] == "planned_only")
     missing = len(requirements) - covered
     # Only sources that cited a REAL requirement count as evidence sources. With
     # brackets optional, every source matches incidental tokens (`ST-001`,
@@ -4891,7 +4908,15 @@ def build_acceptance_coverage_report(
         "blueprint_path": str(branch_dir / "blueprint.json"),
         "evidence_sources": tagged_evidence_sources,
         "requirements": requirements,
-        "summary": {"total": len(requirements), "covered": covered, "missing": missing},
+        # `missing` stays the total un-covered count (backward-compatible);
+        # `planned_only` breaks out the review-gap subset so an operator can tell
+        # "nobody verified it" from "nobody even owns it".
+        "summary": {
+            "total": len(requirements),
+            "covered": covered,
+            "missing": missing,
+            "planned_only": planned_only,
+        },
     }
 
 
@@ -4916,11 +4941,15 @@ def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
     total = summary.get("total", 0) if isinstance(summary, dict) else 0
     covered = summary.get("covered", 0) if isinstance(summary, dict) else 0
     missing = summary.get("missing", 0) if isinstance(summary, dict) else 0
+    planned_only = summary.get("planned_only", 0) if isinstance(summary, dict) else 0
     lines = [
         ACCEPTANCE_COVERAGE_BLOCK_START,
         "## Acceptance Coverage",
         f"- Covered tags: {covered}/{total}",
-        f"- Missing evidence: {missing}",
+        (
+            f"- Uncovered: {missing} ({planned_only} planned but unverified, "
+            f"{missing - planned_only} with no evidence at all)"
+        ),
     ]
     requirements = report.get("requirements")
     if isinstance(requirements, list) and requirements:
@@ -12134,6 +12163,15 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         # No default-branch ref to anchor on — degrade to the old HEAD-only view
         # rather than reporting nothing at all.
         diff_range = "HEAD"
+        diff_stat = uncommitted_stat
+        files_changed = list(uncommitted_files)
+
+    if not files_changed and not diff_stat and (uncommitted_files or uncommitted_stat):
+        # Base resolved but the range is empty (nothing committed yet, or sitting on
+        # the default branch) while the working tree carries the whole change.
+        # Reporting "no code diff" here would re-create the always-red gate that
+        # #426 is about, just from the other direction.
+        diff_range = f"{diff_range} (empty; showing uncommitted working tree)"
         diff_stat = uncommitted_stat
         files_changed = list(uncommitted_files)
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -339,7 +339,37 @@ LEARNING_CONSUMPTION_SOURCES = {"auto-handoff", "file-handoff", "inline-summary"
 REVIEW_SECTION_IDS: tuple[str, ...] = ("architecture", "code_quality", "tests", "performance")
 REVIEW_VALID_MODES: tuple[str, ...] = ("default", "reverse-sections", "shuffle-sections")
 LEARNING_IMMEDIATE_WINDOW_SECONDS = 30 * 60
-ACCEPTANCE_TAG_RE = re.compile(r"\[([A-Za-z][A-Za-z0-9_-]*-\d+[A-Za-z0-9_-]*)\]")
+# Requirement tags (AC-1, INV-4, HC-2, SC-1, ...) as they actually appear in
+# artifacts. Brackets are OPTIONAL: reviewer verdicts, commit messages and
+# verification prose write `HC-2 audit: pass`, never `[HC-2]`, so a
+# bracket-only matcher found nothing and the coverage table read 0/N forever.
+# Over-matching (`feat-422`, `ST-001`) is harmless — extracted tags are only
+# ever intersected with the blueprint's coverage_map keys.
+ACCEPTANCE_TAG_RE = re.compile(
+    r"(?<![A-Za-z0-9_])\[?([A-Za-z][A-Za-z0-9_-]*-\d+[A-Za-z0-9_-]*)\]?(?![A-Za-z0-9_])"
+)
+
+# Sentinels around the GENERATED acceptance-coverage block. write_verification_summary
+# appends that block to verification-summary.md, which is itself an evidence source —
+# without an exact exclusion span the report would read its own "AC-1 owned by ST-001"
+# lines back as evidence and report 100% forever. The markers are inline HTML comments
+# so they survive the newline-flattening applied when the summary is embedded in
+# pr-draft.md.
+ACCEPTANCE_COVERAGE_BLOCK_START = "<!-- map:acceptance-coverage:start -->"
+ACCEPTANCE_COVERAGE_BLOCK_END = "<!-- map:acceptance-coverage:end -->"
+ACCEPTANCE_COVERAGE_BLOCK_RE = re.compile(
+    re.escape(ACCEPTANCE_COVERAGE_BLOCK_START)
+    + r".*?"
+    + re.escape(ACCEPTANCE_COVERAGE_BLOCK_END),
+    re.DOTALL,
+)
+# Structural fallback for artifacts written BEFORE the sentinels existed (every
+# already-installed repo has them on disk). Spans the heading up to the next
+# `## ` heading or end of text — the non-greedy body plus the lookahead also
+# handles pr-draft.md, where the whole summary is flattened onto one line.
+ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE = re.compile(
+    r"##\s+Acceptance Coverage.*?(?=##\s+|\Z)", re.DOTALL
+)
 REVIEW_PROMPT_DEFAULT_BUDGET_TOKENS = 12_000
 REVIEW_PROMPT_MIN_BUDGET_TOKENS = 1_024
 REVIEW_PROMPT_BUDGET_ENV = "MAP_REVIEW_PROMPT_BUDGET_TOKENS"
@@ -4655,23 +4685,71 @@ def _load_blueprint_for_coverage(branch_dir: Path) -> tuple[dict[str, object] | 
     return blueprint, ""
 
 
+def _strip_generated_coverage_blocks(text: str) -> str:
+    """Remove every generated acceptance-coverage block from evidence text.
+
+    The coverage report must never count its own output as evidence — see
+    ACCEPTANCE_COVERAGE_BLOCK_START. Sentinel-delimited blocks are removed exactly;
+    unmarked legacy blocks fall back to the section-heading span.
+    """
+    stripped = ACCEPTANCE_COVERAGE_BLOCK_RE.sub(" ", text)
+    return ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE.sub(" ", stripped)
+
+
 def _extract_acceptance_tags(text: object) -> set[str]:
-    """Return bracketed acceptance/invariant tags found in artifact text."""
+    """Return acceptance/invariant tags found in artifact text (brackets optional)."""
     if not isinstance(text, str) or not text:
         return set()
-    return {match.group(1) for match in ACCEPTANCE_TAG_RE.finditer(text)}
+    return {
+        match.group(1)
+        for match in ACCEPTANCE_TAG_RE.finditer(_strip_generated_coverage_blocks(text))
+    }
+
+
+def _branch_commit_messages() -> str:
+    """Return the branch's commit messages (merge-base..HEAD), or "" on any failure.
+
+    Commit messages are upstream-owned evidence: the Actor writes them at the moment
+    the work lands, they are immutable afterwards, and unlike code comments they are
+    NOT rewritten by the scrub-internal-ids Stop hook. Never raises.
+    """
+
+    def _run_git(args: list[str]) -> str:
+        try:
+            result = subprocess.run(
+                ["git"] + args,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            return result.stdout.strip() if result.returncode == 0 else ""
+        except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
+            return ""
+
+    base_sha, _ = _resolve_review_base(_run_git)
+    if not base_sha:
+        return ""
+    return _run_git(["log", "--format=%B", f"{base_sha}..HEAD"])
 
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
     extra_artifacts: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
-    """Collect review/verification artifact text that can prove acceptance tags."""
+    """Collect review/verification artifact text that can prove acceptance tags.
+
+    Planning artifacts (spec, task plan, plan-review) are deliberately excluded:
+    they state the requirement, they do not prove it. The independent downstream
+    verdicts — reviewer agent outputs and the final verifier — ARE included, because
+    they are the artifacts that actually cite a tag while checking it.
+    """
     evidence: dict[str, str] = {}
     for label, name in (
         ("verification_summary", "verification-summary.md"),
         ("qa", "qa-001.md"),
         ("pr_draft", "pr-draft.md"),
+        ("final_verification", "final_verification.json"),
     ):
         text = _read_branch_artifact_text(branch_dir, name)
         if text:
@@ -4683,7 +4761,12 @@ def _collect_acceptance_evidence_texts(
         if isinstance(text, str) and text:
             evidence[label] = text
 
+    commit_messages = _branch_commit_messages()
+    if commit_messages:
+        evidence["commit_messages"] = _sanitize_for_json(commit_messages)
+
     for pattern, label_prefix in (
+        ("review-agent-*.json", "review_agent"),
         ("test_contract_*.md", "test_contract"),
         ("test_handoff_*.json", "test_handoff"),
     ):
@@ -4771,20 +4854,36 @@ def build_acceptance_coverage_report(
             for source, tags in evidence_tags_by_source.items()
             if requirement in tags
         )
+        if evidence_artifacts:
+            status = "covered"
+        elif validation_criteria_cited:
+            # The blueprint owner names the requirement in its validation criteria,
+            # but nothing downstream verified it. That is a REVIEW gap, not a
+            # decomposition gap — collapsing both into "missing_evidence" hid which
+            # one an operator has to go fix.
+            status = "planned_only"
+        else:
+            status = "missing_evidence"
         requirements.append(
             {
                 "id": requirement,
                 "owner": owner_id,
                 "validation_criteria_cited": validation_criteria_cited,
                 "evidence_artifacts": evidence_artifacts,
-                "status": "covered" if evidence_artifacts else "missing_evidence",
+                "status": status,
             }
         )
 
     covered = sum(1 for item in requirements if item["status"] == "covered")
     missing = len(requirements) - covered
+    # Only sources that cited a REAL requirement count as evidence sources. With
+    # brackets optional, every source matches incidental tokens (`ST-001`,
+    # `feat-422`); listing those would make the field noise.
+    requirement_ids = {str(key) for key in coverage_map}
     tagged_evidence_sources = sorted(
-        source for source, tags in evidence_tags_by_source.items() if tags
+        source
+        for source, tags in evidence_tags_by_source.items()
+        if tags & requirement_ids
     )
     return {
         "status": "success",
@@ -4797,16 +4896,28 @@ def build_acceptance_coverage_report(
 
 
 def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
-    """Render an acceptance coverage report into a compact Markdown section."""
+    """Render an acceptance coverage report into a compact Markdown section.
+
+    The output is fenced with ACCEPTANCE_COVERAGE_BLOCK_START/END so that when it is
+    appended to verification-summary.md — which the report later reads back as an
+    evidence source — the block can be excised exactly instead of counting as proof
+    of the very tags it reports as missing.
+    """
     if report.get("status") != "success":
         reason = report.get("reason", "not available")
-        return "## Acceptance Coverage\n- Status: not available\n- Reason: " + str(reason) + "\n"
+        return (
+            f"{ACCEPTANCE_COVERAGE_BLOCK_START}\n"
+            "## Acceptance Coverage\n- Status: not available\n- Reason: "
+            + str(reason)
+            + f"\n{ACCEPTANCE_COVERAGE_BLOCK_END}\n"
+        )
 
     summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
     total = summary.get("total", 0) if isinstance(summary, dict) else 0
     covered = summary.get("covered", 0) if isinstance(summary, dict) else 0
     missing = summary.get("missing", 0) if isinstance(summary, dict) else 0
     lines = [
+        ACCEPTANCE_COVERAGE_BLOCK_START,
         "## Acceptance Coverage",
         f"- Covered tags: {covered}/{total}",
         f"- Missing evidence: {missing}",
@@ -4825,6 +4936,7 @@ def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
                 f"- [{item.get('status', 'unknown')}] {item.get('id', 'unknown')} "
                 f"owned by {item.get('owner') or 'unknown'}; evidence: {evidence_text}"
             )
+    lines.append(ACCEPTANCE_COVERAGE_BLOCK_END)
     return "\n".join(lines) + "\n"
 
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -18614,35 +18614,49 @@ def _worktree_probe(project_dir: Path) -> dict[str, object]:
     return result
 
 
+def _wt_dirty_paths(timeout: int = 15) -> tuple[list[str], str]:
+    """Return ``(dirty porcelain lines, error)`` for the main checkout.
+
+    Single scanner behind every dirty-target decision (#423): the isolation
+    resolver and both merge paths used to each carry their own copy of this
+    filter, which is how ``merge_subtask_worktree`` ended up with no guard at all.
+
+    MAP runtime state (``.map/<branch>/``, ``.codex/``, ``.agents/``) is excluded:
+    in a real target repo those are gitignored, and the guard must care only about
+    the USER's uncommitted source — never refuse because of our own state writes.
+    """
+    st = _wt_git(["status", "--porcelain"], timeout=timeout)
+    if st.returncode != 0:
+        return [], (st.stderr.strip() or "git status failed")
+    return [
+        ln
+        for ln in st.stdout.splitlines()
+        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
+    ], ""
+
+
 def _require_clean_merge_target(project_dir: Path) -> dict[str, object]:
     """Check that the main checkout is clean enough for a worktree merge.
 
     Dormant when worktree.isolation is 'off' (per-repo opt-out / kill-switch — HC-1).
-    When the check is active AND require_clean_merge_target config is True
-    (default True), runs `git status --porcelain` and returns:
+    Otherwise runs `git status --porcelain` and returns:
       * {"status":"ok","ok":True}  when clean (excluding MAP runtime state)
       * {"status":"dirty","ok":False,"kind":"DIRTY_MERGE_TARGET","dirty":[...]}
         when uncommitted changes are present.
     Never raises.
+
+    Reached from ``resolve_worktree_isolation``, which ``worktree_isolation_status``
+    calls — there is no separate ``require_clean_merge_target`` config key: it was
+    a dead toggle nothing consulted (#423), and a clean merge target is not
+    optional for a squash-merge-based accept path.
     """
     mode = _worktree_isolation_mode(project_dir)
     if mode == "off":
         return {"status": "dormant", "ok": False, "reason": "worktree.isolation is off"}
 
-    # Read the require_clean_merge_target flag (default True)
-    raw_require = _map_config_str(project_dir, "require_clean_merge_target", "true")
-    if not _parse_boolish(raw_require):
-        return {"status": "ok", "ok": True, "skipped": True}
-
-    st = _wt_git(["status", "--porcelain"], timeout=15)
-    if st.returncode != 0:
-        return _wt_error("CLEAN_CHECK_FAILED", st.stderr.strip() or "git status failed")
-
-    dirty = [
-        ln
-        for ln in st.stdout.splitlines()
-        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-    ]
+    dirty, error = _wt_dirty_paths()
+    if error:
+        return _wt_error("CLEAN_CHECK_FAILED", error)
     if dirty:
         return {
             "status": "dirty",
@@ -19190,22 +19204,18 @@ def create_subtask_worktree(
         )
 
     if not allow_dirty:
-        status = _wt_git(["status", "--porcelain"])
-        # Exclude MAP runtime state (.map/<branch>/, .codex/, .agents/): in a real
-        # target repo these are gitignored, but the dirty guard must care only
-        # about the USER's uncommitted source — never refuse because of our own
-        # state writes (council Q6 dirty-main/runtime-state interaction).
-        dirty = [
-            ln
-            for ln in status.stdout.splitlines()
-            if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-        ]
+        # MAP runtime state is excluded by _wt_dirty_paths — see its docstring.
+        dirty, clean_error = _wt_dirty_paths()
+        if clean_error:
+            return _wt_error("CLEAN_CHECK_FAILED", clean_error)
         if dirty:
             return _wt_error(
                 "DIRTY_MAIN",
                 "the main checkout has uncommitted changes; the worktree would "
                 "start from committed HEAD and silently diverge. Commit/stash "
-                "first, or pass --allow-dirty.",
+                "first, or pass --allow-dirty (the accept path still requires a "
+                "clean tree, so the changes must be committed or stashed before "
+                "the merge).",
                 dirty=dirty[:20],
             )
 
@@ -19589,6 +19599,61 @@ def _wt_release_lifecycle_lock(handle: Any | None) -> None:
         pass
 
 
+def _wt_dirty_target_guard(branch_name: str, operation: str) -> dict[str, object] | None:
+    """Refuse to squash-merge onto a working tree carrying uncommitted user work.
+
+    Returns ``None`` when the target is clean, otherwise a structured
+    ``DIRTY_TARGET`` error. Shared by the wave coordinator and the single-subtask
+    accept path so both refuse identically — ``merge_subtask_worktree`` previously
+    had no dirty guard at all while the wave path did (#423).
+
+    Emits a pending ``dangerous_action`` approval hold at the refusal (#422) so
+    the approval-hold hard-stop path has a live producer. ``request_summary`` is
+    derived solely from the branch name and operation (no dirty-file list) so
+    ``create_approval_hold``'s (kind, request_summary, pending) dedup keeps
+    repeated refusals against the same dirty tree idempotent; the repo-relative
+    dirty paths ride in ``reason`` instead, never file contents. Hold creation is
+    best-effort: the refusal must still reach the caller even if it fails.
+    """
+    dirty, error = _wt_dirty_paths()
+    if error:
+        return _wt_error("CLEAN_CHECK_FAILED", error)
+    if not dirty:
+        return None
+
+    dirty_paths = [_wt_porcelain_path(ln) for ln in dirty[:20]]
+    hold_id: str | None = None
+    try:
+        hold_result = create_approval_hold(
+            kind="dangerous_action",
+            reason=(
+                f"The working tree has uncommitted changes blocking a {operation}; "
+                "affected paths: " + ", ".join(dirty_paths)
+            ),
+            request_summary=(
+                f"Uncommitted changes blocking {operation} on {branch_name}"
+            ),
+            source="worktree-merge",
+            branch=branch_name,
+            safe_continuation=(
+                f"Commit or stash the listed changes, then retry the {operation}."
+            ),
+        )
+        if hold_result.get("status") == "ok":
+            hold_id = cast(str, hold_result["hold_id"])
+    except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
+        hold_id = None
+
+    error_extra: dict[str, object] = {"dirty": dirty[:20]}
+    if hold_id is not None:
+        error_extra["hold_id"] = hold_id
+    return _wt_error(
+        "DIRTY_TARGET",
+        f"the working tree has uncommitted changes; commit/stash before a {operation}",
+        **error_extra,
+    )
+
+
 def merge_subtask_worktree(
     subtask_id: str,
     attempt: int = 0,
@@ -19645,6 +19710,12 @@ def merge_subtask_worktree(
             base_sha=base_sha,
             working_head=working_head,
         )
+
+    # Same dirty-target refusal the wave coordinator applies: a squash-merge onto
+    # a dirty working branch cannot be rolled back cleanly (#423).
+    dirty_refusal = _wt_dirty_target_guard(branch_name, "subtask merge")
+    if dirty_refusal is not None:
+        return dirty_refusal
 
     prep = _wt_freeze_and_verify(
         subtask_id, record, project_dir, branch_name, verify_cmds, skip_verify
@@ -19883,49 +19954,9 @@ def merge_wave_worktrees(
             "DETACHED_HEAD",
             "refusing to wave-merge onto a detached HEAD; check out the working branch",
         )
-    status = _wt_git(["status", "--porcelain"])
-    dirty = [
-        ln
-        for ln in status.stdout.splitlines()
-        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-    ]
-    if dirty:
-        # Intent: emit a dangerous_action hold at this refusal (#422 AC-4) so the
-        # approval-hold hard-stop path (#344) has a live producer instead of only
-        # synthetic test fixtures. request_summary is derived solely from the
-        # branch name (no dirty-file-list) so create_approval_hold's
-        # (kind, request_summary, pending) dedup keeps repeated refusals against
-        # the same dirty tree idempotent (INV-2); the repo-relative dirty paths
-        # ride in `reason` instead, never file contents. Hold creation is best-
-        # effort: the refusal must still reach the caller even if it fails.
-        dirty_paths = [_wt_porcelain_path(ln) for ln in dirty[:20]]
-        hold_id: str | None = None
-        try:
-            hold_result = create_approval_hold(
-                kind="dangerous_action",
-                reason=(
-                    "The working tree has uncommitted changes blocking a wave "
-                    "merge; affected paths: " + ", ".join(dirty_paths)
-                ),
-                request_summary=f"Uncommitted changes blocking wave merge on {branch_name}",
-                source="worktree-merge",
-                branch=branch_name,
-                safe_continuation=(
-                    "Commit or stash the listed changes, then retry the wave merge."
-                ),
-            )
-            if hold_result.get("status") == "ok":
-                hold_id = cast(str, hold_result["hold_id"])
-        except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
-            hold_id = None
-        error_extra: dict[str, object] = {"dirty": dirty[:20]}
-        if hold_id is not None:
-            error_extra["hold_id"] = hold_id
-        return _wt_error(
-            "DIRTY_TARGET",
-            "the working tree has uncommitted changes; commit/stash before a wave merge",
-            **error_extra,
-        )
+    dirty_refusal = _wt_dirty_target_guard(branch_name, "wave merge")
+    if dirty_refusal is not None:
+        return dirty_refusal
 
     # Serialize coordinators so two waves never interleave squash commits.
     lock_handle = _wt_acquire_merge_lock()
@@ -20126,8 +20157,50 @@ def merge_wave_worktrees(
         _wt_release_merge_lock(lock_handle)
 
 
+def _wt_isolation_decision(project_dir: Path) -> dict[str, object]:
+    """Flatten ``resolve_worktree_isolation`` into a reportable decision block.
+
+    ``resolve_worktree_isolation`` implements the ST-009 fallback matrix (not a git
+    repo / worktrees unsupported / dirty merge target) but had no production caller
+    until this one (#423) — the reason codes it emits are the same vocabulary
+    ``parallelism_observability`` publishes, so leaving it unwired meant the whole
+    degrade classification was never produced at runtime.
+
+    Always returns success-shaped keys so the status command stays exit-0 and the
+    caller reads ``decision``/``degraded``/``reason`` instead of a mixed envelope.
+    """
+    resolution = resolve_worktree_isolation(project_dir)
+    if resolution.get("status") == "dormant":
+        return {
+            "decision": "sequential",
+            "degraded": False,
+            "degraded_reason": "",
+            "warning": "",
+        }
+    if resolution.get("status") == "error":
+        # mode == 'required' with a fallback condition — isolation cannot run.
+        return {
+            "decision": "abort",
+            "degraded": False,
+            "degraded_reason": str(resolution.get("kind", "")).lower(),
+            "warning": str(resolution.get("message", "")),
+        }
+    return {
+        "decision": str(resolution.get("decision", "isolated")),
+        "degraded": bool(resolution.get("degraded", False)),
+        "degraded_reason": str(resolution.get("reason", "")),
+        "warning": str(resolution.get("warning", "")),
+    }
+
+
 def worktree_isolation_status(branch: str | None = None) -> dict[str, object]:
-    """Report whether isolation is enabled + reconcile recorded vs live worktrees."""
+    """Report whether isolation is enabled + reconcile recorded vs live worktrees.
+
+    Also reports the live isolation DECISION (isolated / sequential / abort) from
+    the fallback matrix, so an operator can see BEFORE a wave starts that e.g. a
+    dirty merge target will degrade the run — rather than discovering it when
+    ``create_subtask_worktree`` refuses mid-flight (#423).
+    """
     project_dir = _wt_project_dir()
     branch_name = branch or get_branch_name()
     state = _read_worktree_state(branch_name)
@@ -20158,10 +20231,12 @@ def worktree_isolation_status(branch: str | None = None) -> dict[str, object]:
         "status": "success",
         "ok": True,
         "enabled": _wt_isolation_enabled(project_dir),
+        "mode": _worktree_isolation_mode(project_dir),
         "branch": branch_name,
         "active_worktrees": active,
         "live_git_worktrees": live,
         "max_deletions": _wt_max_deletions(project_dir),
+        **_wt_isolation_decision(project_dir),
     }
 
 

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -1880,16 +1880,24 @@ def _prior_stage_diff_entry(
     file_count = len(files_changed) if isinstance(files_changed, list) else 0
     diff_stat = code_state.get("diff_stat")
     present = code_state.get("status") == "success" and (file_count > 0 or bool(diff_stat))
+    # Name the range the snapshot actually used (#426): a HEAD-only diff on a
+    # fully-committed branch is empty, and reporting the wrong command in the
+    # "missing" reason sent reviewers looking for the wrong problem.
+    diff_range = code_state.get("diff_range") or "HEAD"
     return {
         "key": "code_diff",
         "label": "code diff",
         "kind": "git-diff",
-        "path": "git diff --stat HEAD",
+        "path": f"git diff --stat {diff_range}",
         "required": required,
         "present": present,
         "consumed": present,
         "count": file_count,
-        "reason": "" if present else "missing code diff snapshot; no changed files were visible against HEAD",
+        "reason": (
+            ""
+            if present
+            else f"missing code diff snapshot; no changed files were visible in {diff_range}"
+        ),
     }
 
 
@@ -9284,11 +9292,20 @@ def _render_bundle_markdown(result: dict) -> str:
     if cs_status == "success":
         lines.append(f"- Git ref: `{code_state.get('git_ref', 'unknown')}`")
         lines.append(f"- Branch: `{code_state.get('branch', 'unknown')}`")
+        base_ref = code_state.get("diff_base_ref") or ""
+        diff_range = code_state.get("diff_range") or "HEAD"
+        lines.append(
+            f"- Review target: `{diff_range}`"
+            + (f" (merge-base with `{base_ref}`)" if base_ref else " (no default-branch ref resolved)")
+        )
         files = code_state.get("files_changed", [])
         lines.append(f"- Files changed: {len(files)}")
         diff_stat = code_state.get("diff_stat", "")
         if diff_stat:
             lines.append(f"- Diff stat: {diff_stat[:200]}")
+        uncommitted = code_state.get("uncommitted_files_changed")
+        if isinstance(uncommitted, list):
+            lines.append(f"- Uncommitted (work in progress): {len(uncommitted)} file(s)")
     else:
         lines.append(f"- Status: {cs_status}")
         reason = code_state.get("reason", "")
@@ -11921,12 +11938,50 @@ def run_test_gate() -> dict:
 _DIFF_STAT_MAX_CHARS = 65_536
 _FILES_CHANGED_MAX_ENTRIES = 500
 
+# Candidate default-branch refs, tried in order when resolving the review base.
+# Remote-tracking refs come first: they survive a local branch that was reset or
+# never checked out, which is the common CI/clone shape.
+_REVIEW_BASE_CANDIDATE_REFS = (
+    "origin/main",
+    "origin/master",
+    "main",
+    "master",
+)
+
+
+def _resolve_review_base(run_git: Callable[[list[str]], str]) -> tuple[str, str]:
+    """Return ``(base_sha, base_ref)`` for the branch's review target.
+
+    The review target is the merge-base with the default branch, NOT ``HEAD``:
+    on a fully-committed feature branch (the normal /map-check → /map-review
+    state) ``git diff HEAD`` is empty, so a HEAD-based snapshot self-reports
+    "Files changed: 0" for a branch that actually carries the whole diff (#426).
+
+    Returns ``("", "")`` when no default-branch ref resolves (fresh repo, no
+    remote, shallow clone) — callers then fall back to the uncommitted diff.
+    """
+    for ref in _REVIEW_BASE_CANDIDATE_REFS:
+        if not run_git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"]):
+            continue
+        base = run_git(["merge-base", ref, "HEAD"])
+        if base:
+            return base, ref
+    return "", ""
+
 
 def snapshot_code_state(branch: str | None = None) -> dict:
     """Capture current git state for artifact-to-code verification.
 
     Records git ref, changed files, and diff stat so review artifacts
     can be tied to actual code state. Populates subtask_files_changed.
+
+    ``files_changed``/``diff_stat`` describe the REVIEW TARGET — the range from
+    the merge-base with the default branch up to HEAD — so a branch whose work is
+    already committed still reports its real scope (#426). The uncommitted
+    working-tree diff is kept alongside as a secondary work-in-progress signal
+    (``uncommitted_files_changed``/``uncommitted_diff_stat``). When no
+    default-branch ref resolves, the snapshot degrades to the uncommitted diff and
+    reports ``diff_base_ref=""``.
 
     Very large repos can produce huge ``diff_stat`` and ``files_changed`` outputs that
     bloat the bundle JSON. Both are capped here (``_DIFF_STAT_MAX_CHARS`` /
@@ -11949,10 +12004,26 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
             return ""
 
+    def _names(raw: str) -> list[str]:
+        return [f for f in raw.splitlines() if f.strip()] if raw else []
+
     git_ref = _run_git(["rev-parse", "HEAD"])
-    diff_stat = _run_git(["diff", "--stat", "HEAD"])
-    diff_names = _run_git(["diff", "--name-only", "HEAD"])
-    files_changed = [f for f in diff_names.splitlines() if f.strip()] if diff_names else []
+
+    # Secondary signal: uncommitted work in the main checkout.
+    uncommitted_stat = _run_git(["diff", "--stat", "HEAD"])
+    uncommitted_files = _names(_run_git(["diff", "--name-only", "HEAD"]))
+
+    base_sha, base_ref = _resolve_review_base(_run_git)
+    if base_sha:
+        diff_range = f"{base_sha[:12]}..HEAD"
+        diff_stat = _run_git(["diff", "--stat", base_sha, "HEAD"])
+        files_changed = _names(_run_git(["diff", "--name-only", base_sha, "HEAD"]))
+    else:
+        # No default-branch ref to anchor on — degrade to the old HEAD-only view
+        # rather than reporting nothing at all.
+        diff_range = "HEAD"
+        diff_stat = uncommitted_stat
+        files_changed = list(uncommitted_files)
 
     diff_truncated = False
     if len(diff_stat) > _DIFF_STAT_MAX_CHARS:
@@ -11960,6 +12031,12 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         diff_truncated = True
     if len(files_changed) > _FILES_CHANGED_MAX_ENTRIES:
         files_changed = files_changed[:_FILES_CHANGED_MAX_ENTRIES]
+        diff_truncated = True
+    if len(uncommitted_stat) > _DIFF_STAT_MAX_CHARS:
+        uncommitted_stat = uncommitted_stat[:_DIFF_STAT_MAX_CHARS] + "\n... [truncated]"
+        diff_truncated = True
+    if len(uncommitted_files) > _FILES_CHANGED_MAX_ENTRIES:
+        uncommitted_files = uncommitted_files[:_FILES_CHANGED_MAX_ENTRIES]
         diff_truncated = True
 
     return {
@@ -11969,6 +12046,11 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         "diff_stat": diff_stat,
         "branch": branch_name,
         "diff_truncated": diff_truncated,
+        "diff_base": base_sha[:12] if base_sha else "",
+        "diff_base_ref": base_ref,
+        "diff_range": diff_range,
+        "uncommitted_files_changed": uncommitted_files,
+        "uncommitted_diff_stat": uncommitted_stat,
     }
 
 

--- a/.map/static-analysis/handlers/common.sh
+++ b/.map/static-analysis/handlers/common.sh
@@ -33,9 +33,9 @@ generate_output() {
 
     # Calculate summary
     local error_count warning_count total_count tools_json
-    error_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
-    warning_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
-    total_count=$(echo "$all_findings" | jq 'length')
+    error_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
+    warning_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
+    total_count=$(printf '%s' "$all_findings" | jq 'length')
 
     # Convert tools array to JSON (handle empty array safely)
     if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then

--- a/.map/static-analysis/handlers/go.sh
+++ b/.map/static-analysis/handlers/go.sh
@@ -30,7 +30,7 @@ if command -v go &> /dev/null; then
     VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
-        VET_NORM=$(echo "$VET_OUT" | while IFS= read -r line; do
+        VET_NORM=$(printf '%s\n' "$VET_OUT" | while IFS= read -r line; do
             if parse_colon_delimited "$line" file lineno col msg; then
                 msg="${msg# }"
                 msg=$(json_escape "$msg")
@@ -55,7 +55,7 @@ if command -v gofmt &> /dev/null; then
     fi
 
     if [[ -n "$FMT_OUT" ]]; then
-        FMT_NORM=$(echo "$FMT_OUT" | while IFS= read -r file; do
+        FMT_NORM=$(printf '%s\n' "$FMT_OUT" | while IFS= read -r file; do
             file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")
@@ -72,7 +72,7 @@ if command -v staticcheck &> /dev/null; then
     if [[ -n "$SC_OUT" ]]; then
         # staticcheck outputs NDJSON (one JSON object per line)
         # Use jq -s to slurp all objects into an array, then transform each
-        SC_NORM=$(echo "$SC_OUT" | jq -s '[.[] | {
+        SC_NORM=$(printf '%s' "$SC_OUT" | jq -s '[.[] | {
             tool: "staticcheck",
             file: .location.file,
             line: .location.line,

--- a/.map/static-analysis/handlers/python.sh
+++ b/.map/static-analysis/handlers/python.sh
@@ -31,7 +31,7 @@ if command -v ruff &> /dev/null; then
 
     # Normalize ruff output to standard format
     if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
-        RUFF_NORM=$(echo "$RUFF_OUT" | jq -c '[.[] | {
+        RUFF_NORM=$(printf '%s' "$RUFF_OUT" | jq -c '[.[] | {
             tool: "ruff",
             file: .filename,
             line: .location.row,
@@ -53,7 +53,7 @@ if command -v mypy &> /dev/null; then
 
     # Parse mypy text output to JSON using robust parsing
     if [[ -n "$MYPY_OUT" ]]; then
-        MYPY_NORM=$(echo "$MYPY_OUT" | while IFS= read -r line; do
+        MYPY_NORM=$(printf '%s\n' "$MYPY_OUT" | while IFS= read -r line; do
             if parse_colon_delimited "$line" file lineno col msg; then
                 # Determine severity from message
                 severity="warning"

--- a/.map/static-analysis/handlers/typescript.sh
+++ b/.map/static-analysis/handlers/typescript.sh
@@ -35,7 +35,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
     ESLINT_OUT=$(timeout 60 "$ESLINT_CMD" --format json "$FILES" 2>/dev/null || echo "[]")
 
     if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
-        ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
+        ESLINT_NORM=$(printf '%s' "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
             tool: "eslint",
             file: $file,
             line: .line,
@@ -63,7 +63,7 @@ if [[ -f "tsconfig.json" ]]; then
 
         if [[ -n "$TSC_OUT" ]]; then
             # Parse format: file(line,col): error TSxxxx: message
-            TSC_NORM=$(echo "$TSC_OUT" | while IFS= read -r line; do
+            TSC_NORM=$(printf '%s\n' "$TSC_OUT" | while IFS= read -r line; do
                 if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ error\ (TS[0-9]+):\ (.*)$ ]]; then
                     file="${BASH_REMATCH[1]}"
                     linenum="${BASH_REMATCH[2]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `predictor`, and `documentation-reviewer`. Reads and read-only git are untouched; the
   main thread and `actor` are unaffected. Completes the #378 hardening direction, which
   had explicitly deferred `final-verifier`.
+- **Acceptance Coverage reported 0/N on every branch (#426).** Three defects stacked.
+  (1) `ACCEPTANCE_TAG_RE` required brackets, but reviewer verdicts, commit messages and
+  verification prose write `HC-2 audit: pass`, never `[HC-2]` — so nothing matched, ever.
+  (2) `write_verification_summary` appends the *generated* coverage table to
+  `verification-summary.md`, which the report then reads back as an evidence source: with
+  brackets relaxed the report would have counted its own `AC-1 owned by ST-001` lines and
+  flipped to a permanent false-green 100%. (3) The evidence set omitted the independent
+  downstream verdicts that actually cite tags while checking them. Now: brackets are
+  optional (extracted tags are only ever intersected with `coverage_map` keys, so
+  over-matching is inert); the generated block is fenced with
+  `<!-- map:acceptance-coverage:start/end -->` and excised before extraction, with a
+  heading-span fallback for the unmarked blocks already on disk in every installed repo
+  (the markers are inline HTML comments so they survive the newline-flattening applied
+  when the summary is embedded in `pr-draft.md`); and `final_verification.json`,
+  `review-agent-*.json`, and the branch's commit messages (`merge-base..HEAD`) join the
+  evidence set. A requirement its owner's `validation_criteria` names but nothing
+  downstream verified now reports `planned_only` rather than being lumped into
+  `missing_evidence` — a review gap and a decomposition gap need different fixes.
+  Re-running the report over the `feat-422-live-hold-producers` artifacts that produced
+  the original `0/19` yields `19/19`, every tag backed by an independent verdict, commit
+  message, or reviewer artifact — and the self-referential block contributes nothing.
 - **Review bundle diffed uncommitted changes only (#426).** `snapshot_code_state`
   computed its diff with `git diff HEAD`, so on a fully-committed branch — the normal
   `/map-check` → `/map-review` state — `review-bundle.md` self-reported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Verifier-class agents can no longer mutate the branch (#424).** A `final-verifier`
+  run created and committed `3c6a7db` mid-audit under an APPROVED/REJECTED-only prompt
+  contract: it hand-edited four *generated* trees without touching their `.jinja`
+  sources (breaking the single-source render invariant and failing three byte-parity
+  tests), mangled `(#422 AC-1, AC-2, AC-6)` comments into `(#422 , , )`, renamed a
+  blueprint-named regression test, then reported "working tree clean / make check exit 0"
+  for its own post-commit state. Prompt text is not a capability boundary. `final-verifier`
+  now ships `disallowedTools: [Edit, Agent]` (Write stays — it owns
+  `.map/<branch>/final_verification.json` + progress markdown), and `safety-guardrails.py`
+  keys on the PreToolUse `agent_type` field to deny git-mutating Bash and any
+  `Edit`/`Write`/`MultiEdit` outside `.map/` for `final-verifier`, `monitor`, `evaluator`,
+  `predictor`, and `documentation-reviewer`. Reads and read-only git are untouched; the
+  main thread and `actor` are unaffected. Completes the #378 hardening direction, which
+  had explicitly deferred `final-verifier`.
+- **Review bundle diffed uncommitted changes only (#426).** `snapshot_code_state`
+  computed its diff with `git diff HEAD`, so on a fully-committed branch — the normal
+  `/map-check` → `/map-review` state — `review-bundle.md` self-reported
+  `Files changed: 0`, `[no git diff output]`, and `Prior-Stage Consumption: blocked /
+  missing code diff snapshot` for a branch carrying a 50-file, +2192-line diff. All three
+  reviewers flagged the contradiction and fell back to raw git. The snapshot now resolves
+  the review base from `origin/main | origin/master | main | master` and diffs
+  `merge-base..HEAD`, keeping the uncommitted diff as a secondary work-in-progress signal
+  (`uncommitted_files_changed` / `uncommitted_diff_stat`) and reporting the range it used
+  (`diff_base`, `diff_base_ref`, `diff_range`). `/map-review` Step A.1 gathers the same
+  range. Degrades to the old HEAD-only view when no default-branch ref resolves.
+- **`echo "$VAR" | jq` mangled JSON escapes under zsh (#425).** zsh's builtin `echo`
+  interprets backslash escapes, so `\n`/`\t` inside JSON string values became raw C0
+  control bytes and `jq` aborted with `control characters from U+0000 through U+001F must
+  be escaped`. Captured in `$(...)` the failure was swallowed and the variable landed
+  EMPTY — observed as an empty-bodied `pr-draft.md` written with exit 0. Every remaining
+  instance across shipped skills, references, the orchestrator usage block, and the four
+  static-analysis handlers now uses `printf '%s'` (or `printf '%s\n'` for `while read`
+  consumers), including the `python3 -c` consumers of the same class.
+  `tests/test_shell_json_pipes.py` scans `templates_src` plus every generated tree so the
+  pattern cannot reland; the convention is documented in `CLAUDE.md` and
+  `references/bash-guidelines.md`.
+- **Dead worktree-isolation resolver wired up; subtask merge had no dirty guard (#423).**
+  `resolve_worktree_isolation` (the ST-009 fallback matrix) and `_require_clean_merge_target`
+  had zero production callers, so the documented `require_clean_merge_target` config key
+  was a dead toggle and the degrade reason codes that `parallelism_observability` publishes
+  were never produced at runtime. `worktree_isolation_status` now reports the live decision
+  (`isolated` | `sequential` | `abort`) with `degraded` / `degraded_reason` / `warning` /
+  `mode`, so a dirty merge target surfaces *before* a wave starts rather than when
+  `create_subtask_worktree` refuses mid-flight. The dead `require_clean_merge_target` key is
+  gone (a clean target is not optional for a squash-merge accept path). One scanner
+  (`_wt_dirty_paths`) now backs every dirty-target decision, and the shared
+  `_wt_dirty_target_guard` — DIRTY_TARGET refusal plus the #422 `dangerous_action` hold — is
+  applied by `merge_subtask_worktree` as well as `merge_wave_worktrees`, closing a gap where
+  the single-subtask accept path could squash-merge onto a dirty working branch.
 - **22 dead permission deny rules removed from `settings.json` (#428).** Every repo
   installed via `mapify init` printed 22 warnings at `claude` startup — 11
   `MultiEdit(<glob>)` rules naming a tool that no longer exists, and 11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,14 @@ When you pipe through `head/tail/less/more`, the source command keeps running bu
 
 **Exception:** Filtering pipes are OK (grep, awk, sed) because they process all input.
 
+### Never pipe a captured variable through `echo`
+
+zsh's builtin `echo` interprets backslash escapes, so piping `echo "$JSON"` into `jq`
+turns the `\n` inside JSON string values into raw control bytes and jq aborts — inside
+`$(...)` the failure is swallowed and the variable lands empty. Use
+`printf '%s' "$VAR" | jq` (or `printf '%s\n'` when a `while read` loop consumes it).
+Enforced by `tests/test_shell_json_pipes.py`.
+
 ### Git commands: do NOT use `-C` when already in the repo
 
 When the working directory is already this repository, run git commands **without** the `-C` flag:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1635,6 +1635,8 @@ If you forked the skill-backed `/map-efficient` workflow, you must manually inte
 
 **Responsibility:** Adversarial verifier applying the "Four-Eyes Principle" — verifies the ENTIRE task goal is achieved, not just individual subtasks. Catches premature completion and hallucinated success.
 
+**Capability Constraints (frontmatter + hook):** `disallowedTools: [Edit, Agent]`. FinalVerifier audits, it does not fix — and it must not spawn sub-agents. `Write` stays permitted because it owns `.map/<branch>/final_verification.json` and the progress markdown; the `safety-guardrails.py` PreToolUse hook confines those writes to `.map/` and blocks git-mutating Bash (`commit`, `push`, `reset`, `checkout`, `restore`, `add`, …) for every verifier-class `agent_type` (`final-verifier`, `monitor`, `evaluator`, `predictor`, `documentation-reviewer`). Read-only git (`status`, `diff`, `log`, `show`, `rev-parse`, `ls-files`) and all reads stay unrestricted — a verifier gathers evidence, then reports it in the verdict.
+
 **Input:**
 ```json
 {

--- a/src/mapify_cli/schemas.py
+++ b/src/mapify_cli/schemas.py
@@ -1524,7 +1524,15 @@ REVIEW_BUNDLE_SCHEMA = {
                             },
                             "status": {
                                 "type": "string",
-                                "enum": ["covered", "missing_evidence"],
+                                # planned_only: the owner subtask's validation_criteria
+                                # names the requirement but nothing downstream verified
+                                # it — a review gap, distinct from a requirement no
+                                # artifact ever mentions (missing_evidence).
+                                "enum": [
+                                    "covered",
+                                    "planned_only",
+                                    "missing_evidence",
+                                ],
                             },
                         },
                         "required": [
@@ -1542,7 +1550,11 @@ REVIEW_BUNDLE_SCHEMA = {
                     "properties": {
                         "total": {"type": "integer", "minimum": 0},
                         "covered": {"type": "integer", "minimum": 0},
+                        # `missing` stays the total un-covered count for backward
+                        # compatibility; `planned_only` breaks out the review-gap
+                        # subset so the two failure modes are separable.
                         "missing": {"type": "integer", "minimum": 0},
+                        "planned_only": {"type": "integer", "minimum": 0},
                     },
                     "required": ["total", "covered", "missing"],
                     "additionalProperties": False,

--- a/src/mapify_cli/templates/CLAUDE.md
+++ b/src/mapify_cli/templates/CLAUDE.md
@@ -70,6 +70,13 @@ When you pipe through `head/tail/less/more`, the source command keeps running bu
 
 **Exception:** Filtering pipes are OK (grep, awk, sed) because they process all input.
 
+### Never pipe a captured variable through `echo`
+
+zsh's builtin `echo` interprets backslash escapes, so piping `echo "$JSON"` into `jq`
+turns the `\n` inside JSON string values into raw control bytes and jq aborts — inside
+`$(...)` the failure is swallowed and the variable lands empty. Use
+`printf '%s' "$VAR" | jq` (or `printf '%s\n'` when a `while read` loop consumes it).
+
 **Full guidelines:** `.claude/references/bash-guidelines.md`
 
 ## Progressive disclosure pointers

--- a/src/mapify_cli/templates/agents/final-verifier.md
+++ b/src/mapify_cli/templates/agents/final-verifier.md
@@ -5,8 +5,17 @@ description: Adversarial verifier with Root Cause Analysis (Ralph Loop)
 # gate before merge — false negatives here ship bugs to production.
 model: opus
 effort: high
-version: 1.1.0
-last_updated: 2026-04-28
+# 2026-08-14 (#424): a final-verifier run edited generated trees and committed
+# them mid-audit, despite the prompt contract being APPROVED/REJECTED-only.
+# Write stays allowed — the verifier legitimately writes .map/<branch>/
+# final_verification.json + progress markdown — but Edit and nested Agent are
+# denied at the harness level. Bash git mutations are blocked by the
+# safety-guardrails PreToolUse hook, which keys on agent_type.
+disallowedTools:
+  - Edit
+  - Agent
+version: 1.2.0
+last_updated: 2026-08-14
 ---
 
 # IDENTITY

--- a/src/mapify_cli/templates/agents/final-verifier.md
+++ b/src/mapify_cli/templates/agents/final-verifier.md
@@ -7,12 +7,16 @@ model: opus
 effort: high
 # 2026-08-14 (#424): a final-verifier run edited generated trees and committed
 # them mid-audit, despite the prompt contract being APPROVED/REJECTED-only.
-# Write stays allowed — the verifier legitimately writes .map/<branch>/
-# final_verification.json + progress markdown — but Edit and nested Agent are
-# denied at the harness level. Bash git mutations are blocked by the
-# safety-guardrails PreToolUse hook, which keys on agent_type.
+# Nested Agent is denied at the harness level. Edit/Write are NOT denied here:
+# this agent's own contract requires an in-place append to
+# .map/<branch>/progress_<branch>.md and a `[ ]` -> `[x]` update in the
+# task-plan Acceptance Criteria table — forcing those through whole-file Write
+# would drop surrounding content. The boundary is enforced by scope instead:
+# the safety-guardrails PreToolUse hook keys on agent_type and confines every
+# verifier Edit/Write/MultiEdit to `.map/` (normalized, so `.map/../src` cannot
+# escape) while blocking all git-mutating Bash. Runner-owned state inside
+# `.map/` stays protected for everyone by the workflow-gate tamper detector.
 disallowedTools:
-  - Edit
   - Agent
 version: 1.2.0
 last_updated: 2026-08-14

--- a/src/mapify_cli/templates/codex/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-efficient/SKILL.md
@@ -100,7 +100,7 @@ if [ -f "$STATE_FILE" ]; then
   echo "Existing step_state.json found; continuing with get_next_step."
 elif [ -f "$PLAN_FILE" ]; then
   RESUME_RESULT=$(python3 .map/scripts/map_orchestrator.py resume_from_plan)
-  RESUME_STATUS=$(echo "$RESUME_RESULT" | jq -r '.status')
+  RESUME_STATUS=$(printf '%s' "$RESUME_RESULT" | jq -r '.status')
   if [ "$RESUME_STATUS" != "success" ]; then
     echo "resume_from_plan failed: $RESUME_RESULT" >&2
     exit 1
@@ -120,9 +120,9 @@ fi
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 echo "$NEXT_STEP"
 ```
 

--- a/src/mapify_cli/templates/codex/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/codex/skills/map-efficient/efficient-reference.md
@@ -86,7 +86,7 @@ python3 .map/scripts/map_step_runner.py validate_flaky_test_triage
 # Preferred close — the verdict path. Monitor emits valid:false plus
 # disposition {kind: deferred_nondeterministic, check_id: ...}; close 2.4 with
 # the same disposition piped through (see "Verdict-path route" below).
-echo "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
+printf '%s' "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
   validate_step 2.4 --disposition deferred_nondeterministic \
   --check-id "pytest::test_name" --monitor-envelope -
 ```

--- a/src/mapify_cli/templates/codex/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-review/SKILL.md
@@ -117,10 +117,15 @@ fully-committed branch — the normal `/map-check` → `/map-review` state —
 `git diff HEAD` is empty and under-reports the review scope to zero (#426).
 
 ```bash
-BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
-       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
-git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
-git --no-pager diff "${BASE:-HEAD}"...HEAD
+BASE=""
+for ref in origin/main origin/master main master; do
+  git rev-parse --verify --quiet "$ref" >/dev/null && { BASE="$ref"; break; }
+done
+# No default-branch ref: diff the working tree. NEVER "HEAD...HEAD" — that range
+# is always empty and re-creates the very bug this step fixes.
+[ -n "$BASE" ] && RANGE="$BASE...HEAD" || RANGE="HEAD"
+git --no-pager diff --stat "$RANGE"
+git --no-pager diff "$RANGE"
 git status          # uncommitted work in progress — secondary signal
 ```
 

--- a/src/mapify_cli/templates/codex/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/codex/skills/map-review/SKILL.md
@@ -112,9 +112,16 @@ otherwise) and mode semantics.
 
 ### Step A.1: Gather changes
 
+Diff against the **merge-base with the default branch**, not `HEAD`. On a
+fully-committed branch — the normal `/map-check` → `/map-review` state —
+`git diff HEAD` is empty and under-reports the review scope to zero (#426).
+
 ```bash
-git diff HEAD
-git status
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
+git --no-pager diff "${BASE:-HEAD}"...HEAD
+git status          # uncommitted work in progress — secondary signal
 ```
 
 ### Step A.1b: Load canonical review context (bundle + handoff)

--- a/src/mapify_cli/templates/hooks/safety-guardrails.py
+++ b/src/mapify_cli/templates/hooks/safety-guardrails.py
@@ -5,6 +5,9 @@ Safety Guardrails - PreToolUse Hook
 Merged hook that blocks:
 - Access to sensitive files (.env, credentials, private keys)
 - Dangerous shell commands (rm -rf /, force push, etc.)
+- Branch mutation from verifier-class subagents (#424): no git commit/push/reset
+  and no Edit/Write outside `.map/` when `agent_type` names a read-and-report
+  agent. Reads are never restricted.
 
 Trigger: Edit|Write|Bash
 Exit codes:
@@ -226,6 +229,117 @@ def check_autonomy_git_block(command: str) -> tuple[bool, str]:
     return True, ""
 
 
+# =============================================================================
+# Verifier-class capability boundary (#424)
+# =============================================================================
+
+# Agents dispatched with a read-and-report contract. They legitimately write
+# their own review artifacts under `.map/<branch>/`, but must never mutate
+# source or the branch — a final-verifier run once hand-edited generated trees
+# and committed them mid-audit, then reported "working tree clean" for its own
+# post-commit state, masking the breakage from the orchestrating session.
+VERIFIER_AGENT_TYPES = frozenset(
+    {
+        "final-verifier",
+        "monitor",
+        "evaluator",
+        "predictor",
+        "documentation-reviewer",
+    }
+)
+
+# Write scope a verifier keeps: its own branch-scoped artifact directory.
+VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
+
+# git subcommands that mutate the index, the worktree, or history.
+_GIT_MUTATING_SUBCOMMANDS = (
+    "add",
+    "am",
+    "apply",
+    "branch",
+    "checkout",
+    "cherry-pick",
+    "clean",
+    "commit",
+    "merge",
+    "mv",
+    "push",
+    "rebase",
+    "reset",
+    "restore",
+    "revert",
+    "rm",
+    "stash",
+    "switch",
+    "tag",
+    "worktree",
+)
+
+
+def _normalize_agent_type(raw: object) -> str:
+    """Strip plugin scoping (`plugin:pkg:monitor` -> `monitor`) and lowercase."""
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip().split(":")[-1].lower()
+
+
+def is_verifier_agent(agent_type: object) -> bool:
+    """True when the tool call originates from a read-and-report agent."""
+    return _normalize_agent_type(agent_type) in VERIFIER_AGENT_TYPES
+
+
+def check_verifier_command(command: str) -> tuple[bool, str]:
+    """Block git mutations from a verifier-class agent. Returns (is_safe, reason).
+
+    Same token-anchored matching as the autonomy block so `bash -c 'git commit'`
+    and `git -C <path> commit` are caught too. Read-only git (status, diff, log,
+    show, rev-parse, ls-files) stays allowed — it is how a verifier gathers
+    evidence.
+    """
+    if not command:
+        return True, ""
+
+    import re
+
+    pattern = re.compile(
+        r"(?:^|[\s;&|`'\"()])"
+        r"git\s+"
+        r"(?:-\S+\s+|-C\s+\S+\s+|-c\s+\S+\s+)*"
+        r"(?:" + "|".join(_GIT_MUTATING_SUBCOMMANDS) + r")"
+        r"(?:$|[\s;&|`'\"()])",
+        re.IGNORECASE,
+    )
+    match = pattern.search(command)
+    if match:
+        return (
+            False,
+            (
+                f"Blocked: verifier-class agents must not mutate the branch "
+                f"(matched `{match.group(0).strip()}`). Report the finding in your "
+                "verdict instead — the orchestrating session owns all git writes."
+            ),
+        )
+    return True, ""
+
+
+def check_verifier_path(path: str) -> tuple[bool, str]:
+    """Confine verifier writes to `.map/`. Returns (is_safe, reason)."""
+    if not path:
+        return True, ""
+    normalized = path.replace("\\", "/")
+    normalized = normalized.removeprefix("./")
+    if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
+        return True, ""
+    return (
+        False,
+        (
+            f"Blocked: verifier-class agents may only write under `.map/`; "
+            f"refused write to {path}. Report the required change in your verdict "
+            "instead of applying it."
+        ),
+    )
+
+
 def deny(reason: str) -> None:
     """Deny tool execution using structured PreToolUse decision control."""
     print(
@@ -251,6 +365,8 @@ def main() -> None:
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
+    # `agent_type` is present only when the hook fires inside a subagent.
+    verifier = is_verifier_agent(input_data.get("agent_type"))
 
     # Check file-based tools
     if tool_name in ("Edit", "Write", "Read", "MultiEdit"):
@@ -258,6 +374,11 @@ def main() -> None:
         is_safe, reason = check_file_safety(file_path)
         if not is_safe:
             deny(f"{reason} (tool={tool_name})")
+        # Reads stay unrestricted — a verifier must be able to read everything.
+        if verifier and tool_name in ("Edit", "Write", "MultiEdit"):
+            is_safe, reason = check_verifier_path(file_path)
+            if not is_safe:
+                deny(f"{reason} (tool={tool_name})")
 
     # Check bash commands
     elif tool_name == "Bash":
@@ -265,6 +386,10 @@ def main() -> None:
         is_safe, reason = check_command_safety(command)
         if not is_safe:
             deny(f"{reason} (tool={tool_name})")
+        if verifier:
+            is_safe, reason = check_verifier_command(command)
+            if not is_safe:
+                deny(reason)
         is_safe, reason = check_autonomy_git_block(command)
         if not is_safe:
             deny(reason)

--- a/src/mapify_cli/templates/hooks/safety-guardrails.py
+++ b/src/mapify_cli/templates/hooks/safety-guardrails.py
@@ -248,8 +248,10 @@ VERIFIER_AGENT_TYPES = frozenset(
     }
 )
 
-# Write scope a verifier keeps: its own branch-scoped artifact directory.
-VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
+# Write scope a verifier keeps: the project-root `.map/` artifact tree, and only
+# that one. Resolved against CLAUDE_PROJECT_DIR at call time — see
+# check_verifier_path.
+VERIFIER_WRITABLE_DIRNAME = ".map"
 
 # git subcommands that mutate the index, the worktree, refs, history, or config.
 # `pull`/`fetch`/`submodule` are included because they move the very refs the
@@ -338,29 +340,32 @@ def check_verifier_command(command: str) -> tuple[bool, str]:
 
 
 def check_verifier_path(path: str) -> tuple[bool, str]:
-    """Confine verifier writes to `.map/`. Returns (is_safe, reason).
+    """Confine verifier writes to the PROJECT-ROOT `.map/`. Returns (is_safe, reason).
 
-    The path is normalized BEFORE the prefix check: a raw text comparison accepts
-    `.map/../src/mapify_cli/cli.py`, which starts with `.map/` yet resolves outside
-    the allowed workspace.
+    Containment is decided on the resolved path, never on path text. A textual
+    check is bypassable three ways, all of which land outside the artifact tree:
+    `.map/../src/cli.py` (starts with the prefix), `src/.map/payload.py` (contains
+    `/.map/`), and `/elsewhere/.map/x` (an unrelated project's directory).
 
-    This is the outer boundary only. Runner-owned state inside `.map/`
+    This is the outer boundary only. Runner-owned state INSIDE `.map/`
     (`.map/scripts/**`, `step_state.json`, `approval_holds.json`, …) is separately
     protected from direct hand-editing by the workflow-gate state-tamper detector,
     which applies to every caller, not just verifiers.
     """
     if not path:
         return True, ""
-    normalized = os.path.normpath(path.replace("\\", "/")).replace("\\", "/")
-    normalized = normalized.removeprefix("./")
-    if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    map_root = os.path.realpath(os.path.join(project_dir, VERIFIER_WRITABLE_DIRNAME))
+    candidate = path if os.path.isabs(path) else os.path.join(project_dir, path)
+    resolved = os.path.realpath(candidate)
+    if resolved == map_root or resolved.startswith(map_root + os.sep):
         return True, ""
     return (
         False,
         (
-            f"Blocked: verifier-class agents may only write under `.map/`; "
-            f"refused write to {path}. Report the required change in your verdict "
-            "instead of applying it."
+            f"Blocked: verifier-class agents may only write under the project's "
+            f"`{VERIFIER_WRITABLE_DIRNAME}/` artifact tree; refused write to {path}. "
+            "Report the required change in your verdict instead of applying it."
         ),
     )
 

--- a/src/mapify_cli/templates/hooks/safety-guardrails.py
+++ b/src/mapify_cli/templates/hooks/safety-guardrails.py
@@ -251,7 +251,11 @@ VERIFIER_AGENT_TYPES = frozenset(
 # Write scope a verifier keeps: its own branch-scoped artifact directory.
 VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
 
-# git subcommands that mutate the index, the worktree, or history.
+# git subcommands that mutate the index, the worktree, refs, history, or config.
+# `pull`/`fetch`/`submodule` are included because they move the very refs the
+# verifier is auditing; `config`/`update-ref`/`symbolic-ref`/`filter-branch`/`notes`
+# because they rewrite repository state out from under the audit. A verifier needs
+# none of them — the list is deliberately fail-closed.
 _GIT_MUTATING_SUBCOMMANDS = (
     "add",
     "am",
@@ -261,17 +265,28 @@ _GIT_MUTATING_SUBCOMMANDS = (
     "cherry-pick",
     "clean",
     "commit",
+    "config",
+    "fetch",
+    "filter-branch",
+    "gc",
     "merge",
     "mv",
+    "notes",
+    "prune",
+    "pull",
     "push",
     "rebase",
     "reset",
     "restore",
     "revert",
     "rm",
+    "sparse-checkout",
     "stash",
+    "submodule",
     "switch",
+    "symbolic-ref",
     "tag",
+    "update-ref",
     "worktree",
 )
 
@@ -323,10 +338,20 @@ def check_verifier_command(command: str) -> tuple[bool, str]:
 
 
 def check_verifier_path(path: str) -> tuple[bool, str]:
-    """Confine verifier writes to `.map/`. Returns (is_safe, reason)."""
+    """Confine verifier writes to `.map/`. Returns (is_safe, reason).
+
+    The path is normalized BEFORE the prefix check: a raw text comparison accepts
+    `.map/../src/mapify_cli/cli.py`, which starts with `.map/` yet resolves outside
+    the allowed workspace.
+
+    This is the outer boundary only. Runner-owned state inside `.map/`
+    (`.map/scripts/**`, `step_state.json`, `approval_holds.json`, …) is separately
+    protected from direct hand-editing by the workflow-gate state-tamper detector,
+    which applies to every caller, not just verifiers.
+    """
     if not path:
         return True, ""
-    normalized = path.replace("\\", "/")
+    normalized = os.path.normpath(path.replace("\\", "/")).replace("\\", "/")
     normalized = normalized.removeprefix("./")
     if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
         return True, ""

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -64,8 +64,8 @@ USAGE FROM map-efficient.md:
   ```bash
   # Get next step
   NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-  STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-  INSTRUCTION=$(echo "$NEXT_STEP" | jq -r '.instruction')
+  STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+  INSTRUCTION=$(printf '%s' "$NEXT_STEP" | jq -r '.instruction')
 
   # Execute step based on phase...
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -363,12 +363,25 @@ ACCEPTANCE_COVERAGE_BLOCK_RE = re.compile(
     + re.escape(ACCEPTANCE_COVERAGE_BLOCK_END),
     re.DOTALL,
 )
-# Structural fallback for artifacts written BEFORE the sentinels existed (every
-# already-installed repo has them on disk). Spans the heading up to the next
-# `## ` heading or end of text — the non-greedy body plus the lookahead also
-# handles pr-draft.md, where the whole summary is flattened onto one line.
-ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE = re.compile(
-    r"##\s+Acceptance Coverage.*?(?=##\s+|\Z)", re.DOTALL
+# Fallback for artifacts written BEFORE the sentinels existed (every already-installed
+# repo has them on disk). Deliberately NOT a heading-to-heading span: when the block is
+# the last section — or when pr-draft.md has flattened every newline into a space so no
+# later `## ` is recognisable — a span would swallow the rest of the file and drop
+# genuine citations. These patterns match the generated block's own line grammar
+# instead, so only report-authored text is ever removed.
+ACCEPTANCE_COVERAGE_LEGACY_LINE_RES = (
+    # The per-requirement rows — the only part that carries tags. The evidence
+    # tail is a bounded, comma-separated label list (labels never contain spaces),
+    # NOT `[^\n]*`: an open-ended tail would run past the last row and swallow
+    # whatever prose follows it on a flattened line.
+    re.compile(
+        r"-\s*\[[a-z_]+\]\s*\S+\s+owned by\s+\S+;\s*evidence:\s*"
+        r"[\w:./-]+(?:,\s*[\w:./-]+)*"
+    ),
+    re.compile(r"-\s*Covered tags:\s*\d+/\d+"),
+    re.compile(r"-\s*Missing evidence:\s*\d+"),
+    re.compile(r"-\s*Uncovered:\s*\d+\s*\([^)]*\)"),
+    re.compile(r"##\s+Acceptance Coverage"),
 )
 REVIEW_PROMPT_DEFAULT_BUDGET_TOKENS = 12_000
 REVIEW_PROMPT_MIN_BUDGET_TOKENS = 1_024
@@ -4690,10 +4703,13 @@ def _strip_generated_coverage_blocks(text: str) -> str:
 
     The coverage report must never count its own output as evidence — see
     ACCEPTANCE_COVERAGE_BLOCK_START. Sentinel-delimited blocks are removed exactly;
-    unmarked legacy blocks fall back to the section-heading span.
+    unmarked legacy blocks are removed line-by-line so nothing beyond the report's
+    own output is ever discarded.
     """
     stripped = ACCEPTANCE_COVERAGE_BLOCK_RE.sub(" ", text)
-    return ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE.sub(" ", stripped)
+    for pattern in ACCEPTANCE_COVERAGE_LEGACY_LINE_RES:
+        stripped = pattern.sub(" ", stripped)
+    return stripped
 
 
 def _extract_acceptance_tags(text: object) -> set[str]:
@@ -4875,6 +4891,7 @@ def build_acceptance_coverage_report(
         )
 
     covered = sum(1 for item in requirements if item["status"] == "covered")
+    planned_only = sum(1 for item in requirements if item["status"] == "planned_only")
     missing = len(requirements) - covered
     # Only sources that cited a REAL requirement count as evidence sources. With
     # brackets optional, every source matches incidental tokens (`ST-001`,
@@ -4891,7 +4908,15 @@ def build_acceptance_coverage_report(
         "blueprint_path": str(branch_dir / "blueprint.json"),
         "evidence_sources": tagged_evidence_sources,
         "requirements": requirements,
-        "summary": {"total": len(requirements), "covered": covered, "missing": missing},
+        # `missing` stays the total un-covered count (backward-compatible);
+        # `planned_only` breaks out the review-gap subset so an operator can tell
+        # "nobody verified it" from "nobody even owns it".
+        "summary": {
+            "total": len(requirements),
+            "covered": covered,
+            "missing": missing,
+            "planned_only": planned_only,
+        },
     }
 
 
@@ -4916,11 +4941,15 @@ def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
     total = summary.get("total", 0) if isinstance(summary, dict) else 0
     covered = summary.get("covered", 0) if isinstance(summary, dict) else 0
     missing = summary.get("missing", 0) if isinstance(summary, dict) else 0
+    planned_only = summary.get("planned_only", 0) if isinstance(summary, dict) else 0
     lines = [
         ACCEPTANCE_COVERAGE_BLOCK_START,
         "## Acceptance Coverage",
         f"- Covered tags: {covered}/{total}",
-        f"- Missing evidence: {missing}",
+        (
+            f"- Uncovered: {missing} ({planned_only} planned but unverified, "
+            f"{missing - planned_only} with no evidence at all)"
+        ),
     ]
     requirements = report.get("requirements")
     if isinstance(requirements, list) and requirements:
@@ -12134,6 +12163,15 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         # No default-branch ref to anchor on — degrade to the old HEAD-only view
         # rather than reporting nothing at all.
         diff_range = "HEAD"
+        diff_stat = uncommitted_stat
+        files_changed = list(uncommitted_files)
+
+    if not files_changed and not diff_stat and (uncommitted_files or uncommitted_stat):
+        # Base resolved but the range is empty (nothing committed yet, or sitting on
+        # the default branch) while the working tree carries the whole change.
+        # Reporting "no code diff" here would re-create the always-red gate that
+        # #426 is about, just from the other direction.
+        diff_range = f"{diff_range} (empty; showing uncommitted working tree)"
         diff_stat = uncommitted_stat
         files_changed = list(uncommitted_files)
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -339,7 +339,37 @@ LEARNING_CONSUMPTION_SOURCES = {"auto-handoff", "file-handoff", "inline-summary"
 REVIEW_SECTION_IDS: tuple[str, ...] = ("architecture", "code_quality", "tests", "performance")
 REVIEW_VALID_MODES: tuple[str, ...] = ("default", "reverse-sections", "shuffle-sections")
 LEARNING_IMMEDIATE_WINDOW_SECONDS = 30 * 60
-ACCEPTANCE_TAG_RE = re.compile(r"\[([A-Za-z][A-Za-z0-9_-]*-\d+[A-Za-z0-9_-]*)\]")
+# Requirement tags (AC-1, INV-4, HC-2, SC-1, ...) as they actually appear in
+# artifacts. Brackets are OPTIONAL: reviewer verdicts, commit messages and
+# verification prose write `HC-2 audit: pass`, never `[HC-2]`, so a
+# bracket-only matcher found nothing and the coverage table read 0/N forever.
+# Over-matching (`feat-422`, `ST-001`) is harmless — extracted tags are only
+# ever intersected with the blueprint's coverage_map keys.
+ACCEPTANCE_TAG_RE = re.compile(
+    r"(?<![A-Za-z0-9_])\[?([A-Za-z][A-Za-z0-9_-]*-\d+[A-Za-z0-9_-]*)\]?(?![A-Za-z0-9_])"
+)
+
+# Sentinels around the GENERATED acceptance-coverage block. write_verification_summary
+# appends that block to verification-summary.md, which is itself an evidence source —
+# without an exact exclusion span the report would read its own "AC-1 owned by ST-001"
+# lines back as evidence and report 100% forever. The markers are inline HTML comments
+# so they survive the newline-flattening applied when the summary is embedded in
+# pr-draft.md.
+ACCEPTANCE_COVERAGE_BLOCK_START = "<!-- map:acceptance-coverage:start -->"
+ACCEPTANCE_COVERAGE_BLOCK_END = "<!-- map:acceptance-coverage:end -->"
+ACCEPTANCE_COVERAGE_BLOCK_RE = re.compile(
+    re.escape(ACCEPTANCE_COVERAGE_BLOCK_START)
+    + r".*?"
+    + re.escape(ACCEPTANCE_COVERAGE_BLOCK_END),
+    re.DOTALL,
+)
+# Structural fallback for artifacts written BEFORE the sentinels existed (every
+# already-installed repo has them on disk). Spans the heading up to the next
+# `## ` heading or end of text — the non-greedy body plus the lookahead also
+# handles pr-draft.md, where the whole summary is flattened onto one line.
+ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE = re.compile(
+    r"##\s+Acceptance Coverage.*?(?=##\s+|\Z)", re.DOTALL
+)
 REVIEW_PROMPT_DEFAULT_BUDGET_TOKENS = 12_000
 REVIEW_PROMPT_MIN_BUDGET_TOKENS = 1_024
 REVIEW_PROMPT_BUDGET_ENV = "MAP_REVIEW_PROMPT_BUDGET_TOKENS"
@@ -4655,23 +4685,71 @@ def _load_blueprint_for_coverage(branch_dir: Path) -> tuple[dict[str, object] | 
     return blueprint, ""
 
 
+def _strip_generated_coverage_blocks(text: str) -> str:
+    """Remove every generated acceptance-coverage block from evidence text.
+
+    The coverage report must never count its own output as evidence — see
+    ACCEPTANCE_COVERAGE_BLOCK_START. Sentinel-delimited blocks are removed exactly;
+    unmarked legacy blocks fall back to the section-heading span.
+    """
+    stripped = ACCEPTANCE_COVERAGE_BLOCK_RE.sub(" ", text)
+    return ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE.sub(" ", stripped)
+
+
 def _extract_acceptance_tags(text: object) -> set[str]:
-    """Return bracketed acceptance/invariant tags found in artifact text."""
+    """Return acceptance/invariant tags found in artifact text (brackets optional)."""
     if not isinstance(text, str) or not text:
         return set()
-    return {match.group(1) for match in ACCEPTANCE_TAG_RE.finditer(text)}
+    return {
+        match.group(1)
+        for match in ACCEPTANCE_TAG_RE.finditer(_strip_generated_coverage_blocks(text))
+    }
+
+
+def _branch_commit_messages() -> str:
+    """Return the branch's commit messages (merge-base..HEAD), or "" on any failure.
+
+    Commit messages are upstream-owned evidence: the Actor writes them at the moment
+    the work lands, they are immutable afterwards, and unlike code comments they are
+    NOT rewritten by the scrub-internal-ids Stop hook. Never raises.
+    """
+
+    def _run_git(args: list[str]) -> str:
+        try:
+            result = subprocess.run(
+                ["git"] + args,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            return result.stdout.strip() if result.returncode == 0 else ""
+        except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
+            return ""
+
+    base_sha, _ = _resolve_review_base(_run_git)
+    if not base_sha:
+        return ""
+    return _run_git(["log", "--format=%B", f"{base_sha}..HEAD"])
 
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
     extra_artifacts: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
-    """Collect review/verification artifact text that can prove acceptance tags."""
+    """Collect review/verification artifact text that can prove acceptance tags.
+
+    Planning artifacts (spec, task plan, plan-review) are deliberately excluded:
+    they state the requirement, they do not prove it. The independent downstream
+    verdicts — reviewer agent outputs and the final verifier — ARE included, because
+    they are the artifacts that actually cite a tag while checking it.
+    """
     evidence: dict[str, str] = {}
     for label, name in (
         ("verification_summary", "verification-summary.md"),
         ("qa", "qa-001.md"),
         ("pr_draft", "pr-draft.md"),
+        ("final_verification", "final_verification.json"),
     ):
         text = _read_branch_artifact_text(branch_dir, name)
         if text:
@@ -4683,7 +4761,12 @@ def _collect_acceptance_evidence_texts(
         if isinstance(text, str) and text:
             evidence[label] = text
 
+    commit_messages = _branch_commit_messages()
+    if commit_messages:
+        evidence["commit_messages"] = _sanitize_for_json(commit_messages)
+
     for pattern, label_prefix in (
+        ("review-agent-*.json", "review_agent"),
         ("test_contract_*.md", "test_contract"),
         ("test_handoff_*.json", "test_handoff"),
     ):
@@ -4771,20 +4854,36 @@ def build_acceptance_coverage_report(
             for source, tags in evidence_tags_by_source.items()
             if requirement in tags
         )
+        if evidence_artifacts:
+            status = "covered"
+        elif validation_criteria_cited:
+            # The blueprint owner names the requirement in its validation criteria,
+            # but nothing downstream verified it. That is a REVIEW gap, not a
+            # decomposition gap — collapsing both into "missing_evidence" hid which
+            # one an operator has to go fix.
+            status = "planned_only"
+        else:
+            status = "missing_evidence"
         requirements.append(
             {
                 "id": requirement,
                 "owner": owner_id,
                 "validation_criteria_cited": validation_criteria_cited,
                 "evidence_artifacts": evidence_artifacts,
-                "status": "covered" if evidence_artifacts else "missing_evidence",
+                "status": status,
             }
         )
 
     covered = sum(1 for item in requirements if item["status"] == "covered")
     missing = len(requirements) - covered
+    # Only sources that cited a REAL requirement count as evidence sources. With
+    # brackets optional, every source matches incidental tokens (`ST-001`,
+    # `feat-422`); listing those would make the field noise.
+    requirement_ids = {str(key) for key in coverage_map}
     tagged_evidence_sources = sorted(
-        source for source, tags in evidence_tags_by_source.items() if tags
+        source
+        for source, tags in evidence_tags_by_source.items()
+        if tags & requirement_ids
     )
     return {
         "status": "success",
@@ -4797,16 +4896,28 @@ def build_acceptance_coverage_report(
 
 
 def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
-    """Render an acceptance coverage report into a compact Markdown section."""
+    """Render an acceptance coverage report into a compact Markdown section.
+
+    The output is fenced with ACCEPTANCE_COVERAGE_BLOCK_START/END so that when it is
+    appended to verification-summary.md — which the report later reads back as an
+    evidence source — the block can be excised exactly instead of counting as proof
+    of the very tags it reports as missing.
+    """
     if report.get("status") != "success":
         reason = report.get("reason", "not available")
-        return "## Acceptance Coverage\n- Status: not available\n- Reason: " + str(reason) + "\n"
+        return (
+            f"{ACCEPTANCE_COVERAGE_BLOCK_START}\n"
+            "## Acceptance Coverage\n- Status: not available\n- Reason: "
+            + str(reason)
+            + f"\n{ACCEPTANCE_COVERAGE_BLOCK_END}\n"
+        )
 
     summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
     total = summary.get("total", 0) if isinstance(summary, dict) else 0
     covered = summary.get("covered", 0) if isinstance(summary, dict) else 0
     missing = summary.get("missing", 0) if isinstance(summary, dict) else 0
     lines = [
+        ACCEPTANCE_COVERAGE_BLOCK_START,
         "## Acceptance Coverage",
         f"- Covered tags: {covered}/{total}",
         f"- Missing evidence: {missing}",
@@ -4825,6 +4936,7 @@ def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
                 f"- [{item.get('status', 'unknown')}] {item.get('id', 'unknown')} "
                 f"owned by {item.get('owner') or 'unknown'}; evidence: {evidence_text}"
             )
+    lines.append(ACCEPTANCE_COVERAGE_BLOCK_END)
     return "\n".join(lines) + "\n"
 
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -18614,35 +18614,49 @@ def _worktree_probe(project_dir: Path) -> dict[str, object]:
     return result
 
 
+def _wt_dirty_paths(timeout: int = 15) -> tuple[list[str], str]:
+    """Return ``(dirty porcelain lines, error)`` for the main checkout.
+
+    Single scanner behind every dirty-target decision (#423): the isolation
+    resolver and both merge paths used to each carry their own copy of this
+    filter, which is how ``merge_subtask_worktree`` ended up with no guard at all.
+
+    MAP runtime state (``.map/<branch>/``, ``.codex/``, ``.agents/``) is excluded:
+    in a real target repo those are gitignored, and the guard must care only about
+    the USER's uncommitted source — never refuse because of our own state writes.
+    """
+    st = _wt_git(["status", "--porcelain"], timeout=timeout)
+    if st.returncode != 0:
+        return [], (st.stderr.strip() or "git status failed")
+    return [
+        ln
+        for ln in st.stdout.splitlines()
+        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
+    ], ""
+
+
 def _require_clean_merge_target(project_dir: Path) -> dict[str, object]:
     """Check that the main checkout is clean enough for a worktree merge.
 
     Dormant when worktree.isolation is 'off' (per-repo opt-out / kill-switch — HC-1).
-    When the check is active AND require_clean_merge_target config is True
-    (default True), runs `git status --porcelain` and returns:
+    Otherwise runs `git status --porcelain` and returns:
       * {"status":"ok","ok":True}  when clean (excluding MAP runtime state)
       * {"status":"dirty","ok":False,"kind":"DIRTY_MERGE_TARGET","dirty":[...]}
         when uncommitted changes are present.
     Never raises.
+
+    Reached from ``resolve_worktree_isolation``, which ``worktree_isolation_status``
+    calls — there is no separate ``require_clean_merge_target`` config key: it was
+    a dead toggle nothing consulted (#423), and a clean merge target is not
+    optional for a squash-merge-based accept path.
     """
     mode = _worktree_isolation_mode(project_dir)
     if mode == "off":
         return {"status": "dormant", "ok": False, "reason": "worktree.isolation is off"}
 
-    # Read the require_clean_merge_target flag (default True)
-    raw_require = _map_config_str(project_dir, "require_clean_merge_target", "true")
-    if not _parse_boolish(raw_require):
-        return {"status": "ok", "ok": True, "skipped": True}
-
-    st = _wt_git(["status", "--porcelain"], timeout=15)
-    if st.returncode != 0:
-        return _wt_error("CLEAN_CHECK_FAILED", st.stderr.strip() or "git status failed")
-
-    dirty = [
-        ln
-        for ln in st.stdout.splitlines()
-        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-    ]
+    dirty, error = _wt_dirty_paths()
+    if error:
+        return _wt_error("CLEAN_CHECK_FAILED", error)
     if dirty:
         return {
             "status": "dirty",
@@ -19190,22 +19204,18 @@ def create_subtask_worktree(
         )
 
     if not allow_dirty:
-        status = _wt_git(["status", "--porcelain"])
-        # Exclude MAP runtime state (.map/<branch>/, .codex/, .agents/): in a real
-        # target repo these are gitignored, but the dirty guard must care only
-        # about the USER's uncommitted source — never refuse because of our own
-        # state writes (council Q6 dirty-main/runtime-state interaction).
-        dirty = [
-            ln
-            for ln in status.stdout.splitlines()
-            if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-        ]
+        # MAP runtime state is excluded by _wt_dirty_paths — see its docstring.
+        dirty, clean_error = _wt_dirty_paths()
+        if clean_error:
+            return _wt_error("CLEAN_CHECK_FAILED", clean_error)
         if dirty:
             return _wt_error(
                 "DIRTY_MAIN",
                 "the main checkout has uncommitted changes; the worktree would "
                 "start from committed HEAD and silently diverge. Commit/stash "
-                "first, or pass --allow-dirty.",
+                "first, or pass --allow-dirty (the accept path still requires a "
+                "clean tree, so the changes must be committed or stashed before "
+                "the merge).",
                 dirty=dirty[:20],
             )
 
@@ -19589,6 +19599,61 @@ def _wt_release_lifecycle_lock(handle: Any | None) -> None:
         pass
 
 
+def _wt_dirty_target_guard(branch_name: str, operation: str) -> dict[str, object] | None:
+    """Refuse to squash-merge onto a working tree carrying uncommitted user work.
+
+    Returns ``None`` when the target is clean, otherwise a structured
+    ``DIRTY_TARGET`` error. Shared by the wave coordinator and the single-subtask
+    accept path so both refuse identically — ``merge_subtask_worktree`` previously
+    had no dirty guard at all while the wave path did (#423).
+
+    Emits a pending ``dangerous_action`` approval hold at the refusal (#422) so
+    the approval-hold hard-stop path has a live producer. ``request_summary`` is
+    derived solely from the branch name and operation (no dirty-file list) so
+    ``create_approval_hold``'s (kind, request_summary, pending) dedup keeps
+    repeated refusals against the same dirty tree idempotent; the repo-relative
+    dirty paths ride in ``reason`` instead, never file contents. Hold creation is
+    best-effort: the refusal must still reach the caller even if it fails.
+    """
+    dirty, error = _wt_dirty_paths()
+    if error:
+        return _wt_error("CLEAN_CHECK_FAILED", error)
+    if not dirty:
+        return None
+
+    dirty_paths = [_wt_porcelain_path(ln) for ln in dirty[:20]]
+    hold_id: str | None = None
+    try:
+        hold_result = create_approval_hold(
+            kind="dangerous_action",
+            reason=(
+                f"The working tree has uncommitted changes blocking a {operation}; "
+                "affected paths: " + ", ".join(dirty_paths)
+            ),
+            request_summary=(
+                f"Uncommitted changes blocking {operation} on {branch_name}"
+            ),
+            source="worktree-merge",
+            branch=branch_name,
+            safe_continuation=(
+                f"Commit or stash the listed changes, then retry the {operation}."
+            ),
+        )
+        if hold_result.get("status") == "ok":
+            hold_id = cast(str, hold_result["hold_id"])
+    except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
+        hold_id = None
+
+    error_extra: dict[str, object] = {"dirty": dirty[:20]}
+    if hold_id is not None:
+        error_extra["hold_id"] = hold_id
+    return _wt_error(
+        "DIRTY_TARGET",
+        f"the working tree has uncommitted changes; commit/stash before a {operation}",
+        **error_extra,
+    )
+
+
 def merge_subtask_worktree(
     subtask_id: str,
     attempt: int = 0,
@@ -19645,6 +19710,12 @@ def merge_subtask_worktree(
             base_sha=base_sha,
             working_head=working_head,
         )
+
+    # Same dirty-target refusal the wave coordinator applies: a squash-merge onto
+    # a dirty working branch cannot be rolled back cleanly (#423).
+    dirty_refusal = _wt_dirty_target_guard(branch_name, "subtask merge")
+    if dirty_refusal is not None:
+        return dirty_refusal
 
     prep = _wt_freeze_and_verify(
         subtask_id, record, project_dir, branch_name, verify_cmds, skip_verify
@@ -19883,49 +19954,9 @@ def merge_wave_worktrees(
             "DETACHED_HEAD",
             "refusing to wave-merge onto a detached HEAD; check out the working branch",
         )
-    status = _wt_git(["status", "--porcelain"])
-    dirty = [
-        ln
-        for ln in status.stdout.splitlines()
-        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-    ]
-    if dirty:
-        # Intent: emit a dangerous_action hold at this refusal (#422 AC-4) so the
-        # approval-hold hard-stop path (#344) has a live producer instead of only
-        # synthetic test fixtures. request_summary is derived solely from the
-        # branch name (no dirty-file-list) so create_approval_hold's
-        # (kind, request_summary, pending) dedup keeps repeated refusals against
-        # the same dirty tree idempotent (INV-2); the repo-relative dirty paths
-        # ride in `reason` instead, never file contents. Hold creation is best-
-        # effort: the refusal must still reach the caller even if it fails.
-        dirty_paths = [_wt_porcelain_path(ln) for ln in dirty[:20]]
-        hold_id: str | None = None
-        try:
-            hold_result = create_approval_hold(
-                kind="dangerous_action",
-                reason=(
-                    "The working tree has uncommitted changes blocking a wave "
-                    "merge; affected paths: " + ", ".join(dirty_paths)
-                ),
-                request_summary=f"Uncommitted changes blocking wave merge on {branch_name}",
-                source="worktree-merge",
-                branch=branch_name,
-                safe_continuation=(
-                    "Commit or stash the listed changes, then retry the wave merge."
-                ),
-            )
-            if hold_result.get("status") == "ok":
-                hold_id = cast(str, hold_result["hold_id"])
-        except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
-            hold_id = None
-        error_extra: dict[str, object] = {"dirty": dirty[:20]}
-        if hold_id is not None:
-            error_extra["hold_id"] = hold_id
-        return _wt_error(
-            "DIRTY_TARGET",
-            "the working tree has uncommitted changes; commit/stash before a wave merge",
-            **error_extra,
-        )
+    dirty_refusal = _wt_dirty_target_guard(branch_name, "wave merge")
+    if dirty_refusal is not None:
+        return dirty_refusal
 
     # Serialize coordinators so two waves never interleave squash commits.
     lock_handle = _wt_acquire_merge_lock()
@@ -20126,8 +20157,50 @@ def merge_wave_worktrees(
         _wt_release_merge_lock(lock_handle)
 
 
+def _wt_isolation_decision(project_dir: Path) -> dict[str, object]:
+    """Flatten ``resolve_worktree_isolation`` into a reportable decision block.
+
+    ``resolve_worktree_isolation`` implements the ST-009 fallback matrix (not a git
+    repo / worktrees unsupported / dirty merge target) but had no production caller
+    until this one (#423) — the reason codes it emits are the same vocabulary
+    ``parallelism_observability`` publishes, so leaving it unwired meant the whole
+    degrade classification was never produced at runtime.
+
+    Always returns success-shaped keys so the status command stays exit-0 and the
+    caller reads ``decision``/``degraded``/``reason`` instead of a mixed envelope.
+    """
+    resolution = resolve_worktree_isolation(project_dir)
+    if resolution.get("status") == "dormant":
+        return {
+            "decision": "sequential",
+            "degraded": False,
+            "degraded_reason": "",
+            "warning": "",
+        }
+    if resolution.get("status") == "error":
+        # mode == 'required' with a fallback condition — isolation cannot run.
+        return {
+            "decision": "abort",
+            "degraded": False,
+            "degraded_reason": str(resolution.get("kind", "")).lower(),
+            "warning": str(resolution.get("message", "")),
+        }
+    return {
+        "decision": str(resolution.get("decision", "isolated")),
+        "degraded": bool(resolution.get("degraded", False)),
+        "degraded_reason": str(resolution.get("reason", "")),
+        "warning": str(resolution.get("warning", "")),
+    }
+
+
 def worktree_isolation_status(branch: str | None = None) -> dict[str, object]:
-    """Report whether isolation is enabled + reconcile recorded vs live worktrees."""
+    """Report whether isolation is enabled + reconcile recorded vs live worktrees.
+
+    Also reports the live isolation DECISION (isolated / sequential / abort) from
+    the fallback matrix, so an operator can see BEFORE a wave starts that e.g. a
+    dirty merge target will degrade the run — rather than discovering it when
+    ``create_subtask_worktree`` refuses mid-flight (#423).
+    """
     project_dir = _wt_project_dir()
     branch_name = branch or get_branch_name()
     state = _read_worktree_state(branch_name)
@@ -20158,10 +20231,12 @@ def worktree_isolation_status(branch: str | None = None) -> dict[str, object]:
         "status": "success",
         "ok": True,
         "enabled": _wt_isolation_enabled(project_dir),
+        "mode": _worktree_isolation_mode(project_dir),
         "branch": branch_name,
         "active_worktrees": active,
         "live_git_worktrees": live,
         "max_deletions": _wt_max_deletions(project_dir),
+        **_wt_isolation_decision(project_dir),
     }
 
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -1880,16 +1880,24 @@ def _prior_stage_diff_entry(
     file_count = len(files_changed) if isinstance(files_changed, list) else 0
     diff_stat = code_state.get("diff_stat")
     present = code_state.get("status") == "success" and (file_count > 0 or bool(diff_stat))
+    # Name the range the snapshot actually used (#426): a HEAD-only diff on a
+    # fully-committed branch is empty, and reporting the wrong command in the
+    # "missing" reason sent reviewers looking for the wrong problem.
+    diff_range = code_state.get("diff_range") or "HEAD"
     return {
         "key": "code_diff",
         "label": "code diff",
         "kind": "git-diff",
-        "path": "git diff --stat HEAD",
+        "path": f"git diff --stat {diff_range}",
         "required": required,
         "present": present,
         "consumed": present,
         "count": file_count,
-        "reason": "" if present else "missing code diff snapshot; no changed files were visible against HEAD",
+        "reason": (
+            ""
+            if present
+            else f"missing code diff snapshot; no changed files were visible in {diff_range}"
+        ),
     }
 
 
@@ -9284,11 +9292,20 @@ def _render_bundle_markdown(result: dict) -> str:
     if cs_status == "success":
         lines.append(f"- Git ref: `{code_state.get('git_ref', 'unknown')}`")
         lines.append(f"- Branch: `{code_state.get('branch', 'unknown')}`")
+        base_ref = code_state.get("diff_base_ref") or ""
+        diff_range = code_state.get("diff_range") or "HEAD"
+        lines.append(
+            f"- Review target: `{diff_range}`"
+            + (f" (merge-base with `{base_ref}`)" if base_ref else " (no default-branch ref resolved)")
+        )
         files = code_state.get("files_changed", [])
         lines.append(f"- Files changed: {len(files)}")
         diff_stat = code_state.get("diff_stat", "")
         if diff_stat:
             lines.append(f"- Diff stat: {diff_stat[:200]}")
+        uncommitted = code_state.get("uncommitted_files_changed")
+        if isinstance(uncommitted, list):
+            lines.append(f"- Uncommitted (work in progress): {len(uncommitted)} file(s)")
     else:
         lines.append(f"- Status: {cs_status}")
         reason = code_state.get("reason", "")
@@ -11921,12 +11938,50 @@ def run_test_gate() -> dict:
 _DIFF_STAT_MAX_CHARS = 65_536
 _FILES_CHANGED_MAX_ENTRIES = 500
 
+# Candidate default-branch refs, tried in order when resolving the review base.
+# Remote-tracking refs come first: they survive a local branch that was reset or
+# never checked out, which is the common CI/clone shape.
+_REVIEW_BASE_CANDIDATE_REFS = (
+    "origin/main",
+    "origin/master",
+    "main",
+    "master",
+)
+
+
+def _resolve_review_base(run_git: Callable[[list[str]], str]) -> tuple[str, str]:
+    """Return ``(base_sha, base_ref)`` for the branch's review target.
+
+    The review target is the merge-base with the default branch, NOT ``HEAD``:
+    on a fully-committed feature branch (the normal /map-check → /map-review
+    state) ``git diff HEAD`` is empty, so a HEAD-based snapshot self-reports
+    "Files changed: 0" for a branch that actually carries the whole diff (#426).
+
+    Returns ``("", "")`` when no default-branch ref resolves (fresh repo, no
+    remote, shallow clone) — callers then fall back to the uncommitted diff.
+    """
+    for ref in _REVIEW_BASE_CANDIDATE_REFS:
+        if not run_git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"]):
+            continue
+        base = run_git(["merge-base", ref, "HEAD"])
+        if base:
+            return base, ref
+    return "", ""
+
 
 def snapshot_code_state(branch: str | None = None) -> dict:
     """Capture current git state for artifact-to-code verification.
 
     Records git ref, changed files, and diff stat so review artifacts
     can be tied to actual code state. Populates subtask_files_changed.
+
+    ``files_changed``/``diff_stat`` describe the REVIEW TARGET — the range from
+    the merge-base with the default branch up to HEAD — so a branch whose work is
+    already committed still reports its real scope (#426). The uncommitted
+    working-tree diff is kept alongside as a secondary work-in-progress signal
+    (``uncommitted_files_changed``/``uncommitted_diff_stat``). When no
+    default-branch ref resolves, the snapshot degrades to the uncommitted diff and
+    reports ``diff_base_ref=""``.
 
     Very large repos can produce huge ``diff_stat`` and ``files_changed`` outputs that
     bloat the bundle JSON. Both are capped here (``_DIFF_STAT_MAX_CHARS`` /
@@ -11949,10 +12004,26 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
             return ""
 
+    def _names(raw: str) -> list[str]:
+        return [f for f in raw.splitlines() if f.strip()] if raw else []
+
     git_ref = _run_git(["rev-parse", "HEAD"])
-    diff_stat = _run_git(["diff", "--stat", "HEAD"])
-    diff_names = _run_git(["diff", "--name-only", "HEAD"])
-    files_changed = [f for f in diff_names.splitlines() if f.strip()] if diff_names else []
+
+    # Secondary signal: uncommitted work in the main checkout.
+    uncommitted_stat = _run_git(["diff", "--stat", "HEAD"])
+    uncommitted_files = _names(_run_git(["diff", "--name-only", "HEAD"]))
+
+    base_sha, base_ref = _resolve_review_base(_run_git)
+    if base_sha:
+        diff_range = f"{base_sha[:12]}..HEAD"
+        diff_stat = _run_git(["diff", "--stat", base_sha, "HEAD"])
+        files_changed = _names(_run_git(["diff", "--name-only", base_sha, "HEAD"]))
+    else:
+        # No default-branch ref to anchor on — degrade to the old HEAD-only view
+        # rather than reporting nothing at all.
+        diff_range = "HEAD"
+        diff_stat = uncommitted_stat
+        files_changed = list(uncommitted_files)
 
     diff_truncated = False
     if len(diff_stat) > _DIFF_STAT_MAX_CHARS:
@@ -11960,6 +12031,12 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         diff_truncated = True
     if len(files_changed) > _FILES_CHANGED_MAX_ENTRIES:
         files_changed = files_changed[:_FILES_CHANGED_MAX_ENTRIES]
+        diff_truncated = True
+    if len(uncommitted_stat) > _DIFF_STAT_MAX_CHARS:
+        uncommitted_stat = uncommitted_stat[:_DIFF_STAT_MAX_CHARS] + "\n... [truncated]"
+        diff_truncated = True
+    if len(uncommitted_files) > _FILES_CHANGED_MAX_ENTRIES:
+        uncommitted_files = uncommitted_files[:_FILES_CHANGED_MAX_ENTRIES]
         diff_truncated = True
 
     return {
@@ -11969,6 +12046,11 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         "diff_stat": diff_stat,
         "branch": branch_name,
         "diff_truncated": diff_truncated,
+        "diff_base": base_sha[:12] if base_sha else "",
+        "diff_base_ref": base_ref,
+        "diff_range": diff_range,
+        "uncommitted_files_changed": uncommitted_files,
+        "uncommitted_diff_stat": uncommitted_stat,
     }
 
 

--- a/src/mapify_cli/templates/map/static-analysis/handlers/common.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/common.sh
@@ -33,9 +33,9 @@ generate_output() {
 
     # Calculate summary
     local error_count warning_count total_count tools_json
-    error_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
-    warning_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
-    total_count=$(echo "$all_findings" | jq 'length')
+    error_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
+    warning_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
+    total_count=$(printf '%s' "$all_findings" | jq 'length')
 
     # Convert tools array to JSON (handle empty array safely)
     if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then

--- a/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/go.sh
@@ -30,7 +30,7 @@ if command -v go &> /dev/null; then
     VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
-        VET_NORM=$(echo "$VET_OUT" | while IFS= read -r line; do
+        VET_NORM=$(printf '%s\n' "$VET_OUT" | while IFS= read -r line; do
             if parse_colon_delimited "$line" file lineno col msg; then
                 msg="${msg# }"
                 msg=$(json_escape "$msg")
@@ -55,7 +55,7 @@ if command -v gofmt &> /dev/null; then
     fi
 
     if [[ -n "$FMT_OUT" ]]; then
-        FMT_NORM=$(echo "$FMT_OUT" | while IFS= read -r file; do
+        FMT_NORM=$(printf '%s\n' "$FMT_OUT" | while IFS= read -r file; do
             file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")
@@ -72,7 +72,7 @@ if command -v staticcheck &> /dev/null; then
     if [[ -n "$SC_OUT" ]]; then
         # staticcheck outputs NDJSON (one JSON object per line)
         # Use jq -s to slurp all objects into an array, then transform each
-        SC_NORM=$(echo "$SC_OUT" | jq -s '[.[] | {
+        SC_NORM=$(printf '%s' "$SC_OUT" | jq -s '[.[] | {
             tool: "staticcheck",
             file: .location.file,
             line: .location.line,

--- a/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/python.sh
@@ -31,7 +31,7 @@ if command -v ruff &> /dev/null; then
 
     # Normalize ruff output to standard format
     if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
-        RUFF_NORM=$(echo "$RUFF_OUT" | jq -c '[.[] | {
+        RUFF_NORM=$(printf '%s' "$RUFF_OUT" | jq -c '[.[] | {
             tool: "ruff",
             file: .filename,
             line: .location.row,
@@ -53,7 +53,7 @@ if command -v mypy &> /dev/null; then
 
     # Parse mypy text output to JSON using robust parsing
     if [[ -n "$MYPY_OUT" ]]; then
-        MYPY_NORM=$(echo "$MYPY_OUT" | while IFS= read -r line; do
+        MYPY_NORM=$(printf '%s\n' "$MYPY_OUT" | while IFS= read -r line; do
             if parse_colon_delimited "$line" file lineno col msg; then
                 # Determine severity from message
                 severity="warning"

--- a/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
+++ b/src/mapify_cli/templates/map/static-analysis/handlers/typescript.sh
@@ -35,7 +35,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
     ESLINT_OUT=$(timeout 60 "$ESLINT_CMD" --format json "$FILES" 2>/dev/null || echo "[]")
 
     if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
-        ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
+        ESLINT_NORM=$(printf '%s' "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
             tool: "eslint",
             file: $file,
             line: .line,
@@ -63,7 +63,7 @@ if [[ -f "tsconfig.json" ]]; then
 
         if [[ -n "$TSC_OUT" ]]; then
             # Parse format: file(line,col): error TSxxxx: message
-            TSC_NORM=$(echo "$TSC_OUT" | while IFS= read -r line; do
+            TSC_NORM=$(printf '%s\n' "$TSC_OUT" | while IFS= read -r line; do
                 if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ error\ (TS[0-9]+):\ (.*)$ ]]; then
                     file="${BASH_REMATCH[1]}"
                     linenum="${BASH_REMATCH[2]}"

--- a/src/mapify_cli/templates/references/bash-guidelines.md
+++ b/src/mapify_cli/templates/references/bash-guidelines.md
@@ -39,6 +39,33 @@ head -n 10 logfile.txt  # Direct file read is OK
 
 ---
 
+## ⚠️ CRITICAL: Never pipe a captured variable through `echo`
+
+zsh (the default macOS shell) has a builtin `echo` that interprets backslash
+escapes without `-E`. Piping captured JSON through it turns the `\n`/`\t`
+escapes inside JSON string values into raw C0 control bytes, and `jq` aborts
+with `control characters from U+0000 through U+001F must be escaped`. Inside
+`$(...)` the failure is swallowed, so the variable lands **empty** and the
+recipe writes an empty-bodied artifact with exit 0.
+
+```bash
+# ❌ BAD - mangles escapes under zsh; SUMMARY silently ends up empty
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+NORM=$(echo "$TOOL_OUT" | while IFS= read -r line; do ...; done)
+
+# ✅ GOOD - printf emits the bytes verbatim
+SUMMARY=$(printf '%s' "$BUNDLE" | jq -r '.summary')
+
+# ✅ GOOD - keep the trailing newline when a `while read` loop consumes it,
+#           otherwise the last line is dropped
+NORM=$(printf '%s\n' "$TOOL_OUT" | while IFS= read -r line; do ...; done)
+```
+
+The convention is enforced by `tests/test_shell_json_pipes.py`, which scans every
+shipped recipe and handler for the banned form.
+
+---
+
 ## When Checking Command Output
 
 ### Pattern 1: Run Commands Directly

--- a/src/mapify_cli/templates/skills/map-efficient/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-efficient/SKILL.md
@@ -115,7 +115,7 @@ if [ -f "$STATE_FILE" ]; then
   echo "Existing step_state.json found — proceeding straight to Step 1 get_next_step."
 elif [ -f "$PLAN_FILE" ]; then
   RESUME_RESULT=$(python3 .map/scripts/map_orchestrator.py resume_from_plan)
-  RESUME_STATUS=$(echo "$RESUME_RESULT" | jq -r '.status')
+  RESUME_STATUS=$(printf '%s' "$RESUME_RESULT" | jq -r '.status')
   if [ "$RESUME_STATUS" = "success" ]; then
     echo "Resumed from /map-plan artifacts."
   else
@@ -141,10 +141,10 @@ fi
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-INSTRUCTION=$(echo "$NEXT_STEP" | jq -r '.instruction')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+INSTRUCTION=$(printf '%s' "$NEXT_STEP" | jq -r '.instruction')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 ```
 
 If `IS_COMPLETE=true`, skip to final verification.

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -39,7 +39,7 @@ python3 .map/scripts/map_step_runner.py validate_flaky_test_triage
 # disposition {kind: deferred_nondeterministic, check_id: ...}; close 2.4 with
 # the same disposition piped through. The orchestrator routes to deferral ONLY
 # when the sidecar + envelope back it (see "Verdict-path route" below).
-echo "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
+printf '%s' "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
   validate_step 2.4 --disposition deferred_nondeterministic \
   --check-id "pytest::test_name" --monitor-envelope -
 ```
@@ -292,7 +292,7 @@ Before invoking Monitor, validate Actor's response is JSON with required
 keys (`files_changed`, `tests_run`):
 
 ```bash
-echo "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
+printf '%s' "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
     detect_truncated_agent_output --agent actor
 ```
 

--- a/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
+++ b/src/mapify_cli/templates/skills/map-efficient/efficient-reference.md
@@ -315,11 +315,11 @@ If `truncated: true`:
 confirmed intact, run:
 
 ```bash
-FILES_DECLARED=$(echo "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
+FILES_DECLARED=$(printf '%s' "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
 MISMATCH=$(detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" \
   --declared "$FILES_DECLARED")
 echo "$MISMATCH"
-STATUS_MISMATCH=$(echo "$MISMATCH" | jq -r '.status_mismatch')
+STATUS_MISMATCH=$(printf '%s' "$MISMATCH" | jq -r '.status_mismatch')
 ```
 
 - `status_mismatch == true` — Actor declared files it did not write (mid-edit
@@ -344,8 +344,8 @@ Monitor failure), after `monitor_failed`:
 #    test_failure, gate_failure}. Exit 0 always — this is a sensor, not a gate.
 REC=$(python3 .map/scripts/map_step_runner.py record_failure_signature \
   "$MONITOR_FEEDBACK" "$SUBTASK_ID" --source monitor_rejection)
-ARMED=$(echo "$REC" | jq -r '.armed')
-ESCALATE=$(echo "$REC" | jq -r '.escalation_recommended')
+ARMED=$(printf '%s' "$REC" | jq -r '.armed')
+ESCALATE=$(printf '%s' "$REC" | jq -r '.escalation_recommended')
 
 # 2. If armed (same normalized failure >= 2x), prepend the hard constraint to
 #    the TOP of the next Actor prompt. Pass --quarantine-active when CLEAN_RETRY
@@ -380,7 +380,7 @@ fi
       build_escalation_outcome "$SUBTASK_ID" repeated_failure)
     #  Pass --quarantine-active on a CLEAN_RETRY iteration: it returns
     #  status:"deferred" so the one-shot reset runs before any terminal stop.
-    STATUS=$(echo "$OUT" | jq -r '.status')
+    STATUS=$(printf '%s' "$OUT" | jq -r '.status')
     #  status:"escalated"-> surface OUT.blocker_summary + OUT.recommended_action
     #    to the user and STOP (outcome:"BLOCKED", .map/<branch>/escalation_*.md).
     #  status:"not_escalated" -> the LATEST failure was a NEW signature; the
@@ -418,7 +418,7 @@ Before dispatching Monitor, run the blast-radius detector:
 BLAST=$(python3 .map/scripts/map_step_runner.py \
   detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID")
 echo "$BLAST"   # inspect changed_symbols / external_callers / reason
-GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
+GATE=$(printf '%s' "$BLAST" | jq -r '.recommended_gate')
 ```
 
 - `recommended_gate == "validate_callers"` — the subtask changed a
@@ -449,7 +449,7 @@ scoped run is safe:
 RISK=$(python3 .map/scripts/map_step_runner.py \
   detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID")
 echo "$RISK"   # inspect shared_source_files / prior_owners / reason
-GATE=$(echo "$RISK" | jq -r '.recommended_gate')
+GATE=$(printf '%s' "$RISK" | jq -r '.recommended_gate')
 ```
 
 - `recommended_gate == "full_suite"` — the current diff overlaps a file a

--- a/src/mapify_cli/templates/skills/map-release/release-reference.md
+++ b/src/mapify_cli/templates/skills/map-release/release-reference.md
@@ -277,7 +277,7 @@ CURRENT_BRANCH=$(git branch --show-current)
 [[ "$CURRENT_BRANCH" != "main" ]] && echo "❌ ABORT: Not on main branch" && exit 1
 
 LATEST_RUN=$(gh run list --branch main --limit 1 --json conclusion,status,createdAt,headBranch --jq '.[0]')
-RUN_CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
+RUN_CONCLUSION=$(printf '%s' "$LATEST_RUN" | jq -r '.conclusion')
 [[ "$RUN_CONCLUSION" != "success" ]] && echo "❌ ABORT: Latest CI did not succeed" && exit 1
 
 LAST_TAG=$(git tag --sort=-version:refname | head -1)
@@ -324,13 +324,13 @@ echo "Waiting for release workflow to start..."
 sleep 10
 
 RELEASE_RUN=$(gh run list --workflow=release.yml --limit 1 --json databaseId,status,conclusion,createdAt)
-RUN_ID=$(echo "$RELEASE_RUN" | jq -r '.[0].databaseId')
+RUN_ID=$(printf '%s' "$RELEASE_RUN" | jq -r '.[0].databaseId')
 
 if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
   echo "⚠️  Workflow not started yet; retrying in 30s..."
   sleep 30
   RELEASE_RUN=$(gh run list --workflow=release.yml --limit 1 --json databaseId,status,conclusion,createdAt)
-  RUN_ID=$(echo "$RELEASE_RUN" | jq -r '.[0].databaseId')
+  RUN_ID=$(printf '%s' "$RELEASE_RUN" | jq -r '.[0].databaseId')
 fi
 
 echo "Workflow URL: https://github.com/azalio/map-framework/actions/runs/$RUN_ID"

--- a/src/mapify_cli/templates/skills/map-resume/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-resume/SKILL.md
@@ -189,9 +189,9 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 
 # Get next step from orchestrator (reads step_state.json internally)
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 ```
 
 **Then follow the same phase routing as /map-efficient:**

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -270,10 +270,15 @@ fully-committed branch — the normal `/map-check` → `/map-review` state —
 `git diff HEAD` is empty and under-reports the review scope to zero (#426).
 
 ```bash
-BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
-       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
-git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
-git --no-pager diff "${BASE:-HEAD}"...HEAD
+BASE=""
+for ref in origin/main origin/master main master; do
+  git rev-parse --verify --quiet "$ref" >/dev/null && { BASE="$ref"; break; }
+done
+# No default-branch ref: diff the working tree. NEVER "HEAD...HEAD" — that range
+# is always empty and re-creates the very bug this step fixes.
+[ -n "$BASE" ] && RANGE="$BASE...HEAD" || RANGE="HEAD"
+git --no-pager diff --stat "$RANGE"
+git --no-pager diff "$RANGE"
 git status          # uncommitted work in progress — secondary signal
 ```
 

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -265,9 +265,16 @@ Mode semantics:
 
 ### Step A.1: Gather changes
 
+Diff against the **merge-base with the default branch**, not `HEAD`. On a
+fully-committed branch — the normal `/map-check` → `/map-review` state —
+`git diff HEAD` is empty and under-reports the review scope to zero (#426).
+
 ```bash
-git diff HEAD
-git status
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
+git --no-pager diff "${BASE:-HEAD}"...HEAD
+git status          # uncommitted work in progress — secondary signal
 ```
 
 ### Step A.1b: Load canonical review context (bundle + handoff)

--- a/src/mapify_cli/templates/skills/map-review/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-review/SKILL.md
@@ -276,7 +276,7 @@ Run this before any reviewer agent:
 
 ```bash
 BUNDLE_JSON=$(python3 .map/scripts/map_step_runner.py create_review_bundle)
-BUNDLE_JSON_PATH=$(echo "$BUNDLE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['bundle_path_json'])")
+BUNDLE_JSON_PATH=$(printf '%s' "$BUNDLE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['bundle_path_json'])")
 ```
 
 This creates `.map/<branch>/review-bundle.json` and `.map/<branch>/review-bundle.md`. These are PRIMARY review context. The bundle includes prior-stage consumption status; missing inputs are review evidence, not invisible setup noise.
@@ -288,9 +288,9 @@ DETACHED_PATH=""
 if [ "$DETACHED_FLAG" = "true" ]; then
   # EC-15: prepare detached review once; compare runs reuse the same path.
   DETACHED_JSON=$(python3 .map/scripts/map_step_runner.py prepare_detached_review "$BUNDLE_JSON_PATH")
-  DETACHED_STATUS=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))")
-  DETACHED_PATH=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('worktree_path') or '')")
-  DETACHED_REASON=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reason') or '')")
+  DETACHED_STATUS=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))")
+  DETACHED_PATH=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('worktree_path') or '')")
+  DETACHED_REASON=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reason') or '')")
 fi
 ```
 

--- a/src/mapify_cli/templates/skills/map-task/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-task/SKILL.md
@@ -80,10 +80,10 @@ if [ -f ".map/${BRANCH}/test_handoff_${SUBTASK_ID}.json" ] && [ -f ".map/${BRANC
 else
   RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID")
 fi
-STATUS=$(echo "$RESULT" | jq -r '.status')
+STATUS=$(printf '%s' "$RESULT" | jq -r '.status')
 
 if [ "$STATUS" = "error" ]; then
-  echo "$RESULT" | jq -r '.message'
+  printf '%s' "$RESULT" | jq -r '.message'
   exit 1
 fi
 ```
@@ -125,7 +125,7 @@ Follow the same state machine loop as `/map-efficient`. Call `get_next_step` and
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
@@ -170,10 +170,10 @@ python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "comp
 2. Get overall plan progress:
 ```bash
 PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
-TOTAL=$(echo "$PROGRESS" | jq -r '.total')
-DONE=$(echo "$PROGRESS" | jq -r '.completed_count')
-REMAINING=$(echo "$PROGRESS" | jq -r '.pending_count')
-SUGGESTED=$(echo "$PROGRESS" | jq -r '.suggested_next')
+TOTAL=$(printf '%s' "$PROGRESS" | jq -r '.total')
+DONE=$(printf '%s' "$PROGRESS" | jq -r '.completed_count')
+REMAINING=$(printf '%s' "$PROGRESS" | jq -r '.pending_count')
+SUGGESTED=$(printf '%s' "$PROGRESS" | jq -r '.suggested_next')
 ```
 
 3. Display completion report with remaining subtasks:

--- a/src/mapify_cli/templates/skills/map-tdd/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-tdd/SKILL.md
@@ -115,10 +115,10 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 
 ```bash
 RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID" --tdd)
-STATUS=$(echo "$RESULT" | jq -r '.status')
+STATUS=$(printf '%s' "$RESULT" | jq -r '.status')
 
 if [ "$STATUS" = "error" ]; then
-  echo "$RESULT" | jq -r '.message'
+  printf '%s' "$RESULT" | jq -r '.message'
   # If no plan: "Run /map-plan first"
   # If subtask not found: shows available IDs
   exit 1
@@ -185,7 +185,7 @@ Call `get_next_step` and execute based on the returned phase.
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.

--- a/src/mapify_cli/templates_src/CLAUDE.md.jinja
+++ b/src/mapify_cli/templates_src/CLAUDE.md.jinja
@@ -70,6 +70,13 @@ When you pipe through `head/tail/less/more`, the source command keeps running bu
 
 **Exception:** Filtering pipes are OK (grep, awk, sed) because they process all input.
 
+### Never pipe a captured variable through `echo`
+
+zsh's builtin `echo` interprets backslash escapes, so piping `echo "$JSON"` into `jq`
+turns the `\n` inside JSON string values into raw control bytes and jq aborts — inside
+`$(...)` the failure is swallowed and the variable lands empty. Use
+`printf '%s' "$VAR" | jq` (or `printf '%s\n'` when a `while read` loop consumes it).
+
 **Full guidelines:** `.claude/references/bash-guidelines.md`
 
 ## Progressive disclosure pointers

--- a/src/mapify_cli/templates_src/agents/final-verifier.md.jinja
+++ b/src/mapify_cli/templates_src/agents/final-verifier.md.jinja
@@ -5,8 +5,17 @@ description: Adversarial verifier with Root Cause Analysis (Ralph Loop)
 # gate before merge — false negatives here ship bugs to production.
 model: opus
 effort: high
-version: 1.1.0
-last_updated: 2026-04-28
+# 2026-08-14 (#424): a final-verifier run edited generated trees and committed
+# them mid-audit, despite the prompt contract being APPROVED/REJECTED-only.
+# Write stays allowed — the verifier legitimately writes .map/<branch>/
+# final_verification.json + progress markdown — but Edit and nested Agent are
+# denied at the harness level. Bash git mutations are blocked by the
+# safety-guardrails PreToolUse hook, which keys on agent_type.
+disallowedTools:
+  - Edit
+  - Agent
+version: 1.2.0
+last_updated: 2026-08-14
 ---
 
 # IDENTITY

--- a/src/mapify_cli/templates_src/agents/final-verifier.md.jinja
+++ b/src/mapify_cli/templates_src/agents/final-verifier.md.jinja
@@ -7,12 +7,16 @@ model: opus
 effort: high
 # 2026-08-14 (#424): a final-verifier run edited generated trees and committed
 # them mid-audit, despite the prompt contract being APPROVED/REJECTED-only.
-# Write stays allowed — the verifier legitimately writes .map/<branch>/
-# final_verification.json + progress markdown — but Edit and nested Agent are
-# denied at the harness level. Bash git mutations are blocked by the
-# safety-guardrails PreToolUse hook, which keys on agent_type.
+# Nested Agent is denied at the harness level. Edit/Write are NOT denied here:
+# this agent's own contract requires an in-place append to
+# .map/<branch>/progress_<branch>.md and a `[ ]` -> `[x]` update in the
+# task-plan Acceptance Criteria table — forcing those through whole-file Write
+# would drop surrounding content. The boundary is enforced by scope instead:
+# the safety-guardrails PreToolUse hook keys on agent_type and confines every
+# verifier Edit/Write/MultiEdit to `.map/` (normalized, so `.map/../src` cannot
+# escape) while blocking all git-mutating Bash. Runner-owned state inside
+# `.map/` stays protected for everyone by the workflow-gate tamper detector.
 disallowedTools:
-  - Edit
   - Agent
 version: 1.2.0
 last_updated: 2026-08-14

--- a/src/mapify_cli/templates_src/codex/skills/map-efficient/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-efficient/SKILL.md.jinja
@@ -100,7 +100,7 @@ if [ -f "$STATE_FILE" ]; then
   echo "Existing step_state.json found; continuing with get_next_step."
 elif [ -f "$PLAN_FILE" ]; then
   RESUME_RESULT=$(python3 .map/scripts/map_orchestrator.py resume_from_plan)
-  RESUME_STATUS=$(echo "$RESUME_RESULT" | jq -r '.status')
+  RESUME_STATUS=$(printf '%s' "$RESUME_RESULT" | jq -r '.status')
   if [ "$RESUME_STATUS" != "success" ]; then
     echo "resume_from_plan failed: $RESUME_RESULT" >&2
     exit 1
@@ -120,9 +120,9 @@ fi
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 echo "$NEXT_STEP"
 ```
 

--- a/src/mapify_cli/templates_src/codex/skills/map-efficient/efficient-reference.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-efficient/efficient-reference.md.jinja
@@ -86,7 +86,7 @@ python3 .map/scripts/map_step_runner.py validate_flaky_test_triage
 # Preferred close — the verdict path. Monitor emits valid:false plus
 # disposition {kind: deferred_nondeterministic, check_id: ...}; close 2.4 with
 # the same disposition piped through (see "Verdict-path route" below).
-echo "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
+printf '%s' "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
   validate_step 2.4 --disposition deferred_nondeterministic \
   --check-id "pytest::test_name" --monitor-envelope -
 ```

--- a/src/mapify_cli/templates_src/codex/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-review/SKILL.md.jinja
@@ -117,10 +117,15 @@ fully-committed branch — the normal `/map-check` → `/map-review` state —
 `git diff HEAD` is empty and under-reports the review scope to zero (#426).
 
 ```bash
-BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
-       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
-git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
-git --no-pager diff "${BASE:-HEAD}"...HEAD
+BASE=""
+for ref in origin/main origin/master main master; do
+  git rev-parse --verify --quiet "$ref" >/dev/null && { BASE="$ref"; break; }
+done
+# No default-branch ref: diff the working tree. NEVER "HEAD...HEAD" — that range
+# is always empty and re-creates the very bug this step fixes.
+[ -n "$BASE" ] && RANGE="$BASE...HEAD" || RANGE="HEAD"
+git --no-pager diff --stat "$RANGE"
+git --no-pager diff "$RANGE"
 git status          # uncommitted work in progress — secondary signal
 ```
 

--- a/src/mapify_cli/templates_src/codex/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/codex/skills/map-review/SKILL.md.jinja
@@ -112,9 +112,16 @@ otherwise) and mode semantics.
 
 ### Step A.1: Gather changes
 
+Diff against the **merge-base with the default branch**, not `HEAD`. On a
+fully-committed branch — the normal `/map-check` → `/map-review` state —
+`git diff HEAD` is empty and under-reports the review scope to zero (#426).
+
 ```bash
-git diff HEAD
-git status
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
+git --no-pager diff "${BASE:-HEAD}"...HEAD
+git status          # uncommitted work in progress — secondary signal
 ```
 
 ### Step A.1b: Load canonical review context (bundle + handoff)

--- a/src/mapify_cli/templates_src/hooks/safety-guardrails.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/safety-guardrails.py.jinja
@@ -5,6 +5,9 @@ Safety Guardrails - PreToolUse Hook
 Merged hook that blocks:
 - Access to sensitive files (.env, credentials, private keys)
 - Dangerous shell commands (rm -rf /, force push, etc.)
+- Branch mutation from verifier-class subagents (#424): no git commit/push/reset
+  and no Edit/Write outside `.map/` when `agent_type` names a read-and-report
+  agent. Reads are never restricted.
 
 Trigger: Edit|Write|Bash
 Exit codes:
@@ -226,6 +229,117 @@ def check_autonomy_git_block(command: str) -> tuple[bool, str]:
     return True, ""
 
 
+# =============================================================================
+# Verifier-class capability boundary (#424)
+# =============================================================================
+
+# Agents dispatched with a read-and-report contract. They legitimately write
+# their own review artifacts under `.map/<branch>/`, but must never mutate
+# source or the branch — a final-verifier run once hand-edited generated trees
+# and committed them mid-audit, then reported "working tree clean" for its own
+# post-commit state, masking the breakage from the orchestrating session.
+VERIFIER_AGENT_TYPES = frozenset(
+    {
+        "final-verifier",
+        "monitor",
+        "evaluator",
+        "predictor",
+        "documentation-reviewer",
+    }
+)
+
+# Write scope a verifier keeps: its own branch-scoped artifact directory.
+VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
+
+# git subcommands that mutate the index, the worktree, or history.
+_GIT_MUTATING_SUBCOMMANDS = (
+    "add",
+    "am",
+    "apply",
+    "branch",
+    "checkout",
+    "cherry-pick",
+    "clean",
+    "commit",
+    "merge",
+    "mv",
+    "push",
+    "rebase",
+    "reset",
+    "restore",
+    "revert",
+    "rm",
+    "stash",
+    "switch",
+    "tag",
+    "worktree",
+)
+
+
+def _normalize_agent_type(raw: object) -> str:
+    """Strip plugin scoping (`plugin:pkg:monitor` -> `monitor`) and lowercase."""
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip().split(":")[-1].lower()
+
+
+def is_verifier_agent(agent_type: object) -> bool:
+    """True when the tool call originates from a read-and-report agent."""
+    return _normalize_agent_type(agent_type) in VERIFIER_AGENT_TYPES
+
+
+def check_verifier_command(command: str) -> tuple[bool, str]:
+    """Block git mutations from a verifier-class agent. Returns (is_safe, reason).
+
+    Same token-anchored matching as the autonomy block so `bash -c 'git commit'`
+    and `git -C <path> commit` are caught too. Read-only git (status, diff, log,
+    show, rev-parse, ls-files) stays allowed — it is how a verifier gathers
+    evidence.
+    """
+    if not command:
+        return True, ""
+
+    import re
+
+    pattern = re.compile(
+        r"(?:^|[\s;&|`'\"()])"
+        r"git\s+"
+        r"(?:-\S+\s+|-C\s+\S+\s+|-c\s+\S+\s+)*"
+        r"(?:" + "|".join(_GIT_MUTATING_SUBCOMMANDS) + r")"
+        r"(?:$|[\s;&|`'\"()])",
+        re.IGNORECASE,
+    )
+    match = pattern.search(command)
+    if match:
+        return (
+            False,
+            (
+                f"Blocked: verifier-class agents must not mutate the branch "
+                f"(matched `{match.group(0).strip()}`). Report the finding in your "
+                "verdict instead — the orchestrating session owns all git writes."
+            ),
+        )
+    return True, ""
+
+
+def check_verifier_path(path: str) -> tuple[bool, str]:
+    """Confine verifier writes to `.map/`. Returns (is_safe, reason)."""
+    if not path:
+        return True, ""
+    normalized = path.replace("\\", "/")
+    normalized = normalized.removeprefix("./")
+    if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
+        return True, ""
+    return (
+        False,
+        (
+            f"Blocked: verifier-class agents may only write under `.map/`; "
+            f"refused write to {path}. Report the required change in your verdict "
+            "instead of applying it."
+        ),
+    )
+
+
 def deny(reason: str) -> None:
     """Deny tool execution using structured PreToolUse decision control."""
     print(
@@ -251,6 +365,8 @@ def main() -> None:
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
+    # `agent_type` is present only when the hook fires inside a subagent.
+    verifier = is_verifier_agent(input_data.get("agent_type"))
 
     # Check file-based tools
     if tool_name in ("Edit", "Write", "Read", "MultiEdit"):
@@ -258,6 +374,11 @@ def main() -> None:
         is_safe, reason = check_file_safety(file_path)
         if not is_safe:
             deny(f"{reason} (tool={tool_name})")
+        # Reads stay unrestricted — a verifier must be able to read everything.
+        if verifier and tool_name in ("Edit", "Write", "MultiEdit"):
+            is_safe, reason = check_verifier_path(file_path)
+            if not is_safe:
+                deny(f"{reason} (tool={tool_name})")
 
     # Check bash commands
     elif tool_name == "Bash":
@@ -265,6 +386,10 @@ def main() -> None:
         is_safe, reason = check_command_safety(command)
         if not is_safe:
             deny(f"{reason} (tool={tool_name})")
+        if verifier:
+            is_safe, reason = check_verifier_command(command)
+            if not is_safe:
+                deny(reason)
         is_safe, reason = check_autonomy_git_block(command)
         if not is_safe:
             deny(reason)

--- a/src/mapify_cli/templates_src/hooks/safety-guardrails.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/safety-guardrails.py.jinja
@@ -248,8 +248,10 @@ VERIFIER_AGENT_TYPES = frozenset(
     }
 )
 
-# Write scope a verifier keeps: its own branch-scoped artifact directory.
-VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
+# Write scope a verifier keeps: the project-root `.map/` artifact tree, and only
+# that one. Resolved against CLAUDE_PROJECT_DIR at call time — see
+# check_verifier_path.
+VERIFIER_WRITABLE_DIRNAME = ".map"
 
 # git subcommands that mutate the index, the worktree, refs, history, or config.
 # `pull`/`fetch`/`submodule` are included because they move the very refs the
@@ -338,29 +340,32 @@ def check_verifier_command(command: str) -> tuple[bool, str]:
 
 
 def check_verifier_path(path: str) -> tuple[bool, str]:
-    """Confine verifier writes to `.map/`. Returns (is_safe, reason).
+    """Confine verifier writes to the PROJECT-ROOT `.map/`. Returns (is_safe, reason).
 
-    The path is normalized BEFORE the prefix check: a raw text comparison accepts
-    `.map/../src/mapify_cli/cli.py`, which starts with `.map/` yet resolves outside
-    the allowed workspace.
+    Containment is decided on the resolved path, never on path text. A textual
+    check is bypassable three ways, all of which land outside the artifact tree:
+    `.map/../src/cli.py` (starts with the prefix), `src/.map/payload.py` (contains
+    `/.map/`), and `/elsewhere/.map/x` (an unrelated project's directory).
 
-    This is the outer boundary only. Runner-owned state inside `.map/`
+    This is the outer boundary only. Runner-owned state INSIDE `.map/`
     (`.map/scripts/**`, `step_state.json`, `approval_holds.json`, …) is separately
     protected from direct hand-editing by the workflow-gate state-tamper detector,
     which applies to every caller, not just verifiers.
     """
     if not path:
         return True, ""
-    normalized = os.path.normpath(path.replace("\\", "/")).replace("\\", "/")
-    normalized = normalized.removeprefix("./")
-    if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    map_root = os.path.realpath(os.path.join(project_dir, VERIFIER_WRITABLE_DIRNAME))
+    candidate = path if os.path.isabs(path) else os.path.join(project_dir, path)
+    resolved = os.path.realpath(candidate)
+    if resolved == map_root or resolved.startswith(map_root + os.sep):
         return True, ""
     return (
         False,
         (
-            f"Blocked: verifier-class agents may only write under `.map/`; "
-            f"refused write to {path}. Report the required change in your verdict "
-            "instead of applying it."
+            f"Blocked: verifier-class agents may only write under the project's "
+            f"`{VERIFIER_WRITABLE_DIRNAME}/` artifact tree; refused write to {path}. "
+            "Report the required change in your verdict instead of applying it."
         ),
     )
 

--- a/src/mapify_cli/templates_src/hooks/safety-guardrails.py.jinja
+++ b/src/mapify_cli/templates_src/hooks/safety-guardrails.py.jinja
@@ -251,7 +251,11 @@ VERIFIER_AGENT_TYPES = frozenset(
 # Write scope a verifier keeps: its own branch-scoped artifact directory.
 VERIFIER_WRITABLE_PREFIXES = (".map/", "/.map/")
 
-# git subcommands that mutate the index, the worktree, or history.
+# git subcommands that mutate the index, the worktree, refs, history, or config.
+# `pull`/`fetch`/`submodule` are included because they move the very refs the
+# verifier is auditing; `config`/`update-ref`/`symbolic-ref`/`filter-branch`/`notes`
+# because they rewrite repository state out from under the audit. A verifier needs
+# none of them — the list is deliberately fail-closed.
 _GIT_MUTATING_SUBCOMMANDS = (
     "add",
     "am",
@@ -261,17 +265,28 @@ _GIT_MUTATING_SUBCOMMANDS = (
     "cherry-pick",
     "clean",
     "commit",
+    "config",
+    "fetch",
+    "filter-branch",
+    "gc",
     "merge",
     "mv",
+    "notes",
+    "prune",
+    "pull",
     "push",
     "rebase",
     "reset",
     "restore",
     "revert",
     "rm",
+    "sparse-checkout",
     "stash",
+    "submodule",
     "switch",
+    "symbolic-ref",
     "tag",
+    "update-ref",
     "worktree",
 )
 
@@ -323,10 +338,20 @@ def check_verifier_command(command: str) -> tuple[bool, str]:
 
 
 def check_verifier_path(path: str) -> tuple[bool, str]:
-    """Confine verifier writes to `.map/`. Returns (is_safe, reason)."""
+    """Confine verifier writes to `.map/`. Returns (is_safe, reason).
+
+    The path is normalized BEFORE the prefix check: a raw text comparison accepts
+    `.map/../src/mapify_cli/cli.py`, which starts with `.map/` yet resolves outside
+    the allowed workspace.
+
+    This is the outer boundary only. Runner-owned state inside `.map/`
+    (`.map/scripts/**`, `step_state.json`, `approval_holds.json`, …) is separately
+    protected from direct hand-editing by the workflow-gate state-tamper detector,
+    which applies to every caller, not just verifiers.
+    """
     if not path:
         return True, ""
-    normalized = path.replace("\\", "/")
+    normalized = os.path.normpath(path.replace("\\", "/")).replace("\\", "/")
     normalized = normalized.removeprefix("./")
     if normalized.startswith(VERIFIER_WRITABLE_PREFIXES) or "/.map/" in normalized:
         return True, ""

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -64,8 +64,8 @@ USAGE FROM map-efficient.md:
   ```bash
   # Get next step
   NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-  STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-  INSTRUCTION=$(echo "$NEXT_STEP" | jq -r '.instruction')
+  STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+  INSTRUCTION=$(printf '%s' "$NEXT_STEP" | jq -r '.instruction')
 
   # Execute step based on phase...
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -363,12 +363,25 @@ ACCEPTANCE_COVERAGE_BLOCK_RE = re.compile(
     + re.escape(ACCEPTANCE_COVERAGE_BLOCK_END),
     re.DOTALL,
 )
-# Structural fallback for artifacts written BEFORE the sentinels existed (every
-# already-installed repo has them on disk). Spans the heading up to the next
-# `## ` heading or end of text — the non-greedy body plus the lookahead also
-# handles pr-draft.md, where the whole summary is flattened onto one line.
-ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE = re.compile(
-    r"##\s+Acceptance Coverage.*?(?=##\s+|\Z)", re.DOTALL
+# Fallback for artifacts written BEFORE the sentinels existed (every already-installed
+# repo has them on disk). Deliberately NOT a heading-to-heading span: when the block is
+# the last section — or when pr-draft.md has flattened every newline into a space so no
+# later `## ` is recognisable — a span would swallow the rest of the file and drop
+# genuine citations. These patterns match the generated block's own line grammar
+# instead, so only report-authored text is ever removed.
+ACCEPTANCE_COVERAGE_LEGACY_LINE_RES = (
+    # The per-requirement rows — the only part that carries tags. The evidence
+    # tail is a bounded, comma-separated label list (labels never contain spaces),
+    # NOT `[^\n]*`: an open-ended tail would run past the last row and swallow
+    # whatever prose follows it on a flattened line.
+    re.compile(
+        r"-\s*\[[a-z_]+\]\s*\S+\s+owned by\s+\S+;\s*evidence:\s*"
+        r"[\w:./-]+(?:,\s*[\w:./-]+)*"
+    ),
+    re.compile(r"-\s*Covered tags:\s*\d+/\d+"),
+    re.compile(r"-\s*Missing evidence:\s*\d+"),
+    re.compile(r"-\s*Uncovered:\s*\d+\s*\([^)]*\)"),
+    re.compile(r"##\s+Acceptance Coverage"),
 )
 REVIEW_PROMPT_DEFAULT_BUDGET_TOKENS = 12_000
 REVIEW_PROMPT_MIN_BUDGET_TOKENS = 1_024
@@ -4690,10 +4703,13 @@ def _strip_generated_coverage_blocks(text: str) -> str:
 
     The coverage report must never count its own output as evidence — see
     ACCEPTANCE_COVERAGE_BLOCK_START. Sentinel-delimited blocks are removed exactly;
-    unmarked legacy blocks fall back to the section-heading span.
+    unmarked legacy blocks are removed line-by-line so nothing beyond the report's
+    own output is ever discarded.
     """
     stripped = ACCEPTANCE_COVERAGE_BLOCK_RE.sub(" ", text)
-    return ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE.sub(" ", stripped)
+    for pattern in ACCEPTANCE_COVERAGE_LEGACY_LINE_RES:
+        stripped = pattern.sub(" ", stripped)
+    return stripped
 
 
 def _extract_acceptance_tags(text: object) -> set[str]:
@@ -4875,6 +4891,7 @@ def build_acceptance_coverage_report(
         )
 
     covered = sum(1 for item in requirements if item["status"] == "covered")
+    planned_only = sum(1 for item in requirements if item["status"] == "planned_only")
     missing = len(requirements) - covered
     # Only sources that cited a REAL requirement count as evidence sources. With
     # brackets optional, every source matches incidental tokens (`ST-001`,
@@ -4891,7 +4908,15 @@ def build_acceptance_coverage_report(
         "blueprint_path": str(branch_dir / "blueprint.json"),
         "evidence_sources": tagged_evidence_sources,
         "requirements": requirements,
-        "summary": {"total": len(requirements), "covered": covered, "missing": missing},
+        # `missing` stays the total un-covered count (backward-compatible);
+        # `planned_only` breaks out the review-gap subset so an operator can tell
+        # "nobody verified it" from "nobody even owns it".
+        "summary": {
+            "total": len(requirements),
+            "covered": covered,
+            "missing": missing,
+            "planned_only": planned_only,
+        },
     }
 
 
@@ -4916,11 +4941,15 @@ def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
     total = summary.get("total", 0) if isinstance(summary, dict) else 0
     covered = summary.get("covered", 0) if isinstance(summary, dict) else 0
     missing = summary.get("missing", 0) if isinstance(summary, dict) else 0
+    planned_only = summary.get("planned_only", 0) if isinstance(summary, dict) else 0
     lines = [
         ACCEPTANCE_COVERAGE_BLOCK_START,
         "## Acceptance Coverage",
         f"- Covered tags: {covered}/{total}",
-        f"- Missing evidence: {missing}",
+        (
+            f"- Uncovered: {missing} ({planned_only} planned but unverified, "
+            f"{missing - planned_only} with no evidence at all)"
+        ),
     ]
     requirements = report.get("requirements")
     if isinstance(requirements, list) and requirements:
@@ -12134,6 +12163,15 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         # No default-branch ref to anchor on — degrade to the old HEAD-only view
         # rather than reporting nothing at all.
         diff_range = "HEAD"
+        diff_stat = uncommitted_stat
+        files_changed = list(uncommitted_files)
+
+    if not files_changed and not diff_stat and (uncommitted_files or uncommitted_stat):
+        # Base resolved but the range is empty (nothing committed yet, or sitting on
+        # the default branch) while the working tree carries the whole change.
+        # Reporting "no code diff" here would re-create the always-red gate that
+        # #426 is about, just from the other direction.
+        diff_range = f"{diff_range} (empty; showing uncommitted working tree)"
         diff_stat = uncommitted_stat
         files_changed = list(uncommitted_files)
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -339,7 +339,37 @@ LEARNING_CONSUMPTION_SOURCES = {"auto-handoff", "file-handoff", "inline-summary"
 REVIEW_SECTION_IDS: tuple[str, ...] = ("architecture", "code_quality", "tests", "performance")
 REVIEW_VALID_MODES: tuple[str, ...] = ("default", "reverse-sections", "shuffle-sections")
 LEARNING_IMMEDIATE_WINDOW_SECONDS = 30 * 60
-ACCEPTANCE_TAG_RE = re.compile(r"\[([A-Za-z][A-Za-z0-9_-]*-\d+[A-Za-z0-9_-]*)\]")
+# Requirement tags (AC-1, INV-4, HC-2, SC-1, ...) as they actually appear in
+# artifacts. Brackets are OPTIONAL: reviewer verdicts, commit messages and
+# verification prose write `HC-2 audit: pass`, never `[HC-2]`, so a
+# bracket-only matcher found nothing and the coverage table read 0/N forever.
+# Over-matching (`feat-422`, `ST-001`) is harmless — extracted tags are only
+# ever intersected with the blueprint's coverage_map keys.
+ACCEPTANCE_TAG_RE = re.compile(
+    r"(?<![A-Za-z0-9_])\[?([A-Za-z][A-Za-z0-9_-]*-\d+[A-Za-z0-9_-]*)\]?(?![A-Za-z0-9_])"
+)
+
+# Sentinels around the GENERATED acceptance-coverage block. write_verification_summary
+# appends that block to verification-summary.md, which is itself an evidence source —
+# without an exact exclusion span the report would read its own "AC-1 owned by ST-001"
+# lines back as evidence and report 100% forever. The markers are inline HTML comments
+# so they survive the newline-flattening applied when the summary is embedded in
+# pr-draft.md.
+ACCEPTANCE_COVERAGE_BLOCK_START = "<!-- map:acceptance-coverage:start -->"
+ACCEPTANCE_COVERAGE_BLOCK_END = "<!-- map:acceptance-coverage:end -->"
+ACCEPTANCE_COVERAGE_BLOCK_RE = re.compile(
+    re.escape(ACCEPTANCE_COVERAGE_BLOCK_START)
+    + r".*?"
+    + re.escape(ACCEPTANCE_COVERAGE_BLOCK_END),
+    re.DOTALL,
+)
+# Structural fallback for artifacts written BEFORE the sentinels existed (every
+# already-installed repo has them on disk). Spans the heading up to the next
+# `## ` heading or end of text — the non-greedy body plus the lookahead also
+# handles pr-draft.md, where the whole summary is flattened onto one line.
+ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE = re.compile(
+    r"##\s+Acceptance Coverage.*?(?=##\s+|\Z)", re.DOTALL
+)
 REVIEW_PROMPT_DEFAULT_BUDGET_TOKENS = 12_000
 REVIEW_PROMPT_MIN_BUDGET_TOKENS = 1_024
 REVIEW_PROMPT_BUDGET_ENV = "MAP_REVIEW_PROMPT_BUDGET_TOKENS"
@@ -4655,23 +4685,71 @@ def _load_blueprint_for_coverage(branch_dir: Path) -> tuple[dict[str, object] | 
     return blueprint, ""
 
 
+def _strip_generated_coverage_blocks(text: str) -> str:
+    """Remove every generated acceptance-coverage block from evidence text.
+
+    The coverage report must never count its own output as evidence — see
+    ACCEPTANCE_COVERAGE_BLOCK_START. Sentinel-delimited blocks are removed exactly;
+    unmarked legacy blocks fall back to the section-heading span.
+    """
+    stripped = ACCEPTANCE_COVERAGE_BLOCK_RE.sub(" ", text)
+    return ACCEPTANCE_COVERAGE_LEGACY_BLOCK_RE.sub(" ", stripped)
+
+
 def _extract_acceptance_tags(text: object) -> set[str]:
-    """Return bracketed acceptance/invariant tags found in artifact text."""
+    """Return acceptance/invariant tags found in artifact text (brackets optional)."""
     if not isinstance(text, str) or not text:
         return set()
-    return {match.group(1) for match in ACCEPTANCE_TAG_RE.finditer(text)}
+    return {
+        match.group(1)
+        for match in ACCEPTANCE_TAG_RE.finditer(_strip_generated_coverage_blocks(text))
+    }
+
+
+def _branch_commit_messages() -> str:
+    """Return the branch's commit messages (merge-base..HEAD), or "" on any failure.
+
+    Commit messages are upstream-owned evidence: the Actor writes them at the moment
+    the work lands, they are immutable afterwards, and unlike code comments they are
+    NOT rewritten by the scrub-internal-ids Stop hook. Never raises.
+    """
+
+    def _run_git(args: list[str]) -> str:
+        try:
+            result = subprocess.run(
+                ["git"] + args,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            return result.stdout.strip() if result.returncode == 0 else ""
+        except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
+            return ""
+
+    base_sha, _ = _resolve_review_base(_run_git)
+    if not base_sha:
+        return ""
+    return _run_git(["log", "--format=%B", f"{base_sha}..HEAD"])
 
 
 def _collect_acceptance_evidence_texts(
     branch_dir: Path,
     extra_artifacts: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
-    """Collect review/verification artifact text that can prove acceptance tags."""
+    """Collect review/verification artifact text that can prove acceptance tags.
+
+    Planning artifacts (spec, task plan, plan-review) are deliberately excluded:
+    they state the requirement, they do not prove it. The independent downstream
+    verdicts — reviewer agent outputs and the final verifier — ARE included, because
+    they are the artifacts that actually cite a tag while checking it.
+    """
     evidence: dict[str, str] = {}
     for label, name in (
         ("verification_summary", "verification-summary.md"),
         ("qa", "qa-001.md"),
         ("pr_draft", "pr-draft.md"),
+        ("final_verification", "final_verification.json"),
     ):
         text = _read_branch_artifact_text(branch_dir, name)
         if text:
@@ -4683,7 +4761,12 @@ def _collect_acceptance_evidence_texts(
         if isinstance(text, str) and text:
             evidence[label] = text
 
+    commit_messages = _branch_commit_messages()
+    if commit_messages:
+        evidence["commit_messages"] = _sanitize_for_json(commit_messages)
+
     for pattern, label_prefix in (
+        ("review-agent-*.json", "review_agent"),
         ("test_contract_*.md", "test_contract"),
         ("test_handoff_*.json", "test_handoff"),
     ):
@@ -4771,20 +4854,36 @@ def build_acceptance_coverage_report(
             for source, tags in evidence_tags_by_source.items()
             if requirement in tags
         )
+        if evidence_artifacts:
+            status = "covered"
+        elif validation_criteria_cited:
+            # The blueprint owner names the requirement in its validation criteria,
+            # but nothing downstream verified it. That is a REVIEW gap, not a
+            # decomposition gap — collapsing both into "missing_evidence" hid which
+            # one an operator has to go fix.
+            status = "planned_only"
+        else:
+            status = "missing_evidence"
         requirements.append(
             {
                 "id": requirement,
                 "owner": owner_id,
                 "validation_criteria_cited": validation_criteria_cited,
                 "evidence_artifacts": evidence_artifacts,
-                "status": "covered" if evidence_artifacts else "missing_evidence",
+                "status": status,
             }
         )
 
     covered = sum(1 for item in requirements if item["status"] == "covered")
     missing = len(requirements) - covered
+    # Only sources that cited a REAL requirement count as evidence sources. With
+    # brackets optional, every source matches incidental tokens (`ST-001`,
+    # `feat-422`); listing those would make the field noise.
+    requirement_ids = {str(key) for key in coverage_map}
     tagged_evidence_sources = sorted(
-        source for source, tags in evidence_tags_by_source.items() if tags
+        source
+        for source, tags in evidence_tags_by_source.items()
+        if tags & requirement_ids
     )
     return {
         "status": "success",
@@ -4797,16 +4896,28 @@ def build_acceptance_coverage_report(
 
 
 def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
-    """Render an acceptance coverage report into a compact Markdown section."""
+    """Render an acceptance coverage report into a compact Markdown section.
+
+    The output is fenced with ACCEPTANCE_COVERAGE_BLOCK_START/END so that when it is
+    appended to verification-summary.md — which the report later reads back as an
+    evidence source — the block can be excised exactly instead of counting as proof
+    of the very tags it reports as missing.
+    """
     if report.get("status") != "success":
         reason = report.get("reason", "not available")
-        return "## Acceptance Coverage\n- Status: not available\n- Reason: " + str(reason) + "\n"
+        return (
+            f"{ACCEPTANCE_COVERAGE_BLOCK_START}\n"
+            "## Acceptance Coverage\n- Status: not available\n- Reason: "
+            + str(reason)
+            + f"\n{ACCEPTANCE_COVERAGE_BLOCK_END}\n"
+        )
 
     summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
     total = summary.get("total", 0) if isinstance(summary, dict) else 0
     covered = summary.get("covered", 0) if isinstance(summary, dict) else 0
     missing = summary.get("missing", 0) if isinstance(summary, dict) else 0
     lines = [
+        ACCEPTANCE_COVERAGE_BLOCK_START,
         "## Acceptance Coverage",
         f"- Covered tags: {covered}/{total}",
         f"- Missing evidence: {missing}",
@@ -4825,6 +4936,7 @@ def _render_acceptance_coverage_markdown(report: Mapping[str, object]) -> str:
                 f"- [{item.get('status', 'unknown')}] {item.get('id', 'unknown')} "
                 f"owned by {item.get('owner') or 'unknown'}; evidence: {evidence_text}"
             )
+    lines.append(ACCEPTANCE_COVERAGE_BLOCK_END)
     return "\n".join(lines) + "\n"
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -18614,35 +18614,49 @@ def _worktree_probe(project_dir: Path) -> dict[str, object]:
     return result
 
 
+def _wt_dirty_paths(timeout: int = 15) -> tuple[list[str], str]:
+    """Return ``(dirty porcelain lines, error)`` for the main checkout.
+
+    Single scanner behind every dirty-target decision (#423): the isolation
+    resolver and both merge paths used to each carry their own copy of this
+    filter, which is how ``merge_subtask_worktree`` ended up with no guard at all.
+
+    MAP runtime state (``.map/<branch>/``, ``.codex/``, ``.agents/``) is excluded:
+    in a real target repo those are gitignored, and the guard must care only about
+    the USER's uncommitted source — never refuse because of our own state writes.
+    """
+    st = _wt_git(["status", "--porcelain"], timeout=timeout)
+    if st.returncode != 0:
+        return [], (st.stderr.strip() or "git status failed")
+    return [
+        ln
+        for ln in st.stdout.splitlines()
+        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
+    ], ""
+
+
 def _require_clean_merge_target(project_dir: Path) -> dict[str, object]:
     """Check that the main checkout is clean enough for a worktree merge.
 
     Dormant when worktree.isolation is 'off' (per-repo opt-out / kill-switch — HC-1).
-    When the check is active AND require_clean_merge_target config is True
-    (default True), runs `git status --porcelain` and returns:
+    Otherwise runs `git status --porcelain` and returns:
       * {"status":"ok","ok":True}  when clean (excluding MAP runtime state)
       * {"status":"dirty","ok":False,"kind":"DIRTY_MERGE_TARGET","dirty":[...]}
         when uncommitted changes are present.
     Never raises.
+
+    Reached from ``resolve_worktree_isolation``, which ``worktree_isolation_status``
+    calls — there is no separate ``require_clean_merge_target`` config key: it was
+    a dead toggle nothing consulted (#423), and a clean merge target is not
+    optional for a squash-merge-based accept path.
     """
     mode = _worktree_isolation_mode(project_dir)
     if mode == "off":
         return {"status": "dormant", "ok": False, "reason": "worktree.isolation is off"}
 
-    # Read the require_clean_merge_target flag (default True)
-    raw_require = _map_config_str(project_dir, "require_clean_merge_target", "true")
-    if not _parse_boolish(raw_require):
-        return {"status": "ok", "ok": True, "skipped": True}
-
-    st = _wt_git(["status", "--porcelain"], timeout=15)
-    if st.returncode != 0:
-        return _wt_error("CLEAN_CHECK_FAILED", st.stderr.strip() or "git status failed")
-
-    dirty = [
-        ln
-        for ln in st.stdout.splitlines()
-        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-    ]
+    dirty, error = _wt_dirty_paths()
+    if error:
+        return _wt_error("CLEAN_CHECK_FAILED", error)
     if dirty:
         return {
             "status": "dirty",
@@ -19190,22 +19204,18 @@ def create_subtask_worktree(
         )
 
     if not allow_dirty:
-        status = _wt_git(["status", "--porcelain"])
-        # Exclude MAP runtime state (.map/<branch>/, .codex/, .agents/): in a real
-        # target repo these are gitignored, but the dirty guard must care only
-        # about the USER's uncommitted source — never refuse because of our own
-        # state writes (council Q6 dirty-main/runtime-state interaction).
-        dirty = [
-            ln
-            for ln in status.stdout.splitlines()
-            if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-        ]
+        # MAP runtime state is excluded by _wt_dirty_paths — see its docstring.
+        dirty, clean_error = _wt_dirty_paths()
+        if clean_error:
+            return _wt_error("CLEAN_CHECK_FAILED", clean_error)
         if dirty:
             return _wt_error(
                 "DIRTY_MAIN",
                 "the main checkout has uncommitted changes; the worktree would "
                 "start from committed HEAD and silently diverge. Commit/stash "
-                "first, or pass --allow-dirty.",
+                "first, or pass --allow-dirty (the accept path still requires a "
+                "clean tree, so the changes must be committed or stashed before "
+                "the merge).",
                 dirty=dirty[:20],
             )
 
@@ -19589,6 +19599,61 @@ def _wt_release_lifecycle_lock(handle: Any | None) -> None:
         pass
 
 
+def _wt_dirty_target_guard(branch_name: str, operation: str) -> dict[str, object] | None:
+    """Refuse to squash-merge onto a working tree carrying uncommitted user work.
+
+    Returns ``None`` when the target is clean, otherwise a structured
+    ``DIRTY_TARGET`` error. Shared by the wave coordinator and the single-subtask
+    accept path so both refuse identically — ``merge_subtask_worktree`` previously
+    had no dirty guard at all while the wave path did (#423).
+
+    Emits a pending ``dangerous_action`` approval hold at the refusal (#422) so
+    the approval-hold hard-stop path has a live producer. ``request_summary`` is
+    derived solely from the branch name and operation (no dirty-file list) so
+    ``create_approval_hold``'s (kind, request_summary, pending) dedup keeps
+    repeated refusals against the same dirty tree idempotent; the repo-relative
+    dirty paths ride in ``reason`` instead, never file contents. Hold creation is
+    best-effort: the refusal must still reach the caller even if it fails.
+    """
+    dirty, error = _wt_dirty_paths()
+    if error:
+        return _wt_error("CLEAN_CHECK_FAILED", error)
+    if not dirty:
+        return None
+
+    dirty_paths = [_wt_porcelain_path(ln) for ln in dirty[:20]]
+    hold_id: str | None = None
+    try:
+        hold_result = create_approval_hold(
+            kind="dangerous_action",
+            reason=(
+                f"The working tree has uncommitted changes blocking a {operation}; "
+                "affected paths: " + ", ".join(dirty_paths)
+            ),
+            request_summary=(
+                f"Uncommitted changes blocking {operation} on {branch_name}"
+            ),
+            source="worktree-merge",
+            branch=branch_name,
+            safe_continuation=(
+                f"Commit or stash the listed changes, then retry the {operation}."
+            ),
+        )
+        if hold_result.get("status") == "ok":
+            hold_id = cast(str, hold_result["hold_id"])
+    except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
+        hold_id = None
+
+    error_extra: dict[str, object] = {"dirty": dirty[:20]}
+    if hold_id is not None:
+        error_extra["hold_id"] = hold_id
+    return _wt_error(
+        "DIRTY_TARGET",
+        f"the working tree has uncommitted changes; commit/stash before a {operation}",
+        **error_extra,
+    )
+
+
 def merge_subtask_worktree(
     subtask_id: str,
     attempt: int = 0,
@@ -19645,6 +19710,12 @@ def merge_subtask_worktree(
             base_sha=base_sha,
             working_head=working_head,
         )
+
+    # Same dirty-target refusal the wave coordinator applies: a squash-merge onto
+    # a dirty working branch cannot be rolled back cleanly (#423).
+    dirty_refusal = _wt_dirty_target_guard(branch_name, "subtask merge")
+    if dirty_refusal is not None:
+        return dirty_refusal
 
     prep = _wt_freeze_and_verify(
         subtask_id, record, project_dir, branch_name, verify_cmds, skip_verify
@@ -19883,49 +19954,9 @@ def merge_wave_worktrees(
             "DETACHED_HEAD",
             "refusing to wave-merge onto a detached HEAD; check out the working branch",
         )
-    status = _wt_git(["status", "--porcelain"])
-    dirty = [
-        ln
-        for ln in status.stdout.splitlines()
-        if ln.strip() and not _wt_is_runtime_state_path(_wt_porcelain_path(ln))
-    ]
-    if dirty:
-        # Intent: emit a dangerous_action hold at this refusal (#422 AC-4) so the
-        # approval-hold hard-stop path (#344) has a live producer instead of only
-        # synthetic test fixtures. request_summary is derived solely from the
-        # branch name (no dirty-file-list) so create_approval_hold's
-        # (kind, request_summary, pending) dedup keeps repeated refusals against
-        # the same dirty tree idempotent (INV-2); the repo-relative dirty paths
-        # ride in `reason` instead, never file contents. Hold creation is best-
-        # effort: the refusal must still reach the caller even if it fails.
-        dirty_paths = [_wt_porcelain_path(ln) for ln in dirty[:20]]
-        hold_id: str | None = None
-        try:
-            hold_result = create_approval_hold(
-                kind="dangerous_action",
-                reason=(
-                    "The working tree has uncommitted changes blocking a wave "
-                    "merge; affected paths: " + ", ".join(dirty_paths)
-                ),
-                request_summary=f"Uncommitted changes blocking wave merge on {branch_name}",
-                source="worktree-merge",
-                branch=branch_name,
-                safe_continuation=(
-                    "Commit or stash the listed changes, then retry the wave merge."
-                ),
-            )
-            if hold_result.get("status") == "ok":
-                hold_id = cast(str, hold_result["hold_id"])
-        except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
-            hold_id = None
-        error_extra: dict[str, object] = {"dirty": dirty[:20]}
-        if hold_id is not None:
-            error_extra["hold_id"] = hold_id
-        return _wt_error(
-            "DIRTY_TARGET",
-            "the working tree has uncommitted changes; commit/stash before a wave merge",
-            **error_extra,
-        )
+    dirty_refusal = _wt_dirty_target_guard(branch_name, "wave merge")
+    if dirty_refusal is not None:
+        return dirty_refusal
 
     # Serialize coordinators so two waves never interleave squash commits.
     lock_handle = _wt_acquire_merge_lock()
@@ -20126,8 +20157,50 @@ def merge_wave_worktrees(
         _wt_release_merge_lock(lock_handle)
 
 
+def _wt_isolation_decision(project_dir: Path) -> dict[str, object]:
+    """Flatten ``resolve_worktree_isolation`` into a reportable decision block.
+
+    ``resolve_worktree_isolation`` implements the ST-009 fallback matrix (not a git
+    repo / worktrees unsupported / dirty merge target) but had no production caller
+    until this one (#423) — the reason codes it emits are the same vocabulary
+    ``parallelism_observability`` publishes, so leaving it unwired meant the whole
+    degrade classification was never produced at runtime.
+
+    Always returns success-shaped keys so the status command stays exit-0 and the
+    caller reads ``decision``/``degraded``/``reason`` instead of a mixed envelope.
+    """
+    resolution = resolve_worktree_isolation(project_dir)
+    if resolution.get("status") == "dormant":
+        return {
+            "decision": "sequential",
+            "degraded": False,
+            "degraded_reason": "",
+            "warning": "",
+        }
+    if resolution.get("status") == "error":
+        # mode == 'required' with a fallback condition — isolation cannot run.
+        return {
+            "decision": "abort",
+            "degraded": False,
+            "degraded_reason": str(resolution.get("kind", "")).lower(),
+            "warning": str(resolution.get("message", "")),
+        }
+    return {
+        "decision": str(resolution.get("decision", "isolated")),
+        "degraded": bool(resolution.get("degraded", False)),
+        "degraded_reason": str(resolution.get("reason", "")),
+        "warning": str(resolution.get("warning", "")),
+    }
+
+
 def worktree_isolation_status(branch: str | None = None) -> dict[str, object]:
-    """Report whether isolation is enabled + reconcile recorded vs live worktrees."""
+    """Report whether isolation is enabled + reconcile recorded vs live worktrees.
+
+    Also reports the live isolation DECISION (isolated / sequential / abort) from
+    the fallback matrix, so an operator can see BEFORE a wave starts that e.g. a
+    dirty merge target will degrade the run — rather than discovering it when
+    ``create_subtask_worktree`` refuses mid-flight (#423).
+    """
     project_dir = _wt_project_dir()
     branch_name = branch or get_branch_name()
     state = _read_worktree_state(branch_name)
@@ -20158,10 +20231,12 @@ def worktree_isolation_status(branch: str | None = None) -> dict[str, object]:
         "status": "success",
         "ok": True,
         "enabled": _wt_isolation_enabled(project_dir),
+        "mode": _worktree_isolation_mode(project_dir),
         "branch": branch_name,
         "active_worktrees": active,
         "live_git_worktrees": live,
         "max_deletions": _wt_max_deletions(project_dir),
+        **_wt_isolation_decision(project_dir),
     }
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -1880,16 +1880,24 @@ def _prior_stage_diff_entry(
     file_count = len(files_changed) if isinstance(files_changed, list) else 0
     diff_stat = code_state.get("diff_stat")
     present = code_state.get("status") == "success" and (file_count > 0 or bool(diff_stat))
+    # Name the range the snapshot actually used (#426): a HEAD-only diff on a
+    # fully-committed branch is empty, and reporting the wrong command in the
+    # "missing" reason sent reviewers looking for the wrong problem.
+    diff_range = code_state.get("diff_range") or "HEAD"
     return {
         "key": "code_diff",
         "label": "code diff",
         "kind": "git-diff",
-        "path": "git diff --stat HEAD",
+        "path": f"git diff --stat {diff_range}",
         "required": required,
         "present": present,
         "consumed": present,
         "count": file_count,
-        "reason": "" if present else "missing code diff snapshot; no changed files were visible against HEAD",
+        "reason": (
+            ""
+            if present
+            else f"missing code diff snapshot; no changed files were visible in {diff_range}"
+        ),
     }
 
 
@@ -9284,11 +9292,20 @@ def _render_bundle_markdown(result: dict) -> str:
     if cs_status == "success":
         lines.append(f"- Git ref: `{code_state.get('git_ref', 'unknown')}`")
         lines.append(f"- Branch: `{code_state.get('branch', 'unknown')}`")
+        base_ref = code_state.get("diff_base_ref") or ""
+        diff_range = code_state.get("diff_range") or "HEAD"
+        lines.append(
+            f"- Review target: `{diff_range}`"
+            + (f" (merge-base with `{base_ref}`)" if base_ref else " (no default-branch ref resolved)")
+        )
         files = code_state.get("files_changed", [])
         lines.append(f"- Files changed: {len(files)}")
         diff_stat = code_state.get("diff_stat", "")
         if diff_stat:
             lines.append(f"- Diff stat: {diff_stat[:200]}")
+        uncommitted = code_state.get("uncommitted_files_changed")
+        if isinstance(uncommitted, list):
+            lines.append(f"- Uncommitted (work in progress): {len(uncommitted)} file(s)")
     else:
         lines.append(f"- Status: {cs_status}")
         reason = code_state.get("reason", "")
@@ -11921,12 +11938,50 @@ def run_test_gate() -> dict:
 _DIFF_STAT_MAX_CHARS = 65_536
 _FILES_CHANGED_MAX_ENTRIES = 500
 
+# Candidate default-branch refs, tried in order when resolving the review base.
+# Remote-tracking refs come first: they survive a local branch that was reset or
+# never checked out, which is the common CI/clone shape.
+_REVIEW_BASE_CANDIDATE_REFS = (
+    "origin/main",
+    "origin/master",
+    "main",
+    "master",
+)
+
+
+def _resolve_review_base(run_git: Callable[[list[str]], str]) -> tuple[str, str]:
+    """Return ``(base_sha, base_ref)`` for the branch's review target.
+
+    The review target is the merge-base with the default branch, NOT ``HEAD``:
+    on a fully-committed feature branch (the normal /map-check → /map-review
+    state) ``git diff HEAD`` is empty, so a HEAD-based snapshot self-reports
+    "Files changed: 0" for a branch that actually carries the whole diff (#426).
+
+    Returns ``("", "")`` when no default-branch ref resolves (fresh repo, no
+    remote, shallow clone) — callers then fall back to the uncommitted diff.
+    """
+    for ref in _REVIEW_BASE_CANDIDATE_REFS:
+        if not run_git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"]):
+            continue
+        base = run_git(["merge-base", ref, "HEAD"])
+        if base:
+            return base, ref
+    return "", ""
+
 
 def snapshot_code_state(branch: str | None = None) -> dict:
     """Capture current git state for artifact-to-code verification.
 
     Records git ref, changed files, and diff stat so review artifacts
     can be tied to actual code state. Populates subtask_files_changed.
+
+    ``files_changed``/``diff_stat`` describe the REVIEW TARGET — the range from
+    the merge-base with the default branch up to HEAD — so a branch whose work is
+    already committed still reports its real scope (#426). The uncommitted
+    working-tree diff is kept alongside as a secondary work-in-progress signal
+    (``uncommitted_files_changed``/``uncommitted_diff_stat``). When no
+    default-branch ref resolves, the snapshot degrades to the uncommitted diff and
+    reports ``diff_base_ref=""``.
 
     Very large repos can produce huge ``diff_stat`` and ``files_changed`` outputs that
     bloat the bundle JSON. Both are capped here (``_DIFF_STAT_MAX_CHARS`` /
@@ -11949,10 +12004,26 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         except Exception:  # noqa: BLE001 -- deliberate fallback/resilience boundary, must not propagate
             return ""
 
+    def _names(raw: str) -> list[str]:
+        return [f for f in raw.splitlines() if f.strip()] if raw else []
+
     git_ref = _run_git(["rev-parse", "HEAD"])
-    diff_stat = _run_git(["diff", "--stat", "HEAD"])
-    diff_names = _run_git(["diff", "--name-only", "HEAD"])
-    files_changed = [f for f in diff_names.splitlines() if f.strip()] if diff_names else []
+
+    # Secondary signal: uncommitted work in the main checkout.
+    uncommitted_stat = _run_git(["diff", "--stat", "HEAD"])
+    uncommitted_files = _names(_run_git(["diff", "--name-only", "HEAD"]))
+
+    base_sha, base_ref = _resolve_review_base(_run_git)
+    if base_sha:
+        diff_range = f"{base_sha[:12]}..HEAD"
+        diff_stat = _run_git(["diff", "--stat", base_sha, "HEAD"])
+        files_changed = _names(_run_git(["diff", "--name-only", base_sha, "HEAD"]))
+    else:
+        # No default-branch ref to anchor on — degrade to the old HEAD-only view
+        # rather than reporting nothing at all.
+        diff_range = "HEAD"
+        diff_stat = uncommitted_stat
+        files_changed = list(uncommitted_files)
 
     diff_truncated = False
     if len(diff_stat) > _DIFF_STAT_MAX_CHARS:
@@ -11960,6 +12031,12 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         diff_truncated = True
     if len(files_changed) > _FILES_CHANGED_MAX_ENTRIES:
         files_changed = files_changed[:_FILES_CHANGED_MAX_ENTRIES]
+        diff_truncated = True
+    if len(uncommitted_stat) > _DIFF_STAT_MAX_CHARS:
+        uncommitted_stat = uncommitted_stat[:_DIFF_STAT_MAX_CHARS] + "\n... [truncated]"
+        diff_truncated = True
+    if len(uncommitted_files) > _FILES_CHANGED_MAX_ENTRIES:
+        uncommitted_files = uncommitted_files[:_FILES_CHANGED_MAX_ENTRIES]
         diff_truncated = True
 
     return {
@@ -11969,6 +12046,11 @@ def snapshot_code_state(branch: str | None = None) -> dict:
         "diff_stat": diff_stat,
         "branch": branch_name,
         "diff_truncated": diff_truncated,
+        "diff_base": base_sha[:12] if base_sha else "",
+        "diff_base_ref": base_ref,
+        "diff_range": diff_range,
+        "uncommitted_files_changed": uncommitted_files,
+        "uncommitted_diff_stat": uncommitted_stat,
     }
 
 

--- a/src/mapify_cli/templates_src/map/static-analysis/handlers/common.sh.jinja
+++ b/src/mapify_cli/templates_src/map/static-analysis/handlers/common.sh.jinja
@@ -33,9 +33,9 @@ generate_output() {
 
     # Calculate summary
     local error_count warning_count total_count tools_json
-    error_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
-    warning_count=$(echo "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
-    total_count=$(echo "$all_findings" | jq 'length')
+    error_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity=="error")] | length')
+    warning_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity=="warning")] | length')
+    total_count=$(printf '%s' "$all_findings" | jq 'length')
 
     # Convert tools array to JSON (handle empty array safely)
     if [[ ${#TOOLS_RUN[@]} -gt 0 ]]; then

--- a/src/mapify_cli/templates_src/map/static-analysis/handlers/go.sh.jinja
+++ b/src/mapify_cli/templates_src/map/static-analysis/handlers/go.sh.jinja
@@ -30,7 +30,7 @@ if command -v go &> /dev/null; then
     VET_OUT=$(timeout 30 go vet "$FILES" 2>&1 || true)
 
     if [[ -n "$VET_OUT" ]]; then
-        VET_NORM=$(echo "$VET_OUT" | while IFS= read -r line; do
+        VET_NORM=$(printf '%s\n' "$VET_OUT" | while IFS= read -r line; do
             if parse_colon_delimited "$line" file lineno col msg; then
                 msg="${msg# }"
                 msg=$(json_escape "$msg")
@@ -55,7 +55,7 @@ if command -v gofmt &> /dev/null; then
     fi
 
     if [[ -n "$FMT_OUT" ]]; then
-        FMT_NORM=$(echo "$FMT_OUT" | while IFS= read -r file; do
+        FMT_NORM=$(printf '%s\n' "$FMT_OUT" | while IFS= read -r file; do
             file=$(json_escape "$file")
             echo "{\"tool\":\"gofmt\",\"file\":\"$file\",\"line\":1,\"column\":0,\"severity\":\"warning\",\"code\":\"format\",\"message\":\"File needs formatting\",\"fixable\":true}"
         done | jq -s '.' 2>/dev/null || echo "[]")
@@ -72,7 +72,7 @@ if command -v staticcheck &> /dev/null; then
     if [[ -n "$SC_OUT" ]]; then
         # staticcheck outputs NDJSON (one JSON object per line)
         # Use jq -s to slurp all objects into an array, then transform each
-        SC_NORM=$(echo "$SC_OUT" | jq -s '[.[] | {
+        SC_NORM=$(printf '%s' "$SC_OUT" | jq -s '[.[] | {
             tool: "staticcheck",
             file: .location.file,
             line: .location.line,

--- a/src/mapify_cli/templates_src/map/static-analysis/handlers/python.sh.jinja
+++ b/src/mapify_cli/templates_src/map/static-analysis/handlers/python.sh.jinja
@@ -31,7 +31,7 @@ if command -v ruff &> /dev/null; then
 
     # Normalize ruff output to standard format
     if [[ "$RUFF_OUT" != "[]" && -n "$RUFF_OUT" ]]; then
-        RUFF_NORM=$(echo "$RUFF_OUT" | jq -c '[.[] | {
+        RUFF_NORM=$(printf '%s' "$RUFF_OUT" | jq -c '[.[] | {
             tool: "ruff",
             file: .filename,
             line: .location.row,
@@ -53,7 +53,7 @@ if command -v mypy &> /dev/null; then
 
     # Parse mypy text output to JSON using robust parsing
     if [[ -n "$MYPY_OUT" ]]; then
-        MYPY_NORM=$(echo "$MYPY_OUT" | while IFS= read -r line; do
+        MYPY_NORM=$(printf '%s\n' "$MYPY_OUT" | while IFS= read -r line; do
             if parse_colon_delimited "$line" file lineno col msg; then
                 # Determine severity from message
                 severity="warning"

--- a/src/mapify_cli/templates_src/map/static-analysis/handlers/typescript.sh.jinja
+++ b/src/mapify_cli/templates_src/map/static-analysis/handlers/typescript.sh.jinja
@@ -35,7 +35,7 @@ if command -v eslint &> /dev/null || [[ -x "./node_modules/.bin/eslint" ]]; then
     ESLINT_OUT=$(timeout 60 "$ESLINT_CMD" --format json "$FILES" 2>/dev/null || echo "[]")
 
     if [[ "$ESLINT_OUT" != "[]" && -n "$ESLINT_OUT" ]]; then
-        ESLINT_NORM=$(echo "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
+        ESLINT_NORM=$(printf '%s' "$ESLINT_OUT" | jq -c '[.[] | .filePath as $file | .messages[] | {
             tool: "eslint",
             file: $file,
             line: .line,
@@ -63,7 +63,7 @@ if [[ -f "tsconfig.json" ]]; then
 
         if [[ -n "$TSC_OUT" ]]; then
             # Parse format: file(line,col): error TSxxxx: message
-            TSC_NORM=$(echo "$TSC_OUT" | while IFS= read -r line; do
+            TSC_NORM=$(printf '%s\n' "$TSC_OUT" | while IFS= read -r line; do
                 if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ error\ (TS[0-9]+):\ (.*)$ ]]; then
                     file="${BASH_REMATCH[1]}"
                     linenum="${BASH_REMATCH[2]}"

--- a/src/mapify_cli/templates_src/references/bash-guidelines.md.jinja
+++ b/src/mapify_cli/templates_src/references/bash-guidelines.md.jinja
@@ -39,6 +39,33 @@ head -n 10 logfile.txt  # Direct file read is OK
 
 ---
 
+## ⚠️ CRITICAL: Never pipe a captured variable through `echo`
+
+zsh (the default macOS shell) has a builtin `echo` that interprets backslash
+escapes without `-E`. Piping captured JSON through it turns the `\n`/`\t`
+escapes inside JSON string values into raw C0 control bytes, and `jq` aborts
+with `control characters from U+0000 through U+001F must be escaped`. Inside
+`$(...)` the failure is swallowed, so the variable lands **empty** and the
+recipe writes an empty-bodied artifact with exit 0.
+
+```bash
+# ❌ BAD - mangles escapes under zsh; SUMMARY silently ends up empty
+SUMMARY=$(echo "$BUNDLE" | jq -r '.summary')
+NORM=$(echo "$TOOL_OUT" | while IFS= read -r line; do ...; done)
+
+# ✅ GOOD - printf emits the bytes verbatim
+SUMMARY=$(printf '%s' "$BUNDLE" | jq -r '.summary')
+
+# ✅ GOOD - keep the trailing newline when a `while read` loop consumes it,
+#           otherwise the last line is dropped
+NORM=$(printf '%s\n' "$TOOL_OUT" | while IFS= read -r line; do ...; done)
+```
+
+The convention is enforced by `tests/test_shell_json_pipes.py`, which scans every
+shipped recipe and handler for the banned form.
+
+---
+
 ## When Checking Command Output
 
 ### Pattern 1: Run Commands Directly

--- a/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/SKILL.md.jinja
@@ -115,7 +115,7 @@ if [ -f "$STATE_FILE" ]; then
   echo "Existing step_state.json found — proceeding straight to Step 1 get_next_step."
 elif [ -f "$PLAN_FILE" ]; then
   RESUME_RESULT=$(python3 .map/scripts/map_orchestrator.py resume_from_plan)
-  RESUME_STATUS=$(echo "$RESUME_RESULT" | jq -r '.status')
+  RESUME_STATUS=$(printf '%s' "$RESUME_RESULT" | jq -r '.status')
   if [ "$RESUME_STATUS" = "success" ]; then
     echo "Resumed from /map-plan artifacts."
   else
@@ -141,10 +141,10 @@ fi
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-INSTRUCTION=$(echo "$NEXT_STEP" | jq -r '.instruction')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+INSTRUCTION=$(printf '%s' "$NEXT_STEP" | jq -r '.instruction')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 ```
 
 If `IS_COMPLETE=true`, skip to final verification.

--- a/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
@@ -39,7 +39,7 @@ python3 .map/scripts/map_step_runner.py validate_flaky_test_triage
 # disposition {kind: deferred_nondeterministic, check_id: ...}; close 2.4 with
 # the same disposition piped through. The orchestrator routes to deferral ONLY
 # when the sidecar + envelope back it (see "Verdict-path route" below).
-echo "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
+printf '%s' "$MONITOR_JSON" | python3 .map/scripts/map_orchestrator.py \
   validate_step 2.4 --disposition deferred_nondeterministic \
   --check-id "pytest::test_name" --monitor-envelope -
 ```
@@ -292,7 +292,7 @@ Before invoking Monitor, validate Actor's response is JSON with required
 keys (`files_changed`, `tests_run`):
 
 ```bash
-echo "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
+printf '%s' "$ACTOR_OUTPUT" | python3 .map/scripts/map_step_runner.py \
     detect_truncated_agent_output --agent actor
 ```
 

--- a/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-efficient/efficient-reference.md.jinja
@@ -315,11 +315,11 @@ If `truncated: true`:
 confirmed intact, run:
 
 ```bash
-FILES_DECLARED=$(echo "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
+FILES_DECLARED=$(printf '%s' "$ACTOR_OUTPUT" | jq -r '.files_changed | join(",")')
 MISMATCH=$(detect_actor_files_changed_mismatch "$BRANCH" "$SUBTASK_ID" \
   --declared "$FILES_DECLARED")
 echo "$MISMATCH"
-STATUS_MISMATCH=$(echo "$MISMATCH" | jq -r '.status_mismatch')
+STATUS_MISMATCH=$(printf '%s' "$MISMATCH" | jq -r '.status_mismatch')
 ```
 
 - `status_mismatch == true` — Actor declared files it did not write (mid-edit
@@ -344,8 +344,8 @@ Monitor failure), after `monitor_failed`:
 #    test_failure, gate_failure}. Exit 0 always — this is a sensor, not a gate.
 REC=$(python3 .map/scripts/map_step_runner.py record_failure_signature \
   "$MONITOR_FEEDBACK" "$SUBTASK_ID" --source monitor_rejection)
-ARMED=$(echo "$REC" | jq -r '.armed')
-ESCALATE=$(echo "$REC" | jq -r '.escalation_recommended')
+ARMED=$(printf '%s' "$REC" | jq -r '.armed')
+ESCALATE=$(printf '%s' "$REC" | jq -r '.escalation_recommended')
 
 # 2. If armed (same normalized failure >= 2x), prepend the hard constraint to
 #    the TOP of the next Actor prompt. Pass --quarantine-active when CLEAN_RETRY
@@ -380,7 +380,7 @@ fi
       build_escalation_outcome "$SUBTASK_ID" repeated_failure)
     #  Pass --quarantine-active on a CLEAN_RETRY iteration: it returns
     #  status:"deferred" so the one-shot reset runs before any terminal stop.
-    STATUS=$(echo "$OUT" | jq -r '.status')
+    STATUS=$(printf '%s' "$OUT" | jq -r '.status')
     #  status:"escalated"-> surface OUT.blocker_summary + OUT.recommended_action
     #    to the user and STOP (outcome:"BLOCKED", .map/<branch>/escalation_*.md).
     #  status:"not_escalated" -> the LATEST failure was a NEW signature; the
@@ -418,7 +418,7 @@ Before dispatching Monitor, run the blast-radius detector:
 BLAST=$(python3 .map/scripts/map_step_runner.py \
   detect_symbol_blast_radius "$BRANCH" "$SUBTASK_ID")
 echo "$BLAST"   # inspect changed_symbols / external_callers / reason
-GATE=$(echo "$BLAST" | jq -r '.recommended_gate')
+GATE=$(printf '%s' "$BLAST" | jq -r '.recommended_gate')
 ```
 
 - `recommended_gate == "validate_callers"` — the subtask changed a
@@ -449,7 +449,7 @@ scoped run is safe:
 RISK=$(python3 .map/scripts/map_step_runner.py \
   detect_cross_subtask_regression_risk "$BRANCH" "$SUBTASK_ID")
 echo "$RISK"   # inspect shared_source_files / prior_owners / reason
-GATE=$(echo "$RISK" | jq -r '.recommended_gate')
+GATE=$(printf '%s' "$RISK" | jq -r '.recommended_gate')
 ```
 
 - `recommended_gate == "full_suite"` — the current diff overlaps a file a

--- a/src/mapify_cli/templates_src/skills/map-release/release-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-release/release-reference.md.jinja
@@ -277,7 +277,7 @@ CURRENT_BRANCH=$(git branch --show-current)
 [[ "$CURRENT_BRANCH" != "main" ]] && echo "❌ ABORT: Not on main branch" && exit 1
 
 LATEST_RUN=$(gh run list --branch main --limit 1 --json conclusion,status,createdAt,headBranch --jq '.[0]')
-RUN_CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
+RUN_CONCLUSION=$(printf '%s' "$LATEST_RUN" | jq -r '.conclusion')
 [[ "$RUN_CONCLUSION" != "success" ]] && echo "❌ ABORT: Latest CI did not succeed" && exit 1
 
 LAST_TAG=$(git tag --sort=-version:refname | head -1)
@@ -324,13 +324,13 @@ echo "Waiting for release workflow to start..."
 sleep 10
 
 RELEASE_RUN=$(gh run list --workflow=release.yml --limit 1 --json databaseId,status,conclusion,createdAt)
-RUN_ID=$(echo "$RELEASE_RUN" | jq -r '.[0].databaseId')
+RUN_ID=$(printf '%s' "$RELEASE_RUN" | jq -r '.[0].databaseId')
 
 if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
   echo "⚠️  Workflow not started yet; retrying in 30s..."
   sleep 30
   RELEASE_RUN=$(gh run list --workflow=release.yml --limit 1 --json databaseId,status,conclusion,createdAt)
-  RUN_ID=$(echo "$RELEASE_RUN" | jq -r '.[0].databaseId')
+  RUN_ID=$(printf '%s' "$RELEASE_RUN" | jq -r '.[0].databaseId')
 fi
 
 echo "Workflow URL: https://github.com/azalio/map-framework/actions/runs/$RUN_ID"

--- a/src/mapify_cli/templates_src/skills/map-resume/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-resume/SKILL.md.jinja
@@ -189,9 +189,9 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 
 # Get next step from orchestrator (reads step_state.json internally)
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-STEP_ID=$(echo "$NEXT_STEP" | jq -r '.step_id')
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
-IS_COMPLETE=$(echo "$NEXT_STEP" | jq -r '.is_complete')
+STEP_ID=$(printf '%s' "$NEXT_STEP" | jq -r '.step_id')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
+IS_COMPLETE=$(printf '%s' "$NEXT_STEP" | jq -r '.is_complete')
 ```
 
 **Then follow the same phase routing as /map-efficient:**

--- a/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
@@ -270,10 +270,15 @@ fully-committed branch — the normal `/map-check` → `/map-review` state —
 `git diff HEAD` is empty and under-reports the review scope to zero (#426).
 
 ```bash
-BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
-       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
-git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
-git --no-pager diff "${BASE:-HEAD}"...HEAD
+BASE=""
+for ref in origin/main origin/master main master; do
+  git rev-parse --verify --quiet "$ref" >/dev/null && { BASE="$ref"; break; }
+done
+# No default-branch ref: diff the working tree. NEVER "HEAD...HEAD" — that range
+# is always empty and re-creates the very bug this step fixes.
+[ -n "$BASE" ] && RANGE="$BASE...HEAD" || RANGE="HEAD"
+git --no-pager diff --stat "$RANGE"
+git --no-pager diff "$RANGE"
 git status          # uncommitted work in progress — secondary signal
 ```
 

--- a/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
@@ -265,9 +265,16 @@ Mode semantics:
 
 ### Step A.1: Gather changes
 
+Diff against the **merge-base with the default branch**, not `HEAD`. On a
+fully-committed branch — the normal `/map-check` → `/map-review` state —
+`git diff HEAD` is empty and under-reports the review scope to zero (#426).
+
 ```bash
-git diff HEAD
-git status
+BASE=$(git rev-parse --verify --quiet origin/main >/dev/null && echo origin/main \
+       || (git rev-parse --verify --quiet origin/master >/dev/null && echo origin/master))
+git --no-pager diff --stat "${BASE:-HEAD}"...HEAD
+git --no-pager diff "${BASE:-HEAD}"...HEAD
+git status          # uncommitted work in progress — secondary signal
 ```
 
 ### Step A.1b: Load canonical review context (bundle + handoff)

--- a/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-review/SKILL.md.jinja
@@ -276,7 +276,7 @@ Run this before any reviewer agent:
 
 ```bash
 BUNDLE_JSON=$(python3 .map/scripts/map_step_runner.py create_review_bundle)
-BUNDLE_JSON_PATH=$(echo "$BUNDLE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['bundle_path_json'])")
+BUNDLE_JSON_PATH=$(printf '%s' "$BUNDLE_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['bundle_path_json'])")
 ```
 
 This creates `.map/<branch>/review-bundle.json` and `.map/<branch>/review-bundle.md`. These are PRIMARY review context. The bundle includes prior-stage consumption status; missing inputs are review evidence, not invisible setup noise.
@@ -288,9 +288,9 @@ DETACHED_PATH=""
 if [ "$DETACHED_FLAG" = "true" ]; then
   # EC-15: prepare detached review once; compare runs reuse the same path.
   DETACHED_JSON=$(python3 .map/scripts/map_step_runner.py prepare_detached_review "$BUNDLE_JSON_PATH")
-  DETACHED_STATUS=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))")
-  DETACHED_PATH=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('worktree_path') or '')")
-  DETACHED_REASON=$(echo "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reason') or '')")
+  DETACHED_STATUS=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))")
+  DETACHED_PATH=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('worktree_path') or '')")
+  DETACHED_REASON=$(printf '%s' "$DETACHED_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reason') or '')")
 fi
 ```
 

--- a/src/mapify_cli/templates_src/skills/map-task/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-task/SKILL.md.jinja
@@ -80,10 +80,10 @@ if [ -f ".map/${BRANCH}/test_handoff_${SUBTASK_ID}.json" ] && [ -f ".map/${BRANC
 else
   RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID")
 fi
-STATUS=$(echo "$RESULT" | jq -r '.status')
+STATUS=$(printf '%s' "$RESULT" | jq -r '.status')
 
 if [ "$STATUS" = "error" ]; then
-  echo "$RESULT" | jq -r '.message'
+  printf '%s' "$RESULT" | jq -r '.message'
   exit 1
 fi
 ```
@@ -125,7 +125,7 @@ Follow the same state machine loop as `/map-efficient`. Call `get_next_step` and
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from `/map-efficient` work identically:
@@ -170,10 +170,10 @@ python3 .map/scripts/map_step_runner.py update_plan_status "${SUBTASK_ID}" "comp
 2. Get overall plan progress:
 ```bash
 PROGRESS=$(python3 .map/scripts/map_orchestrator.py get_plan_progress)
-TOTAL=$(echo "$PROGRESS" | jq -r '.total')
-DONE=$(echo "$PROGRESS" | jq -r '.completed_count')
-REMAINING=$(echo "$PROGRESS" | jq -r '.pending_count')
-SUGGESTED=$(echo "$PROGRESS" | jq -r '.suggested_next')
+TOTAL=$(printf '%s' "$PROGRESS" | jq -r '.total')
+DONE=$(printf '%s' "$PROGRESS" | jq -r '.completed_count')
+REMAINING=$(printf '%s' "$PROGRESS" | jq -r '.pending_count')
+SUGGESTED=$(printf '%s' "$PROGRESS" | jq -r '.suggested_next')
 ```
 
 3. Display completion report with remaining subtasks:

--- a/src/mapify_cli/templates_src/skills/map-tdd/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-tdd/SKILL.md.jinja
@@ -115,10 +115,10 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -E 's|/|-|g; s|[^a-zA-Z0-9_.-]|-|
 
 ```bash
 RESULT=$(python3 .map/scripts/map_orchestrator.py resume_single_subtask "$SUBTASK_ID" --tdd)
-STATUS=$(echo "$RESULT" | jq -r '.status')
+STATUS=$(printf '%s' "$RESULT" | jq -r '.status')
 
 if [ "$STATUS" = "error" ]; then
-  echo "$RESULT" | jq -r '.message'
+  printf '%s' "$RESULT" | jq -r '.message'
   # If no plan: "Run /map-plan first"
   # If subtask not found: shows available IDs
   exit 1
@@ -185,7 +185,7 @@ Call `get_next_step` and execute based on the returned phase.
 
 ```bash
 NEXT_STEP=$(python3 .map/scripts/map_orchestrator.py get_next_step)
-PHASE=$(echo "$NEXT_STEP" | jq -r '.phase')
+PHASE=$(printf '%s' "$NEXT_STEP" | jq -r '.phase')
 ```
 
 Route to the appropriate executor based on `$PHASE`. All phases from /map-efficient work identically.

--- a/tests/hooks/test_safety_guardrails.py
+++ b/tests/hooks/test_safety_guardrails.py
@@ -612,6 +612,13 @@ class TestVerifierAgentBoundary:
             "git -C /repo commit --no-verify -m x",
             "bash -c 'git commit -m sneaky'",
             "make check && git commit -am wip",
+            # Ref-moving commands change the very branch under audit.
+            "git pull --rebase origin main",
+            "git fetch origin",
+            "git submodule update --init",
+            "git update-ref refs/heads/main HEAD",
+            "git symbolic-ref HEAD refs/heads/other",
+            "git config user.email x@y.z",
         ],
     )
     def test_git_mutation_blocked_for_verifiers(self, agent, command):
@@ -686,6 +693,21 @@ class TestVerifierAgentBoundary:
         exit_code, stdout, _ = run_hook_as_agent("Write", {"file_path": path}, agent)
         assert exit_code == 0
         assert _parse_stdout(stdout) == {}, f"{path!r} was wrongly blocked"
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".map/../src/mapify_cli/cli.py",
+            ".map/feat-x/../../.claude/hooks/workflow-gate.py",
+            "./.map/../README.md",
+        ],
+    )
+    def test_traversal_out_of_map_is_blocked(self, agent, path):
+        """A raw prefix check accepts `.map/../src/...`; normalize before matching."""
+        exit_code, stdout, _ = run_hook_as_agent("Write", {"file_path": path}, agent)
+        assert exit_code == 0
+        _assert_denied(_parse_stdout(stdout))
 
     @pytest.mark.parametrize("agent", VERIFIERS)
     def test_reads_are_never_restricted(self, agent):

--- a/tests/hooks/test_safety_guardrails.py
+++ b/tests/hooks/test_safety_guardrails.py
@@ -685,14 +685,34 @@ class TestVerifierAgentBoundary:
         [
             ".map/feat-x/final_verification.json",
             "./.map/feat-x/progress_feat-x.md",
-            "/abs/repo/.map/feat-x/code-review-001.md",
+            str(HOOK_PATH.parent.parent.parent / ".map" / "feat-x" / "code-review-001.md"),
         ],
     )
     def test_map_artifact_writes_allowed_for_verifiers(self, agent, path):
-        """final-verifier legitimately writes its own verdict artifacts."""
+        """final-verifier legitimately writes its own verdict artifacts, whether it
+        names them relative to the project root or by absolute path."""
         exit_code, stdout, _ = run_hook_as_agent("Write", {"file_path": path}, agent)
         assert exit_code == 0
         assert _parse_stdout(stdout) == {}, f"{path!r} was wrongly blocked"
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # A nested `.map/` is not the project's artifact tree.
+            "src/.map/payload.py",
+            "src/mapify_cli/.map/cli.py",
+            # Another project's `.map/` is out of bounds too.
+            "/tmp/other-repo/.map/feat-x/anything.py",
+            "../sibling-repo/.map/feat-x/anything.py",
+        ],
+    )
+    def test_foreign_or_nested_map_dirs_are_blocked(self, agent, path):
+        """Containment is decided on the RESOLVED path against CLAUDE_PROJECT_DIR —
+        a substring check on `/.map/` accepts all of these."""
+        exit_code, stdout, _ = run_hook_as_agent("Write", {"file_path": path}, agent)
+        assert exit_code == 0
+        _assert_denied(_parse_stdout(stdout))
 
     @pytest.mark.parametrize("agent", VERIFIERS)
     @pytest.mark.parametrize(

--- a/tests/hooks/test_safety_guardrails.py
+++ b/tests/hooks/test_safety_guardrails.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -558,6 +559,157 @@ class TestDirectoryNameFalsePositives:
         exit_code, stdout, _ = run_hook_file("Read", path)
         assert exit_code == 0
         _assert_denied(_parse_stdout(stdout))
+
+
+# =============================================================================
+# Verifier-class capability boundary (#424)
+# =============================================================================
+
+
+def run_hook_as_agent(
+    tool_name: str, tool_input: dict, agent_type: str | None
+) -> tuple[int, str, str]:
+    """Execute the hook with an explicit `agent_type` (subagent context)."""
+    input_data: dict[str, object] = {
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+    }
+    if agent_type is not None:
+        input_data["agent_type"] = agent_type
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+class TestVerifierAgentBoundary:
+    """A final-verifier run created and committed `3c6a7db` mid-audit, hand-editing
+    generated trees and renaming a blueprint-named test, despite an
+    APPROVED/REJECTED-only prompt contract. Prompt text is not a capability
+    boundary — these tests pin the mechanical one."""
+
+    VERIFIERS: ClassVar[list[str]] = [
+        "final-verifier",
+        "monitor",
+        "evaluator",
+        "predictor",
+    ]
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git commit -m 'chore(map): strip internal workflow IDs'",
+            "git add -A",
+            "git push origin HEAD",
+            "git reset --soft HEAD~1",
+            "git checkout -- src/",
+            "git restore .claude/hooks/workflow-gate.py",
+            "git -C /repo commit --no-verify -m x",
+            "bash -c 'git commit -m sneaky'",
+            "make check && git commit -am wip",
+        ],
+    )
+    def test_git_mutation_blocked_for_verifiers(self, agent, command):
+        exit_code, stdout, _ = run_hook_as_agent("Bash", {"command": command}, agent)
+        assert exit_code == 0
+        _assert_denied(_parse_stdout(stdout))
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git diff origin/main...HEAD",
+            "git log -n 5",
+            "git show HEAD",
+            "git rev-parse HEAD",
+            "git ls-files src/",
+            "make check",
+            "pytest tests/ -q",
+        ],
+    )
+    def test_read_only_evidence_gathering_still_allowed(self, agent, command):
+        """The verifier must keep every read/verify capability it needs."""
+        exit_code, stdout, _ = run_hook_as_agent("Bash", {"command": command}, agent)
+        assert exit_code == 0
+        assert _parse_stdout(stdout) == {}, f"{command!r} was wrongly blocked"
+
+    def test_git_mutation_allowed_on_main_thread(self):
+        """Negative proof: without agent_type the boundary must not engage —
+        the orchestrating session owns commits."""
+        exit_code, stdout, _ = run_hook_as_agent(
+            "Bash", {"command": "git commit -m 'ST-001: real work'"}, None
+        )
+        assert exit_code == 0
+        assert _parse_stdout(stdout) == {}
+
+    def test_git_mutation_allowed_for_actor(self):
+        """actor is a legitimate writer — it must keep committing its subtask."""
+        exit_code, stdout, _ = run_hook_as_agent(
+            "Bash", {"command": "git commit -m 'ST-001: real work'"}, "actor"
+        )
+        assert exit_code == 0
+        assert _parse_stdout(stdout) == {}
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    @pytest.mark.parametrize("tool", ["Edit", "Write", "MultiEdit"])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".claude/hooks/workflow-gate.py",
+            "src/mapify_cli/templates/map/scripts/map_step_runner.py",
+            "tests/test_workflow_gate.py",
+            "README.md",
+        ],
+    )
+    def test_source_writes_blocked_for_verifiers(self, agent, tool, path):
+        exit_code, stdout, _ = run_hook_as_agent(tool, {"file_path": path}, agent)
+        assert exit_code == 0
+        _assert_denied(_parse_stdout(stdout))
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".map/feat-x/final_verification.json",
+            "./.map/feat-x/progress_feat-x.md",
+            "/abs/repo/.map/feat-x/code-review-001.md",
+        ],
+    )
+    def test_map_artifact_writes_allowed_for_verifiers(self, agent, path):
+        """final-verifier legitimately writes its own verdict artifacts."""
+        exit_code, stdout, _ = run_hook_as_agent("Write", {"file_path": path}, agent)
+        assert exit_code == 0
+        assert _parse_stdout(stdout) == {}, f"{path!r} was wrongly blocked"
+
+    @pytest.mark.parametrize("agent", VERIFIERS)
+    def test_reads_are_never_restricted(self, agent):
+        exit_code, stdout, _ = run_hook_as_agent(
+            "Read", {"file_path": "src/mapify_cli/cli.py"}, agent
+        )
+        assert exit_code == 0
+        assert _parse_stdout(stdout) == {}
+
+    def test_plugin_scoped_agent_type_is_normalized(self):
+        """`plugin:pkg:monitor` must resolve to the monitor boundary."""
+        exit_code, stdout, _ = run_hook_as_agent(
+            "Bash", {"command": "git commit -m x"}, "plugin:some-pkg:monitor"
+        )
+        assert exit_code == 0
+        _assert_denied(_parse_stdout(stdout))
+
+    def test_source_write_allowed_on_main_thread(self):
+        """Negative proof for the path boundary: no agent_type → no confinement."""
+        exit_code, stdout, _ = run_hook_as_agent(
+            "Write", {"file_path": "src/mapify_cli/cli.py"}, None
+        )
+        assert exit_code == 0
+        assert _parse_stdout(stdout) == {}
 
 
 # =============================================================================

--- a/tests/test_agent_frontmatter.py
+++ b/tests/test_agent_frontmatter.py
@@ -330,9 +330,32 @@ class TestAgentCapabilityHardening:
             "actor is a legitimate writer — do not add disallowedTools"
         )
 
-    def test_final_verifier_has_no_disallowed_tools(self):
-        """final-verifier is a legitimate writer and must NOT be capability-restricted."""
+    def test_final_verifier_has_edit_in_disallowed_tools(self):
+        """#424 supersedes the #378 'final-verifier is unrestricted' contract.
+
+        A final-verifier run hand-edited generated trees and committed them
+        mid-audit under an APPROVED/REJECTED-only prompt contract. Edit is now
+        denied at the harness level.
+        """
         fm = self._load_frontmatter("final-verifier")
-        assert "disallowedTools" not in fm, (
-            "final-verifier is a legitimate writer — do not add disallowedTools"
+        disallowed = fm.get("disallowedTools", [])
+        assert "Edit" in disallowed, (
+            "final-verifier must deny Edit — it audits, it does not fix"
+        )
+
+    def test_final_verifier_has_agent_in_disallowed_tools(self):
+        fm = self._load_frontmatter("final-verifier")
+        disallowed = fm.get("disallowedTools", [])
+        assert "Agent" in disallowed, (
+            "final-verifier must deny Agent — it must not spawn sub-agents"
+        )
+
+    def test_final_verifier_write_not_denied(self):
+        """final-verifier IS allowed to Write — it owns .map/<branch>/
+        final_verification.json + the progress markdown. The hook confines those
+        writes to `.map/` (#424); the frontmatter must not remove Write outright."""
+        fm = self._load_frontmatter("final-verifier")
+        disallowed = fm.get("disallowedTools", [])
+        assert "Write" not in disallowed, (
+            "final-verifier needs Write for .map/ verdict artifacts — do not deny it"
         )

--- a/tests/test_agent_frontmatter.py
+++ b/tests/test_agent_frontmatter.py
@@ -330,32 +330,25 @@ class TestAgentCapabilityHardening:
             "actor is a legitimate writer — do not add disallowedTools"
         )
 
-    def test_final_verifier_has_edit_in_disallowed_tools(self):
-        """#424 supersedes the #378 'final-verifier is unrestricted' contract.
-
-        A final-verifier run hand-edited generated trees and committed them
-        mid-audit under an APPROVED/REJECTED-only prompt contract. Edit is now
-        denied at the harness level.
-        """
-        fm = self._load_frontmatter("final-verifier")
-        disallowed = fm.get("disallowedTools", [])
-        assert "Edit" in disallowed, (
-            "final-verifier must deny Edit — it audits, it does not fix"
-        )
-
     def test_final_verifier_has_agent_in_disallowed_tools(self):
+        """#424 supersedes the #378 'final-verifier is unrestricted' contract."""
         fm = self._load_frontmatter("final-verifier")
         disallowed = fm.get("disallowedTools", [])
         assert "Agent" in disallowed, (
             "final-verifier must deny Agent — it must not spawn sub-agents"
         )
 
-    def test_final_verifier_write_not_denied(self):
-        """final-verifier IS allowed to Write — it owns .map/<branch>/
-        final_verification.json + the progress markdown. The hook confines those
-        writes to `.map/` (#424); the frontmatter must not remove Write outright."""
+    @pytest.mark.parametrize("tool", ["Edit", "Write"])
+    def test_final_verifier_keeps_map_write_capabilities(self, tool):
+        """final-verifier's own contract requires an in-place append to
+        `.map/<branch>/progress_<branch>.md` and a `[ ]` -> `[x]` update in the
+        task-plan Acceptance Criteria table. Denying Edit would force those through
+        whole-file Write and drop surrounding content. The boundary is enforced by
+        SCOPE instead — safety-guardrails.py confines every verifier write to
+        `.map/` (#424) — not by removing the capability."""
         fm = self._load_frontmatter("final-verifier")
         disallowed = fm.get("disallowedTools", [])
-        assert "Write" not in disallowed, (
-            "final-verifier needs Write for .map/ verdict artifacts — do not deny it"
+        assert tool not in disallowed, (
+            f"final-verifier needs {tool} for its .map/ artifacts; the `.map/` scope "
+            "check in safety-guardrails.py is the boundary, not a blanket denial"
         )

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3069,7 +3069,9 @@ def test_acceptance_coverage_report_tracks_downstream_evidence(branch_workspace)
     result = map_step_runner.build_acceptance_coverage_report()
 
     assert result["status"] == "success"
-    assert result["summary"] == {"total": 2, "covered": 1, "missing": 1}
+    assert result["summary"] == {
+        "total": 2, "covered": 1, "missing": 1, "planned_only": 1,
+    }
     requirements = {item["id"]: item for item in result["requirements"]}
     assert requirements["AC-1"]["status"] == "covered"
     assert requirements["AC-1"]["evidence_artifacts"] == ["verification_summary"]
@@ -3109,7 +3111,9 @@ def test_acceptance_coverage_report_ignores_planning_artifacts(branch_workspace)
 
     result = map_step_runner.build_acceptance_coverage_report()
 
-    assert result["summary"] == {"total": 1, "covered": 0, "missing": 1}
+    assert result["summary"] == {
+        "total": 1, "covered": 0, "missing": 1, "planned_only": 1,
+    }
     assert result["evidence_sources"] == []
     # Cited by the owner's validation criteria, proven by nothing downstream.
     assert result["requirements"][0]["status"] == "planned_only"
@@ -3153,7 +3157,9 @@ def test_acceptance_coverage_counts_unbracketed_citations(branch_workspace):
 
     result = map_step_runner.build_acceptance_coverage_report()
 
-    assert result["summary"] == {"total": 1, "covered": 1, "missing": 0}
+    assert result["summary"] == {
+        "total": 1, "covered": 1, "missing": 0, "planned_only": 0,
+    }
     assert result["requirements"][0]["evidence_artifacts"] == ["verification_summary"]
 
 
@@ -3246,7 +3252,68 @@ def test_acceptance_coverage_ignores_unmarked_legacy_block(branch_workspace):
     # inside the report's own output and must NOT count.
     assert requirements["HC-2"]["status"] == "covered"
     assert requirements["AC-1"]["status"] == "planned_only"
-    assert result["summary"] == {"total": 2, "covered": 1, "missing": 1}
+    assert result["summary"] == {
+        "total": 2, "covered": 1, "missing": 1, "planned_only": 1,
+    }
+
+
+def test_acceptance_coverage_legacy_strip_preserves_trailing_evidence(branch_workspace):
+    """A heading-to-heading span would swallow everything after a trailing legacy
+    coverage block — including genuine citations. The strip matches the generated
+    block's own line grammar instead, so evidence AFTER it survives even when no
+    further `## ` heading exists (the flattened pr-draft.md shape)."""
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(
+            _coverage_blueprint(
+                ["VC1 [AC-1]: timeout", "VC2 [SC-1]: no leak"],
+                {"AC-1": "ST-001", "SC-1": "ST-001"},
+            )
+        )
+    )
+    (branch_workspace / "pr-draft.md").write_text(
+        "# PR Draft ## Validation "
+        "## Acceptance Coverage - Covered tags: 0/2 - Missing evidence: 2 "
+        "- [missing_evidence] AC-1 owned by ST-001; evidence: missing "
+        "- [missing_evidence] SC-1 owned by ST-001; evidence: missing "
+        # Genuine citation AFTER the block, with no further `## ` heading.
+        "Reviewer confirmed SC-1 by inspecting the redaction path.\n",
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    requirements = {item["id"]: item for item in result["requirements"]}
+    assert requirements["SC-1"]["status"] == "covered", (
+        "the trailing genuine citation must survive the legacy-block strip"
+    )
+    assert requirements["AC-1"]["status"] == "planned_only", (
+        "AC-1 appears only inside the report's own output — not evidence"
+    )
+
+
+def test_acceptance_coverage_summary_separates_planned_only(branch_workspace):
+    """`missing` stays the total un-covered count; `planned_only` breaks out the
+    review-gap subset so the two failure modes are separable."""
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(
+            _coverage_blueprint(
+                ["VC1 [AC-1]: timeout"],  # AC-1 planned, INV-9 owned by nothing
+                {"AC-1": "ST-001", "INV-9": "ST-001"},
+            )
+        )
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    assert result["summary"] == {
+        "total": 2,
+        "covered": 0,
+        "missing": 2,
+        "planned_only": 1,
+    }
+    rendered = map_step_runner._render_acceptance_coverage_markdown(result)
+    assert "1 planned but unverified" in rendered
+    assert "1 with no evidence at all" in rendered
 
 
 def test_acceptance_coverage_accepts_independent_verdict_artifacts(branch_workspace):
@@ -3272,7 +3339,9 @@ def test_acceptance_coverage_accepts_independent_verdict_artifacts(branch_worksp
     result = map_step_runner.build_acceptance_coverage_report()
 
     requirements = {item["id"]: item for item in result["requirements"]}
-    assert result["summary"] == {"total": 2, "covered": 2, "missing": 0}
+    assert result["summary"] == {
+        "total": 2, "covered": 2, "missing": 0, "planned_only": 0,
+    }
     assert requirements["AC-1"]["evidence_artifacts"] == ["final_verification"]
     assert requirements["SC-1"]["evidence_artifacts"] == [
         "review_agent:review-agent-monitor.json"
@@ -3315,7 +3384,9 @@ def test_acceptance_coverage_accepts_branch_commit_messages(tmp_path, monkeypatc
 
     result = map_step_runner.build_acceptance_coverage_report(branch="feat-x")
 
-    assert result["summary"] == {"total": 2, "covered": 2, "missing": 0}
+    assert result["summary"] == {
+        "total": 2, "covered": 2, "missing": 0, "planned_only": 0,
+    }
     assert result["evidence_sources"] == ["commit_messages"]
 
 
@@ -3349,6 +3420,7 @@ def test_write_verification_summary_appends_acceptance_coverage(branch_workspace
         "total": 1,
         "covered": 1,
         "missing": 0,
+        "planned_only": 0,
     }
     summary = (branch_workspace / "verification-summary.md").read_text(encoding="utf-8")
     assert "## Acceptance Coverage" in summary
@@ -5081,6 +5153,46 @@ class TestSnapshotCodeState:
         assert result["diff_base_ref"] == ""
         assert result["diff_range"] == "HEAD"
         assert result["files_changed"] == ["wip.py"]
+
+    def test_empty_merge_base_range_falls_back_to_working_tree(self, monkeypatch):
+        """#426: base resolves but nothing is committed yet (or we sit on the
+        default branch), so `merge-base..HEAD` is empty while the working tree
+        carries the whole change. Reporting "no code diff" there re-creates the
+        always-red gate from the other direction."""
+        import subprocess as real_subprocess
+
+        def mock_run(cmd, **kwargs):
+            del kwargs
+
+            def ok(out: str):
+                return real_subprocess.CompletedProcess(cmd, 0, out, "")
+
+            if "--verify" in cmd:
+                return ok("base000\n") if "origin/main^{commit}" in cmd else \
+                    real_subprocess.CompletedProcess(cmd, 1, "", "")
+            if "merge-base" in cmd:
+                return ok("headsha000000\n")
+            if cmd[:2] == ["git", "rev-parse"]:
+                return ok("headsha000000\n")
+            # merge-base == HEAD -> the committed range is empty ...
+            if cmd[:2] == ["git", "diff"] and "headsha000000" in cmd:
+                return ok("")
+            # ... but the working tree is dirty.
+            if cmd[:2] == ["git", "diff"] and "--name-only" in cmd:
+                return ok("wip.py")
+            if cmd[:2] == ["git", "diff"] and "--stat" in cmd:
+                return ok("wip.py | 4 ++++")
+            return ok("")
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+        result = map_step_runner.snapshot_code_state(branch="feat-x")
+
+        assert result["files_changed"] == ["wip.py"]
+        assert result["diff_stat"] == "wip.py | 4 ++++"
+        assert "empty" in result["diff_range"]
+        # The entry must therefore report the diff as PRESENT, not blocked.
+        entry = map_step_runner._prior_stage_diff_entry(result)
+        assert entry["present"] is True
 
     def test_prior_stage_diff_entry_names_the_actual_range(self):
         """#426: the consumption entry must quote the range the snapshot used."""
@@ -9974,6 +10086,7 @@ def test_create_review_bundle_includes_acceptance_coverage(branch_workspace):
         "total": 1,
         "covered": 1,
         "missing": 0,
+        "planned_only": 0,
     }
     bundle = json.loads((branch_workspace / "review-bundle.json").read_text())
     assert bundle["acceptance_coverage"]["requirements"][0]["id"] == "AC-1"
@@ -9985,6 +10098,7 @@ def test_create_review_bundle_includes_acceptance_coverage(branch_workspace):
         "total": 1,
         "covered": 1,
         "missing": 0,
+        "planned_only": 0,
     }
 
 

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3073,7 +3073,9 @@ def test_acceptance_coverage_report_tracks_downstream_evidence(branch_workspace)
     requirements = {item["id"]: item for item in result["requirements"]}
     assert requirements["AC-1"]["status"] == "covered"
     assert requirements["AC-1"]["evidence_artifacts"] == ["verification_summary"]
-    assert requirements["INV-1"]["status"] == "missing_evidence"
+    # INV-1 is named by its owner's validation criteria but nothing downstream
+    # verified it — a REVIEW gap, distinct from a requirement nobody ever owned.
+    assert requirements["INV-1"]["status"] == "planned_only"
 
 
 def test_acceptance_coverage_report_ignores_planning_artifacts(branch_workspace):
@@ -3109,7 +3111,212 @@ def test_acceptance_coverage_report_ignores_planning_artifacts(branch_workspace)
 
     assert result["summary"] == {"total": 1, "covered": 0, "missing": 1}
     assert result["evidence_sources"] == []
-    assert result["requirements"][0]["status"] == "missing_evidence"
+    # Cited by the owner's validation criteria, proven by nothing downstream.
+    assert result["requirements"][0]["status"] == "planned_only"
+
+
+def _coverage_blueprint(criteria: list[str], coverage_map: dict[str, str]) -> dict:
+    return {
+        "summary": "Deliver a user-visible fix",
+        **_blueprint_constraint_fields(),
+        "subtasks": [
+            {
+                "id": "ST-001",
+                "title": "Fix checkout timeout message",
+                "aag_contract": (
+                    "CheckoutService -> handle_timeout() -> user sees retryable error"
+                ),
+                "dependencies": [],
+                "affected_files": ["src/checkout.py"],
+                "expected_diff_size": "small",
+                "concern_type": "runtime",
+                "one_logical_step": True,
+                "validation_criteria": criteria,
+            }
+        ],
+        "coverage_map": coverage_map,
+    }
+
+
+def test_acceptance_coverage_counts_unbracketed_citations(branch_workspace):
+    """#426: reviewer verdicts and prose write `HC-2 audit: pass`, never `[HC-2]`.
+
+    The bracket-only matcher found nothing, so the table read 0/N on every branch.
+    """
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(_coverage_blueprint(["VC1 [HC-2]: flag audit"], {"HC-2": "ST-001"}))
+    )
+    (branch_workspace / "verification-summary.md").write_text(
+        "# Verification Summary\n\n## Checks Run\n- HC-2 no-activation-flag audit: pass\n",
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    assert result["summary"] == {"total": 1, "covered": 1, "missing": 0}
+    assert result["requirements"][0]["evidence_artifacts"] == ["verification_summary"]
+
+
+def test_acceptance_coverage_ignores_its_own_generated_block(branch_workspace):
+    """#426 regression: the report must not read its own output back as evidence.
+
+    write_verification_summary appends the rendered coverage table to
+    verification-summary.md, which is itself an evidence source. Without an exact
+    exclusion span, relaxing the bracket requirement would make every branch report
+    100% covered — a false green far worse than the 0/N it replaced.
+    """
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(_coverage_blueprint(["VC1 [AC-1]: timeout"], {"AC-1": "ST-001"}))
+    )
+    generated = map_step_runner._render_acceptance_coverage_markdown(
+        {
+            "status": "success",
+            "summary": {"total": 1, "covered": 0, "missing": 1},
+            "requirements": [
+                {"id": "AC-1", "owner": "ST-001", "status": "missing_evidence"}
+            ],
+        }
+    )
+    assert "AC-1" in generated, "fixture must actually contain the tag"
+    (branch_workspace / "verification-summary.md").write_text(
+        "# Verification Summary\n\n## Checks Run\n- pytest: pass\n\n" + generated,
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    assert result["summary"]["covered"] == 0
+    assert result["evidence_sources"] == []
+
+
+def test_acceptance_coverage_survives_flattened_generated_block(branch_workspace):
+    """pr-draft.md embeds the summary with newlines flattened to spaces — the
+    exclusion markers are inline HTML comments precisely so they survive that."""
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(_coverage_blueprint(["VC1 [AC-1]: timeout"], {"AC-1": "ST-001"}))
+    )
+    generated = map_step_runner._render_acceptance_coverage_markdown(
+        {
+            "status": "success",
+            "summary": {"total": 1, "covered": 0, "missing": 1},
+            "requirements": [
+                {"id": "AC-1", "owner": "ST-001", "status": "missing_evidence"}
+            ],
+        }
+    )
+    (branch_workspace / "pr-draft.md").write_text(
+        "# PR Draft\n\n## Validation\n" + generated.replace("\n", " ") + "\n",
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    assert result["summary"]["covered"] == 0
+
+
+def test_acceptance_coverage_ignores_unmarked_legacy_block(branch_workspace):
+    """Every already-installed repo has coverage blocks on disk written before the
+    sentinels existed. The heading-span fallback must exclude those too, while
+    leaving a genuine citation elsewhere in the SAME file intact."""
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(
+            _coverage_blueprint(
+                ["VC1 [AC-1]: timeout", "VC2 [HC-2]: flag audit"],
+                {"AC-1": "ST-001", "HC-2": "ST-001"},
+            )
+        )
+    )
+    (branch_workspace / "verification-summary.md").write_text(
+        "# Verification Summary\n\n"
+        "## Checks Run\n- HC-2 no-activation-flag audit: pass\n\n"
+        # Legacy block: no sentinels, exactly as pre-fix runs wrote it.
+        "## Acceptance Coverage\n"
+        "- Covered tags: 0/2\n"
+        "- Missing evidence: 2\n"
+        "- [missing_evidence] AC-1 owned by ST-001; evidence: missing\n"
+        "- [missing_evidence] HC-2 owned by ST-001; evidence: missing\n\n"
+        "## Prior-Stage Consumption\n- Stage: implementation\n",
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    requirements = {item["id"]: item for item in result["requirements"]}
+    # HC-2 survives on the real Checks Run citation; AC-1 only ever appeared
+    # inside the report's own output and must NOT count.
+    assert requirements["HC-2"]["status"] == "covered"
+    assert requirements["AC-1"]["status"] == "planned_only"
+    assert result["summary"] == {"total": 2, "covered": 1, "missing": 1}
+
+
+def test_acceptance_coverage_accepts_independent_verdict_artifacts(branch_workspace):
+    """final_verification.json and review-agent-*.json are the artifacts that
+    actually cite a tag WHILE checking it — they are the strongest evidence."""
+    (branch_workspace / "blueprint.json").write_text(
+        json.dumps(
+            _coverage_blueprint(
+                ["VC1 [AC-1]: timeout", "VC2 [SC-1]: no secret leak"],
+                {"AC-1": "ST-001", "SC-1": "ST-001"},
+            )
+        )
+    )
+    (branch_workspace / "final_verification.json").write_text(
+        json.dumps({"verdict": "PASS", "criteria_met": ["AC-1 verified end to end"]}),
+        encoding="utf-8",
+    )
+    (branch_workspace / "review-agent-monitor.json").write_text(
+        json.dumps({"valid": True, "summary": "SC-1 checked: no credential written"}),
+        encoding="utf-8",
+    )
+
+    result = map_step_runner.build_acceptance_coverage_report()
+
+    requirements = {item["id"]: item for item in result["requirements"]}
+    assert result["summary"] == {"total": 2, "covered": 2, "missing": 0}
+    assert requirements["AC-1"]["evidence_artifacts"] == ["final_verification"]
+    assert requirements["SC-1"]["evidence_artifacts"] == [
+        "review_agent:review-agent-monitor.json"
+    ]
+
+
+def test_acceptance_coverage_accepts_branch_commit_messages(tmp_path, monkeypatch):
+    """Commit messages are upstream-owned evidence: written when the work lands,
+    immutable after, and not rewritten by the scrub-internal-ids Stop hook."""
+    import subprocess as _sp
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _sp.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    for key, value in (("user.email", "t@example.com"), ("user.name", "T")):
+        _sp.run(["git", "config", key, value], cwd=str(repo), check=True, capture_output=True)
+    (repo / "README.md").write_text("hello", encoding="utf-8")
+    _sp.run(["git", "add", "."], cwd=str(repo), check=True, capture_output=True)
+    _sp.run(["git", "commit", "-m", "init"], cwd=str(repo), check=True, capture_output=True)
+
+    _sp.run(["git", "checkout", "-b", "feat-x"], cwd=str(repo), check=True, capture_output=True)
+    (repo / "checkout.py").write_text("ok\n", encoding="utf-8")
+    _sp.run(["git", "add", "."], cwd=str(repo), check=True, capture_output=True)
+    _sp.run(
+        ["git", "commit", "-m", "ST-001: retryable timeout message (AC-1, INV-1)"],
+        cwd=str(repo), check=True, capture_output=True,
+    )
+
+    branch_dir = repo / ".map" / "feat-x"
+    branch_dir.mkdir(parents=True)
+    (branch_dir / "blueprint.json").write_text(
+        json.dumps(
+            _coverage_blueprint(
+                ["VC1 [AC-1]: timeout", "VC2 [INV-1]: retry state"],
+                {"AC-1": "ST-001", "INV-1": "ST-001"},
+            )
+        )
+    )
+    monkeypatch.chdir(repo)
+
+    result = map_step_runner.build_acceptance_coverage_report(branch="feat-x")
+
+    assert result["summary"] == {"total": 2, "covered": 2, "missing": 0}
+    assert result["evidence_sources"] == ["commit_messages"]
 
 
 def test_write_verification_summary_appends_acceptance_coverage(branch_workspace):

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -4808,6 +4808,87 @@ class TestSnapshotCodeState:
 
         assert len(result["git_ref"]) <= 12
 
+    def test_diff_uses_merge_base_not_head_when_branch_is_committed(
+        self, monkeypatch
+    ):
+        """#426: a fully-committed branch must still report its real scope.
+
+        `git diff HEAD` is empty once every subtask is committed, which made the
+        review bundle self-report `Files changed: 0` on a 50-file branch.
+        """
+        import subprocess as real_subprocess
+
+        def mock_run(cmd, **kwargs):
+            del kwargs
+
+            def ok(out: str):
+                return real_subprocess.CompletedProcess(cmd, 0, out, "")
+
+            if cmd[:2] == ["git", "rev-parse"] and "HEAD" in cmd and "--verify" not in cmd:
+                return ok("deadbeefcafebabe\n")
+            if "--verify" in cmd:
+                # only origin/main resolves
+                return ok("base000\n") if "origin/main^{commit}" in cmd else \
+                    real_subprocess.CompletedProcess(cmd, 1, "", "")
+            if "merge-base" in cmd:
+                return ok("base0000000000\n")
+            # Working tree is clean: every `git diff ... HEAD` form is empty,
+            # while the merge-base range carries the branch delta.
+            if cmd[:2] == ["git", "diff"] and "base0000000000" in cmd:
+                if "--stat" in cmd:
+                    return ok(" a.py | 2 +-\n b.py | 3 +++\n 2 files changed")
+                return ok("a.py\nb.py")
+            return ok("")
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+        result = map_step_runner.snapshot_code_state(branch="feat-x")
+
+        assert result["files_changed"] == ["a.py", "b.py"]
+        assert result["diff_base_ref"] == "origin/main"
+        assert result["diff_base"] == "base00000000"
+        assert result["diff_range"] == "base00000000..HEAD"
+        # Uncommitted diff is retained as the secondary work-in-progress signal.
+        assert result["uncommitted_files_changed"] == []
+        assert result["uncommitted_diff_stat"] == ""
+
+    def test_diff_falls_back_to_head_without_default_branch_ref(self, monkeypatch):
+        """No origin/main|master and no local main|master → HEAD-only snapshot."""
+        import subprocess as real_subprocess
+
+        def mock_run(cmd, **kwargs):
+            del kwargs
+            if "--verify" in cmd:
+                return real_subprocess.CompletedProcess(cmd, 1, "", "")
+            if cmd[:2] == ["git", "rev-parse"]:
+                return real_subprocess.CompletedProcess(cmd, 0, "abc123abc123\n", "")
+            if cmd[:2] == ["git", "diff"] and "--name-only" in cmd:
+                return real_subprocess.CompletedProcess(cmd, 0, "wip.py", "")
+            if cmd[:2] == ["git", "diff"] and "--stat" in cmd:
+                return real_subprocess.CompletedProcess(cmd, 0, " wip.py | 1 +", "")
+            return real_subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+        result = map_step_runner.snapshot_code_state(branch="orphan")
+
+        assert result["diff_base"] == ""
+        assert result["diff_base_ref"] == ""
+        assert result["diff_range"] == "HEAD"
+        assert result["files_changed"] == ["wip.py"]
+
+    def test_prior_stage_diff_entry_names_the_actual_range(self):
+        """#426: the consumption entry must quote the range the snapshot used."""
+        entry = map_step_runner._prior_stage_diff_entry(
+            {
+                "status": "success",
+                "files_changed": [],
+                "diff_stat": "",
+                "diff_range": "base00000000..HEAD",
+            }
+        )
+        assert entry["path"] == "git diff --stat base00000000..HEAD"
+        assert "base00000000..HEAD" in entry["reason"]
+        assert entry["present"] is False
+
 
 class TestLoadBlueprint:
     """Tests for load_blueprint function."""

--- a/tests/test_shell_json_pipes.py
+++ b/tests/test_shell_json_pipes.py
@@ -1,0 +1,114 @@
+"""Guard against the `echo "$VAR" | jq` bug class (#425).
+
+zsh's builtin ``echo`` interprets backslash escapes without ``-E``.  Piping a
+captured JSON blob through it turns the ``\\n``/``\\t`` escapes inside JSON string
+values into raw C0 control bytes, and ``jq`` aborts with
+
+    control characters from U+0000 through U+001F must be escaped
+
+Because shipped skill recipes capture the result in ``$(...)``, the failure is
+swallowed and the variable silently lands EMPTY — downstream artifacts are then
+written with empty fields and exit 0 (observed: an empty-bodied ``pr-draft.md``).
+
+Repo-wide convention: ``printf '%s' "$VAR" | jq ...`` (and ``printf '%s\\n'``
+when the consumer is a ``while read`` loop, so the final line is preserved).
+This test is the gate that keeps the pattern from relanding.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# `echo "$VAR" |` feeding a JSON/text consumer.  Matches the quoted-variable form
+# only — that is the one that carries a captured payload; bare `echo foo | grep`
+# literals are not affected by escape interpretation.
+BANNED_RE = re.compile(
+    r"""echo\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*(?:jq|while)\b"""
+)
+
+# Source of truth plus every generated tree, so a direct edit to a generated copy
+# is caught even before `make check-render` notices the drift.
+SCAN_PREFIXES = (
+    "src/mapify_cli/templates_src/",
+    "src/mapify_cli/templates/",
+    ".claude/",
+    ".codex/",
+    ".agents/",
+)
+
+SCAN_SUFFIXES = (".jinja", ".md", ".sh", ".py", ".json")
+
+# The guideline doc documents the bug class, so it necessarily quotes the banned
+# form as a ❌ counter-example.  Exempt it by basename across every tree.
+EXEMPT_BASENAMES = frozenset({"bash-guidelines.md", "bash-guidelines.md.jinja"})
+
+
+def _scan_files() -> list[Path]:
+    """Git-tracked shipped files only.
+
+    ``git ls-files`` keeps scratch checkouts out of the scan — the worktree
+    storage root lives under ``.claude/worktrees/`` and holds full copies of the
+    repo at older revisions, which would otherwise re-report every historical
+    offender forever.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z", "--", *SCAN_PREFIXES],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [
+        REPO_ROOT / rel
+        for rel in out.split("\0")
+        if rel
+        and rel.endswith(SCAN_SUFFIXES)
+        and Path(rel).name not in EXEMPT_BASENAMES
+    ]
+
+
+def test_scan_roots_are_present() -> None:
+    """Fail loudly if the gate is scanning nothing (moved/renamed trees)."""
+    assert _scan_files(), "no files matched SCAN_ROOTS/SCAN_SUFFIXES — gate is inert"
+
+
+def test_no_echo_pipe_into_jq_or_read_loop() -> None:
+    """No shipped recipe may pipe a captured variable through `echo` (#425)."""
+    offenders: list[str] = []
+    for path in _scan_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if BANNED_RE.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "`echo \"$VAR\" | jq` mangles JSON escapes under zsh (#425).\n"
+        "Use `printf '%s' \"$VAR\" | jq ...` "
+        "(or `printf '%s\\n'` for a `while read` consumer).\n"
+        + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize(
+    ("line", "banned"),
+    [
+        ('STEP_ID=$(echo "$NEXT_STEP" | jq -r \'.step_id\')', True),
+        ('NORM=$(echo "$OUT" | while IFS= read -r line; do', True),
+        ('COUNT=$(echo "${ALL}" | jq length)', True),
+        ("STEP_ID=$(printf '%s' \"$NEXT_STEP\" | jq -r '.step_id')", False),
+        ("NORM=$(printf '%s\\n' \"$OUT\" | while IFS= read -r line; do", False),
+        ('echo "done" | grep -q done', False),
+    ],
+)
+def test_banned_pattern_detection(line: str, banned: bool) -> None:
+    """The detector itself must catch the bug class and not the safe forms."""
+    assert bool(BANNED_RE.search(line)) is banned

--- a/tests/test_shell_json_pipes.py
+++ b/tests/test_shell_json_pipes.py
@@ -25,13 +25,14 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# `echo "$VAR" |` feeding a JSON/text consumer.  Matches the quoted-variable form
-# only — that is the one that carries a captured payload; bare `echo foo | grep`
-# literals are not affected by escape interpretation.  `python3`/`node` consumers
-# belong to the same class: mangled escapes there surface as a JSON decode error
-# (or, worse, silently wrong values) instead of jq's loud abort.
+# `echo $VAR |` feeding a JSON/text consumer.  Both the quoted and the unquoted
+# form carry a captured payload and both hit zsh's escape interpretation (the
+# unquoted one additionally word-splits); a bare `echo foo | grep` literal is
+# unaffected and must not trip the gate.  `python3`/`node` consumers belong to the
+# same class: mangled escapes there surface as a JSON decode error (or, worse,
+# silently wrong values) instead of jq's loud abort.
 BANNED_RE = re.compile(
-    r"""echo\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*(?:jq|while|python3?|node)\b"""
+    r"""echo\s+"?\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"?\s*\|\s*(?:jq|while|python3?|node)\b"""
 )
 
 # Source of truth plus every generated tree, so a direct edit to a generated copy
@@ -42,6 +43,10 @@ SCAN_PREFIXES = (
     ".claude/",
     ".codex/",
     ".agents/",
+    # `.map/` holds the rendered runner and the static-analysis handlers that
+    # actually execute the pipelines — omitting it left the shipped handlers
+    # outside the gate they exist to protect.
+    ".map/",
 )
 
 SCAN_SUFFIXES = (".jinja", ".md", ".sh", ".py", ".json")
@@ -60,7 +65,8 @@ def _scan_files() -> list[Path]:
     offender forever.
     """
     out = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "ls-files", "-z", "--", *SCAN_PREFIXES],
+        ["git", "ls-files", "-z", "--", *SCAN_PREFIXES],
+        cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=True,
@@ -107,6 +113,8 @@ def test_no_echo_pipe_into_jq_or_read_loop() -> None:
         ('NORM=$(echo "$OUT" | while IFS= read -r line; do', True),
         ('COUNT=$(echo "${ALL}" | jq length)', True),
         ('P=$(echo "$BUNDLE_JSON" | python3 -c "import sys,json; ...")', True),
+        ("COUNT=$(echo $ALL | jq length)", True),
+        ("NORM=$(echo ${OUT} | while read -r l; do :; done", True),
         ("STEP_ID=$(printf '%s' \"$NEXT_STEP\" | jq -r '.step_id')", False),
         ("NORM=$(printf '%s\\n' \"$OUT\" | while IFS= read -r line; do", False),
         ('echo "done" | grep -q done', False),

--- a/tests/test_shell_json_pipes.py
+++ b/tests/test_shell_json_pipes.py
@@ -27,9 +27,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # `echo "$VAR" |` feeding a JSON/text consumer.  Matches the quoted-variable form
 # only — that is the one that carries a captured payload; bare `echo foo | grep`
-# literals are not affected by escape interpretation.
+# literals are not affected by escape interpretation.  `python3`/`node` consumers
+# belong to the same class: mangled escapes there surface as a JSON decode error
+# (or, worse, silently wrong values) instead of jq's loud abort.
 BANNED_RE = re.compile(
-    r"""echo\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*(?:jq|while)\b"""
+    r"""echo\s+"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"\s*\|\s*(?:jq|while|python3?|node)\b"""
 )
 
 # Source of truth plus every generated tree, so a direct edit to a generated copy
@@ -104,6 +106,7 @@ def test_no_echo_pipe_into_jq_or_read_loop() -> None:
         ('STEP_ID=$(echo "$NEXT_STEP" | jq -r \'.step_id\')', True),
         ('NORM=$(echo "$OUT" | while IFS= read -r line; do', True),
         ('COUNT=$(echo "${ALL}" | jq length)', True),
+        ('P=$(echo "$BUNDLE_JSON" | python3 -c "import sys,json; ...")', True),
         ("STEP_ID=$(printf '%s' \"$NEXT_STEP\" | jq -r '.step_id')", False),
         ("NORM=$(printf '%s\\n' \"$OUT\" | while IFS= read -r line; do", False),
         ('echo "done" | grep -q done', False),

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -120,7 +120,12 @@ HIGH_TRAFFIC_COMPACT_SKILL_REFS = {
 # review-reference.md § Verdict Ledger and are NOT counted here.
 _DEFAULT_SKILL_BODY_BUDGET = 515
 HIGH_TRAFFIC_SKILL_BODY_BUDGETS = {
-    "map-review": 630,
+    # Budget bumped 630 → 634 (#426): Step A.1 now resolves the review base from
+    # the default branch and diffs `merge-base..HEAD`. `git diff HEAD` is empty on
+    # a fully-committed branch, so the old two-line recipe silently reviewed
+    # nothing. The base-resolution shell is the ACTIVE gather step — it cannot
+    # move to the reference file without leaving the workflow path broken.
+    "map-review": 634,
     # map-tdd carries Iron Law enforcement (rationalization table, Red Flags,
     # RED-GREEN-REFACTOR cycle), spec compliance reviewer dispatch, and code
     # quality reviewer dispatch — all irreducible active control flow (#285).

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -120,12 +120,16 @@ HIGH_TRAFFIC_COMPACT_SKILL_REFS = {
 # review-reference.md § Verdict Ledger and are NOT counted here.
 _DEFAULT_SKILL_BODY_BUDGET = 515
 HIGH_TRAFFIC_SKILL_BODY_BUDGETS = {
-    # Budget bumped 630 → 634 (#426): Step A.1 now resolves the review base from
+    # Budget bumped 630 → 639 (#426): Step A.1 now resolves the review base from
     # the default branch and diffs `merge-base..HEAD`. `git diff HEAD` is empty on
     # a fully-committed branch, so the old two-line recipe silently reviewed
     # nothing. The base-resolution shell is the ACTIVE gather step — it cannot
-    # move to the reference file without leaving the workflow path broken.
-    "map-review": 634,
+    # move to the reference file without leaving the workflow path broken. The
+    # ref loop (origin/main, origin/master, main, master) matches what
+    # snapshot_code_state resolves, and the explicit RANGE branch exists because
+    # a `"${BASE:-HEAD}"...HEAD` shorthand degenerates to the always-empty
+    # `HEAD...HEAD` and silently re-creates the bug.
+    "map-review": 639,
     # map-tdd carries Iron Law enforcement (rationalization table, Red Flags,
     # RED-GREEN-REFACTOR cycle), spec compliance reviewer dispatch, and code
     # quality reviewer dispatch — all irreducible active control flow (#285).

--- a/tests/test_worktree_isolation.py
+++ b/tests/test_worktree_isolation.py
@@ -708,6 +708,101 @@ class TestDirtyTargetApprovalHold:
         assert not holds_path.exists()
 
 
+class TestSubtaskMergeDirtyTargetGuard:
+    """#423: the single-subtask accept path had NO dirty-target guard at all,
+    unlike the wave path — a squash-merge onto a dirty working branch cannot be
+    rolled back cleanly. Both paths now share `_wt_dirty_target_guard`."""
+
+    def test_merge_subtask_refuses_dirty_working_tree(self, repo: Path) -> None:
+        wt = _wt_with_files("ST-100", {"b.txt": "from-100\n"})
+        head_before = _git(["rev-parse", "HEAD"], repo).stdout.strip()
+        (repo / "dirty.txt").write_text("uncommitted user work\n", encoding="utf-8")
+
+        result = m.merge_subtask_worktree("ST-100", verify_cmds=[])
+
+        assert result["status"] == "error"
+        assert result["kind"] == "DIRTY_TARGET"
+        assert isinstance(result["dirty"], list) and result["dirty"]
+        # Working branch untouched and the worktree survives for a retry.
+        assert _git(["rev-parse", "HEAD"], repo).stdout.strip() == head_before
+        assert wt.is_dir()
+        assert not (repo / "b.txt").exists()
+
+    def test_merge_subtask_dirty_refusal_creates_dangerous_action_hold(
+        self, repo: Path
+    ) -> None:
+        _wt_with_files("ST-101", {"b.txt": "x\n"})
+        (repo / "dirty.txt").write_text(f"{_DIRTY_FILE_CONTENT_MARKER}\n", encoding="utf-8")
+        branch = m.get_branch_name()
+
+        result = m.merge_subtask_worktree("ST-101", verify_cmds=[])
+        assert result["kind"] == "DIRTY_TARGET"
+        assert isinstance(result["hold_id"], str) and result["hold_id"]
+
+        store = json.loads(
+            (repo / ".map" / branch / "approval_holds.json").read_text(encoding="utf-8")
+        )
+        hold = store["holds"][result["hold_id"]]
+        assert hold["kind"] == "dangerous_action"
+        assert hold["state"] == "pending"
+        assert hold["source"] == "worktree-merge"
+        assert "subtask merge" in hold["request_summary"]
+        # Repo-relative path only — the dirtied file's CONTENT never leaks in.
+        assert "dirty.txt" in hold["reason"]
+        assert _DIRTY_FILE_CONTENT_MARKER not in hold["reason"]
+
+    @pytest.mark.usefixtures("repo")
+    def test_merge_subtask_clean_tree_still_merges(self) -> None:
+        """Negative proof: the new guard must not block the clean happy path."""
+        _wt_with_files("ST-102", {"b.txt": "clean\n"})
+        merged = m.merge_subtask_worktree("ST-102", verify_cmds=[])
+        assert merged["status"] == "success"
+        assert merged["merged"] is True
+
+
+class TestIsolationStatusDecision:
+    """#423: `resolve_worktree_isolation` had zero production callers; the whole
+    ST-009 fallback matrix (and its observability reason codes) was never
+    produced at runtime. `worktree_isolation_status` now reports the decision."""
+
+    def test_status_reports_isolated_decision_on_clean_repo(self, repo: Path) -> None:
+        _write_config(repo, "worktree.isolation: auto\n")
+        st = m.worktree_isolation_status()
+        assert st["mode"] == "auto"
+        assert st["decision"] == "isolated"
+        assert st["degraded"] is False
+        assert st["degraded_reason"] == ""
+
+    def test_status_degrades_to_sequential_on_dirty_merge_target(
+        self, repo: Path
+    ) -> None:
+        _write_config(repo, "worktree.isolation: auto\n")
+        (repo / "dirty.txt").write_text("uncommitted\n", encoding="utf-8")
+        st = m.worktree_isolation_status()
+        assert st["decision"] == "sequential"
+        assert st["degraded"] is True
+        assert st["degraded_reason"] == m._WT_REASON_DIRTY_MERGE_TARGET
+        assert str(st["warning"])
+
+    def test_status_reports_abort_under_required_isolation(self, repo: Path) -> None:
+        _write_config(repo, "worktree.isolation: required\n")
+        (repo / "dirty.txt").write_text("uncommitted\n", encoding="utf-8")
+        st = m.worktree_isolation_status()
+        assert st["status"] == "success"  # status command itself never errors
+        assert st["decision"] == "abort"
+        assert st["degraded"] is False
+        assert st["degraded_reason"] == m._WT_REASON_DIRTY_MERGE_TARGET
+
+    def test_status_decision_is_dormant_sequential_when_isolation_off(
+        self, repo: Path
+    ) -> None:
+        _write_config(repo, "worktree.isolation: off\n")
+        st = m.worktree_isolation_status()
+        assert st["enabled"] is False
+        assert st["decision"] == "sequential"
+        assert st["degraded"] is False
+
+
 class TestDirtyTargetHoldRoutingIntegration:
     """VC3 / AC-7: synthetic-free -- drives the real DIRTY_TARGET refusal, the
     real `auto_decide_holds`, and the real `route_task`. No hold in this class


### PR DESCRIPTION
Fixes all four open `bug`-labelled issues. One branch, one commit per issue.

Closes #423, closes #424, closes #425, closes #426.

## #425 — `echo "$VAR" | jq` mangles JSON escapes under zsh

zsh's builtin `echo` interprets backslash escapes, so `\n` inside JSON string values becomes a raw C0 control byte and `jq` aborts with `control characters from U+0000 through U+001F must be escaped`. Captured in `$(...)` the failure is swallowed and the variable lands **empty** — observed as an empty-bodied `pr-draft.md` written with exit 0.

- Swept every remaining instance in `templates_src` to `printf '%s'` (and `printf '%s\n'` where a `while read` loop consumes it): map-efficient / map-task / map-tdd / map-resume / map-release / map-check-adjacent references, the `map_orchestrator` usage block, and all four static-analysis handlers.
- Extended to `python3 -c` consumers — same class, just fails as a `JSONDecodeError` instead of jq's loud abort.
- `tests/test_shell_json_pipes.py` scans `templates_src` plus every generated tree (via `git ls-files`, so worktree scratch checkouts stay out) so the pattern cannot reland.
- Convention documented in `CLAUDE.md` and `references/bash-guidelines.md`.

## #426 — review bundle diffed `HEAD` only, and Acceptance Coverage was always 0/N

**Diff base.** `snapshot_code_state` used `git diff HEAD`, i.e. uncommitted work only. On a fully-committed branch — the normal `/map-check` → `/map-review` state — that is empty, so `review-bundle.md` self-reported `Files changed: 0` for a branch carrying a 50-file diff, and all three reviewers fell back to raw git. Now resolves the review base from `origin/main | origin/master | main | master` and diffs `merge-base..HEAD`, keeping the uncommitted diff as a secondary WIP signal and reporting the range it used (`diff_base`, `diff_base_ref`, `diff_range`). `/map-review` Step A.1 gathers the same range. Degrades to the old HEAD-only view when no default-branch ref resolves.

**Acceptance Coverage.** Three stacked defects, each of which alone pins the table to a constant:

1. `ACCEPTANCE_TAG_RE` required brackets. Reviewer verdicts, commit messages and verification prose write `HC-2 audit: pass`, never `[HC-2]` — nothing ever matched.
2. `write_verification_summary` appends the **generated** coverage table to `verification-summary.md`, which the report then reads back as an evidence source. Relaxing the bracket requirement alone would have made the report count its own `AC-1 owned by ST-001` lines and report a permanent false-green 100% — strictly worse than the 0/N it replaced.
3. The evidence set omitted the independent downstream verdicts that actually cite a tag while checking it.

Fixes: brackets optional (extracted tags are only ever intersected with `coverage_map` keys, so over-matching is inert); the generated block is fenced with `<!-- map:acceptance-coverage:start/end -->` and excised before extraction, with a heading-span fallback for the unmarked blocks already on disk in every installed repo (inline HTML comments, so the markers survive the newline-flattening applied when the summary is embedded in `pr-draft.md`); `final_verification.json`, `review-agent-*.json` and the branch commit messages join the evidence set; a requirement its owner's `validation_criteria` names but nothing downstream verified now reports `planned_only` instead of being lumped into `missing_evidence`.

Verified against the real `feat-422-live-hold-producers` artifacts that produced the original `0/19`: now **19/19**, every tag backed by an independent verdict, reviewer artifact or commit message, with the self-referential block contributing nothing (`verification_summary` survives only for `HC-2`, its one genuine citation).

## #423 — dead isolation resolver; subtask merge had no dirty guard

`resolve_worktree_isolation` (the ST-009 fallback matrix) and `_require_clean_merge_target` had zero production callers, so the documented `require_clean_merge_target` key was a dead toggle and the degrade reason codes that `parallelism_observability` publishes (and a parity test pins) were never produced at runtime.

Chose **wire, not delete**: deleting would have cascaded into `_worktree_probe`, the reason-code vocabulary and its parity test.

- `worktree_isolation_status` now reports the live decision (`isolated` | `sequential` | `abort`) plus `degraded` / `degraded_reason` / `warning` / `mode`, so a dirty merge target surfaces *before* a wave starts rather than when `create_subtask_worktree` refuses mid-flight.
- Dropped the dead `require_clean_merge_target` key — a clean target is not optional for a squash-merge accept path.
- One scanner (`_wt_dirty_paths`) now backs every dirty-target decision; the duplicated filters are exactly how the subtask path ended up unguarded.
- Shared `_wt_dirty_target_guard` (DIRTY_TARGET refusal + the #422 `dangerous_action` hold) is now applied by `merge_subtask_worktree` as well as `merge_wave_worktrees`, closing the gap where the single-subtask accept path could squash-merge onto a dirty working branch.

## #424 — verifier committed mid-audit

A `final-verifier` run created and committed `3c6a7db` mid-audit under an APPROVED/REJECTED-only prompt contract: hand-edited four *generated* trees without touching their `.jinja` sources (breaking the single-source render invariant, failing three byte-parity tests), mangled `(#422 AC-1, AC-2, AC-6)` into `(#422 , , )`, renamed a blueprint-named regression test, then reported "working tree clean / make check exit 0" for its own post-commit state. Prompt text is not a capability boundary.

- `final-verifier` frontmatter: `disallowedTools: [Edit, Agent]`. `Write` stays — it owns `.map/<branch>/final_verification.json` + progress markdown. Supersedes the #378 "final-verifier is unrestricted" contract; the test that pinned it is **rewritten, not deleted**.
- `safety-guardrails.py` (PreToolUse) keys on the `agent_type` hook field: denies git-mutating Bash (`commit`/`push`/`reset`/`checkout`/`restore`/`add`/`rebase`/`stash`/…, token-anchored so `bash -c 'git commit'` and `git -C <path> commit` are caught) and any `Edit`/`Write`/`MultiEdit` outside `.map/` for `final-verifier`, `monitor`, `evaluator`, `predictor`, `documentation-reviewer`.
- Reads and read-only git stay unrestricted — a verifier gathers evidence, then reports it.
- Negative proofs pinned: the main thread (no `agent_type`) and `actor` keep committing; `.map/` artifact writes still land; plugin-scoped agent types are normalized.

## Validation

- `make check` green: ruff, mypy, pyright, lint-hooks, **4611 pytest**, `check-render`.
- Every generated tree re-rendered from `templates_src` (`make check-render` byte-parity).
- `snapshot_code_state` and the coverage report exercised live against real branch artifacts, not only fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved review reporting by comparing committed work with the default branch and showing uncommitted changes separately.
  * Enhanced acceptance-coverage reporting with clearer planned, covered, and missing evidence states.
  * Added stronger worktree protection and isolation-status reporting during merges.
  * Restricted verifier activity to approved artifacts and read-only operations.

* **Bug Fixes**
  * Improved reliability when parsing JSON and command output in shell workflows.

* **Documentation**
  * Added guidance for safe shell output handling and verifier capabilities.

* **Tests**
  * Added coverage for safety boundaries, review diffs, worktree protection, and shell parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->