### PR TITLE
fix(hook): respect checks.go.goos/build config for Linux-only Go projects

### DIFF
--- a/.claude/hooks/end-of-turn.sh
+++ b/.claude/hooks/end-of-turn.sh
@@ -45,6 +45,28 @@ add_critical() {
     CRITICAL_ISSUES+=("$1")
 }
 
+# Read a flat dotted key from .map/config.yaml using minimal stdlib Python.
+# Falls back to $2 when the file is absent, the key is missing, or python3
+# is unavailable.  Never raises: all errors are silently swallowed so the
+# hook degrades gracefully to host defaults.
+_read_map_config_value() {
+    local key="$1" default="$2"
+    if [[ ! -f ".map/config.yaml" ]] || ! command -v python3 &>/dev/null; then
+        printf '%s' "$default"
+        return
+    fi
+    python3 -B -c "
+import re, sys
+key, default = sys.argv[1], sys.argv[2]
+try:
+    text = open('.map/config.yaml', encoding='utf-8').read()
+    m = re.search(r'^\s*' + re.escape(key) + r'\s*:\s*(\S+)', text, re.MULTILINE)
+    print(m.group(1).strip() if m else default)
+except Exception:
+    print(default)
+" "$key" "$default" 2>/dev/null || printf '%s' "$default"
+}
+
 # -----------------------------------------------------------------------------
 # Early Exit: Check for Dirty State
 # -----------------------------------------------------------------------------
@@ -163,18 +185,40 @@ fi
 
 # Go: Check for compile errors only (fast, critical)
 if command -v go &>/dev/null && [[ -f "go.mod" ]]; then
-    GO_FILES=""
-    for file in $CHANGED_FILES; do
-        if [[ "$file" == *.go ]] && [[ -f "$file" ]]; then
-            GO_FILES="$GO_FILES $file"
-        fi
-    done
-    if [[ -n "$GO_FILES" ]]; then
-        # Quick syntax check via go build with no output
-        if ! go build -o /dev/null ./... 2>/dev/null; then
-            add_critical "Go build errors detected (run 'go build ./...' for details)"
-        fi
-    fi
+    # Allow disabling this check entirely via .map/config.yaml:
+    #   checks.go.build: false
+    _go_build_cfg=$(_read_map_config_value "checks.go.build" "true")
+    case "$_go_build_cfg" in
+        false|False|no|No|off|Off|0)
+            log "Go build check disabled via checks.go.build config"
+            ;;
+        *)
+            GO_FILES=""
+            for file in $CHANGED_FILES; do
+                if [[ "$file" == *.go ]] && [[ -f "$file" ]]; then
+                    GO_FILES="$GO_FILES $file"
+                fi
+            done
+            if [[ -n "$GO_FILES" ]]; then
+                # Determine effective GOOS: env var takes precedence, then
+                # .map/config.yaml checks.go.goos, then host default.
+                # This prevents false criticals for Linux-only projects
+                # developed on macOS (e.g. projects using cgroups/eBPF/netlink).
+                #   Example config:  checks.go.goos: linux
+                _go_goos="${GOOS:-$(_read_map_config_value 'checks.go.goos' '')}"
+                _go_build_ok=true
+                if [[ -n "$_go_goos" ]]; then
+                    GOOS="$_go_goos" go build -o /dev/null ./... 2>/dev/null \
+                        || _go_build_ok=false
+                else
+                    go build -o /dev/null ./... 2>/dev/null || _go_build_ok=false
+                fi
+                if [[ "$_go_build_ok" == "false" ]]; then
+                    add_critical "Go build errors detected (run 'go build ./...' for details)"
+                fi
+            fi
+            ;;
+    esac
 fi
 
 # -----------------------------------------------------------------------------

--- a/src/mapify_cli/templates/hooks/end-of-turn.sh
+++ b/src/mapify_cli/templates/hooks/end-of-turn.sh
@@ -45,6 +45,28 @@ add_critical() {
     CRITICAL_ISSUES+=("$1")
 }
 
+# Read a flat dotted key from .map/config.yaml using minimal stdlib Python.
+# Falls back to $2 when the file is absent, the key is missing, or python3
+# is unavailable.  Never raises: all errors are silently swallowed so the
+# hook degrades gracefully to host defaults.
+_read_map_config_value() {
+    local key="$1" default="$2"
+    if [[ ! -f ".map/config.yaml" ]] || ! command -v python3 &>/dev/null; then
+        printf '%s' "$default"
+        return
+    fi
+    python3 -B -c "
+import re, sys
+key, default = sys.argv[1], sys.argv[2]
+try:
+    text = open('.map/config.yaml', encoding='utf-8').read()
+    m = re.search(r'^\s*' + re.escape(key) + r'\s*:\s*(\S+)', text, re.MULTILINE)
+    print(m.group(1).strip() if m else default)
+except Exception:
+    print(default)
+" "$key" "$default" 2>/dev/null || printf '%s' "$default"
+}
+
 # -----------------------------------------------------------------------------
 # Early Exit: Check for Dirty State
 # -----------------------------------------------------------------------------
@@ -163,18 +185,40 @@ fi
 
 # Go: Check for compile errors only (fast, critical)
 if command -v go &>/dev/null && [[ -f "go.mod" ]]; then
-    GO_FILES=""
-    for file in $CHANGED_FILES; do
-        if [[ "$file" == *.go ]] && [[ -f "$file" ]]; then
-            GO_FILES="$GO_FILES $file"
-        fi
-    done
-    if [[ -n "$GO_FILES" ]]; then
-        # Quick syntax check via go build with no output
-        if ! go build -o /dev/null ./... 2>/dev/null; then
-            add_critical "Go build errors detected (run 'go build ./...' for details)"
-        fi
-    fi
+    # Allow disabling this check entirely via .map/config.yaml:
+    #   checks.go.build: false
+    _go_build_cfg=$(_read_map_config_value "checks.go.build" "true")
+    case "$_go_build_cfg" in
+        false|False|no|No|off|Off|0)
+            log "Go build check disabled via checks.go.build config"
+            ;;
+        *)
+            GO_FILES=""
+            for file in $CHANGED_FILES; do
+                if [[ "$file" == *.go ]] && [[ -f "$file" ]]; then
+                    GO_FILES="$GO_FILES $file"
+                fi
+            done
+            if [[ -n "$GO_FILES" ]]; then
+                # Determine effective GOOS: env var takes precedence, then
+                # .map/config.yaml checks.go.goos, then host default.
+                # This prevents false criticals for Linux-only projects
+                # developed on macOS (e.g. projects using cgroups/eBPF/netlink).
+                #   Example config:  checks.go.goos: linux
+                _go_goos="${GOOS:-$(_read_map_config_value 'checks.go.goos' '')}"
+                _go_build_ok=true
+                if [[ -n "$_go_goos" ]]; then
+                    GOOS="$_go_goos" go build -o /dev/null ./... 2>/dev/null \
+                        || _go_build_ok=false
+                else
+                    go build -o /dev/null ./... 2>/dev/null || _go_build_ok=false
+                fi
+                if [[ "$_go_build_ok" == "false" ]]; then
+                    add_critical "Go build errors detected (run 'go build ./...' for details)"
+                fi
+            fi
+            ;;
+    esac
 fi
 
 # -----------------------------------------------------------------------------

--- a/src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja
+++ b/src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja
@@ -45,6 +45,28 @@ add_critical() {
     CRITICAL_ISSUES+=("$1")
 }
 
+# Read a flat dotted key from .map/config.yaml using minimal stdlib Python.
+# Falls back to $2 when the file is absent, the key is missing, or python3
+# is unavailable.  Never raises: all errors are silently swallowed so the
+# hook degrades gracefully to host defaults.
+_read_map_config_value() {
+    local key="$1" default="$2"
+    if [[ ! -f ".map/config.yaml" ]] || ! command -v python3 &>/dev/null; then
+        printf '%s' "$default"
+        return
+    fi
+    python3 -B -c "
+import re, sys
+key, default = sys.argv[1], sys.argv[2]
+try:
+    text = open('.map/config.yaml', encoding='utf-8').read()
+    m = re.search(r'^\s*' + re.escape(key) + r'\s*:\s*(\S+)', text, re.MULTILINE)
+    print(m.group(1).strip() if m else default)
+except Exception:
+    print(default)
+" "$key" "$default" 2>/dev/null || printf '%s' "$default"
+}
+
 # -----------------------------------------------------------------------------
 # Early Exit: Check for Dirty State
 # -----------------------------------------------------------------------------
@@ -163,18 +185,40 @@ fi
 
 # Go: Check for compile errors only (fast, critical)
 if command -v go &>/dev/null && [[ -f "go.mod" ]]; then
-    GO_FILES=""
-    for file in $CHANGED_FILES; do
-        if [[ "$file" == *.go ]] && [[ -f "$file" ]]; then
-            GO_FILES="$GO_FILES $file"
-        fi
-    done
-    if [[ -n "$GO_FILES" ]]; then
-        # Quick syntax check via go build with no output
-        if ! go build -o /dev/null ./... 2>/dev/null; then
-            add_critical "Go build errors detected (run 'go build ./...' for details)"
-        fi
-    fi
+    # Allow disabling this check entirely via .map/config.yaml:
+    #   checks.go.build: false
+    _go_build_cfg=$(_read_map_config_value "checks.go.build" "true")
+    case "$_go_build_cfg" in
+        false|False|no|No|off|Off|0)
+            log "Go build check disabled via checks.go.build config"
+            ;;
+        *)
+            GO_FILES=""
+            for file in $CHANGED_FILES; do
+                if [[ "$file" == *.go ]] && [[ -f "$file" ]]; then
+                    GO_FILES="$GO_FILES $file"
+                fi
+            done
+            if [[ -n "$GO_FILES" ]]; then
+                # Determine effective GOOS: env var takes precedence, then
+                # .map/config.yaml checks.go.goos, then host default.
+                # This prevents false criticals for Linux-only projects
+                # developed on macOS (e.g. projects using cgroups/eBPF/netlink).
+                #   Example config:  checks.go.goos: linux
+                _go_goos="${GOOS:-$(_read_map_config_value 'checks.go.goos' '')}"
+                _go_build_ok=true
+                if [[ -n "$_go_goos" ]]; then
+                    GOOS="$_go_goos" go build -o /dev/null ./... 2>/dev/null \
+                        || _go_build_ok=false
+                else
+                    go build -o /dev/null ./... 2>/dev/null || _go_build_ok=false
+                fi
+                if [[ "$_go_build_ok" == "false" ]]; then
+                    add_critical "Go build errors detected (run 'go build ./...' for details)"
+                fi
+            fi
+            ;;
+    esac
 fi
 
 # -----------------------------------------------------------------------------

--- a/tests/hooks/test_end_of_turn.py
+++ b/tests/hooks/test_end_of_turn.py
@@ -8,6 +8,7 @@ Tests the lightweight version that:
 - Only reports critical issues (secrets, .env files, syntax errors)
 """
 import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -268,6 +269,148 @@ class TestOutputFormat:
             exit_code, stdout, _ = run_hook(cwd=tmpdir)
             assert exit_code == 0
             assert stdout.strip() == "{}"
+
+
+def _setup_git_repo(tmp: Path) -> None:
+    """Initialise a bare git repo with one commit in *tmp*."""
+    subprocess.run(["git", "init"], cwd=tmp, capture_output=True, check=False)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"], cwd=tmp, capture_output=True, check=False,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"], cwd=tmp, capture_output=True, check=False,
+    )
+    (tmp / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=tmp, capture_output=True, check=False,
+    )
+
+
+# =============================================================================
+# Go Build Config Tests
+# =============================================================================
+
+GO_AVAILABLE = shutil.which("go") is not None
+
+
+class TestGoCheckConfig:
+    """Tests for .map/config.yaml checks.go.* knobs (issue #435)."""
+
+    def _make_go_project(self, tmp: Path) -> None:
+        """Write a minimal Go project with a compile error into *tmp*."""
+        (tmp / "go.mod").write_text("module example.com/hook_test\n\ngo 1.21\n")
+        # This file references an undefined symbol so 'go build ./...' fails.
+        (tmp / "main.go").write_text(
+            "package main\n\nfunc main() { undefinedSymbolThatDoesNotExist() }\n"
+        )
+
+    def _make_map_config(self, tmp: Path, content: str) -> None:
+        map_dir = tmp / ".map"
+        map_dir.mkdir(exist_ok=True)
+        (map_dir / "config.yaml").write_text(content)
+
+    def test_read_map_config_value_no_file(self):
+        """Helper returns default when .map/config.yaml is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _setup_git_repo(tmp)
+            # No .map/config.yaml — write a trivial untracked file to keep
+            # the hook from exiting early on 'no changes'.
+            (tmp / "touch.txt").write_text("x\n")
+            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            # Hook must still pass (no go.mod present).
+            exit_code, _, _ = run_hook(cwd=str(tmp))
+            assert exit_code == 0
+
+    def test_go_build_disabled_via_config(self):
+        """checks.go.build: false skips the Go build check entirely."""
+        if not GO_AVAILABLE:
+            import pytest
+            pytest.skip("go not in PATH")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _setup_git_repo(tmp)
+            self._make_go_project(tmp)
+            self._make_map_config(tmp, "checks.go.build: false\n")
+            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            exit_code, _, stderr = run_hook(cwd=str(tmp))
+            assert exit_code == 0, (
+                f"build check disabled via config but hook still failed; stderr: {stderr}"
+            )
+            assert "Go build errors" not in stderr
+
+    def test_go_build_enabled_by_default_catches_errors(self):
+        """Without config, a broken Go project is still caught."""
+        if not GO_AVAILABLE:
+            import pytest
+            pytest.skip("go not in PATH")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _setup_git_repo(tmp)
+            self._make_go_project(tmp)
+            # No .map/config.yaml — default behaviour must report the error.
+            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            exit_code, _, stderr = run_hook(cwd=str(tmp))
+            assert exit_code == 2, (
+                f"broken Go project should exit 2 by default; stderr: {stderr}"
+            )
+            assert "Go build errors" in stderr
+
+    def test_go_goos_from_env_respected(self):
+        """GOOS env var is forwarded to go build (existing behaviour preserved)."""
+        if not GO_AVAILABLE:
+            import pytest
+            pytest.skip("go not in PATH")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _setup_git_repo(tmp)
+            # A valid, portable Go project.
+            (tmp / "go.mod").write_text("module example.com/hook_env_test\n\ngo 1.21\n")
+            (tmp / "main.go").write_text("package main\n\nfunc main() {}\n")
+            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            # Should succeed with an explicit GOOS that matches the current platform.
+            import platform
+            host_os = platform.system().lower()
+            exit_code, _, stderr = run_hook(cwd=str(tmp), env={"GOOS": host_os})
+            assert exit_code == 0, f"valid Go project should pass; stderr: {stderr}"
+
+    def test_go_goos_from_config(self):
+        """checks.go.goos in config sets the GOOS used by go build."""
+        if not GO_AVAILABLE:
+            import pytest
+            pytest.skip("go not in PATH")
+        import platform
+        host_os = platform.system().lower()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _setup_git_repo(tmp)
+            (tmp / "go.mod").write_text("module example.com/hook_cfg_test\n\ngo 1.21\n")
+            (tmp / "main.go").write_text("package main\n\nfunc main() {}\n")
+            # Set checks.go.goos to the host OS so the build succeeds.
+            self._make_map_config(tmp, f"checks.go.goos: {host_os}\n")
+            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            exit_code, _, stderr = run_hook(cwd=str(tmp))
+            assert exit_code == 0, (
+                f"valid project with matching checks.go.goos should pass; stderr: {stderr}"
+            )
+
+    def test_go_build_disabled_case_insensitive(self):
+        """checks.go.build accepts False/No/Off/0 spellings."""
+        if not GO_AVAILABLE:
+            import pytest
+            pytest.skip("go not in PATH")
+        for value in ("False", "No", "Off", "0"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                _setup_git_repo(tmp)
+                self._make_go_project(tmp)
+                self._make_map_config(tmp, f"checks.go.build: {value}\n")
+                subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+                exit_code, _, stderr = run_hook(cwd=str(tmp))
+                assert exit_code == 0, (
+                    f"checks.go.build: {value!r} should disable check; stderr: {stderr}"
+                )
 
 
 class TestSyntaxCheckHygiene:

--- a/tests/test_sofa_client.py
+++ b/tests/test_sofa_client.py
@@ -2128,8 +2128,8 @@ def test_vc4_store_does_not_clobber_invalid_existing_credentials(
 
 
 def test_vc4_store_does_not_clobber_unreadable_credentials(tmp_path: Path) -> None:
-    if os.name == "nt":
-        pytest.skip("POSIX unreadable-file contract")
+    if os.name == "nt" or (os.name == "posix" and os.getuid() == 0):
+        pytest.skip("POSIX unreadable-file contract does not apply to root or Windows")
     sofa_dir = tmp_path / ".sofa"
     sofa_dir.mkdir()
     credentials_file = sofa_dir / "credentials.json"


### PR DESCRIPTION
## Summary

Fixes #435 — the `end-of-turn` hook ran `go build ./...` with the host GOOS, giving a false critical on every turn for projects whose only valid build target is Linux (cgroups, eBPF, netlink, etc.) when developed on macOS.

## Changes

### Hook fix (`end-of-turn.sh.jinja` → rendered to `.claude/hooks/` and `src/mapify_cli/templates/hooks/`)

- **`_read_map_config_value` helper** — reads a flat dotted key from `.map/config.yaml` via inline Python (stdlib regex, no PyYAML). Fails silently and returns the default so the hook degrades gracefully to host behavior when config is absent or Python is unavailable.

- **`checks.go.goos: linux`** — when set, that GOOS is forwarded to `go build`. The `GOOS` environment variable takes precedence, so existing workflows and users who already export `GOOS=linux` are unaffected.

- **`checks.go.build: false`** — disables the Go build check entirely for projects that manage cross-compilation externally (Docker, Makefile, CI). Accepts `false`/`False`/`no`/`No`/`off`/`Off`/`0`.

Usage example in `.map/config.yaml`:
```yaml
# Linux-only project — use Linux GOOS for the build check
checks.go.goos: linux

# Or disable it entirely and rely on your container/Makefile
checks.go.build: false
```

### Pre-existing test fix (`tests/test_sofa_client.py`)

`test_vc4_store_does_not_clobber_unreadable_credentials` always failed when pytest runs as root: `chmod 0o000` does not restrict root on Linux, so the file remained readable and the expected `ok=False` never triggered. Added `os.getuid() == 0` to the existing skip condition alongside the Windows skip — both bypass POSIX user-land permission enforcement.

## Test plan

- [ ] `tests/hooks/test_end_of_turn.py::TestGoCheckConfig::test_go_build_disabled_via_config` — `checks.go.build: false` skips check even for broken Go code
- [ ] `tests/hooks/test_end_of_turn.py::TestGoCheckConfig::test_go_build_enabled_by_default_catches_errors` — broken Go project still caught without config
- [ ] `tests/hooks/test_end_of_turn.py::TestGoCheckConfig::test_go_goos_from_env_respected` — `GOOS` env var forwarded to build
- [ ] `tests/hooks/test_end_of_turn.py::TestGoCheckConfig::test_go_goos_from_config` — `checks.go.goos` config key used when env not set
- [ ] `tests/hooks/test_end_of_turn.py::TestGoCheckConfig::test_go_build_disabled_case_insensitive` — all spelling variants of false accepted
- [ ] `make check` — 5277 passed, 4 skipped, 0 failed ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNtLfwP78NoK49TKfBBFpN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to disable Go build checks and select the target operating system.
  * Added safe fallback behavior when configuration files are missing or invalid.
* **Bug Fixes**
  * Preserved clear reporting for failed Go builds.
  * Improved credential-permission tests across Windows and root environments.
* **Tests**
  * Added coverage for Go build defaults, configuration overrides, disabled checks, and environment-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->