### PR TITLE
fix: atomic_write_text OSError masking; route_task block_reason schema split (#448)

### DIFF
--- a/.map/scripts/map_step_runner.py
+++ b/.map/scripts/map_step_runner.py
@@ -16346,7 +16346,7 @@ def route_task(
     )
     save_artifact_manifest(manifest, branch_name)
 
-    return {
+    result: dict[str, object] = {
         "status": "blocked" if chain_status == "blocked" else "success",
         "branch": branch_name,
         "path": str(artifact_path),
@@ -16355,8 +16355,10 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
-        "block_reason": block_reason if chain_status == "blocked" else None,
     }
+    if chain_status == "blocked":
+        result["block_reason"] = block_reason
+    return result
 
 
 def record_auto_phase(

--- a/.map/scripts/map_utils.py
+++ b/.map/scripts/map_utils.py
@@ -158,7 +158,7 @@ def atomic_write_text(path: Path, content: str) -> None:
             os.close(descriptor)
         try:
             temporary_path.unlink()
-        except FileNotFoundError:
+        except OSError:
             pass
 
 

--- a/src/mapify_cli/templates/map/scripts/map_step_runner.py
+++ b/src/mapify_cli/templates/map/scripts/map_step_runner.py
@@ -16346,7 +16346,7 @@ def route_task(
     )
     save_artifact_manifest(manifest, branch_name)
 
-    return {
+    result: dict[str, object] = {
         "status": "blocked" if chain_status == "blocked" else "success",
         "branch": branch_name,
         "path": str(artifact_path),
@@ -16355,8 +16355,10 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
-        "block_reason": block_reason if chain_status == "blocked" else None,
     }
+    if chain_status == "blocked":
+        result["block_reason"] = block_reason
+    return result
 
 
 def record_auto_phase(

--- a/src/mapify_cli/templates/map/scripts/map_utils.py
+++ b/src/mapify_cli/templates/map/scripts/map_utils.py
@@ -158,7 +158,7 @@ def atomic_write_text(path: Path, content: str) -> None:
             os.close(descriptor)
         try:
             temporary_path.unlink()
-        except FileNotFoundError:
+        except OSError:
             pass
 
 

--- a/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja
@@ -16321,7 +16321,7 @@ def route_task(
     )
     save_artifact_manifest(manifest, branch_name)
 
-    return {
+    result: dict[str, object] = {
         "status": "blocked" if chain_status == "blocked" else "success",
         "branch": branch_name,
         "path": str(artifact_path),
@@ -16330,8 +16330,10 @@ def route_task(
         "next_command": next_command,
         "executed": executed,
         "blocked_by": blocked_by,
-        "block_reason": block_reason if chain_status == "blocked" else None,
     }
+    if chain_status == "blocked":
+        result["block_reason"] = block_reason
+    return result
 
 
 def record_auto_phase(

--- a/src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja
+++ b/src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja
@@ -158,7 +158,7 @@ def atomic_write_text(path: Path, content: str) -> None:
             os.close(descriptor)
         try:
             temporary_path.unlink()
-        except FileNotFoundError:
+        except OSError:
             pass
 
 

--- a/tests/test_map_step_runner.py
+++ b/tests/test_map_step_runner.py
@@ -2226,6 +2226,47 @@ def test_route_task_blocks_on_pending_hard_stop_hold_under_dry_run(branch_worksp
     assert result["blocked_by"] == [hold_id]
 
 
+# route_task block_reason schema consistency (issue #448) --------------------
+# The return dict must omit block_reason when not blocked, matching the
+# on-disk artifact schema (which only writes block_reason when chain is blocked).
+
+
+def test_route_task_success_return_dict_omits_block_reason(branch_workspace):
+    """Non-blocked route_task must not include block_reason in the return dict."""
+    branch = branch_workspace.name
+    result = map_step_runner.route_task("some task", branch=branch, dry_run=True)
+
+    assert result["chain_status"] == "recommended_only"
+    assert "block_reason" not in result, (
+        f"route_task return dict must omit block_reason when chain is not blocked; "
+        f"got block_reason={result.get('block_reason')!r}"
+    )
+
+
+def test_route_task_blocked_return_dict_includes_block_reason(branch_workspace):
+    """Blocked route_task must include block_reason in both return dict and artifact."""
+    branch = branch_workspace.name
+    map_step_runner.create_approval_hold(
+        kind="dangerous_action",
+        reason="Risky command",
+        request_summary="rm -rf production",
+        branch=branch,
+    )
+
+    result = map_step_runner.route_task("do it", branch=branch, dry_run=False)
+
+    assert result["chain_status"] == "blocked"
+    assert "block_reason" in result, "blocked route_task must include block_reason in return dict"
+    assert result["block_reason"], "block_reason must be non-empty when blocked"
+
+    artifact = _read_auto_route_artifact(branch_workspace)
+    # Return dict and artifact must agree on whether block_reason is present.
+    assert "block_reason" in artifact, "blocked artifact must persist block_reason"
+    assert result["block_reason"] == artifact["block_reason"], (
+        "return dict block_reason must match the artifact's block_reason"
+    )
+
+
 # auto_decide_holds (issue #414 : auto-approve workflow-control
 # holds via a positive allowlist; dangerous_action/safety_guardrail can
 # never be decided by this code path) -------------------------------------

--- a/tests/test_map_utils_sanitize.py
+++ b/tests/test_map_utils_sanitize.py
@@ -12,7 +12,9 @@ allow path traversal via ``..``.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -25,11 +27,18 @@ _MAP_UTILS_PATH = (
     / "scripts"
     / "map_utils.py"
 )
-_SPEC = importlib.util.spec_from_file_location("map_utils_under_test", _MAP_UTILS_PATH)
-assert _SPEC is not None and _SPEC.loader is not None
-_MODULE = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(_MODULE)
+_prev_no_bytecode = sys.dont_write_bytecode
+sys.dont_write_bytecode = True
+try:
+    _SPEC = importlib.util.spec_from_file_location("map_utils_under_test", _MAP_UTILS_PATH)
+    assert _SPEC is not None and _SPEC.loader is not None
+    _MODULE = importlib.util.module_from_spec(_SPEC)
+    _SPEC.loader.exec_module(_MODULE)
+finally:
+    sys.dont_write_bytecode = _prev_no_bytecode
+
 sanitize_branch_name = _MODULE.sanitize_branch_name
+atomic_write_text = _MODULE.atomic_write_text
 
 
 class TestSanitizeBranchName:
@@ -88,3 +97,57 @@ class TestSanitizeBranchName:
         # argparse default leaks through), fall back instead of raising.
         assert sanitize_branch_name(None) == "default"  # type: ignore[arg-type]
         assert sanitize_branch_name(123) == "default"  # type: ignore[arg-type]
+
+
+class TestAtomicWriteText:
+    """Tests for the atomic_write_text helper (issue #448).
+
+    Verifies that a cleanup OSError in the finally block does not mask the
+    original replace() error -- the fix changed ``except FileNotFoundError``
+    to ``except OSError`` so ALL cleanup errors are swallowed instead of only
+    FileNotFoundError.
+    """
+
+    def test_writes_content_to_destination(self, tmp_path: Path) -> None:
+        dest = tmp_path / "out.json"
+        atomic_write_text(dest, '{"ok": true}')
+        assert dest.read_text(encoding="utf-8") == '{"ok": true}'
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sub" / "dir" / "out.txt"
+        atomic_write_text(dest, "hello")
+        assert dest.read_text(encoding="utf-8") == "hello"
+
+    def test_replace_error_propagates_not_masked_by_unlink_oserror(
+        self, tmp_path: Path
+    ) -> None:
+        """If replace() fails, a subsequent OSError from unlink() must not mask it.
+
+        Before the fix, the finally block caught only FileNotFoundError; any
+        other OSError from unlink() would propagate and hide the replace() error.
+        After the fix, OSError from cleanup is always swallowed, so the original
+        replace() error reaches the caller.
+        """
+        dest = tmp_path / "target.json"
+        replace_error = PermissionError("replace denied")
+        unlink_error = PermissionError("unlink denied")
+
+        def patched_replace(self: Path, target: object) -> Path:
+            raise replace_error
+
+        def patched_unlink(self: Path, missing_ok: bool = False) -> None:
+            raise unlink_error
+
+        with (
+            patch.object(Path, "replace", patched_replace),
+            patch.object(Path, "unlink", patched_unlink),
+            pytest.raises(PermissionError) as exc_info,
+        ):
+            atomic_write_text(dest, "data")
+
+        # The original replace() error must be what the caller sees, not the
+        # unlink() error that occurred in cleanup.
+        assert exc_info.value is replace_error, (
+            "replace() error was masked by the unlink() cleanup error; "
+            "expected the original PermissionError from replace() to propagate"
+        )


### PR DESCRIPTION
Fixes #448.

## Summary

- **Bug 1 (`map_utils.py`)**: `atomic_write_text` caught only `FileNotFoundError` in the `finally` cleanup block. If `replace()` raised `PermissionError` and `unlink()` also raised `PermissionError` (same root cause, e.g. file locked on Windows), the cleanup exception masked the original error — caller sees the wrong message. Fix: catch `OSError` instead so all cleanup errors are swallowed while the original `replace()` error propagates.

- **Bug 2 (`map_step_runner.py`)**: `route_task` included `"block_reason": None` in the return dict even when the chain was not blocked, but the on-disk artifact omits the key when not blocked. Any caller reading the return dict found the key (with `None`); any caller re-reading the artifact got `KeyError` — silent schema split. Fix: only include `block_reason` in the return dict when `chain_status == "blocked"`, matching the artifact.

## Changes

- `src/mapify_cli/templates_src/map/scripts/map_utils.py.jinja` — Bug 1 fix
- `src/mapify_cli/templates_src/map/scripts/map_step_runner.py.jinja` — Bug 2 fix
- Generated trees rendered (`make render-templates`)
- `tests/test_map_utils_sanitize.py` — 3 new tests for `atomic_write_text` including the masking regression
- `tests/test_map_step_runner.py` — 2 new tests asserting `block_reason` schema consistency between return dict and artifact

5541 tests pass; lint and render-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFxrWLgiWdGUNHCm1Z15Z4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFxrWLgiWdGUNHCm1Z15Z4)_