### PR TITLE
fix(map_step_runner): atomic writes and OSError guards (closes #432)

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -635,6 +635,14 @@ def _write_json_file(path: Path, payload: dict | list) -> None:
     tmp_file.replace(path)
 
 
+def _write_text_file(path: Path, content: str) -> None:
+    """Atomically write text content to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = path.parent / (path.name + ".tmp")
+    tmp_file.write_text(content, encoding="utf-8")
+    tmp_file.replace(path)
+
+
 def _read_json_file(path: Path) -> dict[str, object] | None:
     """Read a JSON object from disk, returning None on invalid or missing files."""
     if not path.exists():
@@ -8664,9 +8672,7 @@ def write_stage_gate(
         "updated_at": datetime.now(UTC).isoformat(),
         "notes": notes or "",
     }
-    gate_file.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(gate_file, payload)
     return {
         "status": "success",
         "path": str(gate_file),
@@ -9662,16 +9668,10 @@ def create_review_bundle(branch: str | None = None) -> dict:
         pass
 
     # Write JSON bundle (ensure_ascii=True for jq-safe output per INV-8)
-    bundle_json_path.write_text(
-        json.dumps(result, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
-    )
+    _write_json_file(bundle_json_path, result)
 
     # Write human-readable Markdown bundle
-    bundle_md_path.write_text(
-        _render_bundle_markdown(result),
-        encoding="utf-8",
-    )
+    _write_text_file(bundle_md_path, _render_bundle_markdown(result))
 
     # --- Manifest integration (AC-4 / INV-5) ---
     # Both bundle files are written; now record them in artifact_manifest.json.
@@ -14211,15 +14211,22 @@ def detect_already_done(
     requested_ref = since_ref or "HEAD~50"
     # Probe the requested ref; if it can't be resolved (e.g., HEAD~50 in a
     # repo with only 3 commits), fall back to the entire reachable history.
-    probe = subprocess.run(
-        ["git", "rev-parse", "--verify", requested_ref],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
-    window_ref: str | None = requested_ref if probe.returncode == 0 else None
+    try:
+        probe = subprocess.run(
+            ["git", "rev-parse", "--verify", requested_ref],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        window_ref: str | None = requested_ref if probe.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "status": "error",
+            "subtask_id": subtask_id,
+            "message": f"git rev-parse failed: {exc}",
+        }
     evidence: list[dict] = []
     missing: list[str] = []
     have_commit: list[str] = []
@@ -15441,14 +15448,17 @@ def _resolve_subtask_diff_base(
         except (json.JSONDecodeError, OSError):
             pass
     if base_ref and recorded and base_ref == recorded:
-        parent_probe = subprocess.run(
-            ["git", "rev-parse", "--verify", f"{recorded}^"],
-            cwd=project_dir,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
+        try:
+            parent_probe = subprocess.run(
+                ["git", "rev-parse", "--verify", f"{recorded}^"],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return base_ref
         if parent_probe.returncode == 0:
             return f"{recorded}^"
         # Root commit (no parent): no usable parent to re-base onto. Keep the
@@ -15461,14 +15471,17 @@ def _resolve_subtask_diff_base(
     # No recorded subtask commit — probe HEAD before using it; `git rev-parse
     # HEAD` fails in a fresh repo with no commits, and we want porcelain-only
     # rather than a confusing "ambiguous HEAD".
-    head_probe = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
+    try:
+        head_probe = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if head_probe.returncode == 0:
         return "HEAD"
     return None

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -635,6 +635,14 @@ def _write_json_file(path: Path, payload: dict | list) -> None:
     tmp_file.replace(path)
 
 
+def _write_text_file(path: Path, content: str) -> None:
+    """Atomically write text content to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = path.parent / (path.name + ".tmp")
+    tmp_file.write_text(content, encoding="utf-8")
+    tmp_file.replace(path)
+
+
 def _read_json_file(path: Path) -> dict[str, object] | None:
     """Read a JSON object from disk, returning None on invalid or missing files."""
     if not path.exists():
@@ -8664,9 +8672,7 @@ def write_stage_gate(
         "updated_at": datetime.now(UTC).isoformat(),
         "notes": notes or "",
     }
-    gate_file.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(gate_file, payload)
     return {
         "status": "success",
         "path": str(gate_file),
@@ -9662,16 +9668,10 @@ def create_review_bundle(branch: str | None = None) -> dict:
         pass
 
     # Write JSON bundle (ensure_ascii=True for jq-safe output per INV-8)
-    bundle_json_path.write_text(
-        json.dumps(result, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
-    )
+    _write_json_file(bundle_json_path, result)
 
     # Write human-readable Markdown bundle
-    bundle_md_path.write_text(
-        _render_bundle_markdown(result),
-        encoding="utf-8",
-    )
+    _write_text_file(bundle_md_path, _render_bundle_markdown(result))
 
     # --- Manifest integration (AC-4 / INV-5) ---
     # Both bundle files are written; now record them in artifact_manifest.json.
@@ -14211,15 +14211,22 @@ def detect_already_done(
     requested_ref = since_ref or "HEAD~50"
     # Probe the requested ref; if it can't be resolved (e.g., HEAD~50 in a
     # repo with only 3 commits), fall back to the entire reachable history.
-    probe = subprocess.run(
-        ["git", "rev-parse", "--verify", requested_ref],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
-    window_ref: str | None = requested_ref if probe.returncode == 0 else None
+    try:
+        probe = subprocess.run(
+            ["git", "rev-parse", "--verify", requested_ref],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        window_ref: str | None = requested_ref if probe.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "status": "error",
+            "subtask_id": subtask_id,
+            "message": f"git rev-parse failed: {exc}",
+        }
     evidence: list[dict] = []
     missing: list[str] = []
     have_commit: list[str] = []
@@ -15441,14 +15448,17 @@ def _resolve_subtask_diff_base(
         except (json.JSONDecodeError, OSError):
             pass
     if base_ref and recorded and base_ref == recorded:
-        parent_probe = subprocess.run(
-            ["git", "rev-parse", "--verify", f"{recorded}^"],
-            cwd=project_dir,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
+        try:
+            parent_probe = subprocess.run(
+                ["git", "rev-parse", "--verify", f"{recorded}^"],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return base_ref
         if parent_probe.returncode == 0:
             return f"{recorded}^"
         # Root commit (no parent): no usable parent to re-base onto. Keep the
@@ -15461,14 +15471,17 @@ def _resolve_subtask_diff_base(
     # No recorded subtask commit — probe HEAD before using it; `git rev-parse
     # HEAD` fails in a fresh repo with no commits, and we want porcelain-only
     # rather than a confusing "ambiguous HEAD".
-    head_probe = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
+    try:
+        head_probe = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if head_probe.returncode == 0:
         return "HEAD"
     return None

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -635,6 +635,14 @@ def _write_json_file(path: Path, payload: dict | list) -> None:
     tmp_file.replace(path)
 
 
+def _write_text_file(path: Path, content: str) -> None:
+    """Atomically write text content to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = path.parent / (path.name + ".tmp")
+    tmp_file.write_text(content, encoding="utf-8")
+    tmp_file.replace(path)
+
+
 def _read_json_file(path: Path) -> dict[str, object] | None:
     """Read a JSON object from disk, returning None on invalid or missing files."""
     if not path.exists():
@@ -8664,9 +8672,7 @@ def write_stage_gate(
         "updated_at": datetime.now(UTC).isoformat(),
         "notes": notes or "",
     }
-    gate_file.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    _write_json_file(gate_file, payload)
     return {
         "status": "success",
         "path": str(gate_file),
@@ -9662,16 +9668,10 @@ def create_review_bundle(branch: str | None = None) -> dict:
         pass
 
     # Write JSON bundle (ensure_ascii=True for jq-safe output per INV-8)
-    bundle_json_path.write_text(
-        json.dumps(result, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
-    )
+    _write_json_file(bundle_json_path, result)
 
     # Write human-readable Markdown bundle
-    bundle_md_path.write_text(
-        _render_bundle_markdown(result),
-        encoding="utf-8",
-    )
+    _write_text_file(bundle_md_path, _render_bundle_markdown(result))
 
     # --- Manifest integration (AC-4 / INV-5) ---
     # Both bundle files are written; now record them in artifact_manifest.json.
@@ -14211,15 +14211,22 @@ def detect_already_done(
     requested_ref = since_ref or "HEAD~50"
     # Probe the requested ref; if it can't be resolved (e.g., HEAD~50 in a
     # repo with only 3 commits), fall back to the entire reachable history.
-    probe = subprocess.run(
-        ["git", "rev-parse", "--verify", requested_ref],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
-    window_ref: str | None = requested_ref if probe.returncode == 0 else None
+    try:
+        probe = subprocess.run(
+            ["git", "rev-parse", "--verify", requested_ref],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        window_ref: str | None = requested_ref if probe.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "status": "error",
+            "subtask_id": subtask_id,
+            "message": f"git rev-parse failed: {exc}",
+        }
     evidence: list[dict] = []
     missing: list[str] = []
     have_commit: list[str] = []
@@ -15441,14 +15448,17 @@ def _resolve_subtask_diff_base(
         except (json.JSONDecodeError, OSError):
             pass
     if base_ref and recorded and base_ref == recorded:
-        parent_probe = subprocess.run(
-            ["git", "rev-parse", "--verify", f"{recorded}^"],
-            cwd=project_dir,
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        )
+        try:
+            parent_probe = subprocess.run(
+                ["git", "rev-parse", "--verify", f"{recorded}^"],
+                cwd=project_dir,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return base_ref
         if parent_probe.returncode == 0:
             return f"{recorded}^"
         # Root commit (no parent): no usable parent to re-base onto. Keep the
@@ -15461,14 +15471,17 @@ def _resolve_subtask_diff_base(
     # No recorded subtask commit — probe HEAD before using it; `git rev-parse
     # HEAD` fails in a fresh repo with no commits, and we want porcelain-only
     # rather than a confusing "ambiguous HEAD".
-    head_probe = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=False,
-    )
+    try:
+        head_probe = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
     if head_probe.returncode == 0:
         return "HEAD"
     return None

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -4566,6 +4566,15 @@ class TestWriteStageGate:
         assert result["status"] == "success"
         assert (other_dir / "plan-gate.json").exists()
 
+    def test_write_stage_gate_no_tmp_residue(self, branch_workspace):
+        """Regression #432 Bug 1: write_stage_gate must use an atomic
+        tmp→replace write so no .tmp file remains after a successful call."""
+        result = map_step_runner.write_stage_gate("plan", "ready")
+
+        assert result["status"] == "success"
+        tmp_files = list(branch_workspace.glob("*.tmp"))
+        assert tmp_files == [], f"Stale .tmp files after write_stage_gate: {tmp_files}"
+
 
 # ---------------------------------------------------------------------------
 # ensure_active_issues_file — focused unit tests
@@ -8010,6 +8019,35 @@ class TestDetectAlreadyDone:
         assert report["status"] == "unclear"
         assert "never_made.py" in report["missing_or_no_commits"]
 
+    def test_probe_oserror_returns_error_not_exception(
+        self, branch_workspace, monkeypatch
+    ):
+        """Regression #432 Bug 4: OSError from the initial ref-probe subprocess.run
+        must be caught and returned as status='error', not propagate as an exception.
+        """
+        repo = branch_workspace.parents[1]
+        self._init_git(repo, [])
+        bp = {"subtasks": [{"id": "ST-007", "affected_files": ["a.py"]}]}
+        (branch_workspace / "blueprint.json").write_text(json.dumps(bp))
+        (repo / "a.py").write_text("x")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+
+        import subprocess as real_subprocess
+
+        original_run = real_subprocess.run
+        call_count: list[int] = [0]
+
+        def _raise_on_first(*args: object, **kwargs: object) -> object:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise OSError("git: No such file or directory")
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr(map_step_runner.subprocess, "run", _raise_on_first)
+        report = map_step_runner.detect_already_done("test-branch", "ST-007")
+        assert report["status"] == "error", report
+        assert "git" in report["message"].lower()
+
 
 class TestBuildContextBlockInlinesResearch:
     """build_context_block now auto-loads load_research for the current
@@ -9835,6 +9873,18 @@ class TestCreateReviewBundle:
                 f"Role '{role}': required_keys {required_keys - skeleton_keys} "
                 f"not present in skeleton"
             )
+
+    def test_create_review_bundle_no_tmp_residue(self, branch_workspace):
+        """Regression #432 Bugs 2+3: create_review_bundle must use atomic
+        tmp→replace writes so no .tmp files remain for the JSON or markdown
+        bundle after a successful call."""
+        result = map_step_runner.create_review_bundle()
+
+        assert result["status"] == "success"
+        tmp_files = list(branch_workspace.glob("*.tmp"))
+        assert tmp_files == [], (
+            f"Stale .tmp files after create_review_bundle: {tmp_files}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -17128,3 +17178,79 @@ def test_write_prd_review_rejects_non_array_blocking_questions(
     assert result["status"] == "error"
     assert "blocking_questions must be a JSON array" in result["message"]
     assert not (branch_workspace / "prd-review.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _write_text_file — unit tests (issue #432)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTextFile:
+    """Unit tests for the _write_text_file atomic-write helper (issue #432)."""
+
+    def test_writes_content_to_path(self, tmp_path):
+        """Content is written correctly to the destination path."""
+        dest = tmp_path / "output.md"
+        map_step_runner._write_text_file(dest, "# Hello\n")
+        assert dest.read_text(encoding="utf-8") == "# Hello\n"
+
+    def test_no_tmp_residue_on_success(self, tmp_path):
+        """Regression #432: no .tmp file remains after a successful atomic write."""
+        dest = tmp_path / "output.md"
+        map_step_runner._write_text_file(dest, "content")
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == [], f"Stale .tmp file after _write_text_file: {tmp_files}"
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Parent directories are created if they do not exist."""
+        dest = tmp_path / "nested" / "deep" / "file.md"
+        map_step_runner._write_text_file(dest, "data")
+        assert dest.exists()
+        assert dest.read_text(encoding="utf-8") == "data"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_subtask_diff_base OSError handling (issue #432, Bugs 5a/5b)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSubtaskDiffBase:
+    """Unit tests for _resolve_subtask_diff_base internal error handling (issue #432)."""
+
+    def test_parent_probe_oserror_returns_base_ref_not_raises(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression #432 Bug 5a: OSError from the parent-commit probe
+        subprocess.run must be caught; the function returns base_ref, not raises."""
+        fake_sha = "abc123def456abc123def456abc123def456abc123"
+        state_dir = tmp_path / ".map" / "test-branch"
+        state_dir.mkdir(parents=True)
+        (state_dir / "step_state.json").write_text(json.dumps({
+            "last_subtask_commit_sha": fake_sha,
+            "subtask_results": {"ST-001": {"commit_sha": fake_sha}},
+        }))
+
+        def _always_raise(*args: object, **kwargs: object) -> object:
+            del args, kwargs
+            raise OSError("git: No such file or directory")
+
+        monkeypatch.setattr(map_step_runner.subprocess, "run", _always_raise)
+        result = map_step_runner._resolve_subtask_diff_base(
+            "test-branch", "ST-001", tmp_path
+        )
+        assert result == fake_sha
+
+    def test_head_probe_oserror_returns_none_not_raises(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression #432 Bug 5b: OSError from the HEAD probe subprocess.run
+        must be caught; the function returns None, not raises."""
+        def _always_raise(*args: object, **kwargs: object) -> object:
+            del args, kwargs
+            raise OSError("git: No such file or directory")
+
+        monkeypatch.setattr(map_step_runner.subprocess, "run", _always_raise)
+        result = map_step_runner._resolve_subtask_diff_base(
+            "test-branch", "ST-001", tmp_path
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

Five bugs in the same class as #409 (non-atomic writes / unguarded subprocess calls), found by code audit of recently changed code in `map_step_runner.py.jinja`:

- **Bug 1** – `write_stage_gate`: called `write_text()` directly; switched to `_write_json_file()` for atomic tmp→replace write.
- **Bug 2** – `create_review_bundle` JSON bundle: called `write_text()` directly; switched to `_write_json_file()`.
- **Bug 3** – `create_review_bundle` markdown bundle: called `write_text()` directly; introduced new `_write_text_file()` helper (same tmp→replace pattern as `_write_json_file`).
- **Bug 4** – `detect_already_done`: initial ref-probe `subprocess.run` was outside any `try/except`; OSError (git not on PATH) propagated as an uncaught exception instead of returning `status='error'`.
- **Bugs 5a/5b** – `_resolve_subtask_diff_base`: `parent_probe` and `head_probe` subprocess calls were not wrapped; added `(OSError, subprocess.TimeoutExpired)` guards so both return gracefully (`base_ref` and `None` respectively) instead of raising.

## Changes

- `src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja` — all five fixes + new `_write_text_file` helper
- Generated trees updated via `make render-templates` (`.map/scripts/`, `src/mapify_cli/templates/`)
- `tests/test_map_step_runner.py` — 8 new regression tests:
  - `TestWriteStageGate::test_write_stage_gate_no_tmp_residue`
  - `TestCreateReviewBundle::test_create_review_bundle_no_tmp_residue`
  - `TestWriteTextFile` (3 tests: content, no-tmp-residue, creates-parents)
  - `TestDetectAlreadyDone::test_probe_oserror_returns_error_not_exception`
  - `TestResolveSubtaskDiffBase::test_parent_probe_oserror_returns_base_ref_not_raises`
  - `TestResolveSubtaskDiffBase::test_head_probe_oserror_returns_none_not_raises`

## Test plan

- All 8 new tests pass
- Full suite: 4670 collected, 4662 passed, 4 skipped — no regressions
- `ruff check src/ tests/` — clean
- `make check-render` — generated trees in sync

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwf4F4rU8ozzQPgG36Sze7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving review bundles, stage gates, and other generated files.
  * Automatically creates missing directories and prevents incomplete files from replacing existing output.
  * Git-related checks now handle system and timeout errors gracefully, providing fallback results instead of stopping unexpectedly.

* **Tests**
  * Added regression coverage for safe file writing, temporary-file cleanup, and Git error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->