### PR TITLE
fix: 7 concurrent-write and logic bugs in map_step_runner/orchestrator (#446)

### DIFF
--- a/.claude/references/host-paths.md
+++ b/.claude/references/host-paths.md
@@ -37,10 +37,10 @@ These four variables are reserved by MAP runtime layers. Do not repurpose or sha
 
 MAP uses the following host and project paths:
 
-- **`.map/`** — project-local MAP state. `.map/<branch>/` holds per-branch workflow artifacts. The automatic updater owns the gitignored `.map/update-state.json`, `.map/update.lock`, `.map/installer.lock`, and `.map/provider-refresh.lock` files.
+- **`.map/`** — project-local MAP state. `.map/<branch>/` holds per-branch workflow artifacts. `.map/.locks/<branch>.transaction.lock` serializes each branch's complete read-modify-write transaction across orchestrator and step-runner processes; the lock directory is gitignored. The automatic updater owns the separate gitignored `.map/update-state.json`, `.map/update.lock`, `.map/installer.lock`, and `.map/provider-refresh.lock` files.
 - **`.sofa/`** — opt-in SOFA credentials. `.sofa/credentials.lock` serializes private credential-file reads and writes and is ignored with the rest of `.sofa/`.
 - **`~/.map/`** — host-scoped shared state. Two subdirectories matter:
-  - `~/.map/locks/` — advisory lock files acquired by the orchestrator to prevent concurrent MAP sessions on the same branch.
+  - `~/.map/locks/` — host-scoped advisory locks and state sidecars owned by `mapify_cli._locking`; these are separate from project-local branch transaction locks.
   - `~/.map/hooks/` — host-level hook scripts invoked by the MAP hook harness before/after workflow phases.
 
 Root `.gitignore` mutation uses one cross-process lock keyed by the SHA-256 of
@@ -90,7 +90,7 @@ acquires only the provider barrier after installation completes.
 in_progress  created  updated  skipped  timeout  error
 ```
 
-This PR ships the enum and the sidecar writer; no MAP workflow surface is wired to call `flock_with_state` yet (Phase A consumes it for hook serialization, Phase E for memory-flush). The pre-existing `step_state.json` subtask statuses (`pending|in_progress|complete|blocked`) are a separate, unrelated enum owned by the orchestrator.
+Memory finalization uses `flock_with_state` to serialize a repository's flush. The project-local `.map/.locks/<branch>.transaction.lock` protocol is independent and has no state sidecar. The pre-existing `step_state.json` subtask statuses (`pending|in_progress|complete|blocked`) are a separate, unrelated enum owned by the orchestrator.
 
 **INV-5 invariant:** This is a closed enum. Adding a new state requires editing BOTH `src/mapify_cli/_locking.py:LockState` AND this document in the same PR. A PR that adds a state to one without the other must be rejected.
 

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -841,7 +841,7 @@ class StepState:
     def save(self, state_file: Path) -> None:
         """Save state to file."""
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(
             json.dumps(self.to_dict(), indent=2, ensure_ascii=True),
             encoding="utf-8",
@@ -2123,7 +2123,9 @@ def _append_restored_subtask_to_plan(
         "- **Validation:** Implement this restored scope or re-plan it before "
         "approving execution.\n"
     )
-    plan_file.write_text(content.rstrip() + addition, encoding="utf-8")
+    tmp = plan_file.with_name(f".{plan_file.name}.{os.getpid()}.tmp")
+    tmp.write_text(content.rstrip() + addition, encoding="utf-8")
+    tmp.replace(plan_file)
     return True
 
 

--- a/.map/scripts/map_orchestrator.py
+++ b/.map/scripts/map_orchestrator.py
@@ -840,13 +840,10 @@ class StepState:
 
     def save(self, state_file: Path) -> None:
         """Save state to file."""
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(
+        atomic_write_text(
+            state_file,
             json.dumps(self.to_dict(), indent=2, ensure_ascii=True),
-            encoding="utf-8",
         )
-        tmp_file.replace(state_file)
 
 
 def _get_step_order(tdd_mode: bool = False) -> list[str]:
@@ -855,7 +852,11 @@ def _get_step_order(tdd_mode: bool = False) -> list[str]:
 
 
 from map_utils import (  # pyright: ignore[reportMissingImports]
+    acquire_branch_transaction,
+    atomic_write_text,
+    branch_transaction,
     get_branch_name,
+    release_branch_transaction,
     sanitize_branch_name,
 )
 
@@ -2102,37 +2103,45 @@ def _restored_subtask_from_deferred(item: dict, subtask_id: str) -> dict:
 def _append_restored_subtask_to_plan(
     plan_file: Path, subtask: dict, item: dict
 ) -> bool:
-    if not plan_file.exists():
-        return False
-    content = plan_file.read_text(encoding="utf-8")
-    subtask_id = str(subtask.get("id"))
-    if re.search(rf"^###\s+{re.escape(subtask_id)}\b", content, re.MULTILINE):
-        return False
-    item_id = str(item.get("id") or "YG-???")
-    title = str(subtask.get("title") or "Restored deferred YAGNI item")
-    rationale = str(item.get("rationale") or "No rationale recorded")
-    restore_hint = str(item.get("restore_hint") or "No restore hint recorded")
-    addition = (
-        "\n\n## Restored Deferred YAGNI\n\n"
-        f"### {subtask_id}: {title}\n"
-        "- **Status:** pending\n"
-        f"- **Restored from:** {item_id}\n"
-        "- **Requiredness:** optional\n"
-        f"- **Rationale:** {rationale}\n"
-        f"- **Restore hint:** {restore_hint}\n"
-        "- **Validation:** Implement this restored scope or re-plan it before "
-        "approving execution.\n"
-    )
-    tmp = plan_file.with_name(f".{plan_file.name}.{os.getpid()}.tmp")
-    tmp.write_text(content.rstrip() + addition, encoding="utf-8")
-    tmp.replace(plan_file)
-    return True
+    """Append one restored subtask under the shared branch transaction lock."""
+    with branch_transaction(plan_file.parent):
+        if not plan_file.exists():
+            return False
+        content = plan_file.read_text(encoding="utf-8")
+        subtask_id = str(subtask.get("id"))
+        if re.search(rf"^###\s+{re.escape(subtask_id)}\b", content, re.MULTILINE):
+            return False
+        item_id = str(item.get("id") or "YG-???")
+        title = str(subtask.get("title") or "Restored deferred YAGNI item")
+        rationale = str(item.get("rationale") or "No rationale recorded")
+        restore_hint = str(item.get("restore_hint") or "No restore hint recorded")
+        addition = (
+            "\n\n## Restored Deferred YAGNI\n\n"
+            f"### {subtask_id}: {title}\n"
+            "- **Status:** pending\n"
+            f"- **Restored from:** {item_id}\n"
+            "- **Requiredness:** optional\n"
+            f"- **Rationale:** {rationale}\n"
+            f"- **Restore hint:** {restore_hint}\n"
+            "- **Validation:** Implement this restored scope or re-plan it before "
+            "approving execution.\n"
+        )
+        atomic_write_text(plan_file, content.rstrip() + addition)
+        return True
 
 
 def restore_deferred_yagni(
     item_id: str, branch: str, new_subtask_id: str | None = None
 ) -> dict:
     """Move one deferred_yagni item into active subtasks before plan approval."""
+    with branch_transaction(Path(f".map/{branch}")):
+        return _restore_deferred_yagni_unlocked(item_id, branch, new_subtask_id)
+
+
+def _restore_deferred_yagni_unlocked(
+    item_id: str, branch: str, new_subtask_id: str | None = None
+) -> dict:
+    """Restore one deferred item while the caller holds the branch lock."""
     normalized_item_id = (item_id or "").strip()
     if not re.fullmatch(r"YG-\d{3,}", normalized_item_id):
         return {
@@ -2203,12 +2212,10 @@ def restore_deferred_yagni(
     del deferred_yagni[match_index]
     subtasks.append(restored_subtask)
 
-    tmp_path = blueprint_path.with_suffix(".tmp")
-    tmp_path.write_text(
+    atomic_write_text(
+        blueprint_path,
         json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
     )
-    tmp_path.replace(blueprint_path)
 
     plan_file = plan_dir / f"task_plan_{branch}.md"
     task_plan_updated = _append_restored_subtask_to_plan(
@@ -5083,7 +5090,17 @@ def main():
     # mapify_cli package is not importable from this script's environment.
     _emit_context_budget_warning(branch, args.transcript_path)
 
+    transaction_acquired = False
     try:
+        # A script-anchored fallback may point at the shipped template tree
+        # when invoked outside an initialized project. Keep read-only misses
+        # side-effect free instead of manufacturing ``templates/.map/.locks``.
+        # Installed MAP projects already contain ``.map/`` because this script
+        # itself lives under ``.map/scripts``.
+        if Path(".map").is_dir():
+            acquire_branch_transaction(Path(".map") / branch)
+            transaction_acquired = True
+
         if args.command == "get_next_step":
             result = get_next_step(branch)
             print(json.dumps(result, indent=2))
@@ -5500,6 +5517,9 @@ def main():
     except Exception as e:  # noqa: BLE001 — CLI top-level error handler
         print(json.dumps({"error": str(e)}), file=sys.stderr)
         sys.exit(1)
+    finally:
+        if transaction_acquired:
+            release_branch_transaction()
 
 
 if __name__ == "__main__":

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -708,7 +708,7 @@ def _validate_exact_string_fields(
 def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_suffix(".tmp")
+    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp_file.write_text(
         json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
     )
@@ -718,7 +718,7 @@ def _write_json_file(path: Path, payload: dict | list) -> None:
 def _write_text_file(path: Path, content: str) -> None:
     """Atomically write text content to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.parent / (path.name + ".tmp")
+    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp_file.write_text(content, encoding="utf-8")
     tmp_file.replace(path)
 
@@ -12853,7 +12853,7 @@ def update_step_state(
         state["current_subtask"] = subtask_id
 
         # Write back atomically
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         tmp_file.replace(state_file)
 
@@ -12931,7 +12931,7 @@ def update_step_state_batch(
             state["current_state"] = updates[-1].get("new_state", "UPDATED")
 
         # Write back atomically
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         tmp_file.replace(state_file)
 
@@ -16340,6 +16340,7 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
+        "block_reason": block_reason if chain_status == "blocked" else None,
     }
 
 
@@ -16408,7 +16409,7 @@ def record_auto_phase(
         }
 
     terminal_chain_status = artifact.get("chain_status")
-    if terminal_chain_status in {"aborted", "blocked"}:
+    if terminal_chain_status in {"aborted", "blocked", "completed"}:
         return {
             "status": "refused",
             "branch": branch_name,
@@ -19434,10 +19435,24 @@ def auto_decide_holds(branch: str | None = None) -> dict[str, Any]:
         hold_id = str(hold.get("id", ""))
         kind = str(hold.get("kind", ""))
         if kind in AUTO_APPROVABLE_HOLD_KINDS:
-            decide_approval_hold(hold_id, "approved", "auto-approved by map-auto", branch_name)
-            auto_approved.append(
-                {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+            _decide_result = decide_approval_hold(
+                hold_id, "approved", "auto-approved by map-auto", branch_name
             )
+            if _decide_result.get("status") not in {"ok", "success"}:
+                hard_stops.append(
+                    {
+                        "id": hold_id,
+                        "kind": kind,
+                        "reason": (
+                            "decide_approval_hold failed: "
+                            + str(_decide_result.get("reasons", _decide_result.get("message", "unknown error")))
+                        ),
+                    }
+                )
+            else:
+                auto_approved.append(
+                    {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+                )
         elif kind in HARD_STOP_HOLD_KINDS:
             hard_stops.append(
                 {

--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -707,20 +707,15 @@ def _validate_exact_string_fields(
 
 def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_file.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    atomic_write_text(
+        path,
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
     )
-    tmp_file.replace(path)
 
 
 def _write_text_file(path: Path, content: str) -> None:
     """Atomically write text content to disk."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_file.write_text(content, encoding="utf-8")
-    tmp_file.replace(path)
+    atomic_write_text(path, content)
 
 
 def _read_json_file(path: Path) -> dict[str, object] | None:
@@ -12804,7 +12799,11 @@ def add_known_issue(
     }
 
 
-from map_utils import get_branch_name  # type: ignore[import-not-found]
+from map_utils import (  # type: ignore[import-not-found]
+    atomic_write_text,
+    branch_transaction,
+    get_branch_name,
+)
 
 
 def update_step_state(
@@ -12829,6 +12828,19 @@ def update_step_state(
         branch = get_branch_name()
 
     state_file = Path(f".map/{branch}/step_state.json")
+    with branch_transaction(state_file.parent):
+        return _update_step_state_locked(
+            state_file, subtask_id, step_name, new_state
+        )
+
+
+def _update_step_state_locked(
+    state_file: Path,
+    subtask_id: str,
+    step_name: str,
+    new_state: str,
+) -> dict:
+    """Apply one state update while the caller holds the branch lock."""
 
     if not state_file.exists():
         return {"status": "error", "message": "step_state.json not found"}
@@ -12852,10 +12864,7 @@ def update_step_state(
         state["current_state"] = new_state
         state["current_subtask"] = subtask_id
 
-        # Write back atomically
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
-        tmp_file.replace(state_file)
+        _write_json_file(state_file, state)
 
         return {
             "status": "success",
@@ -12891,6 +12900,15 @@ def update_step_state_batch(
         branch = get_branch_name()
 
     state_file = Path(f".map/{branch}/step_state.json")
+    with branch_transaction(state_file.parent):
+        return _update_step_state_batch_locked(state_file, updates)
+
+
+def _update_step_state_batch_locked(
+    state_file: Path,
+    updates: list[dict],
+) -> dict:
+    """Apply a batch state update while the caller holds the branch lock."""
 
     if not state_file.exists():
         return {"status": "error", "message": "step_state.json not found"}
@@ -12930,10 +12948,7 @@ def update_step_state_batch(
             state["current_subtask"] = active_subtasks[0]
             state["current_state"] = updates[-1].get("new_state", "UPDATED")
 
-        # Write back atomically
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
-        tmp_file.replace(state_file)
+        _write_json_file(state_file, state)
 
         return {
             "status": "success",
@@ -16383,13 +16398,13 @@ def record_auto_phase(
     audit note (INV-4).
 
     HC-2 fail-closed guard (code review 2): once chain_status is "aborted"
-    (3rd-attempt refusal above) or "blocked" (route_task hard-stop hold),
-    the chain must stay terminal until an explicit NEW route_task call --
-    route_task's own overwrite policy is the only legitimate way out of
-    "aborted"/"blocked". A call naming a DIFFERENT phase must never act as a
-    side door that resurrects the chain by appending a fresh entry and
-    flipping chain_status back to in_progress/completed. This guard runs
-    BEFORE the attempt-counter logic (which only protects the SAME phase
+    (3rd-attempt refusal above), "blocked" (route_task hard-stop hold), or
+    "completed", the chain must stay terminal until an explicit NEW route_task
+    call -- route_task's own overwrite policy is the only legitimate way out
+    of "aborted"/"blocked"/"completed". A call naming a DIFFERENT phase must
+    never act as a side door that resurrects the chain by appending a fresh
+    entry and flipping chain_status back to in_progress/completed. This guard
+    runs BEFORE the attempt-counter logic (which only protects the SAME phase
     name) and mutates nothing on the terminal-state path: no phases[]
     append, no chain_status change, no abort_reason/block_reason pop, no
     manifest write.
@@ -22645,23 +22660,24 @@ if __name__ == "__main__":
             _sys.exit(1)
         branch_name = get_branch_name()
         state_path = Path(f".map/{branch_name}/step_state.json")
-        if not state_path.exists():
-            print(json.dumps({"status": "error", "message": "step_state.json not found"}))
-            _sys.exit(1)
-        from map_orchestrator import StepState  # type: ignore[import-not-found]
-        st = StepState.load(state_path)
-        subtask_id = data.get("subtask_id") or st.current_subtask_id or ""
-        if not subtask_id:
-            print(json.dumps({"status": "skipped", "message": "No subtask_id"}))
-            _sys.exit(0)
-        st.record_subtask_result(
-            subtask_id=subtask_id,
-            files_changed=data.get("files", []),
-            status=data.get("status", "valid"),
-            summary=data.get("summary", ""),
-            commit_sha=data.get("commit_sha"),
-        )
-        st.save(state_path)
+        with branch_transaction(state_path.parent):
+            if not state_path.exists():
+                print(json.dumps({"status": "error", "message": "step_state.json not found"}))
+                _sys.exit(1)
+            from map_orchestrator import StepState  # type: ignore[import-not-found]
+            st = StepState.load(state_path)
+            subtask_id = data.get("subtask_id") or st.current_subtask_id or ""
+            if not subtask_id:
+                print(json.dumps({"status": "skipped", "message": "No subtask_id"}))
+                _sys.exit(0)
+            st.record_subtask_result(
+                subtask_id=subtask_id,
+                files_changed=data.get("files", []),
+                status=data.get("status", "valid"),
+                summary=data.get("summary", ""),
+                commit_sha=data.get("commit_sha"),
+            )
+            st.save(state_path)
         print(json.dumps({"status": "success", "subtask_id": subtask_id}))
 
     elif func_name == "build_context_block" and len(sys.argv) >= 4:

--- a/.map/scripts/map_utils.py
+++ b/.map/scripts/map_utils.py
@@ -1,7 +1,166 @@
 """Shared utilities for MAP workflow scripts."""
 
+import contextlib
+import errno
+import importlib
+import os
 import re
 import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+_BRANCH_TRANSACTION_THREAD_LOCK = threading.RLock()
+_BRANCH_TRANSACTION_DEPTH = 0
+_BRANCH_TRANSACTION_DESCRIPTOR: int | None = None
+_BRANCH_TRANSACTION_PATH: Path | None = None
+
+
+def _lock_branch_descriptor(descriptor: int) -> None:
+    """Acquire a blocking cross-process lock for an open lock file."""
+    if os.name == "nt":
+        msvcrt: Any = importlib.import_module("msvcrt")
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        while True:
+            try:
+                msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in {
+                    errno.EACCES,
+                    errno.EAGAIN,
+                    errno.EDEADLK,
+                } and getattr(exc, "winerror", None) not in {33, 36}:
+                    raise
+                time.sleep(0.05)
+
+    fcntl: Any = importlib.import_module("fcntl")
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+
+def _unlock_branch_descriptor(descriptor: int) -> None:
+    """Release a lock acquired by :func:`_lock_branch_descriptor`."""
+    if os.name == "nt":
+        msvcrt: Any = importlib.import_module("msvcrt")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        return
+
+    fcntl: Any = importlib.import_module("fcntl")
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def acquire_branch_transaction(branch_dir: Path) -> None:
+    """Serialize a complete branch read-modify-write transaction.
+
+    The process-local ``RLock`` covers threads and makes nested calls reentrant;
+    the persistent advisory lock file coordinates independent CLI processes.
+    """
+    global _BRANCH_TRANSACTION_DEPTH
+    global _BRANCH_TRANSACTION_DESCRIPTOR
+    global _BRANCH_TRANSACTION_PATH
+
+    resolved_branch_dir = branch_dir.resolve()
+    lock_path = (
+        resolved_branch_dir.parent
+        / ".locks"
+        / f"{resolved_branch_dir.name}.transaction.lock"
+    )
+    _BRANCH_TRANSACTION_THREAD_LOCK.acquire()
+    descriptor: int | None = None
+    try:
+        if _BRANCH_TRANSACTION_DEPTH:
+            if _BRANCH_TRANSACTION_PATH != lock_path:
+                raise RuntimeError(
+                    "cannot nest MAP branch transactions for different directories"
+                )
+            _BRANCH_TRANSACTION_DEPTH += 1
+            return
+
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = (
+            os.O_RDWR
+            | os.O_CREAT
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(lock_path, flags, 0o600)
+        _lock_branch_descriptor(descriptor)
+        _BRANCH_TRANSACTION_DESCRIPTOR = descriptor
+        _BRANCH_TRANSACTION_PATH = lock_path
+        _BRANCH_TRANSACTION_DEPTH = 1
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        _BRANCH_TRANSACTION_THREAD_LOCK.release()
+        raise
+
+
+def release_branch_transaction() -> None:
+    """Release one nesting level of the current branch transaction."""
+    global _BRANCH_TRANSACTION_DEPTH
+    global _BRANCH_TRANSACTION_DESCRIPTOR
+    global _BRANCH_TRANSACTION_PATH
+
+    if _BRANCH_TRANSACTION_DEPTH <= 0:
+        raise RuntimeError("no MAP branch transaction is currently held")
+
+    descriptor: int | None = None
+    try:
+        _BRANCH_TRANSACTION_DEPTH -= 1
+        if _BRANCH_TRANSACTION_DEPTH == 0:
+            descriptor = _BRANCH_TRANSACTION_DESCRIPTOR
+            _BRANCH_TRANSACTION_DESCRIPTOR = None
+            _BRANCH_TRANSACTION_PATH = None
+            if descriptor is None:
+                raise RuntimeError("MAP branch transaction lost its lock descriptor")
+            try:
+                _unlock_branch_descriptor(descriptor)
+            finally:
+                os.close(descriptor)
+    finally:
+        _BRANCH_TRANSACTION_THREAD_LOCK.release()
+
+
+@contextlib.contextmanager
+def branch_transaction(branch_dir: Path) -> Iterator[None]:
+    """Hold the shared branch lock for one complete state transaction."""
+    acquire_branch_transaction(branch_dir)
+    try:
+        yield
+    finally:
+        release_branch_transaction()
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically publish text through an invocation-unique sibling file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with stream:
+            stream.write(content)
+        temporary_path.replace(path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/.map/scripts/map_utils.py
+++ b/.map/scripts/map_utils.py
@@ -145,11 +145,10 @@ def atomic_write_text(path: Path, content: str) -> None:
         dir=str(path.parent),
         prefix=f".{path.name}.",
         suffix=".tmp",
-        text=True,
     )
     temporary_path = Path(temporary_name)
     try:
-        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        stream = os.fdopen(descriptor, "w", encoding="utf-8", newline="\n")
         descriptor = -1
         with stream:
             stream.write(content)

--- a/src/mapify_cli/templates/.gitignore
+++ b/src/mapify_cli/templates/.gitignore
@@ -4,6 +4,7 @@
 .map/provider-refresh.lock
 .map/installer.lock
 .map/gitignore.lock
+.map/.locks/
 .map/*/sessions/scratch/
 # Offloaded tool outputs (#232) may contain secrets — never commit. A
 # self-contained .map/<branch>/compacted/.gitignore enforces this too.

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -841,7 +841,7 @@ class StepState:
     def save(self, state_file: Path) -> None:
         """Save state to file."""
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(
             json.dumps(self.to_dict(), indent=2, ensure_ascii=True),
             encoding="utf-8",
@@ -2123,7 +2123,9 @@ def _append_restored_subtask_to_plan(
         "- **Validation:** Implement this restored scope or re-plan it before "
         "approving execution.\n"
     )
-    plan_file.write_text(content.rstrip() + addition, encoding="utf-8")
+    tmp = plan_file.with_name(f".{plan_file.name}.{os.getpid()}.tmp")
+    tmp.write_text(content.rstrip() + addition, encoding="utf-8")
+    tmp.replace(plan_file)
     return True
 
 

--- a/src/mapify_cli/templates/map/scripts/map_orchestrator.py
+++ b/src/mapify_cli/templates/map/scripts/map_orchestrator.py
@@ -840,13 +840,10 @@ class StepState:
 
     def save(self, state_file: Path) -> None:
         """Save state to file."""
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(
+        atomic_write_text(
+            state_file,
             json.dumps(self.to_dict(), indent=2, ensure_ascii=True),
-            encoding="utf-8",
         )
-        tmp_file.replace(state_file)
 
 
 def _get_step_order(tdd_mode: bool = False) -> list[str]:
@@ -855,7 +852,11 @@ def _get_step_order(tdd_mode: bool = False) -> list[str]:
 
 
 from map_utils import (  # pyright: ignore[reportMissingImports]
+    acquire_branch_transaction,
+    atomic_write_text,
+    branch_transaction,
     get_branch_name,
+    release_branch_transaction,
     sanitize_branch_name,
 )
 
@@ -2102,37 +2103,45 @@ def _restored_subtask_from_deferred(item: dict, subtask_id: str) -> dict:
 def _append_restored_subtask_to_plan(
     plan_file: Path, subtask: dict, item: dict
 ) -> bool:
-    if not plan_file.exists():
-        return False
-    content = plan_file.read_text(encoding="utf-8")
-    subtask_id = str(subtask.get("id"))
-    if re.search(rf"^###\s+{re.escape(subtask_id)}\b", content, re.MULTILINE):
-        return False
-    item_id = str(item.get("id") or "YG-???")
-    title = str(subtask.get("title") or "Restored deferred YAGNI item")
-    rationale = str(item.get("rationale") or "No rationale recorded")
-    restore_hint = str(item.get("restore_hint") or "No restore hint recorded")
-    addition = (
-        "\n\n## Restored Deferred YAGNI\n\n"
-        f"### {subtask_id}: {title}\n"
-        "- **Status:** pending\n"
-        f"- **Restored from:** {item_id}\n"
-        "- **Requiredness:** optional\n"
-        f"- **Rationale:** {rationale}\n"
-        f"- **Restore hint:** {restore_hint}\n"
-        "- **Validation:** Implement this restored scope or re-plan it before "
-        "approving execution.\n"
-    )
-    tmp = plan_file.with_name(f".{plan_file.name}.{os.getpid()}.tmp")
-    tmp.write_text(content.rstrip() + addition, encoding="utf-8")
-    tmp.replace(plan_file)
-    return True
+    """Append one restored subtask under the shared branch transaction lock."""
+    with branch_transaction(plan_file.parent):
+        if not plan_file.exists():
+            return False
+        content = plan_file.read_text(encoding="utf-8")
+        subtask_id = str(subtask.get("id"))
+        if re.search(rf"^###\s+{re.escape(subtask_id)}\b", content, re.MULTILINE):
+            return False
+        item_id = str(item.get("id") or "YG-???")
+        title = str(subtask.get("title") or "Restored deferred YAGNI item")
+        rationale = str(item.get("rationale") or "No rationale recorded")
+        restore_hint = str(item.get("restore_hint") or "No restore hint recorded")
+        addition = (
+            "\n\n## Restored Deferred YAGNI\n\n"
+            f"### {subtask_id}: {title}\n"
+            "- **Status:** pending\n"
+            f"- **Restored from:** {item_id}\n"
+            "- **Requiredness:** optional\n"
+            f"- **Rationale:** {rationale}\n"
+            f"- **Restore hint:** {restore_hint}\n"
+            "- **Validation:** Implement this restored scope or re-plan it before "
+            "approving execution.\n"
+        )
+        atomic_write_text(plan_file, content.rstrip() + addition)
+        return True
 
 
 def restore_deferred_yagni(
     item_id: str, branch: str, new_subtask_id: str | None = None
 ) -> dict:
     """Move one deferred_yagni item into active subtasks before plan approval."""
+    with branch_transaction(Path(f".map/{branch}")):
+        return _restore_deferred_yagni_unlocked(item_id, branch, new_subtask_id)
+
+
+def _restore_deferred_yagni_unlocked(
+    item_id: str, branch: str, new_subtask_id: str | None = None
+) -> dict:
+    """Restore one deferred item while the caller holds the branch lock."""
     normalized_item_id = (item_id or "").strip()
     if not re.fullmatch(r"YG-\d{3,}", normalized_item_id):
         return {
@@ -2203,12 +2212,10 @@ def restore_deferred_yagni(
     del deferred_yagni[match_index]
     subtasks.append(restored_subtask)
 
-    tmp_path = blueprint_path.with_suffix(".tmp")
-    tmp_path.write_text(
+    atomic_write_text(
+        blueprint_path,
         json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
     )
-    tmp_path.replace(blueprint_path)
 
     plan_file = plan_dir / f"task_plan_{branch}.md"
     task_plan_updated = _append_restored_subtask_to_plan(
@@ -5083,7 +5090,17 @@ def main():
     # mapify_cli package is not importable from this script's environment.
     _emit_context_budget_warning(branch, args.transcript_path)
 
+    transaction_acquired = False
     try:
+        # A script-anchored fallback may point at the shipped template tree
+        # when invoked outside an initialized project. Keep read-only misses
+        # side-effect free instead of manufacturing ``templates/.map/.locks``.
+        # Installed MAP projects already contain ``.map/`` because this script
+        # itself lives under ``.map/scripts``.
+        if Path(".map").is_dir():
+            acquire_branch_transaction(Path(".map") / branch)
+            transaction_acquired = True
+
         if args.command == "get_next_step":
             result = get_next_step(branch)
             print(json.dumps(result, indent=2))
@@ -5500,6 +5517,9 @@ def main():
     except Exception as e:  # noqa: BLE001 — CLI top-level error handler
         print(json.dumps({"error": str(e)}), file=sys.stderr)
         sys.exit(1)
+    finally:
+        if transaction_acquired:
+            release_branch_transaction()
 
 
 if __name__ == "__main__":

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -708,7 +708,7 @@ def _validate_exact_string_fields(
 def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_suffix(".tmp")
+    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp_file.write_text(
         json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
     )
@@ -718,7 +718,7 @@ def _write_json_file(path: Path, payload: dict | list) -> None:
 def _write_text_file(path: Path, content: str) -> None:
     """Atomically write text content to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.parent / (path.name + ".tmp")
+    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp_file.write_text(content, encoding="utf-8")
     tmp_file.replace(path)
 
@@ -12853,7 +12853,7 @@ def update_step_state(
         state["current_subtask"] = subtask_id
 
         # Write back atomically
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         tmp_file.replace(state_file)
 
@@ -12931,7 +12931,7 @@ def update_step_state_batch(
             state["current_state"] = updates[-1].get("new_state", "UPDATED")
 
         # Write back atomically
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         tmp_file.replace(state_file)
 
@@ -16340,6 +16340,7 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
+        "block_reason": block_reason if chain_status == "blocked" else None,
     }
 
 
@@ -16408,7 +16409,7 @@ def record_auto_phase(
         }
 
     terminal_chain_status = artifact.get("chain_status")
-    if terminal_chain_status in {"aborted", "blocked"}:
+    if terminal_chain_status in {"aborted", "blocked", "completed"}:
         return {
             "status": "refused",
             "branch": branch_name,
@@ -19434,10 +19435,24 @@ def auto_decide_holds(branch: str | None = None) -> dict[str, Any]:
         hold_id = str(hold.get("id", ""))
         kind = str(hold.get("kind", ""))
         if kind in AUTO_APPROVABLE_HOLD_KINDS:
-            decide_approval_hold(hold_id, "approved", "auto-approved by map-auto", branch_name)
-            auto_approved.append(
-                {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+            _decide_result = decide_approval_hold(
+                hold_id, "approved", "auto-approved by map-auto", branch_name
             )
+            if _decide_result.get("status") not in {"ok", "success"}:
+                hard_stops.append(
+                    {
+                        "id": hold_id,
+                        "kind": kind,
+                        "reason": (
+                            "decide_approval_hold failed: "
+                            + str(_decide_result.get("reasons", _decide_result.get("message", "unknown error")))
+                        ),
+                    }
+                )
+            else:
+                auto_approved.append(
+                    {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+                )
         elif kind in HARD_STOP_HOLD_KINDS:
             hard_stops.append(
                 {

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -707,20 +707,15 @@ def _validate_exact_string_fields(
 
 def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_file.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    atomic_write_text(
+        path,
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
     )
-    tmp_file.replace(path)
 
 
 def _write_text_file(path: Path, content: str) -> None:
     """Atomically write text content to disk."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_file.write_text(content, encoding="utf-8")
-    tmp_file.replace(path)
+    atomic_write_text(path, content)
 
 
 def _read_json_file(path: Path) -> dict[str, object] | None:
@@ -12804,7 +12799,11 @@ def add_known_issue(
     }
 
 
-from map_utils import get_branch_name  # type: ignore[import-not-found]
+from map_utils import (  # type: ignore[import-not-found]
+    atomic_write_text,
+    branch_transaction,
+    get_branch_name,
+)
 
 
 def update_step_state(
@@ -12829,6 +12828,19 @@ def update_step_state(
         branch = get_branch_name()
 
     state_file = Path(f".map/{branch}/step_state.json")
+    with branch_transaction(state_file.parent):
+        return _update_step_state_locked(
+            state_file, subtask_id, step_name, new_state
+        )
+
+
+def _update_step_state_locked(
+    state_file: Path,
+    subtask_id: str,
+    step_name: str,
+    new_state: str,
+) -> dict:
+    """Apply one state update while the caller holds the branch lock."""
 
     if not state_file.exists():
         return {"status": "error", "message": "step_state.json not found"}
@@ -12852,10 +12864,7 @@ def update_step_state(
         state["current_state"] = new_state
         state["current_subtask"] = subtask_id
 
-        # Write back atomically
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
-        tmp_file.replace(state_file)
+        _write_json_file(state_file, state)
 
         return {
             "status": "success",
@@ -12891,6 +12900,15 @@ def update_step_state_batch(
         branch = get_branch_name()
 
     state_file = Path(f".map/{branch}/step_state.json")
+    with branch_transaction(state_file.parent):
+        return _update_step_state_batch_locked(state_file, updates)
+
+
+def _update_step_state_batch_locked(
+    state_file: Path,
+    updates: list[dict],
+) -> dict:
+    """Apply a batch state update while the caller holds the branch lock."""
 
     if not state_file.exists():
         return {"status": "error", "message": "step_state.json not found"}
@@ -12930,10 +12948,7 @@ def update_step_state_batch(
             state["current_subtask"] = active_subtasks[0]
             state["current_state"] = updates[-1].get("new_state", "UPDATED")
 
-        # Write back atomically
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
-        tmp_file.replace(state_file)
+        _write_json_file(state_file, state)
 
         return {
             "status": "success",
@@ -16383,13 +16398,13 @@ def record_auto_phase(
     audit note (INV-4).
 
     HC-2 fail-closed guard (code review 2): once chain_status is "aborted"
-    (3rd-attempt refusal above) or "blocked" (route_task hard-stop hold),
-    the chain must stay terminal until an explicit NEW route_task call --
-    route_task's own overwrite policy is the only legitimate way out of
-    "aborted"/"blocked". A call naming a DIFFERENT phase must never act as a
-    side door that resurrects the chain by appending a fresh entry and
-    flipping chain_status back to in_progress/completed. This guard runs
-    BEFORE the attempt-counter logic (which only protects the SAME phase
+    (3rd-attempt refusal above), "blocked" (route_task hard-stop hold), or
+    "completed", the chain must stay terminal until an explicit NEW route_task
+    call -- route_task's own overwrite policy is the only legitimate way out
+    of "aborted"/"blocked"/"completed". A call naming a DIFFERENT phase must
+    never act as a side door that resurrects the chain by appending a fresh
+    entry and flipping chain_status back to in_progress/completed. This guard
+    runs BEFORE the attempt-counter logic (which only protects the SAME phase
     name) and mutates nothing on the terminal-state path: no phases[]
     append, no chain_status change, no abort_reason/block_reason pop, no
     manifest write.
@@ -22645,23 +22660,24 @@ if __name__ == "__main__":
             _sys.exit(1)
         branch_name = get_branch_name()
         state_path = Path(f".map/{branch_name}/step_state.json")
-        if not state_path.exists():
-            print(json.dumps({"status": "error", "message": "step_state.json not found"}))
-            _sys.exit(1)
-        from map_orchestrator import StepState  # type: ignore[import-not-found]
-        st = StepState.load(state_path)
-        subtask_id = data.get("subtask_id") or st.current_subtask_id or ""
-        if not subtask_id:
-            print(json.dumps({"status": "skipped", "message": "No subtask_id"}))
-            _sys.exit(0)
-        st.record_subtask_result(
-            subtask_id=subtask_id,
-            files_changed=data.get("files", []),
-            status=data.get("status", "valid"),
-            summary=data.get("summary", ""),
-            commit_sha=data.get("commit_sha"),
-        )
-        st.save(state_path)
+        with branch_transaction(state_path.parent):
+            if not state_path.exists():
+                print(json.dumps({"status": "error", "message": "step_state.json not found"}))
+                _sys.exit(1)
+            from map_orchestrator import StepState  # type: ignore[import-not-found]
+            st = StepState.load(state_path)
+            subtask_id = data.get("subtask_id") or st.current_subtask_id or ""
+            if not subtask_id:
+                print(json.dumps({"status": "skipped", "message": "No subtask_id"}))
+                _sys.exit(0)
+            st.record_subtask_result(
+                subtask_id=subtask_id,
+                files_changed=data.get("files", []),
+                status=data.get("status", "valid"),
+                summary=data.get("summary", ""),
+                commit_sha=data.get("commit_sha"),
+            )
+            st.save(state_path)
         print(json.dumps({"status": "success", "subtask_id": subtask_id}))
 
     elif func_name == "build_context_block" and len(sys.argv) >= 4:

--- a/src/mapify_cli/templates/map/scripts/map_utils.py
+++ b/src/mapify_cli/templates/map/scripts/map_utils.py
@@ -1,7 +1,166 @@
 """Shared utilities for MAP workflow scripts."""
 
+import contextlib
+import errno
+import importlib
+import os
 import re
 import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+_BRANCH_TRANSACTION_THREAD_LOCK = threading.RLock()
+_BRANCH_TRANSACTION_DEPTH = 0
+_BRANCH_TRANSACTION_DESCRIPTOR: int | None = None
+_BRANCH_TRANSACTION_PATH: Path | None = None
+
+
+def _lock_branch_descriptor(descriptor: int) -> None:
+    """Acquire a blocking cross-process lock for an open lock file."""
+    if os.name == "nt":
+        msvcrt: Any = importlib.import_module("msvcrt")
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        while True:
+            try:
+                msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in {
+                    errno.EACCES,
+                    errno.EAGAIN,
+                    errno.EDEADLK,
+                } and getattr(exc, "winerror", None) not in {33, 36}:
+                    raise
+                time.sleep(0.05)
+
+    fcntl: Any = importlib.import_module("fcntl")
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+
+def _unlock_branch_descriptor(descriptor: int) -> None:
+    """Release a lock acquired by :func:`_lock_branch_descriptor`."""
+    if os.name == "nt":
+        msvcrt: Any = importlib.import_module("msvcrt")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        return
+
+    fcntl: Any = importlib.import_module("fcntl")
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def acquire_branch_transaction(branch_dir: Path) -> None:
+    """Serialize a complete branch read-modify-write transaction.
+
+    The process-local ``RLock`` covers threads and makes nested calls reentrant;
+    the persistent advisory lock file coordinates independent CLI processes.
+    """
+    global _BRANCH_TRANSACTION_DEPTH
+    global _BRANCH_TRANSACTION_DESCRIPTOR
+    global _BRANCH_TRANSACTION_PATH
+
+    resolved_branch_dir = branch_dir.resolve()
+    lock_path = (
+        resolved_branch_dir.parent
+        / ".locks"
+        / f"{resolved_branch_dir.name}.transaction.lock"
+    )
+    _BRANCH_TRANSACTION_THREAD_LOCK.acquire()
+    descriptor: int | None = None
+    try:
+        if _BRANCH_TRANSACTION_DEPTH:
+            if _BRANCH_TRANSACTION_PATH != lock_path:
+                raise RuntimeError(
+                    "cannot nest MAP branch transactions for different directories"
+                )
+            _BRANCH_TRANSACTION_DEPTH += 1
+            return
+
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = (
+            os.O_RDWR
+            | os.O_CREAT
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(lock_path, flags, 0o600)
+        _lock_branch_descriptor(descriptor)
+        _BRANCH_TRANSACTION_DESCRIPTOR = descriptor
+        _BRANCH_TRANSACTION_PATH = lock_path
+        _BRANCH_TRANSACTION_DEPTH = 1
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        _BRANCH_TRANSACTION_THREAD_LOCK.release()
+        raise
+
+
+def release_branch_transaction() -> None:
+    """Release one nesting level of the current branch transaction."""
+    global _BRANCH_TRANSACTION_DEPTH
+    global _BRANCH_TRANSACTION_DESCRIPTOR
+    global _BRANCH_TRANSACTION_PATH
+
+    if _BRANCH_TRANSACTION_DEPTH <= 0:
+        raise RuntimeError("no MAP branch transaction is currently held")
+
+    descriptor: int | None = None
+    try:
+        _BRANCH_TRANSACTION_DEPTH -= 1
+        if _BRANCH_TRANSACTION_DEPTH == 0:
+            descriptor = _BRANCH_TRANSACTION_DESCRIPTOR
+            _BRANCH_TRANSACTION_DESCRIPTOR = None
+            _BRANCH_TRANSACTION_PATH = None
+            if descriptor is None:
+                raise RuntimeError("MAP branch transaction lost its lock descriptor")
+            try:
+                _unlock_branch_descriptor(descriptor)
+            finally:
+                os.close(descriptor)
+    finally:
+        _BRANCH_TRANSACTION_THREAD_LOCK.release()
+
+
+@contextlib.contextmanager
+def branch_transaction(branch_dir: Path) -> Iterator[None]:
+    """Hold the shared branch lock for one complete state transaction."""
+    acquire_branch_transaction(branch_dir)
+    try:
+        yield
+    finally:
+        release_branch_transaction()
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically publish text through an invocation-unique sibling file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with stream:
+            stream.write(content)
+        temporary_path.replace(path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/src/mapify_cli/templates/map/scripts/map_utils.py
+++ b/src/mapify_cli/templates/map/scripts/map_utils.py
@@ -145,11 +145,10 @@ def atomic_write_text(path: Path, content: str) -> None:
         dir=str(path.parent),
         prefix=f".{path.name}.",
         suffix=".tmp",
-        text=True,
     )
     temporary_path = Path(temporary_name)
     try:
-        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        stream = os.fdopen(descriptor, "w", encoding="utf-8", newline="\n")
         descriptor = -1
         with stream:
             stream.write(content)

--- a/src/mapify_cli/templates/references/host-paths.md
+++ b/src/mapify_cli/templates/references/host-paths.md
@@ -37,10 +37,10 @@ These four variables are reserved by MAP runtime layers. Do not repurpose or sha
 
 MAP uses the following host and project paths:
 
-- **`.map/`** — project-local MAP state. `.map/<branch>/` holds per-branch workflow artifacts. The automatic updater owns the gitignored `.map/update-state.json`, `.map/update.lock`, `.map/installer.lock`, and `.map/provider-refresh.lock` files.
+- **`.map/`** — project-local MAP state. `.map/<branch>/` holds per-branch workflow artifacts. `.map/.locks/<branch>.transaction.lock` serializes each branch's complete read-modify-write transaction across orchestrator and step-runner processes; the lock directory is gitignored. The automatic updater owns the separate gitignored `.map/update-state.json`, `.map/update.lock`, `.map/installer.lock`, and `.map/provider-refresh.lock` files.
 - **`.sofa/`** — opt-in SOFA credentials. `.sofa/credentials.lock` serializes private credential-file reads and writes and is ignored with the rest of `.sofa/`.
 - **`~/.map/`** — host-scoped shared state. Two subdirectories matter:
-  - `~/.map/locks/` — advisory lock files acquired by the orchestrator to prevent concurrent MAP sessions on the same branch.
+  - `~/.map/locks/` — host-scoped advisory locks and state sidecars owned by `mapify_cli._locking`; these are separate from project-local branch transaction locks.
   - `~/.map/hooks/` — host-level hook scripts invoked by the MAP hook harness before/after workflow phases.
 
 Root `.gitignore` mutation uses one cross-process lock keyed by the SHA-256 of
@@ -90,7 +90,7 @@ acquires only the provider barrier after installation completes.
 in_progress  created  updated  skipped  timeout  error
 ```
 
-This PR ships the enum and the sidecar writer; no MAP workflow surface is wired to call `flock_with_state` yet (Phase A consumes it for hook serialization, Phase E for memory-flush). The pre-existing `step_state.json` subtask statuses (`pending|in_progress|complete|blocked`) are a separate, unrelated enum owned by the orchestrator.
+Memory finalization uses `flock_with_state` to serialize a repository's flush. The project-local `.map/.locks/<branch>.transaction.lock` protocol is independent and has no state sidecar. The pre-existing `step_state.json` subtask statuses (`pending|in_progress|complete|blocked`) are a separate, unrelated enum owned by the orchestrator.
 
 **INV-5 invariant:** This is a closed enum. Adding a new state requires editing BOTH `src/mapify_cli/_locking.py:LockState` AND this document in the same PR. A PR that adds a state to one without the other must be rejected.
 

--- a/src/mapify_cli/templates_src/.gitignore.jinja
+++ b/src/mapify_cli/templates_src/.gitignore.jinja
@@ -4,6 +4,7 @@
 .map/provider-refresh.lock
 .map/installer.lock
 .map/gitignore.lock
+.map/.locks/
 .map/*/sessions/scratch/
 # Offloaded tool outputs (#232) may contain secrets — never commit. A
 # self-contained .map/<branch>/compacted/.gitignore enforces this too.

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -815,13 +815,10 @@ class StepState:
 
     def save(self, state_file: Path) -> None:
         """Save state to file."""
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(
+        atomic_write_text(
+            state_file,
             json.dumps(self.to_dict(), indent=2, ensure_ascii=True),
-            encoding="utf-8",
         )
-        tmp_file.replace(state_file)
 
 
 def _get_step_order(tdd_mode: bool = False) -> list[str]:
@@ -830,7 +827,11 @@ def _get_step_order(tdd_mode: bool = False) -> list[str]:
 
 
 from map_utils import (  # pyright: ignore[reportMissingImports]
+    acquire_branch_transaction,
+    atomic_write_text,
+    branch_transaction,
     get_branch_name,
+    release_branch_transaction,
     sanitize_branch_name,
 )
 
@@ -2077,37 +2078,45 @@ def _restored_subtask_from_deferred(item: dict, subtask_id: str) -> dict:
 def _append_restored_subtask_to_plan(
     plan_file: Path, subtask: dict, item: dict
 ) -> bool:
-    if not plan_file.exists():
-        return False
-    content = plan_file.read_text(encoding="utf-8")
-    subtask_id = str(subtask.get("id"))
-    if re.search(rf"^###\s+{re.escape(subtask_id)}\b", content, re.MULTILINE):
-        return False
-    item_id = str(item.get("id") or "YG-???")
-    title = str(subtask.get("title") or "Restored deferred YAGNI item")
-    rationale = str(item.get("rationale") or "No rationale recorded")
-    restore_hint = str(item.get("restore_hint") or "No restore hint recorded")
-    addition = (
-        "\n\n## Restored Deferred YAGNI\n\n"
-        f"### {subtask_id}: {title}\n"
-        "- **Status:** pending\n"
-        f"- **Restored from:** {item_id}\n"
-        "- **Requiredness:** optional\n"
-        f"- **Rationale:** {rationale}\n"
-        f"- **Restore hint:** {restore_hint}\n"
-        "- **Validation:** Implement this restored scope or re-plan it before "
-        "approving execution.\n"
-    )
-    tmp = plan_file.with_name(f".{plan_file.name}.{os.getpid()}.tmp")
-    tmp.write_text(content.rstrip() + addition, encoding="utf-8")
-    tmp.replace(plan_file)
-    return True
+    """Append one restored subtask under the shared branch transaction lock."""
+    with branch_transaction(plan_file.parent):
+        if not plan_file.exists():
+            return False
+        content = plan_file.read_text(encoding="utf-8")
+        subtask_id = str(subtask.get("id"))
+        if re.search(rf"^###\s+{re.escape(subtask_id)}\b", content, re.MULTILINE):
+            return False
+        item_id = str(item.get("id") or "YG-???")
+        title = str(subtask.get("title") or "Restored deferred YAGNI item")
+        rationale = str(item.get("rationale") or "No rationale recorded")
+        restore_hint = str(item.get("restore_hint") or "No restore hint recorded")
+        addition = (
+            "\n\n## Restored Deferred YAGNI\n\n"
+            f"### {subtask_id}: {title}\n"
+            "- **Status:** pending\n"
+            f"- **Restored from:** {item_id}\n"
+            "- **Requiredness:** optional\n"
+            f"- **Rationale:** {rationale}\n"
+            f"- **Restore hint:** {restore_hint}\n"
+            "- **Validation:** Implement this restored scope or re-plan it before "
+            "approving execution.\n"
+        )
+        atomic_write_text(plan_file, content.rstrip() + addition)
+        return True
 
 
 def restore_deferred_yagni(
     item_id: str, branch: str, new_subtask_id: str | None = None
 ) -> dict:
     """Move one deferred_yagni item into active subtasks before plan approval."""
+    with branch_transaction(Path(f".map/{branch}")):
+        return _restore_deferred_yagni_unlocked(item_id, branch, new_subtask_id)
+
+
+def _restore_deferred_yagni_unlocked(
+    item_id: str, branch: str, new_subtask_id: str | None = None
+) -> dict:
+    """Restore one deferred item while the caller holds the branch lock."""
     normalized_item_id = (item_id or "").strip()
     if not re.fullmatch(r"YG-\d{3,}", normalized_item_id):
         return {
@@ -2178,12 +2187,10 @@ def restore_deferred_yagni(
     del deferred_yagni[match_index]
     subtasks.append(restored_subtask)
 
-    tmp_path = blueprint_path.with_suffix(".tmp")
-    tmp_path.write_text(
+    atomic_write_text(
+        blueprint_path,
         json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
     )
-    tmp_path.replace(blueprint_path)
 
     plan_file = plan_dir / f"task_plan_{branch}.md"
     task_plan_updated = _append_restored_subtask_to_plan(
@@ -5058,7 +5065,17 @@ def main():
     # mapify_cli package is not importable from this script's environment.
     _emit_context_budget_warning(branch, args.transcript_path)
 
+    transaction_acquired = False
     try:
+        # A script-anchored fallback may point at the shipped template tree
+        # when invoked outside an initialized project. Keep read-only misses
+        # side-effect free instead of manufacturing ``templates/.map/.locks``.
+        # Installed MAP projects already contain ``.map/`` because this script
+        # itself lives under ``.map/scripts``.
+        if Path(".map").is_dir():
+            acquire_branch_transaction(Path(".map") / branch)
+            transaction_acquired = True
+
         if args.command == "get_next_step":
             result = get_next_step(branch)
             print(json.dumps(result, indent=2))
@@ -5475,6 +5492,9 @@ def main():
     except Exception as e:  # noqa: BLE001 — CLI top-level error handler
         print(json.dumps({"error": str(e)}), file=sys.stderr)
         sys.exit(1)
+    finally:
+        if transaction_acquired:
+            release_branch_transaction()
 
 
 if __name__ == "__main__":

--- a/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_orchestrator.py.jinja
@@ -816,7 +816,7 @@ class StepState:
     def save(self, state_file: Path) -> None:
         """Save state to file."""
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(
             json.dumps(self.to_dict(), indent=2, ensure_ascii=True),
             encoding="utf-8",
@@ -2098,7 +2098,9 @@ def _append_restored_subtask_to_plan(
         "- **Validation:** Implement this restored scope or re-plan it before "
         "approving execution.\n"
     )
-    plan_file.write_text(content.rstrip() + addition, encoding="utf-8")
+    tmp = plan_file.with_name(f".{plan_file.name}.{os.getpid()}.tmp")
+    tmp.write_text(content.rstrip() + addition, encoding="utf-8")
+    tmp.replace(plan_file)
     return True
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -683,7 +683,7 @@ def _validate_exact_string_fields(
 def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_suffix(".tmp")
+    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp_file.write_text(
         json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
     )
@@ -693,7 +693,7 @@ def _write_json_file(path: Path, payload: dict | list) -> None:
 def _write_text_file(path: Path, content: str) -> None:
     """Atomically write text content to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.parent / (path.name + ".tmp")
+    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp_file.write_text(content, encoding="utf-8")
     tmp_file.replace(path)
 
@@ -12828,7 +12828,7 @@ def update_step_state(
         state["current_subtask"] = subtask_id
 
         # Write back atomically
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         tmp_file.replace(state_file)
 
@@ -12906,7 +12906,7 @@ def update_step_state_batch(
             state["current_state"] = updates[-1].get("new_state", "UPDATED")
 
         # Write back atomically
-        tmp_file = state_file.with_suffix(".tmp")
+        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
         tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
         tmp_file.replace(state_file)
 
@@ -16315,6 +16315,7 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
+        "block_reason": block_reason if chain_status == "blocked" else None,
     }
 
 
@@ -16383,7 +16384,7 @@ def record_auto_phase(
         }
 
     terminal_chain_status = artifact.get("chain_status")
-    if terminal_chain_status in {"aborted", "blocked"}:
+    if terminal_chain_status in {"aborted", "blocked", "completed"}:
         return {
             "status": "refused",
             "branch": branch_name,
@@ -19409,10 +19410,24 @@ def auto_decide_holds(branch: str | None = None) -> dict[str, Any]:
         hold_id = str(hold.get("id", ""))
         kind = str(hold.get("kind", ""))
         if kind in AUTO_APPROVABLE_HOLD_KINDS:
-            decide_approval_hold(hold_id, "approved", "auto-approved by map-auto", branch_name)
-            auto_approved.append(
-                {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+            _decide_result = decide_approval_hold(
+                hold_id, "approved", "auto-approved by map-auto", branch_name
             )
+            if _decide_result.get("status") not in {"ok", "success"}:
+                hard_stops.append(
+                    {
+                        "id": hold_id,
+                        "kind": kind,
+                        "reason": (
+                            "decide_approval_hold failed: "
+                            + str(_decide_result.get("reasons", _decide_result.get("message", "unknown error")))
+                        ),
+                    }
+                )
+            else:
+                auto_approved.append(
+                    {"id": hold_id, "kind": kind, "note": "auto-approved by map-auto"}
+                )
         elif kind in HARD_STOP_HOLD_KINDS:
             hard_stops.append(
                 {

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -682,20 +682,15 @@ def _validate_exact_string_fields(
 
 def _write_json_file(path: Path, payload: dict | list) -> None:
     """Atomically write JSON payload to disk."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_file.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
+    atomic_write_text(
+        path,
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
     )
-    tmp_file.replace(path)
 
 
 def _write_text_file(path: Path, content: str) -> None:
     """Atomically write text content to disk."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_file.write_text(content, encoding="utf-8")
-    tmp_file.replace(path)
+    atomic_write_text(path, content)
 
 
 def _read_json_file(path: Path) -> dict[str, object] | None:
@@ -12779,7 +12774,11 @@ def add_known_issue(
     }
 
 
-from map_utils import get_branch_name  # type: ignore[import-not-found]
+from map_utils import (  # type: ignore[import-not-found]
+    atomic_write_text,
+    branch_transaction,
+    get_branch_name,
+)
 
 
 def update_step_state(
@@ -12804,6 +12803,19 @@ def update_step_state(
         branch = get_branch_name()
 
     state_file = Path(f".map/{branch}/step_state.json")
+    with branch_transaction(state_file.parent):
+        return _update_step_state_locked(
+            state_file, subtask_id, step_name, new_state
+        )
+
+
+def _update_step_state_locked(
+    state_file: Path,
+    subtask_id: str,
+    step_name: str,
+    new_state: str,
+) -> dict:
+    """Apply one state update while the caller holds the branch lock."""
 
     if not state_file.exists():
         return {"status": "error", "message": "step_state.json not found"}
@@ -12827,10 +12839,7 @@ def update_step_state(
         state["current_state"] = new_state
         state["current_subtask"] = subtask_id
 
-        # Write back atomically
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
-        tmp_file.replace(state_file)
+        _write_json_file(state_file, state)
 
         return {
             "status": "success",
@@ -12866,6 +12875,15 @@ def update_step_state_batch(
         branch = get_branch_name()
 
     state_file = Path(f".map/{branch}/step_state.json")
+    with branch_transaction(state_file.parent):
+        return _update_step_state_batch_locked(state_file, updates)
+
+
+def _update_step_state_batch_locked(
+    state_file: Path,
+    updates: list[dict],
+) -> dict:
+    """Apply a batch state update while the caller holds the branch lock."""
 
     if not state_file.exists():
         return {"status": "error", "message": "step_state.json not found"}
@@ -12905,10 +12923,7 @@ def update_step_state_batch(
             state["current_subtask"] = active_subtasks[0]
             state["current_state"] = updates[-1].get("new_state", "UPDATED")
 
-        # Write back atomically
-        tmp_file = state_file.with_name(f".{state_file.name}.{os.getpid()}.tmp")
-        tmp_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
-        tmp_file.replace(state_file)
+        _write_json_file(state_file, state)
 
         return {
             "status": "success",
@@ -16358,13 +16373,13 @@ def record_auto_phase(
     audit note (INV-4).
 
     HC-2 fail-closed guard (code review 2): once chain_status is "aborted"
-    (3rd-attempt refusal above) or "blocked" (route_task hard-stop hold),
-    the chain must stay terminal until an explicit NEW route_task call --
-    route_task's own overwrite policy is the only legitimate way out of
-    "aborted"/"blocked". A call naming a DIFFERENT phase must never act as a
-    side door that resurrects the chain by appending a fresh entry and
-    flipping chain_status back to in_progress/completed. This guard runs
-    BEFORE the attempt-counter logic (which only protects the SAME phase
+    (3rd-attempt refusal above), "blocked" (route_task hard-stop hold), or
+    "completed", the chain must stay terminal until an explicit NEW route_task
+    call -- route_task's own overwrite policy is the only legitimate way out
+    of "aborted"/"blocked"/"completed". A call naming a DIFFERENT phase must
+    never act as a side door that resurrects the chain by appending a fresh
+    entry and flipping chain_status back to in_progress/completed. This guard
+    runs BEFORE the attempt-counter logic (which only protects the SAME phase
     name) and mutates nothing on the terminal-state path: no phases[]
     append, no chain_status change, no abort_reason/block_reason pop, no
     manifest write.
@@ -22620,23 +22635,24 @@ if __name__ == "__main__":
             _sys.exit(1)
         branch_name = get_branch_name()
         state_path = Path(f".map/{branch_name}/step_state.json")
-        if not state_path.exists():
-            print(json.dumps({"status": "error", "message": "step_state.json not found"}))
-            _sys.exit(1)
-        from map_orchestrator import StepState  # type: ignore[import-not-found]
-        st = StepState.load(state_path)
-        subtask_id = data.get("subtask_id") or st.current_subtask_id or ""
-        if not subtask_id:
-            print(json.dumps({"status": "skipped", "message": "No subtask_id"}))
-            _sys.exit(0)
-        st.record_subtask_result(
-            subtask_id=subtask_id,
-            files_changed=data.get("files", []),
-            status=data.get("status", "valid"),
-            summary=data.get("summary", ""),
-            commit_sha=data.get("commit_sha"),
-        )
-        st.save(state_path)
+        with branch_transaction(state_path.parent):
+            if not state_path.exists():
+                print(json.dumps({"status": "error", "message": "step_state.json not found"}))
+                _sys.exit(1)
+            from map_orchestrator import StepState  # type: ignore[import-not-found]
+            st = StepState.load(state_path)
+            subtask_id = data.get("subtask_id") or st.current_subtask_id or ""
+            if not subtask_id:
+                print(json.dumps({"status": "skipped", "message": "No subtask_id"}))
+                _sys.exit(0)
+            st.record_subtask_result(
+                subtask_id=subtask_id,
+                files_changed=data.get("files", []),
+                status=data.get("status", "valid"),
+                summary=data.get("summary", ""),
+                commit_sha=data.get("commit_sha"),
+            )
+            st.save(state_path)
         print(json.dumps({"status": "success", "subtask_id": subtask_id}))
 
     elif func_name == "build_context_block" and len(sys.argv) >= 4:

--- a/src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja
@@ -1,7 +1,166 @@
 """Shared utilities for MAP workflow scripts."""
 
+import contextlib
+import errno
+import importlib
+import os
 import re
 import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+_BRANCH_TRANSACTION_THREAD_LOCK = threading.RLock()
+_BRANCH_TRANSACTION_DEPTH = 0
+_BRANCH_TRANSACTION_DESCRIPTOR: int | None = None
+_BRANCH_TRANSACTION_PATH: Path | None = None
+
+
+def _lock_branch_descriptor(descriptor: int) -> None:
+    """Acquire a blocking cross-process lock for an open lock file."""
+    if os.name == "nt":
+        msvcrt: Any = importlib.import_module("msvcrt")
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        while True:
+            try:
+                msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in {
+                    errno.EACCES,
+                    errno.EAGAIN,
+                    errno.EDEADLK,
+                } and getattr(exc, "winerror", None) not in {33, 36}:
+                    raise
+                time.sleep(0.05)
+
+    fcntl: Any = importlib.import_module("fcntl")
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+
+def _unlock_branch_descriptor(descriptor: int) -> None:
+    """Release a lock acquired by :func:`_lock_branch_descriptor`."""
+    if os.name == "nt":
+        msvcrt: Any = importlib.import_module("msvcrt")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        return
+
+    fcntl: Any = importlib.import_module("fcntl")
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def acquire_branch_transaction(branch_dir: Path) -> None:
+    """Serialize a complete branch read-modify-write transaction.
+
+    The process-local ``RLock`` covers threads and makes nested calls reentrant;
+    the persistent advisory lock file coordinates independent CLI processes.
+    """
+    global _BRANCH_TRANSACTION_DEPTH
+    global _BRANCH_TRANSACTION_DESCRIPTOR
+    global _BRANCH_TRANSACTION_PATH
+
+    resolved_branch_dir = branch_dir.resolve()
+    lock_path = (
+        resolved_branch_dir.parent
+        / ".locks"
+        / f"{resolved_branch_dir.name}.transaction.lock"
+    )
+    _BRANCH_TRANSACTION_THREAD_LOCK.acquire()
+    descriptor: int | None = None
+    try:
+        if _BRANCH_TRANSACTION_DEPTH:
+            if _BRANCH_TRANSACTION_PATH != lock_path:
+                raise RuntimeError(
+                    "cannot nest MAP branch transactions for different directories"
+                )
+            _BRANCH_TRANSACTION_DEPTH += 1
+            return
+
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        flags = (
+            os.O_RDWR
+            | os.O_CREAT
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(lock_path, flags, 0o600)
+        _lock_branch_descriptor(descriptor)
+        _BRANCH_TRANSACTION_DESCRIPTOR = descriptor
+        _BRANCH_TRANSACTION_PATH = lock_path
+        _BRANCH_TRANSACTION_DEPTH = 1
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        _BRANCH_TRANSACTION_THREAD_LOCK.release()
+        raise
+
+
+def release_branch_transaction() -> None:
+    """Release one nesting level of the current branch transaction."""
+    global _BRANCH_TRANSACTION_DEPTH
+    global _BRANCH_TRANSACTION_DESCRIPTOR
+    global _BRANCH_TRANSACTION_PATH
+
+    if _BRANCH_TRANSACTION_DEPTH <= 0:
+        raise RuntimeError("no MAP branch transaction is currently held")
+
+    descriptor: int | None = None
+    try:
+        _BRANCH_TRANSACTION_DEPTH -= 1
+        if _BRANCH_TRANSACTION_DEPTH == 0:
+            descriptor = _BRANCH_TRANSACTION_DESCRIPTOR
+            _BRANCH_TRANSACTION_DESCRIPTOR = None
+            _BRANCH_TRANSACTION_PATH = None
+            if descriptor is None:
+                raise RuntimeError("MAP branch transaction lost its lock descriptor")
+            try:
+                _unlock_branch_descriptor(descriptor)
+            finally:
+                os.close(descriptor)
+    finally:
+        _BRANCH_TRANSACTION_THREAD_LOCK.release()
+
+
+@contextlib.contextmanager
+def branch_transaction(branch_dir: Path) -> Iterator[None]:
+    """Hold the shared branch lock for one complete state transaction."""
+    acquire_branch_transaction(branch_dir)
+    try:
+        yield
+    finally:
+        release_branch_transaction()
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically publish text through an invocation-unique sibling file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with stream:
+            stream.write(content)
+        temporary_path.replace(path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja
@@ -145,11 +145,10 @@ def atomic_write_text(path: Path, content: str) -> None:
         dir=str(path.parent),
         prefix=f".{path.name}.",
         suffix=".tmp",
-        text=True,
     )
     temporary_path = Path(temporary_name)
     try:
-        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        stream = os.fdopen(descriptor, "w", encoding="utf-8", newline="\n")
         descriptor = -1
         with stream:
             stream.write(content)

--- a/src/mapify_cli/templates_src/references/host-paths.md.jinja
+++ b/src/mapify_cli/templates_src/references/host-paths.md.jinja
@@ -37,10 +37,10 @@ These four variables are reserved by MAP runtime layers. Do not repurpose or sha
 
 MAP uses the following host and project paths:
 
-- **`.map/`** — project-local MAP state. `.map/<branch>/` holds per-branch workflow artifacts. The automatic updater owns the gitignored `.map/update-state.json`, `.map/update.lock`, `.map/installer.lock`, and `.map/provider-refresh.lock` files.
+- **`.map/`** — project-local MAP state. `.map/<branch>/` holds per-branch workflow artifacts. `.map/.locks/<branch>.transaction.lock` serializes each branch's complete read-modify-write transaction across orchestrator and step-runner processes; the lock directory is gitignored. The automatic updater owns the separate gitignored `.map/update-state.json`, `.map/update.lock`, `.map/installer.lock`, and `.map/provider-refresh.lock` files.
 - **`.sofa/`** — opt-in SOFA credentials. `.sofa/credentials.lock` serializes private credential-file reads and writes and is ignored with the rest of `.sofa/`.
 - **`~/.map/`** — host-scoped shared state. Two subdirectories matter:
-  - `~/.map/locks/` — advisory lock files acquired by the orchestrator to prevent concurrent MAP sessions on the same branch.
+  - `~/.map/locks/` — host-scoped advisory locks and state sidecars owned by `mapify_cli._locking`; these are separate from project-local branch transaction locks.
   - `~/.map/hooks/` — host-level hook scripts invoked by the MAP hook harness before/after workflow phases.
 
 Root `.gitignore` mutation uses one cross-process lock keyed by the SHA-256 of
@@ -90,7 +90,7 @@ acquires only the provider barrier after installation completes.
 in_progress  created  updated  skipped  timeout  error
 ```
 
-This PR ships the enum and the sidecar writer; no MAP workflow surface is wired to call `flock_with_state` yet (Phase A consumes it for hook serialization, Phase E for memory-flush). The pre-existing `step_state.json` subtask statuses (`pending|in_progress|complete|blocked`) are a separate, unrelated enum owned by the orchestrator.
+Memory finalization uses `flock_with_state` to serialize a repository's flush. The project-local `.map/.locks/<branch>.transaction.lock` protocol is independent and has no state sidecar. The pre-existing `step_state.json` subtask statuses (`pending|in_progress|complete|blocked`) are a separate, unrelated enum owned by the orchestrator.
 
 **INV-5 invariant:** This is a closed enum. Adding a new state requires editing BOTH `src/mapify_cli/_locking.py:LockState` AND this document in the same PR. A PR that adds a state to one without the other must be rejected.
 

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -6332,5 +6332,56 @@ class TestSetWavesImportFallback:
         assert waves[1] == ["ST-002"]
 
 
+def test_step_state_save_uses_pid_scoped_temp_name():
+    """Bug #446 (Bug 3): StepState.save must use a PID-scoped temp file name so
+    concurrent orchestrator instances don't collide on the same .tmp file.
+    """
+    source = (ORCHESTRATOR_PATH / "map_orchestrator.py").read_text(encoding="utf-8")
+    # Locate save() method body tightly: it ends at the first top-level def/class
+    # after the method start (save is the last method in StepState, so the next
+    # top-level symbol starts at column 0).
+    save_start = source.index("def save(self, state_file: Path)")
+    # Find the end of the method: either the next top-level def/class or end of file
+    import re as _re
+    top_level_match = _re.search(r"\n(?:def |class )", source[save_start + 1:])
+    if top_level_match:
+        save_end = save_start + 1 + top_level_match.start()
+    else:
+        save_end = len(source)
+    save_body = source[save_start:save_end]
+    assert "os.getpid()" in save_body, (
+        "StepState.save must use os.getpid() in the temp file name to avoid "
+        "concurrent-writer collisions (Bug #446 Bug 3)"
+    )
+    assert 'with_suffix(".tmp")' not in save_body, (
+        "StepState.save must not use a fixed .tmp suffix — use a PID-scoped name instead"
+    )
+
+
+def test_append_restored_subtask_to_plan_is_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Bug #446 (Bug 4): _append_restored_subtask_to_plan must write the plan file
+    atomically (temp-file + replace), not via a direct write_text() that truncates
+    the file before the new content is written.
+    """
+    source = (ORCHESTRATOR_PATH / "map_orchestrator.py").read_text(encoding="utf-8")
+    fn_start = source.index("def _append_restored_subtask_to_plan(")
+    fn_end = source.index("\ndef ", fn_start + 1)
+    fn_body = source[fn_start:fn_end]
+    # The function must use an atomic temp-file pattern, not a bare write_text
+    assert "os.getpid()" in fn_body, (
+        "_append_restored_subtask_to_plan must use os.getpid() in the temp file name "
+        "for atomic writes (Bug #446 Bug 4)"
+    )
+    assert fn_body.count(".replace(plan_file)") >= 1, (
+        "_append_restored_subtask_to_plan must use .replace() for an atomic rename"
+    )
+    # The bare non-atomic write must be gone
+    bare_write_count = fn_body.count("plan_file.write_text(")
+    assert bare_write_count == 0, (
+        "_append_restored_subtask_to_plan must not call plan_file.write_text() directly "
+        "— use a temp-file + replace() atomic pattern instead (Bug #446 Bug 4)"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -6332,55 +6332,194 @@ class TestSetWavesImportFallback:
         assert waves[1] == ["ST-002"]
 
 
-def test_step_state_save_uses_pid_scoped_temp_name():
-    """Bug #446 (Bug 3): StepState.save must use a PID-scoped temp file name so
-    concurrent orchestrator instances don't collide on the same .tmp file.
-    """
-    source = (ORCHESTRATOR_PATH / "map_orchestrator.py").read_text(encoding="utf-8")
-    # Locate save() method body tightly: it ends at the first top-level def/class
-    # after the method start (save is the last method in StepState, so the next
-    # top-level symbol starts at column 0).
-    save_start = source.index("def save(self, state_file: Path)")
-    # Find the end of the method: either the next top-level def/class or end of file
-    import re as _re
-    top_level_match = _re.search(r"\n(?:def |class )", source[save_start + 1:])
-    if top_level_match:
-        save_end = save_start + 1 + top_level_match.start()
-    else:
-        save_end = len(source)
-    save_body = source[save_start:save_end]
-    assert "os.getpid()" in save_body, (
-        "StepState.save must use os.getpid() in the temp file name to avoid "
-        "concurrent-writer collisions (Bug #446 Bug 3)"
-    )
-    assert 'with_suffix(".tmp")' not in save_body, (
-        "StepState.save must not use a fixed .tmp suffix — use a PID-scoped name instead"
+def test_step_state_save_uses_invocation_unique_temp_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Each save publishes valid JSON through a fresh temporary file."""
+    state_file = tmp_path / "step_state.json"
+    replaced_from: list[Path] = []
+    original_replace = Path.replace
+
+    def recording_replace(source: Path, target: Path) -> Path:
+        replaced_from.append(source)
+        return original_replace(source, target)
+
+    monkeypatch.setattr(Path, "replace", recording_replace)
+
+    map_orchestrator.StepState(current_step_id="1.0").save(state_file)
+    map_orchestrator.StepState(current_step_id="1.5").save(state_file)
+
+    assert json.loads(state_file.read_text(encoding="utf-8"))["current_step_id"] == "1.5"
+    assert len(replaced_from) == 2
+    assert replaced_from[0] != replaced_from[1]
+    assert all(path.parent == tmp_path for path in replaced_from)
+    assert all(path.name.startswith(".step_state.json.") for path in replaced_from)
+    assert all(path.name.endswith(".tmp") for path in replaced_from)
+    assert list(tmp_path.glob(".step_state.json.*.tmp")) == []
+
+
+def test_step_state_save_replace_failure_preserves_target_and_cleans_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A failed atomic publish leaves the prior state intact and no temp residue."""
+    state_file = tmp_path / "step_state.json"
+    original = '{"current_step_id": "original"}\n'
+    state_file.write_text(original, encoding="utf-8")
+
+    def fail_replace(_source: Path, _target: Path) -> Path:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        map_orchestrator.StepState(current_step_id="1.5").save(state_file)
+
+    assert state_file.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(".step_state.json.*.tmp")) == []
+
+
+def _restored_plan_inputs(subtask_id: str = "ST-002") -> tuple[dict, dict]:
+    return (
+        {"id": subtask_id, "title": "Add optional export"},
+        {
+            "id": "YG-001",
+            "rationale": "Not required for the initial flow.",
+            "restore_hint": "Add CSV export when requested.",
+        },
     )
 
 
-def test_append_restored_subtask_to_plan_is_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Bug #446 (Bug 4): _append_restored_subtask_to_plan must write the plan file
-    atomically (temp-file + replace), not via a direct write_text() that truncates
-    the file before the new content is written.
-    """
-    source = (ORCHESTRATOR_PATH / "map_orchestrator.py").read_text(encoding="utf-8")
-    fn_start = source.index("def _append_restored_subtask_to_plan(")
-    fn_end = source.index("\ndef ", fn_start + 1)
-    fn_body = source[fn_start:fn_end]
-    # The function must use an atomic temp-file pattern, not a bare write_text
-    assert "os.getpid()" in fn_body, (
-        "_append_restored_subtask_to_plan must use os.getpid() in the temp file name "
-        "for atomic writes (Bug #446 Bug 4)"
+def test_append_restored_subtask_to_plan_writes_content_and_is_idempotent(
+    tmp_path: Path,
+):
+    """The plan append is valid at runtime and repeated calls are a no-op."""
+    plan_file = tmp_path / "task_plan_test.md"
+    plan_file.write_text("# Task Plan\n", encoding="utf-8")
+    subtask, item = _restored_plan_inputs()
+
+    assert map_orchestrator._append_restored_subtask_to_plan(
+        plan_file, subtask, item
+    ) is True
+    updated = plan_file.read_text(encoding="utf-8")
+    assert "### ST-002: Add optional export" in updated
+    assert "- **Restored from:** YG-001" in updated
+
+    assert map_orchestrator._append_restored_subtask_to_plan(
+        plan_file, subtask, item
+    ) is False
+    assert plan_file.read_text(encoding="utf-8") == updated
+    assert list(tmp_path.glob(".task_plan_test.md.*.tmp")) == []
+
+
+def test_append_restored_subtask_replace_failure_preserves_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A failed plan publish preserves the old plan and removes its temp file."""
+    plan_file = tmp_path / "task_plan_test.md"
+    original = "# Task Plan\n"
+    plan_file.write_text(original, encoding="utf-8")
+    subtask, item = _restored_plan_inputs()
+
+    def fail_replace(_source: Path, _target: Path) -> Path:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        map_orchestrator._append_restored_subtask_to_plan(plan_file, subtask, item)
+
+    assert plan_file.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(".task_plan_test.md.*.tmp")) == []
+
+
+def test_cli_state_transaction_waits_for_branch_lock(tmp_path: Path):
+    """A CLI mutation waits until the full branch transaction lock is released."""
+    branch = "concurrent-branch"
+    branch_path = tmp_path / ".map" / branch
+    branch_path.mkdir(parents=True)
+    state_file = branch_path / "step_state.json"
+    map_orchestrator.StepState(plan_approved=False).save(state_file)
+
+    helper = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(ORCHESTRATOR_PATH)!r})\n"
+        "from pathlib import Path\n"
+        "from map_utils import branch_transaction\n"
+        f"with branch_transaction(Path({str(branch_path)!r})):\n"
+        "    print('locked', flush=True)\n"
+        "    sys.stdin.readline()\n"
     )
-    assert fn_body.count(".replace(plan_file)") >= 1, (
-        "_append_restored_subtask_to_plan must use .replace() for an atomic rename"
+    holder = subprocess.Popen(
+        [sys.executable, "-c", helper],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
-    # The bare non-atomic write must be gone
-    bare_write_count = fn_body.count("plan_file.write_text(")
-    assert bare_write_count == 0, (
-        "_append_restored_subtask_to_plan must not call plan_file.write_text() directly "
-        "— use a temp-file + replace() atomic pattern instead (Bug #446 Bug 4)"
+    command: subprocess.Popen[str] | None = None
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "locked"
+
+        env = os.environ.copy()
+        env["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+        command = subprocess.Popen(
+            [
+                sys.executable,
+                str(ORCHESTRATOR_PATH / "map_orchestrator.py"),
+                "set_plan_approved",
+                "true",
+                "--branch",
+                branch,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            command.wait(timeout=0.5)
+
+        assert holder.stdin is not None
+        holder.stdin.write("\n")
+        holder.stdin.flush()
+        holder.wait(timeout=5)
+
+        stdout, stderr = command.communicate(timeout=10)
+        assert command.returncode == 0, stderr
+        assert json.loads(stdout)["status"] == "success"
+        assert map_orchestrator.StepState.load(state_file).plan_approved is True
+    finally:
+        if holder.poll() is None:
+            holder.kill()
+            holder.wait(timeout=5)
+        if command is not None and command.poll() is None:
+            command.kill()
+            command.wait(timeout=5)
+
+
+def test_cli_without_map_state_does_not_create_lock_directory(tmp_path: Path):
+    """A state lookup in an uninitialized project must remain side-effect free."""
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ORCHESTRATOR_PATH / "map_orchestrator.py"),
+            "peek_current_step",
+            "--branch",
+            "missing-branch",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
     )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not (tmp_path / ".map").exists()
 
 
 if __name__ == "__main__":

--- a/tests/test_map_orchestrator.py
+++ b/tests/test_map_orchestrator.py
@@ -32,6 +32,7 @@ ORCHESTRATOR_PATH = (
 sys.path.insert(0, str(ORCHESTRATOR_PATH))
 
 import map_orchestrator  # pyright: ignore[reportMissingImports]
+import map_utils  # pyright: ignore[reportMissingImports]
 
 
 @pytest.fixture
@@ -6356,6 +6357,36 @@ def test_step_state_save_uses_invocation_unique_temp_files(
     assert all(path.name.startswith(".step_state.json.") for path in replaced_from)
     assert all(path.name.endswith(".tmp") for path in replaced_from)
     assert list(tmp_path.glob(".step_state.json.*.tmp")) == []
+
+
+def test_atomic_write_text_uses_binary_descriptor_and_explicit_lf_newlines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Atomic text writes avoid stacked newline translation on Windows."""
+    mkstemp_kwargs: dict[str, object] = {}
+    fdopen_kwargs: dict[str, object] = {}
+    original_mkstemp = map_utils.tempfile.mkstemp
+    original_fdopen = map_utils.os.fdopen
+
+    def recording_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        mkstemp_kwargs.update(kwargs)
+        return original_mkstemp(*args, **kwargs)
+
+    def recording_fdopen(
+        descriptor: int, *args: object, **kwargs: object
+    ) -> object:
+        fdopen_kwargs.update(kwargs)
+        return original_fdopen(descriptor, *args, **kwargs)
+
+    monkeypatch.setattr(map_utils.tempfile, "mkstemp", recording_mkstemp)
+    monkeypatch.setattr(map_utils.os, "fdopen", recording_fdopen)
+
+    target = tmp_path / "state.txt"
+    map_utils.atomic_write_text(target, "first\nsecond\n")
+
+    assert "text" not in mkstemp_kwargs
+    assert fdopen_kwargs["newline"] == "\n"
+    assert target.read_bytes() == b"first\nsecond\n"
 
 
 def test_step_state_save_replace_failure_preserves_target_and_cleans_temp(

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2646,6 +2646,127 @@ def test_record_auto_phase_is_the_sole_phases_mutator_in_source():
     )
 
 
+def test_record_auto_phase_refuses_after_chain_completed(branch_workspace):
+    """Bug #446 (Bug 5): record_auto_phase must refuse when chain_status is
+    'completed', not just 'aborted'/'blocked'. A replayed or erroneous call
+    after a successful chain close must not corrupt the artifact.
+    """
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship feature", branch=branch)
+
+    # Advance the chain to completed via record_auto_phase
+    map_step_runner.record_auto_phase("map-plan", "in_progress", branch=branch)
+    complete_result = map_step_runner.record_auto_phase(
+        "map-plan", "completed", branch=branch
+    )
+    assert complete_result["status"] == "success"
+    assert complete_result["chain_status"] == "completed"
+
+    artifact_before = _read_auto_route_artifact(branch_workspace)
+    assert artifact_before["chain_status"] == "completed"
+
+    # A subsequent call on a completed chain must be refused
+    refused = map_step_runner.record_auto_phase(
+        "map-efficient", "in_progress", branch=branch
+    )
+
+    assert refused["status"] == "refused"
+    assert refused["chain_status"] == "completed"
+
+    artifact_after = _read_auto_route_artifact(branch_workspace)
+    assert artifact_after == artifact_before, (
+        "no field of the artifact may change on a refused call against a completed chain"
+    )
+
+
+def test_route_task_includes_block_reason_when_blocked(branch_workspace):
+    """Bug #446 (Bug 6): route_task must include 'block_reason' in the return
+    dict when chain_status is 'blocked', so consuming agents and SKILL.md callers
+    can surface why the chain was blocked.
+    """
+    branch = branch_workspace.name
+    hold_result = map_step_runner.create_approval_hold(
+        kind="dangerous_action",
+        reason="Destructive shell command",
+        request_summary="rm -rf production bucket",
+        branch=branch,
+    )
+    hold_id = hold_result["hold_id"]
+
+    result = map_step_runner.route_task("run the cleanup", branch=branch, dry_run=False)
+
+    assert result["chain_status"] == "blocked"
+    assert result["blocked_by"] == [hold_id]
+    # Bug 6: block_reason was absent from the return dict
+    assert "block_reason" in result, "block_reason must be present in blocked route_task response"
+    assert result["block_reason"], "block_reason must be non-empty when chain is blocked"
+
+
+def test_auto_decide_holds_routes_decide_error_to_hard_stops(branch_workspace, monkeypatch):
+    """Bug #446 (Bug 7): auto_decide_holds must check the return value of
+    decide_approval_hold. When it returns an error (hold missing, already decided),
+    the hold must go to hard_stops[], not auto_approved[].
+    """
+    branch = branch_workspace.name
+    map_step_runner.route_task("ship something", branch=branch)
+
+    created = map_step_runner.create_approval_hold(
+        kind="plan_approval",
+        reason="plan needs sign-off",
+        request_summary="approve blueprint before executing",
+        branch=branch,
+    )
+    hold_id = created["hold_id"]
+
+    # Patch decide_approval_hold to simulate a failure (e.g. already decided)
+    original_decide = map_step_runner.decide_approval_hold
+
+    def failing_decide(hid: str, decision: str, note: str = "", branch: str | None = None) -> dict:  # type: ignore[override]
+        if hid == hold_id:
+            return {"status": "error", "message": f"hold {hid!r} already decided"}
+        return original_decide(hid, decision, note, branch)
+
+    monkeypatch.setattr(map_step_runner, "decide_approval_hold", failing_decide)
+
+    result = map_step_runner.auto_decide_holds(branch=branch)
+
+    # Bug 7: the hold must not appear in auto_approved when decide fails
+    assert not any(e["id"] == hold_id for e in result["auto_approved"]), (
+        "a hold whose decide_approval_hold call failed must not be in auto_approved"
+    )
+    # It must be routed to hard_stops instead
+    assert any(e["id"] == hold_id for e in result["hard_stops"]), (
+        "a hold whose decide_approval_hold call failed must appear in hard_stops"
+    )
+
+
+def test_write_json_file_uses_pid_scoped_temp_name(tmp_path):
+    """Bug #446 (Bugs 1-2): _write_json_file and _write_text_file must use
+    PID-scoped temp file names so concurrent writers don't collide.
+    """
+    import sys
+
+    sys.dont_write_bytecode = True
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "map_step_runner_tmp",
+        str(SCRIPTS_PATH / "map_step_runner.py"),
+    )
+    assert spec and spec.loader
+
+    # Just verify the naming pattern in the source rather than monkeypatching internals.
+    source = (SCRIPTS_PATH / "map_step_runner.py").read_text(encoding="utf-8")
+    # Check that the fixed naming pattern exists in the source
+    assert "os.getpid()" in source, (
+        "_write_json_file and _write_text_file must use os.getpid() for temp file naming"
+    )
+    # Confirm the old fixed-suffix pattern is gone
+    assert 'with_suffix(".tmp")' not in source or source.count('with_suffix(".tmp")') == 0, (
+        "fixed .tmp suffix (non-PID-unique) must not appear in map_step_runner.py"
+    )
+
+
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):
     blueprint = {
         "summary": "Deliver a user-visible fix",

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2740,31 +2740,32 @@ def test_auto_decide_holds_routes_decide_error_to_hard_stops(branch_workspace, m
     )
 
 
-def test_write_json_file_uses_pid_scoped_temp_name(tmp_path):
-    """Bug #446 (Bugs 1-2): _write_json_file and _write_text_file must use
-    PID-scoped temp file names so concurrent writers don't collide.
-    """
-    import sys
+def test_write_helpers_use_invocation_unique_temp_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """JSON and text helpers publish through a fresh temp file on every call."""
+    json_path = tmp_path / "state.json"
+    text_path = tmp_path / "report.md"
+    replaced_from: list[Path] = []
+    original_replace = Path.replace
 
-    sys.dont_write_bytecode = True
-    import importlib.util
+    def recording_replace(source: Path, target: Path) -> Path:
+        replaced_from.append(source)
+        return original_replace(source, target)
 
-    spec = importlib.util.spec_from_file_location(
-        "map_step_runner_tmp",
-        str(SCRIPTS_PATH / "map_step_runner.py"),
-    )
-    assert spec and spec.loader
+    monkeypatch.setattr(Path, "replace", recording_replace)
 
-    # Just verify the naming pattern in the source rather than monkeypatching internals.
-    source = (SCRIPTS_PATH / "map_step_runner.py").read_text(encoding="utf-8")
-    # Check that the fixed naming pattern exists in the source
-    assert "os.getpid()" in source, (
-        "_write_json_file and _write_text_file must use os.getpid() for temp file naming"
-    )
-    # Confirm the old fixed-suffix pattern is gone
-    assert 'with_suffix(".tmp")' not in source or source.count('with_suffix(".tmp")') == 0, (
-        "fixed .tmp suffix (non-PID-unique) must not appear in map_step_runner.py"
-    )
+    map_step_runner._write_json_file(json_path, {"version": 1})
+    map_step_runner._write_json_file(json_path, {"version": 2})
+    map_step_runner._write_text_file(text_path, "complete\n")
+
+    assert json.loads(json_path.read_text(encoding="utf-8")) == {"version": 2}
+    assert text_path.read_text(encoding="utf-8") == "complete\n"
+    assert len(replaced_from) == 3
+    assert len(set(replaced_from)) == 3
+    assert all(path.parent == tmp_path for path in replaced_from)
+    assert all(path.name.endswith(".tmp") for path in replaced_from)
+    assert list(tmp_path.glob(".*.tmp")) == []
 
 
 def test_validate_blueprint_contract_accepts_contract_sized_plan(branch_workspace):

--- a/tests/test_parallelism_observability.py
+++ b/tests/test_parallelism_observability.py
@@ -200,8 +200,8 @@ def test_detection_not_implemented() -> None:
 def _load_runner_module() -> object:
     """Import the rendered runner script as a module (bytecode-free).
 
-    The runner does ``from map_utils import get_branch_name`` at module level,
-    which fails outside an installed MAP project.  We inject a stub into
+    The runner imports its standalone ``map_utils`` dependencies at module
+    level, which fails outside an installed MAP project. We inject a stub into
     sys.modules before exec so the import resolves without a real map_utils.
     The stub is cleaned up after exec to avoid polluting the test session.
     """
@@ -217,6 +217,17 @@ def _load_runner_module() -> object:
         del _a, _kw  # del is valid in a def body (illegal in a lambda)
         return "stub"
 
+    def _unused_stub(*_a: object, **_kw: object) -> None:
+        del _a, _kw
+
+    def _unused_transaction(*_a: object, **_kw: object):
+        from contextlib import nullcontext
+
+        del _a, _kw
+        return nullcontext()
+
+    stub.atomic_write_text = _unused_stub  # type: ignore[attr-defined]
+    stub.branch_transaction = _unused_transaction  # type: ignore[attr-defined]
     stub.get_branch_name = _stub_branch_name  # type: ignore[attr-defined]
     injected = "map_utils" not in sys.modules
     if injected:


### PR DESCRIPTION
## Summary

Fixes #446.

This PR fixes seven concurrency and workflow-state bugs in the generated MAP orchestrator and step runner.

### Concurrency and atomic writes

- Serializes the complete per-branch read-modify-write transaction with a reentrant process-local lock plus a cross-process advisory lock at `.map/.locks/<branch>.transaction.lock`.
- Uses invocation-unique sibling files from `tempfile.mkstemp` before atomic replacement, so simultaneous writes from the same PID cannot collide.
- Cleans temporary files when publication fails and preserves the previous target.
- Routes JSON and text writers through one shared `atomic_write_text` implementation.
- Keeps an uninitialized, read-only lookup side-effect free.
- Ships the canonical Jinja changes and regenerated Claude/Codex/template surfaces together.

### Workflow-state fixes

- Treats `completed` auto-route chains as terminal.
- Includes `block_reason` in blocked route results.
- Routes failed automatic hold decisions to `hard_stops` instead of `auto_approved`.

### Review follow-up

- Replaced source-scanning assertions with runtime positive, no-op, failure-cleanup, unique-temp, and lock-contention tests.
- Updated the `record_auto_phase` terminal-state documentation.
- Documented and gitignored the branch lock directory.

### Verification

- `make check` — 5,540 passed, 12 deselected.
- Ruff, mypy, Pyright, and hook-contract checks passed.
- `make check-render` — generated trees match `templates_src`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent state and plan updates to reduce file-write conflicts and prevent corrupted data.
  - Completed chains are now correctly treated as terminal and cannot receive further automatic updates.
  - Blocked chain results now include a reason explaining why execution was stopped.
  - Failed automatic approval decisions are recorded as hard stops instead of being marked as approved.
  - Improved file publishing reliability with atomic updates and cleanup after failures.
  - Restored plan updates are now safely handled when repeated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
