### PR TITLE
fix(runner): prior-stage gate false-blocks batch mode on missing test_contract

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -1999,7 +1999,15 @@ def _prior_stage_glob_entry(
         "present": present,
         "consumed": present,
         "count": len(paths),
-        "reason": "" if present else f"missing required artifact matching: {branch_dir / pattern}",
+        "reason": (
+            ""
+            if present
+            else (
+                f"missing required artifact matching: {branch_dir / pattern}"
+                if required
+                else f"optional artifact absent: {branch_dir / pattern}"
+            )
+        ),
     }
 
 
@@ -2056,6 +2064,16 @@ def build_prior_stage_consumption_report(
     branch_name = branch or get_branch_name()
     branch_dir = get_branch_dir(branch_name)
     current_code_state = code_state or snapshot_code_state(branch_name)
+    # test_contract_*.md exists only when /map-tdd ran in single-subtask mode:
+    # mark_contract_ready records the contract+handoff pair in step_state.json's
+    # contract_ready_subtasks. In batch/full-workflow mode the skill forbids
+    # creating the contract, so requiring it unconditionally false-blocks every
+    # batch run. Require it only when a contract handoff was actually recorded.
+    step_state = _read_json_file(branch_dir / "step_state.json")
+    contract_ready_subtasks = (
+        step_state.get("contract_ready_subtasks") if isinstance(step_state, dict) else None
+    )
+    contract_required = bool(contract_ready_subtasks)
     required_artifacts = [
         _prior_stage_file_entry(
             "spec", "specification", branch_dir / f"spec_{branch_name}.md"
@@ -2065,7 +2083,11 @@ def build_prior_stage_consumption_report(
         ),
         _prior_stage_file_entry("blueprint", "blueprint", branch_dir / "blueprint.json"),
         _prior_stage_glob_entry(
-            "test_contract", "test contract", branch_dir, "test_contract_*.md"
+            "test_contract",
+            "test contract",
+            branch_dir,
+            "test_contract_*.md",
+            required=contract_required,
         ),
         _prior_stage_diff_entry(current_code_state),
     ]
@@ -2118,7 +2140,12 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
     for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
-        status = "consumed" if item.get("consumed") else "missing"
+        if item.get("consumed"):
+            status = "consumed"
+        elif item.get("required"):
+            status = "missing"
+        else:
+            status = "not-required"
         label = item.get("label") or item.get("key") or "artifact"
         path = item.get("path") or ""
         count = item.get("count", 0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Prior-stage consumption gate no longer demands `test_contract_*.md` in
+  batch/full-workflow mode.** `build_prior_stage_consumption_report` required the
+  TDD contract unconditionally, while `/map-tdd` explicitly forbids creating it
+  when `$SUBTASK_ID` is empty — every batch-mode run therefore reported a
+  false-positive `blocked` status at implementation/review closeout. The contract
+  is now required only when `mark_contract_ready` actually recorded a handoff in
+  `step_state.json` (`contract_ready_subtasks` non-empty); the report renders the
+  absent-by-design entry as `not-required` instead of `missing`.
+
 ## [3.29.0] - 2026-08-28
 
 ### Added

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -1999,7 +1999,15 @@ def _prior_stage_glob_entry(
         "present": present,
         "consumed": present,
         "count": len(paths),
-        "reason": "" if present else f"missing required artifact matching: {branch_dir / pattern}",
+        "reason": (
+            ""
+            if present
+            else (
+                f"missing required artifact matching: {branch_dir / pattern}"
+                if required
+                else f"optional artifact absent: {branch_dir / pattern}"
+            )
+        ),
     }
 
 
@@ -2056,6 +2064,16 @@ def build_prior_stage_consumption_report(
     branch_name = branch or get_branch_name()
     branch_dir = get_branch_dir(branch_name)
     current_code_state = code_state or snapshot_code_state(branch_name)
+    # test_contract_*.md exists only when /map-tdd ran in single-subtask mode:
+    # mark_contract_ready records the contract+handoff pair in step_state.json's
+    # contract_ready_subtasks. In batch/full-workflow mode the skill forbids
+    # creating the contract, so requiring it unconditionally false-blocks every
+    # batch run. Require it only when a contract handoff was actually recorded.
+    step_state = _read_json_file(branch_dir / "step_state.json")
+    contract_ready_subtasks = (
+        step_state.get("contract_ready_subtasks") if isinstance(step_state, dict) else None
+    )
+    contract_required = bool(contract_ready_subtasks)
     required_artifacts = [
         _prior_stage_file_entry(
             "spec", "specification", branch_dir / f"spec_{branch_name}.md"
@@ -2065,7 +2083,11 @@ def build_prior_stage_consumption_report(
         ),
         _prior_stage_file_entry("blueprint", "blueprint", branch_dir / "blueprint.json"),
         _prior_stage_glob_entry(
-            "test_contract", "test contract", branch_dir, "test_contract_*.md"
+            "test_contract",
+            "test contract",
+            branch_dir,
+            "test_contract_*.md",
+            required=contract_required,
         ),
         _prior_stage_diff_entry(current_code_state),
     ]
@@ -2118,7 +2140,12 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
     for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
-        status = "consumed" if item.get("consumed") else "missing"
+        if item.get("consumed"):
+            status = "consumed"
+        elif item.get("required"):
+            status = "missing"
+        else:
+            status = "not-required"
         label = item.get("label") or item.get("key") or "artifact"
         path = item.get("path") or ""
         count = item.get("count", 0)

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -1974,7 +1974,15 @@ def _prior_stage_glob_entry(
         "present": present,
         "consumed": present,
         "count": len(paths),
-        "reason": "" if present else f"missing required artifact matching: {branch_dir / pattern}",
+        "reason": (
+            ""
+            if present
+            else (
+                f"missing required artifact matching: {branch_dir / pattern}"
+                if required
+                else f"optional artifact absent: {branch_dir / pattern}"
+            )
+        ),
     }
 
 
@@ -2031,6 +2039,16 @@ def build_prior_stage_consumption_report(
     branch_name = branch or get_branch_name()
     branch_dir = get_branch_dir(branch_name)
     current_code_state = code_state or snapshot_code_state(branch_name)
+    # test_contract_*.md exists only when /map-tdd ran in single-subtask mode:
+    # mark_contract_ready records the contract+handoff pair in step_state.json's
+    # contract_ready_subtasks. In batch/full-workflow mode the skill forbids
+    # creating the contract, so requiring it unconditionally false-blocks every
+    # batch run. Require it only when a contract handoff was actually recorded.
+    step_state = _read_json_file(branch_dir / "step_state.json")
+    contract_ready_subtasks = (
+        step_state.get("contract_ready_subtasks") if isinstance(step_state, dict) else None
+    )
+    contract_required = bool(contract_ready_subtasks)
     required_artifacts = [
         _prior_stage_file_entry(
             "spec", "specification", branch_dir / f"spec_{branch_name}.md"
@@ -2040,7 +2058,11 @@ def build_prior_stage_consumption_report(
         ),
         _prior_stage_file_entry("blueprint", "blueprint", branch_dir / "blueprint.json"),
         _prior_stage_glob_entry(
-            "test_contract", "test contract", branch_dir, "test_contract_*.md"
+            "test_contract",
+            "test contract",
+            branch_dir,
+            "test_contract_*.md",
+            required=contract_required,
         ),
         _prior_stage_diff_entry(current_code_state),
     ]
@@ -2093,7 +2115,12 @@ def _render_prior_stage_consumption_markdown(report: Mapping[str, object]) -> st
     for item in required_artifacts if isinstance(required_artifacts, list) else []:
         if not isinstance(item, Mapping):
             continue
-        status = "consumed" if item.get("consumed") else "missing"
+        if item.get("consumed"):
+            status = "consumed"
+        elif item.get("required"):
+            status = "missing"
+        else:
+            status = "not-required"
         label = item.get("label") or item.get("key") or "artifact"
         path = item.get("path") or ""
         count = item.get("count", 0)

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -3434,6 +3434,16 @@ def test_build_prior_stage_consumption_report_accepts_complete_inputs(branch_wor
     (branch_workspace / f"task_plan_{branch}.md").write_text("# Plan\n", encoding="utf-8")
     (branch_workspace / "blueprint.json").write_text('{"subtasks":[]}', encoding="utf-8")
     (branch_workspace / "test_contract_ST-001.md").write_text("# Contract\n", encoding="utf-8")
+    (branch_workspace / "step_state.json").write_text(
+        json.dumps(
+            {
+                "contract_ready_subtasks": {
+                    "ST-001": {"contract_path": "test_contract_ST-001.md"}
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     code_state = {
         "status": "success",
         "files_changed": ["src/app.py"],
@@ -3447,6 +3457,84 @@ def test_build_prior_stage_consumption_report_accepts_complete_inputs(branch_wor
     assert result["valid"] is True
     assert result["status"] == "ready"
     assert result["summary"] == {"required": 5, "consumed": 5, "missing": 0}
+
+
+def test_build_prior_stage_consumption_report_batch_mode_contract_not_required(
+    branch_workspace,
+):
+    """Batch/full-workflow mode never writes test_contract_*.md by design.
+
+    /map-tdd forbids creating the contract when SUBTASK_ID is empty, so the
+    gate must not demand it unless mark_contract_ready recorded a handoff.
+    """
+    branch = "test-branch"
+    (branch_workspace / f"spec_{branch}.md").write_text("# Spec\n", encoding="utf-8")
+    (branch_workspace / f"task_plan_{branch}.md").write_text("# Plan\n", encoding="utf-8")
+    (branch_workspace / "blueprint.json").write_text('{"subtasks":[]}', encoding="utf-8")
+    (branch_workspace / "step_state.json").write_text(
+        json.dumps({"contract_ready_subtasks": {}}), encoding="utf-8"
+    )
+    code_state = {
+        "status": "success",
+        "files_changed": ["src/app.py"],
+        "diff_stat": "src/app.py | 1 +",
+    }
+
+    result = map_step_runner.build_prior_stage_consumption_report(
+        "implementation", code_state=code_state
+    )
+
+    assert result["valid"] is True
+    assert result["status"] == "ready"
+    assert result["summary"] == {"required": 4, "consumed": 4, "missing": 0}
+    contract_entry = next(
+        item
+        for item in result["required_artifacts"]
+        if item["key"] == "test_contract"
+    )
+    assert contract_entry["required"] is False
+    assert "optional artifact absent" in contract_entry["reason"]
+
+    # Same verdict when step_state.json does not exist at all (e.g. /map-plan
+    # stopped before INIT_STATE): the contract stays not-required.
+    (branch_workspace / "step_state.json").unlink()
+    result = map_step_runner.build_prior_stage_consumption_report(
+        "implementation", code_state=code_state
+    )
+    assert result["valid"] is True
+    assert result["summary"]["required"] == 4
+
+
+def test_build_prior_stage_consumption_report_blocks_when_recorded_contract_missing(
+    branch_workspace,
+):
+    branch = "test-branch"
+    (branch_workspace / f"spec_{branch}.md").write_text("# Spec\n", encoding="utf-8")
+    (branch_workspace / f"task_plan_{branch}.md").write_text("# Plan\n", encoding="utf-8")
+    (branch_workspace / "blueprint.json").write_text('{"subtasks":[]}', encoding="utf-8")
+    (branch_workspace / "step_state.json").write_text(
+        json.dumps(
+            {
+                "contract_ready_subtasks": {
+                    "ST-001": {"contract_path": "test_contract_ST-001.md"}
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    code_state = {
+        "status": "success",
+        "files_changed": ["src/app.py"],
+        "diff_stat": "src/app.py | 1 +",
+    }
+
+    result = map_step_runner.build_prior_stage_consumption_report(
+        "implementation", code_state=code_state
+    )
+
+    assert result["valid"] is False
+    assert result["status"] == "blocked"
+    assert any("test_contract_*.md" in err for err in result["errors"])
 
 
 def test_validate_prior_stage_consumption_cli_exits_nonzero_on_missing(tmp_path):


### PR DESCRIPTION
## Summary
`build_prior_stage_consumption_report` required `test_contract_*.md` unconditionally for the implementation and review stages, while `/map-tdd` explicitly forbids creating the contract in batch/full-workflow mode (empty `$SUBTASK_ID`, SKILL.md: "do not write test_contract_.md, do not call mark_contract_ready"). Every batch-mode workflow therefore hit a false-positive `blocked` verdict at closeout — surfaced as a HIGH Monitor finding on a downstream repo where the contract could not have existed by design.

## Fix
- The `test_contract` entry is required only when `mark_contract_ready` actually recorded a handoff in `step_state.json` (`contract_ready_subtasks` non-empty) — the only durable signal that single-subtask TDD mode ran.
- A recorded-but-deleted contract still blocks (state says it must exist).
- Markdown report renders the absent-by-design entry as `not-required` instead of `missing`; glob-entry reason distinguishes `optional artifact absent` from `missing required artifact`.

## Verification
- New regression test `test_build_prior_stage_consumption_report_batch_mode_contract_not_required` — negative-proof run confirmed it fails on pre-fix code.
- New `..._blocks_when_recorded_contract_missing` covers the still-blocking path.
- `make check`: 5529 passed, `check-render` byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected artifact status reporting for batch and full-workflow runs.
  * Test contract artifacts are now required only when a contract handoff was recorded.
  * Optional artifacts absent by design are reported as **not required** instead of **missing**.
* **Documentation**
  * Added an entry to the unreleased changelog describing the artifact validation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->