### PR TITLE
fix: add -y/--yes flag to bump-version.sh for non-interactive runs

### DIFF
--- a/.claude/skills/map-release/SKILL.md
+++ b/.claude/skills/map-release/SKILL.md
@@ -84,7 +84,7 @@ See [release-reference.md § Phase 2](release-reference.md#phase-2-version-deter
 
 ## Phase 3: Execute Version Bump Script
 
-Run `./scripts/bump-version.sh "$BUMP_TYPE"`, then verify:
+Run `./scripts/bump-version.sh --yes "$BUMP_TYPE"`, then verify:
 
 ```bash
 # Verify tag points to HEAD

--- a/.claude/skills/map-release/release-reference.md
+++ b/.claude/skills/map-release/release-reference.md
@@ -223,7 +223,7 @@ echo "Changes will be committed locally but NOT pushed yet."
 ### 3.2 Execute
 
 ```bash
-./scripts/bump-version.sh "$BUMP_TYPE"
+./scripts/bump-version.sh --yes "$BUMP_TYPE"
 ```
 
 ### 3.3 Verify
@@ -387,7 +387,7 @@ Common issues:
 # Example: clean up and retry
 git status
 git add . && git commit -m "chore: prepare for release"
-./scripts/bump-version.sh patch
+./scripts/bump-version.sh --yes patch
 ```
 
 ### Scenario 3: Tag Pushed, But CI/CD Failed (Phase 5)
@@ -401,7 +401,7 @@ gh run view --log
 # Fix issue in new commit, then create a new patch release
 git add . && git commit -m "fix: resolve release workflow failure"
 git push origin main
-./scripts/bump-version.sh patch
+./scripts/bump-version.sh --yes patch
 git push origin main
 git push origin v1.0.2
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`bump-version.sh` supports non-interactive runs via `-y`/`--yes`.** The script's
+  30-second `read -t 30` confirmation prompt timed out and cancelled the bump whenever
+  it ran without a TTY answer — the v3.26.0 release had to work around it by piping
+  `y` on stdin. The new flag skips the prompt; `/map-release` Phase 3 (and the rollback
+  examples) now invoke `./scripts/bump-version.sh --yes`, since the workflow already
+  gates the bump behind an explicit `AskUserQuestion` confirmation.
+
 ## [3.26.0] - 2026-08-15
 
 ### Fixed

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,13 +10,14 @@
 #   creates annotated git tag with changelog excerpt.
 #
 # USAGE:
-#   ./scripts/bump-version.sh <major|minor|patch|X.Y.Z>
+#   ./scripts/bump-version.sh [-y|--yes] <major|minor|patch|X.Y.Z>
 #
 # EXAMPLES:
 #   ./scripts/bump-version.sh patch      # 1.0.0 -> 1.0.1
 #   ./scripts/bump-version.sh minor      # 1.0.0 -> 1.1.0
 #   ./scripts/bump-version.sh major      # 1.0.0 -> 2.0.0
 #   ./scripts/bump-version.sh 1.2.3      # explicit version
+#   ./scripts/bump-version.sh -y minor   # skip confirmation prompt
 #
 # BEHAVIOR:
 #   1. Validates input: major/minor/patch or explicit X.Y.Z semver format
@@ -100,7 +101,7 @@ die() {
 # Usage information
 usage() {
     cat << EOF
-Usage: $(basename "$0") <major|minor|patch|X.Y.Z>
+Usage: $(basename "$0") [-y|--yes] <major|minor|patch|X.Y.Z>
 
 Arguments:
   major         Bump major version (X.0.0)
@@ -108,11 +109,15 @@ Arguments:
   patch         Bump patch version (x.y.Z)
   X.Y.Z         Explicit version (e.g., 1.2.3)
 
+Options:
+  -y, --yes     Skip the confirmation prompt (non-interactive use)
+
 Examples:
   $(basename "$0") patch      # 1.0.0 -> 1.0.1
   $(basename "$0") minor      # 1.0.0 -> 1.1.0
   $(basename "$0") major      # 1.0.0 -> 2.0.0
   $(basename "$0") 1.2.3      # explicit version
+  $(basename "$0") -y minor   # no confirmation prompt
 
 Description:
   Automates version bumping by:
@@ -423,12 +428,26 @@ ${changelog_excerpt}
 
 # Main execution
 main() {
-    # Check arguments
-    if [[ $# -ne 1 ]]; then
+    # Parse arguments: optional -y/--yes flag + one bump-type argument
+    local assume_yes=0
+    local input=""
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -y|--yes)
+                assume_yes=1
+                ;;
+            *)
+                [[ -n "$input" ]] && usage
+                input="$arg"
+                ;;
+        esac
+    done
+
+    if [[ -z "$input" ]]; then
         usage
     fi
 
-    local input="$1"
     local current_version
     local new_version
 
@@ -497,15 +516,19 @@ main() {
     echo "  3. Create git commit"
     echo "  4. Create git tag v${new_version}"
     echo ""
-    read -t 30 -p "Continue? [y/N] " -n 1 -r || true
-    echo
+    if [[ "$assume_yes" -eq 1 ]]; then
+        info "Confirmation skipped (--yes)"
+    else
+        read -t 30 -p "Continue? [y/N] " -n 1 -r || true
+        echo
 
-    if [[ -z "$REPLY" ]]; then
-        warn "Version bump cancelled (no response: timed out after 30 seconds)"
-        exit 0
-    elif [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        warn "Version bump cancelled (explicitly declined)"
-        exit 0
+        if [[ -z "$REPLY" ]]; then
+            warn "Version bump cancelled (no response: timed out after 30 seconds)"
+            exit 0
+        elif [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            warn "Version bump cancelled (explicitly declined)"
+            exit 0
+        fi
     fi
 
     # Execute version bump

--- a/src/mapify_cli/templates/skills/map-release/SKILL.md
+++ b/src/mapify_cli/templates/skills/map-release/SKILL.md
@@ -84,7 +84,7 @@ See [release-reference.md § Phase 2](release-reference.md#phase-2-version-deter
 
 ## Phase 3: Execute Version Bump Script
 
-Run `./scripts/bump-version.sh "$BUMP_TYPE"`, then verify:
+Run `./scripts/bump-version.sh --yes "$BUMP_TYPE"`, then verify:
 
 ```bash
 # Verify tag points to HEAD

--- a/src/mapify_cli/templates/skills/map-release/release-reference.md
+++ b/src/mapify_cli/templates/skills/map-release/release-reference.md
@@ -223,7 +223,7 @@ echo "Changes will be committed locally but NOT pushed yet."
 ### 3.2 Execute
 
 ```bash
-./scripts/bump-version.sh "$BUMP_TYPE"
+./scripts/bump-version.sh --yes "$BUMP_TYPE"
 ```
 
 ### 3.3 Verify
@@ -387,7 +387,7 @@ Common issues:
 # Example: clean up and retry
 git status
 git add . && git commit -m "chore: prepare for release"
-./scripts/bump-version.sh patch
+./scripts/bump-version.sh --yes patch
 ```
 
 ### Scenario 3: Tag Pushed, But CI/CD Failed (Phase 5)
@@ -401,7 +401,7 @@ gh run view --log
 # Fix issue in new commit, then create a new patch release
 git add . && git commit -m "fix: resolve release workflow failure"
 git push origin main
-./scripts/bump-version.sh patch
+./scripts/bump-version.sh --yes patch
 git push origin main
 git push origin v1.0.2
 ```

--- a/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-release/SKILL.md.jinja
@@ -84,7 +84,7 @@ See [release-reference.md § Phase 2](release-reference.md#phase-2-version-deter
 
 ## Phase 3: Execute Version Bump Script
 
-Run `./scripts/bump-version.sh "$BUMP_TYPE"`, then verify:
+Run `./scripts/bump-version.sh --yes "$BUMP_TYPE"`, then verify:
 
 ```bash
 # Verify tag points to HEAD

--- a/src/mapify_cli/templates_src/skills/map-release/release-reference.md.jinja
+++ b/src/mapify_cli/templates_src/skills/map-release/release-reference.md.jinja
@@ -223,7 +223,7 @@ echo "Changes will be committed locally but NOT pushed yet."
 ### 3.2 Execute
 
 ```bash
-./scripts/bump-version.sh "$BUMP_TYPE"
+./scripts/bump-version.sh --yes "$BUMP_TYPE"
 ```
 
 ### 3.3 Verify
@@ -387,7 +387,7 @@ Common issues:
 # Example: clean up and retry
 git status
 git add . && git commit -m "chore: prepare for release"
-./scripts/bump-version.sh patch
+./scripts/bump-version.sh --yes patch
 ```
 
 ### Scenario 3: Tag Pushed, But CI/CD Failed (Phase 5)
@@ -401,7 +401,7 @@ gh run view --log
 # Fix issue in new commit, then create a new patch release
 git add . && git commit -m "fix: resolve release workflow failure"
 git push origin main
-./scripts/bump-version.sh patch
+./scripts/bump-version.sh --yes patch
 git push origin main
 git push origin v1.0.2
 ```


### PR DESCRIPTION
## Summary
- `scripts/bump-version.sh` gains `-y`/`--yes` to skip the interactive confirmation prompt. Without it, the `read -t 30` prompt timed out and cancelled the bump on any non-TTY run — the v3.26.0 release had to pipe `y` on stdin as a workaround.
- `/map-release` Phase 3 and the rollback examples (templates_src `.jinja` + rendered trees) now invoke `./scripts/bump-version.sh --yes` — the workflow already gates the bump behind an explicit `AskUserQuestion` confirmation, so the shell prompt was redundant there.

## Testing
- `bash -n` syntax check.
- Negative paths: no args / `-y` alone / extra arg → usage exit.
- Positive path: scratch git repo, `--yes patch` with stdin closed (`< /dev/null`) → commit + tag + all three version fields updated, no prompt.
- `make render-templates` + `make check-render` — generated trees byte-identical to sources.
- `pytest tests/test_template_render.py tests/test_skills.py` — 384 passed, 2 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `-y`/`--yes` support for non-interactive version updates.
  - Version updates can now skip confirmation prompts when explicitly requested.

- **Documentation**
  - Updated release workflow guidance and recovery procedures to use non-interactive confirmation.
  - Added usage details and examples for the new option.

- **Changelog**
  - Documented the new non-interactive version update capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->