### PR TITLE
fix(hooks): end-of-turn Stop hook livelock + no-commit gate false positives (closes #437, closes #438)

### DIFF
--- a/.claude/hooks/end-of-turn.sh
+++ b/.claude/hooks/end-of-turn.sh
@@ -59,7 +59,13 @@ add_critical() {
 # turn (human decision, upstream fix, action outside the agent's authority)
 # livelocks the session: the turn tries to end, the hook blocks again, forever.
 if [[ ! -t 0 ]]; then
-    HOOK_INPUT="$(cat 2>/dev/null || true)"
+    # Bound the read: a harness that leaves stdin open without writing must
+    # not hang the hook ('timeout' is not portable to stock macOS, so use the
+    # bash builtin read -t instead of 'timeout cat').
+    HOOK_INPUT=""
+    while IFS= read -r -t 2 hook_line; do
+        HOOK_INPUT="$HOOK_INPUT$hook_line"$'\n'
+    done || true
     if printf '%s' "$HOOK_INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*"*true'; then
         log "stop_hook_active=true, letting the turn end"
         echo '{}'
@@ -132,9 +138,12 @@ else
     UNTRACKED=""
     CURRENT_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
     if [[ -f "$SNAPSHOT_FILE" ]]; then
+        SNAPSHOT_SET="$(cat "$SNAPSHOT_FILE" 2>/dev/null || true)"
         while IFS= read -r file; do
             [[ -z "$file" ]] && continue
-            if find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
+            # Changed this turn = new (absent from the snapshot) or modified
+            # since the previous run (mtime newer than the snapshot file).
+            if ! grep -qxF "$file" <<< "$SNAPSHOT_SET" || find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
                 UNTRACKED="$UNTRACKED"$'\n'"$file"
             fi
         done <<< "$CURRENT_UNTRACKED"

--- a/.claude/hooks/end-of-turn.sh
+++ b/.claude/hooks/end-of-turn.sh
@@ -11,6 +11,11 @@
 #   - Auto-fixes what it can (silent)
 #   - Only reports critical issues that need manual intervention
 #   - Full linting moved to /map-check command
+#   - Stop-hook re-entry is honored (stop_hook_active) and persistent findings
+#     are self-capped, so a finding the agent cannot resolve inside the turn
+#     never livelocks the session (#437)
+#   - Before the first commit, per-language gates run only on files the current
+#     turn actually wrote (stateful snapshot), not on every untracked file (#438)
 #
 # Exit codes:
 #   0 = Success (continue normally)
@@ -46,6 +51,23 @@ add_critical() {
 }
 
 # -----------------------------------------------------------------------------
+# Stop-hook Re-entry Guard (#437)
+# -----------------------------------------------------------------------------
+# Claude Code re-invokes a Stop hook that blocked, passing 'stop_hook_active:
+# true' in the hook input, so the hook can let the turn end instead of blocking
+# forever. Without this check, any finding that cannot be resolved inside the
+# turn (human decision, upstream fix, action outside the agent's authority)
+# livelocks the session: the turn tries to end, the hook blocks again, forever.
+if [[ ! -t 0 ]]; then
+    HOOK_INPUT="$(cat 2>/dev/null || true)"
+    if printf '%s' "$HOOK_INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*"*true'; then
+        log "stop_hook_active=true, letting the turn end"
+        echo '{}'
+        exit 0
+    fi
+fi
+
+# -----------------------------------------------------------------------------
 # Early Exit: Check for Dirty State
 # -----------------------------------------------------------------------------
 
@@ -54,6 +76,15 @@ if ! git rev-parse --git-dir &>/dev/null; then
     echo '{}'
     exit 0
 fi
+
+# Runtime state lives inside the git dir, so it never pollutes the working tree
+# and never shows up in 'git status'. Used by:
+#   - the no-commit changed-file snapshot (#438)
+#   - the repeated-finding self-cap (#437)
+GIT_DIR_PATH="$(git rev-parse --git-dir 2>/dev/null || true)"
+STATE_DIR="$GIT_DIR_PATH/mapify-end-of-turn"
+SNAPSHOT_FILE="$STATE_DIR/untracked.snapshot"
+BLOCK_STATE_FILE="$STATE_DIR/block.state"
 
 # No changes? Exit silently.
 if [[ -z "$(git status --porcelain 2>/dev/null)" ]]; then
@@ -78,15 +109,39 @@ if [[ -n "$STAGED" ]]; then
 fi
 
 # Unstaged changes (only if HEAD exists)
-if git rev-parse HEAD &>/dev/null; then
+if git rev-parse --verify HEAD &>/dev/null; then
     UNSTAGED=$(git diff --name-only HEAD 2>/dev/null || true)
     if [[ -n "$UNSTAGED" ]]; then
         CHANGED_FILES="$CHANGED_FILES"$'\n'"$UNSTAGED"
     fi
 fi
 
-# Untracked files
-UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+# Untracked files.
+# With HEAD present, plain 'git ls-files --others' is fine. Before the first
+# commit there is no baseline, so it would report every init-created file as
+# "changed" on every turn and the per-language gates would fire on unrelated
+# turns (#438). In that state we gate only files the current turn actually
+# wrote: untracked files that are new or were modified since the previous hook
+# run ended (their mtime is newer than the snapshot written at the end of that
+# run). The very first run has no baseline and treats everything as changed.
+NO_HEAD_MODE=0
+if git rev-parse --verify HEAD &>/dev/null; then
+    UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+else
+    NO_HEAD_MODE=1
+    UNTRACKED=""
+    CURRENT_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+    if [[ -f "$SNAPSHOT_FILE" ]]; then
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
+                UNTRACKED="$UNTRACKED"$'\n'"$file"
+            fi
+        done <<< "$CURRENT_UNTRACKED"
+    else
+        UNTRACKED="$CURRENT_UNTRACKED"
+    fi
+fi
 if [[ -n "$UNTRACKED" ]]; then
     CHANGED_FILES="$CHANGED_FILES"$'\n'"$UNTRACKED"
 fi
@@ -94,7 +149,18 @@ fi
 # Remove empty lines and duplicates
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^$' | sort -u || true)
 
+# Persist the untracked snapshot (no-commit repos only) so the next turn can
+# tell which files are new. Written at the end of the run so its mtime marks
+# "previous run finished" for the -newer comparison above.
+persist_snapshot() {
+    if [[ "$NO_HEAD_MODE" == "1" ]]; then
+        mkdir -p "$STATE_DIR" 2>/dev/null || true
+        printf '%s\n' "$CURRENT_UNTRACKED" | grep -v '^$' | sort -u > "$SNAPSHOT_FILE" 2>/dev/null || true
+    fi
+}
+
 if [[ -z "$CHANGED_FILES" ]]; then
+    persist_snapshot
     log "No specific files to check"
     echo '{}'
     exit 0
@@ -110,7 +176,7 @@ log "Changed files: $(echo "$CHANGED_FILES" | tr '\n' ' ')"
 if command -v ruff &>/dev/null; then
     for file in $CHANGED_FILES; do
         if [[ "$file" == *.py ]] && [[ -f "$file" ]]; then
-            ruff check --fix --quiet "$file" 2>/dev/null || true
+            ruff check --fix --quiet "$file" >/dev/null 2>&1 || true
         fi
     done
 fi
@@ -145,9 +211,9 @@ if [[ -n "$STAGED_FILES" ]]; then
 fi
 
 # Python: Check for syntax errors only (fast, critical).
-# We use `ast.parse` instead of `py_compile` because `py_compile` always
-# writes `__pycache__/*.pyc` next to the source — even with `-B` or
-# PYTHONDONTWRITEBYTECODE, since emitting bytecode is `py_compile`'s entire
+# We use 'ast.parse' instead of 'py_compile' because 'py_compile' always
+# writes '__pycache__/*.pyc' next to the source — even with '-B' or
+# PYTHONDONTWRITEBYTECODE, since emitting bytecode is 'py_compile''s entire
 # job. Touching any .py under .map/scripts/ or src/mapify_cli/templates/ then
 # leaves a tracked __pycache__/ that the template-hygiene gate
 # (tests/test_template_render.py) rejects.
@@ -178,8 +244,48 @@ if command -v go &>/dev/null && [[ -f "go.mod" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Repeated-finding Self-cap (#437)
+# -----------------------------------------------------------------------------
+# A Stop hook that blocks on a finding the agent cannot resolve within the turn
+# would re-block the end of every subsequent turn forever (livelock). The
+# primary guard is the stop_hook_active re-entry check above; this cap is the
+# fallback for harnesses that do not re-invoke Stop hooks with that flag: after
+# N consecutive turns with the exact same critical findings the hook stops
+# blocking and downgrades to a non-blocking warning so the session can proceed.
+if [[ ${#CRITICAL_ISSUES[@]} -gt 0 ]]; then
+    BLOCK_CAP="${MAPIFY_END_OF_TURN_BLOCK_CAP:-3}"
+    [[ "$BLOCK_CAP" =~ ^[0-9]+$ ]] || BLOCK_CAP=3
+    ISSUES_TEXT="$(printf '%s\n' "${CRITICAL_ISSUES[@]}")"
+    COUNT=1
+    if [[ -f "$BLOCK_STATE_FILE" ]]; then
+        PREV_COUNT="$(sed -n '1s/^count=//p' "$BLOCK_STATE_FILE" 2>/dev/null || true)"
+        PREV_TEXT="$(sed -n '3,$p' "$BLOCK_STATE_FILE" 2>/dev/null || true)"
+        if [[ "$PREV_TEXT" == "$ISSUES_TEXT" ]] && [[ "$PREV_COUNT" =~ ^[0-9]+$ ]]; then
+            COUNT=$((PREV_COUNT + 1))
+        fi
+    fi
+    mkdir -p "$STATE_DIR" 2>/dev/null || true
+    printf 'count=%s\n---\n%s\n' "$COUNT" "$ISSUES_TEXT" > "$BLOCK_STATE_FILE" 2>/dev/null || true
+    if [[ "$COUNT" -gt "$BLOCK_CAP" ]]; then
+        echo "⚠️  Same critical issue for $((COUNT - 1)) consecutive turns (self-capped, no longer blocking):" >&2
+        for issue in "${CRITICAL_ISSUES[@]}"; do
+            echo "  - $issue" >&2
+        done
+        echo "" >&2
+        echo "Run /map-check for full diagnostics. Set MAPIFY_END_OF_TURN_BLOCK_CAP to adjust the cap." >&2
+        persist_snapshot
+        exit 1
+    fi
+else
+    # No critical issues this turn: reset the repeat counter.
+    rm -f "$BLOCK_STATE_FILE" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------------
 # Report Results
 # -----------------------------------------------------------------------------
+
+persist_snapshot
 
 if [[ ${#CRITICAL_ISSUES[@]} -gt 0 ]]; then
     echo "⚠️  Critical issues found:" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   init-created file as changed, so per-language checks fired on every turn —
   including docs-only turns. The hook now keeps a per-repo untracked snapshot
   under `.git/mapify-end-of-turn/` and, in commit-less repos, gates only files
-  that are new or were modified since the previous hook run. Closes
+  that are new (absent from the snapshot) or were modified since the previous
+  hook run. The very first run has no baseline and treats all untracked files
+  as changed, so the gate stays useful from turn one. Closes
   azalio/map-framework#438.
 - **`end-of-turn.sh` auto-fix layer is fully silent.** `ruff check --fix`
   diagnostics were written to stdout and leaked into the hook output; stdout is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`end-of-turn.sh` Stop hook no longer livelocks the session.** The hook now
+  honors `stop_hook_active` from the hook input (exits 0 on re-entry so the
+  turn can always end) and self-caps repeated findings: the same critical
+  finding blocks at most `MAPIFY_END_OF_TURN_BLOCK_CAP` (default 3) consecutive
+  turns, then downgrades to a non-blocking warning. A finding the agent cannot
+  resolve inside the turn (human decision, upstream fix, out-of-authority
+  action) no longer blocks the end of every subsequent turn forever. Closes
+  azalio/map-framework#437.
+- **`end-of-turn.sh` gates only files the current turn actually wrote before
+  the first commit.** With no commits, `git status --porcelain` reports every
+  init-created file as changed, so per-language checks fired on every turn —
+  including docs-only turns. The hook now keeps a per-repo untracked snapshot
+  under `.git/mapify-end-of-turn/` and, in commit-less repos, gates only files
+  that are new or were modified since the previous hook run. Closes
+  azalio/map-framework#438.
+- **`end-of-turn.sh` auto-fix layer is fully silent.** `ruff check --fix`
+  diagnostics were written to stdout and leaked into the hook output; stdout is
+  now redirected as well as stderr.
+
 ## [3.27.0] - 2026-08-16
 
 ### Fixed

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2080,7 +2080,7 @@ PreToolUse and Stop hooks that run before/after tool execution:
 |------|------|---------|
 | `block-secrets.py` | PreToolUse | Blocks access to .env, credentials, private keys |
 | `block-dangerous.sh` | PreToolUse | Blocks rm -rf, force push to main, git reset --hard |
-| `end-of-turn.sh` | Stop | Lints code, scans for secrets in staging |
+| `end-of-turn.sh` | Stop | Gates changed files only (syntax/secrets/.env); honors `stop_hook_active` |
 
 **Enforcement:** Hard (deterministic exit codes)
 
@@ -2133,21 +2133,33 @@ Blocks dangerous Bash commands:
 
 #### end-of-turn.sh (Stop)
 
-Quality gate that runs after Claude finishes responding:
+Lightweight quality gate that runs when Claude finishes responding (Stop event).
+Only files the current turn changed are checked; full linting is moved to
+`/map-check`.
 
-**Checks performed:**
-1. **Language-specific linting:**
-   - Python: runs `ruff` if available
-   - Node.js: runs `npm run lint` if available
-   - Go: runs `go vet` and `staticcheck`
-   - Rust: runs `cargo clippy`
+**Checks performed (changed files only):**
+1. **Auto-fix (silent):** `ruff check --fix` on changed `.py` files, `gofmt -w` on changed `.go` files
+2. **Secret scanning:** detects hardcoded secrets in staged files
+3. **.env guard:** blocks staging of `.env` files
+4. **Python syntax:** fast `ast.parse` check on changed `.py` files
+5. **Go build:** runs `go build ./...` when a Go module is present and any changed `.go` file exists
 
-2. **Secret scanning:** Detects hardcoded secrets in staged files
-3. **.env check:** Warns if .env files are staged for commit
+**Livelock protection (Stop-hook contract):**
+- Honors `stop_hook_active` from the hook input: a re-invocation after a block
+  exits 0 immediately, so the turn can always end
+- Self-caps repeated findings: the same critical finding blocks at most
+  `MAPIFY_END_OF_TURN_BLOCK_CAP` (default 3) consecutive turns, then downgrades
+  to a non-blocking warning so a finding the agent cannot resolve inside the
+  turn (human decision, upstream fix) never livelocks the session
+
+**Greenfield repos (no commits yet):**
+- Before the first commit every file is untracked, so the hook keeps a per-repo
+  snapshot under `.git/mapify-end-of-turn/` and gates only files the current
+  turn actually wrote — a docs-only turn is not gated on unrelated sources
 
 **Exit codes:**
 - `0` = No issues
-- `1` = Warnings (non-blocking)
+- `1` = Warnings (non-blocking; also the self-capped repeat-finding downgrade)
 - `2` = Critical issues (blocks and feeds to Claude)
 
 ### Customizing Security
@@ -2544,7 +2556,7 @@ MAP Framework includes additional hooks for security and quality:
 | `improve-prompt.py` | UserPromptSubmit | Prompt clarification and enhancement |
 | `block-secrets.py` | PreToolUse | Block access to sensitive files |
 | `block-dangerous.sh` | PreToolUse | Block dangerous shell commands |
-| `end-of-turn.sh` | Stop | Quality gates (linting, secret scanning) |
+| `end-of-turn.sh` | Stop | Quality gates on changed files (syntax, secrets, .env) |
 
 **Configuration:** See `.claude/settings.json` for hook configuration (or manage via `/hooks`).
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2144,6 +2144,10 @@ Only files the current turn changed are checked; full linting is moved to
 4. **Python syntax:** fast `ast.parse` check on changed `.py` files
 5. **Go build:** runs `go build ./...` when a Go module is present and any changed `.go` file exists
 
+**Blocking:** secrets, `.env` staged, Python syntax errors, and Go build errors
+are critical and block with exit 2; lint/format issues are auto-fixed silently
+and never block.
+
 **Livelock protection (Stop-hook contract):**
 - Honors `stop_hook_active` from the hook input: a re-invocation after a block
   exits 0 immediately, so the turn can always end
@@ -2156,6 +2160,9 @@ Only files the current turn changed are checked; full linting is moved to
 - Before the first commit every file is untracked, so the hook keeps a per-repo
   snapshot under `.git/mapify-end-of-turn/` and gates only files the current
   turn actually wrote — a docs-only turn is not gated on unrelated sources
+- The very first run has no baseline and treats all untracked files as changed;
+  later runs gate only files that are new (absent from the snapshot) or were
+  modified since the previous run (mtime newer than the snapshot file)
 
 **Exit codes:**
 - `0` = No issues
@@ -2263,21 +2270,26 @@ Checks return `skipped` when they cannot run due to missing prerequisites:
 
 ### Hooks Contract: When Hooks Block
 
-**Critical:** Hooks only return exit code 2 (blocking) for **security-critical issues**:
+**Critical:** Stop hooks block with exit code 2; PreToolUse hooks block with a
+JSON `permissionDecision: deny`. Both stop Claude and feed the reason back:
 
-| Blocking (Exit 2) | Non-Blocking (Exit 0-1) |
-|-------------------|-------------------------|
-| Hardcoded secrets in staged files | Linting failures |
-| `.env` file staged for commit | Type errors |
-| Dangerous commands (rm -rf /, force push main) | Formatting issues |
-| Access to credential files | Test failures |
+| Blocking (exit 2 / JSON deny) | Non-Blocking (exit 0-1) |
+|------------------------------|-------------------------|
+| Hardcoded secrets in staged files (exit 2) | Linting failures |
+| `.env` file staged for commit (exit 2) | Type errors |
+| Python syntax errors in changed files (exit 2) | Formatting issues |
+| Go build errors with changed `.go` files (exit 2) | Test failures |
+| Dangerous commands (rm -rf /, force push main) | |
+| Access to credential files | |
 
 **Why this matters:**
-- Exit 2 stops Claude and feeds stderr back for correction
+- Exit 2 (or JSON deny) stops Claude and feeds the reason back for correction
 - Exit 1 shows warning but continues
 - Exit 0 passes silently
 
-**Design principle:** Quality checks (linting, types) should inform, not block. Only security violations warrant blocking.
+**Design principle:** Quality checks (linting, types) should inform, not block.
+Only critical issues — security violations, or code that cannot compile
+(Python syntax errors, Go build failures) — warrant blocking.
 
 ### Early Termination with `won't_do` Status
 

--- a/src/mapify_cli/templates/hooks/end-of-turn.sh
+++ b/src/mapify_cli/templates/hooks/end-of-turn.sh
@@ -59,7 +59,13 @@ add_critical() {
 # turn (human decision, upstream fix, action outside the agent's authority)
 # livelocks the session: the turn tries to end, the hook blocks again, forever.
 if [[ ! -t 0 ]]; then
-    HOOK_INPUT="$(cat 2>/dev/null || true)"
+    # Bound the read: a harness that leaves stdin open without writing must
+    # not hang the hook ('timeout' is not portable to stock macOS, so use the
+    # bash builtin read -t instead of 'timeout cat').
+    HOOK_INPUT=""
+    while IFS= read -r -t 2 hook_line; do
+        HOOK_INPUT="$HOOK_INPUT$hook_line"$'\n'
+    done || true
     if printf '%s' "$HOOK_INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*"*true'; then
         log "stop_hook_active=true, letting the turn end"
         echo '{}'
@@ -132,9 +138,12 @@ else
     UNTRACKED=""
     CURRENT_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
     if [[ -f "$SNAPSHOT_FILE" ]]; then
+        SNAPSHOT_SET="$(cat "$SNAPSHOT_FILE" 2>/dev/null || true)"
         while IFS= read -r file; do
             [[ -z "$file" ]] && continue
-            if find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
+            # Changed this turn = new (absent from the snapshot) or modified
+            # since the previous run (mtime newer than the snapshot file).
+            if ! grep -qxF "$file" <<< "$SNAPSHOT_SET" || find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
                 UNTRACKED="$UNTRACKED"$'\n'"$file"
             fi
         done <<< "$CURRENT_UNTRACKED"

--- a/src/mapify_cli/templates/hooks/end-of-turn.sh
+++ b/src/mapify_cli/templates/hooks/end-of-turn.sh
@@ -11,6 +11,11 @@
 #   - Auto-fixes what it can (silent)
 #   - Only reports critical issues that need manual intervention
 #   - Full linting moved to /map-check command
+#   - Stop-hook re-entry is honored (stop_hook_active) and persistent findings
+#     are self-capped, so a finding the agent cannot resolve inside the turn
+#     never livelocks the session (#437)
+#   - Before the first commit, per-language gates run only on files the current
+#     turn actually wrote (stateful snapshot), not on every untracked file (#438)
 #
 # Exit codes:
 #   0 = Success (continue normally)
@@ -46,6 +51,23 @@ add_critical() {
 }
 
 # -----------------------------------------------------------------------------
+# Stop-hook Re-entry Guard (#437)
+# -----------------------------------------------------------------------------
+# Claude Code re-invokes a Stop hook that blocked, passing 'stop_hook_active:
+# true' in the hook input, so the hook can let the turn end instead of blocking
+# forever. Without this check, any finding that cannot be resolved inside the
+# turn (human decision, upstream fix, action outside the agent's authority)
+# livelocks the session: the turn tries to end, the hook blocks again, forever.
+if [[ ! -t 0 ]]; then
+    HOOK_INPUT="$(cat 2>/dev/null || true)"
+    if printf '%s' "$HOOK_INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*"*true'; then
+        log "stop_hook_active=true, letting the turn end"
+        echo '{}'
+        exit 0
+    fi
+fi
+
+# -----------------------------------------------------------------------------
 # Early Exit: Check for Dirty State
 # -----------------------------------------------------------------------------
 
@@ -54,6 +76,15 @@ if ! git rev-parse --git-dir &>/dev/null; then
     echo '{}'
     exit 0
 fi
+
+# Runtime state lives inside the git dir, so it never pollutes the working tree
+# and never shows up in 'git status'. Used by:
+#   - the no-commit changed-file snapshot (#438)
+#   - the repeated-finding self-cap (#437)
+GIT_DIR_PATH="$(git rev-parse --git-dir 2>/dev/null || true)"
+STATE_DIR="$GIT_DIR_PATH/mapify-end-of-turn"
+SNAPSHOT_FILE="$STATE_DIR/untracked.snapshot"
+BLOCK_STATE_FILE="$STATE_DIR/block.state"
 
 # No changes? Exit silently.
 if [[ -z "$(git status --porcelain 2>/dev/null)" ]]; then
@@ -78,15 +109,39 @@ if [[ -n "$STAGED" ]]; then
 fi
 
 # Unstaged changes (only if HEAD exists)
-if git rev-parse HEAD &>/dev/null; then
+if git rev-parse --verify HEAD &>/dev/null; then
     UNSTAGED=$(git diff --name-only HEAD 2>/dev/null || true)
     if [[ -n "$UNSTAGED" ]]; then
         CHANGED_FILES="$CHANGED_FILES"$'\n'"$UNSTAGED"
     fi
 fi
 
-# Untracked files
-UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+# Untracked files.
+# With HEAD present, plain 'git ls-files --others' is fine. Before the first
+# commit there is no baseline, so it would report every init-created file as
+# "changed" on every turn and the per-language gates would fire on unrelated
+# turns (#438). In that state we gate only files the current turn actually
+# wrote: untracked files that are new or were modified since the previous hook
+# run ended (their mtime is newer than the snapshot written at the end of that
+# run). The very first run has no baseline and treats everything as changed.
+NO_HEAD_MODE=0
+if git rev-parse --verify HEAD &>/dev/null; then
+    UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+else
+    NO_HEAD_MODE=1
+    UNTRACKED=""
+    CURRENT_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+    if [[ -f "$SNAPSHOT_FILE" ]]; then
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
+                UNTRACKED="$UNTRACKED"$'\n'"$file"
+            fi
+        done <<< "$CURRENT_UNTRACKED"
+    else
+        UNTRACKED="$CURRENT_UNTRACKED"
+    fi
+fi
 if [[ -n "$UNTRACKED" ]]; then
     CHANGED_FILES="$CHANGED_FILES"$'\n'"$UNTRACKED"
 fi
@@ -94,7 +149,18 @@ fi
 # Remove empty lines and duplicates
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^$' | sort -u || true)
 
+# Persist the untracked snapshot (no-commit repos only) so the next turn can
+# tell which files are new. Written at the end of the run so its mtime marks
+# "previous run finished" for the -newer comparison above.
+persist_snapshot() {
+    if [[ "$NO_HEAD_MODE" == "1" ]]; then
+        mkdir -p "$STATE_DIR" 2>/dev/null || true
+        printf '%s\n' "$CURRENT_UNTRACKED" | grep -v '^$' | sort -u > "$SNAPSHOT_FILE" 2>/dev/null || true
+    fi
+}
+
 if [[ -z "$CHANGED_FILES" ]]; then
+    persist_snapshot
     log "No specific files to check"
     echo '{}'
     exit 0
@@ -110,7 +176,7 @@ log "Changed files: $(echo "$CHANGED_FILES" | tr '\n' ' ')"
 if command -v ruff &>/dev/null; then
     for file in $CHANGED_FILES; do
         if [[ "$file" == *.py ]] && [[ -f "$file" ]]; then
-            ruff check --fix --quiet "$file" 2>/dev/null || true
+            ruff check --fix --quiet "$file" >/dev/null 2>&1 || true
         fi
     done
 fi
@@ -145,9 +211,9 @@ if [[ -n "$STAGED_FILES" ]]; then
 fi
 
 # Python: Check for syntax errors only (fast, critical).
-# We use `ast.parse` instead of `py_compile` because `py_compile` always
-# writes `__pycache__/*.pyc` next to the source — even with `-B` or
-# PYTHONDONTWRITEBYTECODE, since emitting bytecode is `py_compile`'s entire
+# We use 'ast.parse' instead of 'py_compile' because 'py_compile' always
+# writes '__pycache__/*.pyc' next to the source — even with '-B' or
+# PYTHONDONTWRITEBYTECODE, since emitting bytecode is 'py_compile''s entire
 # job. Touching any .py under .map/scripts/ or src/mapify_cli/templates/ then
 # leaves a tracked __pycache__/ that the template-hygiene gate
 # (tests/test_template_render.py) rejects.
@@ -178,8 +244,48 @@ if command -v go &>/dev/null && [[ -f "go.mod" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Repeated-finding Self-cap (#437)
+# -----------------------------------------------------------------------------
+# A Stop hook that blocks on a finding the agent cannot resolve within the turn
+# would re-block the end of every subsequent turn forever (livelock). The
+# primary guard is the stop_hook_active re-entry check above; this cap is the
+# fallback for harnesses that do not re-invoke Stop hooks with that flag: after
+# N consecutive turns with the exact same critical findings the hook stops
+# blocking and downgrades to a non-blocking warning so the session can proceed.
+if [[ ${#CRITICAL_ISSUES[@]} -gt 0 ]]; then
+    BLOCK_CAP="${MAPIFY_END_OF_TURN_BLOCK_CAP:-3}"
+    [[ "$BLOCK_CAP" =~ ^[0-9]+$ ]] || BLOCK_CAP=3
+    ISSUES_TEXT="$(printf '%s\n' "${CRITICAL_ISSUES[@]}")"
+    COUNT=1
+    if [[ -f "$BLOCK_STATE_FILE" ]]; then
+        PREV_COUNT="$(sed -n '1s/^count=//p' "$BLOCK_STATE_FILE" 2>/dev/null || true)"
+        PREV_TEXT="$(sed -n '3,$p' "$BLOCK_STATE_FILE" 2>/dev/null || true)"
+        if [[ "$PREV_TEXT" == "$ISSUES_TEXT" ]] && [[ "$PREV_COUNT" =~ ^[0-9]+$ ]]; then
+            COUNT=$((PREV_COUNT + 1))
+        fi
+    fi
+    mkdir -p "$STATE_DIR" 2>/dev/null || true
+    printf 'count=%s\n---\n%s\n' "$COUNT" "$ISSUES_TEXT" > "$BLOCK_STATE_FILE" 2>/dev/null || true
+    if [[ "$COUNT" -gt "$BLOCK_CAP" ]]; then
+        echo "⚠️  Same critical issue for $((COUNT - 1)) consecutive turns (self-capped, no longer blocking):" >&2
+        for issue in "${CRITICAL_ISSUES[@]}"; do
+            echo "  - $issue" >&2
+        done
+        echo "" >&2
+        echo "Run /map-check for full diagnostics. Set MAPIFY_END_OF_TURN_BLOCK_CAP to adjust the cap." >&2
+        persist_snapshot
+        exit 1
+    fi
+else
+    # No critical issues this turn: reset the repeat counter.
+    rm -f "$BLOCK_STATE_FILE" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------------
 # Report Results
 # -----------------------------------------------------------------------------
+
+persist_snapshot
 
 if [[ ${#CRITICAL_ISSUES[@]} -gt 0 ]]; then
     echo "⚠️  Critical issues found:" >&2

--- a/src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja
+++ b/src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja
@@ -59,7 +59,13 @@ add_critical() {
 # turn (human decision, upstream fix, action outside the agent's authority)
 # livelocks the session: the turn tries to end, the hook blocks again, forever.
 if [[ ! -t 0 ]]; then
-    HOOK_INPUT="$(cat 2>/dev/null || true)"
+    # Bound the read: a harness that leaves stdin open without writing must
+    # not hang the hook ('timeout' is not portable to stock macOS, so use the
+    # bash builtin read -t instead of 'timeout cat').
+    HOOK_INPUT=""
+    while IFS= read -r -t 2 hook_line; do
+        HOOK_INPUT="$HOOK_INPUT$hook_line"$'\n'
+    done || true
     if printf '%s' "$HOOK_INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*"*true'; then
         log "stop_hook_active=true, letting the turn end"
         echo '{}'
@@ -132,9 +138,12 @@ else
     UNTRACKED=""
     CURRENT_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
     if [[ -f "$SNAPSHOT_FILE" ]]; then
+        SNAPSHOT_SET="$(cat "$SNAPSHOT_FILE" 2>/dev/null || true)"
         while IFS= read -r file; do
             [[ -z "$file" ]] && continue
-            if find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
+            # Changed this turn = new (absent from the snapshot) or modified
+            # since the previous run (mtime newer than the snapshot file).
+            if ! grep -qxF "$file" <<< "$SNAPSHOT_SET" || find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
                 UNTRACKED="$UNTRACKED"$'\n'"$file"
             fi
         done <<< "$CURRENT_UNTRACKED"

--- a/src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja
+++ b/src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja
@@ -11,6 +11,11 @@
 #   - Auto-fixes what it can (silent)
 #   - Only reports critical issues that need manual intervention
 #   - Full linting moved to /map-check command
+#   - Stop-hook re-entry is honored (stop_hook_active) and persistent findings
+#     are self-capped, so a finding the agent cannot resolve inside the turn
+#     never livelocks the session (#437)
+#   - Before the first commit, per-language gates run only on files the current
+#     turn actually wrote (stateful snapshot), not on every untracked file (#438)
 #
 # Exit codes:
 #   0 = Success (continue normally)
@@ -46,6 +51,23 @@ add_critical() {
 }
 
 # -----------------------------------------------------------------------------
+# Stop-hook Re-entry Guard (#437)
+# -----------------------------------------------------------------------------
+# Claude Code re-invokes a Stop hook that blocked, passing 'stop_hook_active:
+# true' in the hook input, so the hook can let the turn end instead of blocking
+# forever. Without this check, any finding that cannot be resolved inside the
+# turn (human decision, upstream fix, action outside the agent's authority)
+# livelocks the session: the turn tries to end, the hook blocks again, forever.
+if [[ ! -t 0 ]]; then
+    HOOK_INPUT="$(cat 2>/dev/null || true)"
+    if printf '%s' "$HOOK_INPUT" | grep -qE '"stop_hook_active"[[:space:]]*:[[:space:]]*"*true'; then
+        log "stop_hook_active=true, letting the turn end"
+        echo '{}'
+        exit 0
+    fi
+fi
+
+# -----------------------------------------------------------------------------
 # Early Exit: Check for Dirty State
 # -----------------------------------------------------------------------------
 
@@ -54,6 +76,15 @@ if ! git rev-parse --git-dir &>/dev/null; then
     echo '{}'
     exit 0
 fi
+
+# Runtime state lives inside the git dir, so it never pollutes the working tree
+# and never shows up in 'git status'. Used by:
+#   - the no-commit changed-file snapshot (#438)
+#   - the repeated-finding self-cap (#437)
+GIT_DIR_PATH="$(git rev-parse --git-dir 2>/dev/null || true)"
+STATE_DIR="$GIT_DIR_PATH/mapify-end-of-turn"
+SNAPSHOT_FILE="$STATE_DIR/untracked.snapshot"
+BLOCK_STATE_FILE="$STATE_DIR/block.state"
 
 # No changes? Exit silently.
 if [[ -z "$(git status --porcelain 2>/dev/null)" ]]; then
@@ -78,15 +109,39 @@ if [[ -n "$STAGED" ]]; then
 fi
 
 # Unstaged changes (only if HEAD exists)
-if git rev-parse HEAD &>/dev/null; then
+if git rev-parse --verify HEAD &>/dev/null; then
     UNSTAGED=$(git diff --name-only HEAD 2>/dev/null || true)
     if [[ -n "$UNSTAGED" ]]; then
         CHANGED_FILES="$CHANGED_FILES"$'\n'"$UNSTAGED"
     fi
 fi
 
-# Untracked files
-UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+# Untracked files.
+# With HEAD present, plain 'git ls-files --others' is fine. Before the first
+# commit there is no baseline, so it would report every init-created file as
+# "changed" on every turn and the per-language gates would fire on unrelated
+# turns (#438). In that state we gate only files the current turn actually
+# wrote: untracked files that are new or were modified since the previous hook
+# run ended (their mtime is newer than the snapshot written at the end of that
+# run). The very first run has no baseline and treats everything as changed.
+NO_HEAD_MODE=0
+if git rev-parse --verify HEAD &>/dev/null; then
+    UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+else
+    NO_HEAD_MODE=1
+    UNTRACKED=""
+    CURRENT_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null || true)
+    if [[ -f "$SNAPSHOT_FILE" ]]; then
+        while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if find "$file" -newer "$SNAPSHOT_FILE" -print 2>/dev/null | grep -q .; then
+                UNTRACKED="$UNTRACKED"$'\n'"$file"
+            fi
+        done <<< "$CURRENT_UNTRACKED"
+    else
+        UNTRACKED="$CURRENT_UNTRACKED"
+    fi
+fi
 if [[ -n "$UNTRACKED" ]]; then
     CHANGED_FILES="$CHANGED_FILES"$'\n'"$UNTRACKED"
 fi
@@ -94,7 +149,18 @@ fi
 # Remove empty lines and duplicates
 CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^$' | sort -u || true)
 
+# Persist the untracked snapshot (no-commit repos only) so the next turn can
+# tell which files are new. Written at the end of the run so its mtime marks
+# "previous run finished" for the -newer comparison above.
+persist_snapshot() {
+    if [[ "$NO_HEAD_MODE" == "1" ]]; then
+        mkdir -p "$STATE_DIR" 2>/dev/null || true
+        printf '%s\n' "$CURRENT_UNTRACKED" | grep -v '^$' | sort -u > "$SNAPSHOT_FILE" 2>/dev/null || true
+    fi
+}
+
 if [[ -z "$CHANGED_FILES" ]]; then
+    persist_snapshot
     log "No specific files to check"
     echo '{}'
     exit 0
@@ -110,7 +176,7 @@ log "Changed files: $(echo "$CHANGED_FILES" | tr '\n' ' ')"
 if command -v ruff &>/dev/null; then
     for file in $CHANGED_FILES; do
         if [[ "$file" == *.py ]] && [[ -f "$file" ]]; then
-            ruff check --fix --quiet "$file" 2>/dev/null || true
+            ruff check --fix --quiet "$file" >/dev/null 2>&1 || true
         fi
     done
 fi
@@ -145,9 +211,9 @@ if [[ -n "$STAGED_FILES" ]]; then
 fi
 
 # Python: Check for syntax errors only (fast, critical).
-# We use `ast.parse` instead of `py_compile` because `py_compile` always
-# writes `__pycache__/*.pyc` next to the source — even with `-B` or
-# PYTHONDONTWRITEBYTECODE, since emitting bytecode is `py_compile`'s entire
+# We use 'ast.parse' instead of 'py_compile' because 'py_compile' always
+# writes '__pycache__/*.pyc' next to the source — even with '-B' or
+# PYTHONDONTWRITEBYTECODE, since emitting bytecode is 'py_compile''s entire
 # job. Touching any .py under .map/scripts/ or src/mapify_cli/templates/ then
 # leaves a tracked __pycache__/ that the template-hygiene gate
 # (tests/test_template_render.py) rejects.
@@ -178,8 +244,48 @@ if command -v go &>/dev/null && [[ -f "go.mod" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Repeated-finding Self-cap (#437)
+# -----------------------------------------------------------------------------
+# A Stop hook that blocks on a finding the agent cannot resolve within the turn
+# would re-block the end of every subsequent turn forever (livelock). The
+# primary guard is the stop_hook_active re-entry check above; this cap is the
+# fallback for harnesses that do not re-invoke Stop hooks with that flag: after
+# N consecutive turns with the exact same critical findings the hook stops
+# blocking and downgrades to a non-blocking warning so the session can proceed.
+if [[ ${#CRITICAL_ISSUES[@]} -gt 0 ]]; then
+    BLOCK_CAP="${MAPIFY_END_OF_TURN_BLOCK_CAP:-3}"
+    [[ "$BLOCK_CAP" =~ ^[0-9]+$ ]] || BLOCK_CAP=3
+    ISSUES_TEXT="$(printf '%s\n' "${CRITICAL_ISSUES[@]}")"
+    COUNT=1
+    if [[ -f "$BLOCK_STATE_FILE" ]]; then
+        PREV_COUNT="$(sed -n '1s/^count=//p' "$BLOCK_STATE_FILE" 2>/dev/null || true)"
+        PREV_TEXT="$(sed -n '3,$p' "$BLOCK_STATE_FILE" 2>/dev/null || true)"
+        if [[ "$PREV_TEXT" == "$ISSUES_TEXT" ]] && [[ "$PREV_COUNT" =~ ^[0-9]+$ ]]; then
+            COUNT=$((PREV_COUNT + 1))
+        fi
+    fi
+    mkdir -p "$STATE_DIR" 2>/dev/null || true
+    printf 'count=%s\n---\n%s\n' "$COUNT" "$ISSUES_TEXT" > "$BLOCK_STATE_FILE" 2>/dev/null || true
+    if [[ "$COUNT" -gt "$BLOCK_CAP" ]]; then
+        echo "⚠️  Same critical issue for $((COUNT - 1)) consecutive turns (self-capped, no longer blocking):" >&2
+        for issue in "${CRITICAL_ISSUES[@]}"; do
+            echo "  - $issue" >&2
+        done
+        echo "" >&2
+        echo "Run /map-check for full diagnostics. Set MAPIFY_END_OF_TURN_BLOCK_CAP to adjust the cap." >&2
+        persist_snapshot
+        exit 1
+    fi
+else
+    # No critical issues this turn: reset the repeat counter.
+    rm -f "$BLOCK_STATE_FILE" 2>/dev/null || true
+fi
+
+# -----------------------------------------------------------------------------
 # Report Results
 # -----------------------------------------------------------------------------
+
+persist_snapshot
 
 if [[ ${#CRITICAL_ISSUES[@]} -gt 0 ]]; then
     echo "⚠️  Critical issues found:" >&2

--- a/tests/hooks/test_end_of_turn.py
+++ b/tests/hooks/test_end_of_turn.py
@@ -7,23 +7,40 @@ Tests the lightweight version that:
 - Auto-fixes what it can
 - Only reports critical issues (secrets, .env files, syntax errors)
 """
+
+import json
 import os
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 # Path to the hook script
 HOOK_PATH = Path(__file__).parent.parent.parent / ".claude" / "hooks" / "end-of-turn.sh"
 
 
-def run_hook(cwd: str | None = None, env: dict | None = None) -> tuple[int, str, str]:
-    """Execute the hook in given directory."""
+def run_hook(
+    cwd: str | None = None,
+    env: dict | None = None,
+    input_text: str = "",
+) -> tuple[int, str, str]:
+    """Execute the hook in given directory.
+
+    ``input_text`` is piped to the hook's stdin (Claude Code passes the hook
+    input JSON there, e.g. with ``stop_hook_active``); empty by default so the
+    hook never blocks on an inherited terminal.
+    """
     run_env = os.environ.copy()
     if env:
         run_env.update(env)
     result = subprocess.run(
-        ["bash", str(HOOK_PATH)], capture_output=True, text=True, cwd=cwd, env=run_env,
+        ["bash", str(HOOK_PATH)],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=run_env,
         check=False,
+        input=input_text,
     )
     return result.returncode, result.stdout, result.stderr
 
@@ -73,7 +90,9 @@ class TestEarlyExit:
         """Should exit 0 if git repo has no changes."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Init git repo with a commit
-            subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "init"], cwd=tmpdir, capture_output=True, check=False
+            )
             subprocess.run(
                 ["git", "config", "user.email", "test@test.com"],
                 cwd=tmpdir,
@@ -81,14 +100,20 @@ class TestEarlyExit:
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True,
+                ["git", "config", "user.name", "Test"],
+                cwd=tmpdir,
+                capture_output=True,
                 check=False,
             )
             # Create and commit a file
             (Path(tmpdir) / "file.txt").write_text("content\n")
-            subprocess.run(["git", "add", "."], cwd=tmpdir, capture_output=True, check=False)
             subprocess.run(
-                ["git", "commit", "-m", "initial"], cwd=tmpdir, capture_output=True,
+                ["git", "add", "."], cwd=tmpdir, capture_output=True, check=False
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "initial"],
+                cwd=tmpdir,
+                capture_output=True,
                 check=False,
             )
 
@@ -110,7 +135,9 @@ class TestSecretDetection:
         """VC3: Secret scanning finds 'API_KEY=abc123' pattern."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Initialize git repo
-            subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "init"], cwd=tmpdir, capture_output=True, check=False
+            )
             subprocess.run(
                 ["git", "config", "user.email", "test@test.com"],
                 cwd=tmpdir,
@@ -118,7 +145,9 @@ class TestSecretDetection:
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True,
+                ["git", "config", "user.name", "Test"],
+                cwd=tmpdir,
+                capture_output=True,
                 check=False,
             )
 
@@ -127,7 +156,12 @@ class TestSecretDetection:
             secret_file.write_text('API_KEY = "sk_live_1234567890abcdef"\n')
 
             # Stage it
-            subprocess.run(["git", "add", "config.py"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "add", "config.py"],
+                cwd=tmpdir,
+                capture_output=True,
+                check=False,
+            )
 
             # Run hook
             exit_code, _, stderr = run_hook(cwd=tmpdir)
@@ -139,7 +173,9 @@ class TestSecretDetection:
     def test_no_secret_in_clean_file(self):
         """No false positives for clean files."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "init"], cwd=tmpdir, capture_output=True, check=False
+            )
             subprocess.run(
                 ["git", "config", "user.email", "test@test.com"],
                 cwd=tmpdir,
@@ -147,14 +183,18 @@ class TestSecretDetection:
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True,
+                ["git", "config", "user.name", "Test"],
+                cwd=tmpdir,
+                capture_output=True,
                 check=False,
             )
 
             clean_file = Path(tmpdir) / "clean.py"
             clean_file.write_text('print("Hello")\n')
 
-            subprocess.run(["git", "add", "clean.py"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "add", "clean.py"], cwd=tmpdir, capture_output=True, check=False
+            )
 
             exit_code, _, _ = run_hook(cwd=tmpdir)
             assert exit_code == 0, "Should exit 0 for clean file"
@@ -171,7 +211,9 @@ class TestEnvFileDetection:
     def test_detect_env_staged(self):
         """VC4: Warns if .env file is in git staging area."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "init"], cwd=tmpdir, capture_output=True, check=False
+            )
             subprocess.run(
                 ["git", "config", "user.email", "test@test.com"],
                 cwd=tmpdir,
@@ -179,14 +221,18 @@ class TestEnvFileDetection:
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True,
+                ["git", "config", "user.name", "Test"],
+                cwd=tmpdir,
+                capture_output=True,
                 check=False,
             )
 
             env_file = Path(tmpdir) / ".env"
             env_file.write_text("DATABASE_URL=postgres://localhost\n")
 
-            subprocess.run(["git", "add", ".env"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "add", ".env"], cwd=tmpdir, capture_output=True, check=False
+            )
 
             exit_code, _, stderr = run_hook(cwd=tmpdir)
 
@@ -221,7 +267,9 @@ class TestVerboseMode:
         """CLAUDE_HOOK_VERBOSE=true enables logging when changes exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Init repo with uncommitted file
-            subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "init"], cwd=tmpdir, capture_output=True, check=False
+            )
             subprocess.run(
                 ["git", "config", "user.email", "test@test.com"],
                 cwd=tmpdir,
@@ -229,11 +277,15 @@ class TestVerboseMode:
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True,
+                ["git", "config", "user.name", "Test"],
+                cwd=tmpdir,
+                capture_output=True,
                 check=False,
             )
             (Path(tmpdir) / "file.txt").write_text("content\n")
-            subprocess.run(["git", "add", "file.txt"], cwd=tmpdir, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "add", "file.txt"], cwd=tmpdir, capture_output=True, check=False
+            )
 
             exit_code, _, stderr = run_hook(
                 cwd=tmpdir, env={"CLAUDE_HOOK_VERBOSE": "true"}
@@ -286,17 +338,25 @@ class TestSyntaxCheckHygiene:
             tmp = Path(tmpdir)
             subprocess.run(["git", "init"], cwd=tmp, capture_output=True, check=False)
             subprocess.run(
-                ["git", "config", "user.email", "t@t.com"], cwd=tmp, capture_output=True,
+                ["git", "config", "user.email", "t@t.com"],
+                cwd=tmp,
+                capture_output=True,
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "t"], cwd=tmp, capture_output=True,
+                ["git", "config", "user.name", "t"],
+                cwd=tmp,
+                capture_output=True,
                 check=False,
             )
             (tmp / "seed.txt").write_text("seed\n")
-            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
             subprocess.run(
-                ["git", "commit", "-m", "init"], cwd=tmp, capture_output=True,
+                ["git", "add", "."], cwd=tmp, capture_output=True, check=False
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "init"],
+                cwd=tmp,
+                capture_output=True,
                 check=False,
             )
 
@@ -304,7 +364,9 @@ class TestSyntaxCheckHygiene:
             # syntax-check loop.
             py_file = tmp / "module_under_check.py"
             py_file.write_text("x = 1\n")
-            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "add", "."], cwd=tmp, capture_output=True, check=False
+            )
 
             exit_code, _, _ = run_hook(cwd=str(tmp))
             assert exit_code == 0, "syntax-check must pass for valid .py"
@@ -315,34 +377,146 @@ class TestSyntaxCheckHygiene:
                 f"hook must not create __pycache__ next to changed files; "
                 f"found: {pycache_dirs}"
             )
-            assert not pyc_files, (
-                f"hook must not create .pyc files; found: {pyc_files}"
-            )
+            assert not pyc_files, f"hook must not create .pyc files; found: {pyc_files}"
 
     def test_hook_still_catches_syntax_errors(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             subprocess.run(["git", "init"], cwd=tmp, capture_output=True, check=False)
             subprocess.run(
-                ["git", "config", "user.email", "t@t.com"], cwd=tmp, capture_output=True,
+                ["git", "config", "user.email", "t@t.com"],
+                cwd=tmp,
+                capture_output=True,
                 check=False,
             )
             subprocess.run(
-                ["git", "config", "user.name", "t"], cwd=tmp, capture_output=True,
+                ["git", "config", "user.name", "t"],
+                cwd=tmp,
+                capture_output=True,
                 check=False,
             )
             (tmp / "seed.txt").write_text("seed\n")
-            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
             subprocess.run(
-                ["git", "commit", "-m", "init"], cwd=tmp, capture_output=True,
+                ["git", "add", "."], cwd=tmp, capture_output=True, check=False
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "init"],
+                cwd=tmp,
+                capture_output=True,
                 check=False,
             )
 
             (tmp / "broken.py").write_text("def f(:\n    pass\n")
-            subprocess.run(["git", "add", "."], cwd=tmp, capture_output=True, check=False)
+            subprocess.run(
+                ["git", "add", "."], cwd=tmp, capture_output=True, check=False
+            )
 
             exit_code, _, stderr = run_hook(cwd=str(tmp))
-            assert exit_code == 2, (
-                "broken Python must trigger critical-issue blocking exit"
-            )
+            assert (
+                exit_code == 2
+            ), "broken Python must trigger critical-issue blocking exit"
             assert "Python syntax error" in stderr, stderr
+
+
+def _init_git(tmp: Path) -> None:
+    """Init a git repo with identity configured (no commits made)."""
+    subprocess.run(["git", "init"], cwd=tmp, capture_output=True, check=False)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"],
+        cwd=tmp,
+        capture_output=True,
+        check=False,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"],
+        cwd=tmp,
+        capture_output=True,
+        check=False,
+    )
+
+
+class TestRegressionStopHookAndNoCommit:
+    """Regression tests for the Stop-hook livelock (#437) and the no-commit
+    changed-file false positives (#438)."""
+
+    def test_stop_hook_active_lets_turn_end(self):
+        """A blocked Stop hook is re-invoked with stop_hook_active=true; the
+        hook must exit 0 so the turn can end instead of livelocking (#437)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _init_git(tmp)
+            (tmp / "broken.py").write_text("def f(:\n    pass\n")
+
+            # Without the flag the finding blocks.
+            code, _, stderr = run_hook(cwd=str(tmp))
+            assert code == 2, stderr
+
+            # With stop_hook_active=true the hook lets the turn end.
+            payload = json.dumps({"session_id": "s1", "stop_hook_active": True})
+            code, stdout, _ = run_hook(cwd=str(tmp), input_text=payload)
+            assert code == 0, "stop_hook_active=true must exit 0"
+            assert stdout.strip() == "{}"
+
+    def test_self_cap_stops_blocking_persistent_finding(self):
+        """A finding that persists across turns must stop blocking after the
+        cap (default 3), downgrading to a non-blocking warning (#437)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _init_git(tmp)
+            broken = tmp / "broken.py"
+            broken.write_text("def f(:\n    pass\n")
+
+            # The no-commit snapshot (#438) stops re-gating untouched files, so
+            # simulate the real re-fire scenario (the file is touched again each
+            # turn while the error persists) by bumping the mtime.
+            for _ in range(3):
+                os.utime(broken, (time.time() + 60, time.time() + 60))
+                code, _, stderr = run_hook(cwd=str(tmp))
+                assert code == 2, stderr
+
+            os.utime(broken, (time.time() + 60, time.time() + 60))
+            code, _, stderr = run_hook(cwd=str(tmp))
+            assert code == 1, f"expected downgraded warning, got {code}: {stderr}"
+            assert "self-capped" in stderr
+
+    def test_self_cap_resets_when_finding_changes(self):
+        """The cap counts consecutive identical findings only; a different
+        finding starts a fresh count and blocks again (#437)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _init_git(tmp)
+            broken = tmp / "broken.py"
+            broken.write_text("def f(:\n    pass\n")
+
+            for _ in range(3):
+                os.utime(broken, (time.time() + 60, time.time() + 60))
+                code, _, _ = run_hook(cwd=str(tmp))
+                assert code == 2
+
+            # Different finding: fix broken.py and break another file.
+            broken.write_text("x = 1\n")
+            broken2 = tmp / "broken2.py"
+            broken2.write_text("def g(:\n    pass\n")
+            os.utime(broken, (time.time() + 60, time.time() + 60))
+            os.utime(broken2, (time.time() + 60, time.time() + 60))
+
+            code, _, stderr = run_hook(cwd=str(tmp))
+            assert code == 2, f"new finding must block again: {stderr}"
+
+    def test_no_commit_repo_gates_only_current_turn_files(self):
+        """#438: before the first commit every file is untracked; the
+        per-language gates must not re-fire on files from previous turns, so a
+        docs-only turn is not gated on unrelated sources."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            _init_git(tmp)
+            (tmp / "broken.py").write_text("def f(:\n    pass\n")
+
+            # Turn 1: broken.py is new -> the gate blocks.
+            code, _, stderr = run_hook(cwd=str(tmp))
+            assert code == 2, stderr
+
+            # Turn 2: only docs touched; broken.py unchanged -> no block.
+            (tmp / "README.md").write_text("# Docs\n")
+            code, _, stderr = run_hook(cwd=str(tmp))
+            assert code == 0, f"docs-only turn must pass: {stderr}"


### PR DESCRIPTION
## Summary

Fixes two open bugs in the shipped `.claude/hooks/end-of-turn.sh` Stop hook (single source of truth: `src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja`):

- **Closes #437 — Stop hook livelocks the session.** The hook never read the hook input, so it ignored `stop_hook_active` — the exact contract Claude Code gives a Stop hook to let a blocked turn end — and had no cap on persistent findings. Any finding the agent cannot resolve inside the turn (human decision, upstream fix, action outside its authority) re-blocked the end of every subsequent turn forever.
- **Closes #438 — before the first commit every file counts as changed.** In a repository with zero commits, `git status --porcelain` reports every init-created file as changed, so the per-language gates fired on **every** turn — including docs-only turns — gating on unrelated sources.

## Changes

### #437 — livelock
- **`stop_hook_active` guard:** reads the hook input JSON from stdin (skipped when stdin is a TTY) and exits 0 immediately when `stop_hook_active: true` — converts the livelock into at most one block per turn.
- **Self-cap:** persistent state in `.git/mapify-end-of-turn/block.state`; the *same* critical-finding set blocks at most `MAPIFY_END_OF_TURN_BLOCK_CAP` (default 3) consecutive turns, then downgrades to a non-blocking warning (exit 1). The counter resets when the findings change or a turn passes. This is the fallback for harnesses that do not re-invoke Stop hooks with `stop_hook_active`.

### #438 — no-commit gating
- In a commit-less repo (no `HEAD`), untracked files are gated only if they are **new or were modified since the previous hook run** (mtime vs. `.git/mapify-end-of-turn/untracked.snapshot`). The very first run has no baseline and treats everything as changed, so the gate stays useful from turn one. HEAD-repo behavior is unchanged.
- Runtime state lives under the git dir, so it never pollutes the working tree or `git status`.

### Cleanup
- The `ruff check --fix` auto-fix wrote diagnostics to **stdout** (only stderr was silenced), leaking into the hook output; now fully silent (`>/dev/null 2>&1`).

## Verification

- 4 new regression tests in `tests/hooks/test_end_of_turn.py`: `stop_hook_active` re-entry, self-cap downgrade, cap reset on finding change, docs-only turn in a no-commit repo.
- `tests/hooks/` + `tests/test_template_render.py` + `tests/test_skills.py`: **777 passed**.
- `template_renderer --check` passes — generated trees are byte-identical to the jinja source.
- `scripts/lint-hooks.py`: all 17 hooks still conform to the `MAP_INVOKED_BY` recursion-guard contract.
- Full suite: 5231 passed / 48 failed — all 48 failures are sandbox `PermissionError` on `~/.map/locks/...` (writes outside the workspace denied by the local sandbox), unrelated to this change.
- End-to-end simulations of the reported scenarios (JSON piped on stdin, greenfield Go repo, persistent Go build failure): block once per turn → `stop_hook_active` ends the turn → after the cap the hook downgrades to a warning.

## Files changed

- `src/mapify_cli/templates_src/hooks/end-of-turn.sh.jinja` — the fix
- `.claude/hooks/end-of-turn.sh`, `src/mapify_cli/templates/hooks/end-of-turn.sh` — re-rendered generated copies
- `tests/hooks/test_end_of_turn.py` — regression tests
- `docs/USAGE.md` — hook documentation updated
- `CHANGELOG.md` — entries for both issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated blocking findings and stop-hook loops.
  * Limited checks in repositories without commits to files changed since the previous run.
  * Prevented syntax checks from creating cache files.
  * Suppressed unnecessary lint output.

* **Documentation**
  * Updated usage and changelog documentation to describe changed-file checks, automatic fixes, and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->